### PR TITLE
Support dsd disc images via UI and URL params

### DIFF
--- a/app-frogman.js
+++ b/app-frogman.js
@@ -66,7 +66,7 @@ requirejs(['video', '6502', 'soundchip', 'fdc', 'models', 'tests/test.js', 'util
         cpu.initialise().then(function () {
             return disc.ssdLoad("discs/" + discName + ".ssd");
         }).then(function (data) {
-            cpu.fdc.loadDisc(0, disc.ssdFor(cpu.fdc, data));
+            cpu.fdc.loadDisc(0, disc.ssdFor(cpu.fdc, false, data));
             var trace = false;
             cpu.debugInstruction.add(function (addr) {
                 //if (addr === 0x11ae) {

--- a/app.js
+++ b/app.js
@@ -59,7 +59,7 @@ requirejs(['video', '6502', 'soundchip', 'fdc', 'models'],
         cpu.initialise().then(function () {
             return disc.ssdLoad("discs/" + discName + ".ssd");
         }).then(function (data) {
-            cpu.fdc.loadDisc(0, disc.ssdFor(cpu.fdc, data));
+            cpu.fdc.loadDisc(0, disc.ssdFor(cpu.fdc, false, data));
             cpu.sysvia.keyDown(16);
             cpu.execute(10 * 1000 * 1000);
             cpu.sysvia.keyUp(16);

--- a/d8js-bench.js
+++ b/d8js-bench.js
@@ -63,7 +63,7 @@ requirejs(['video', '6502', 'soundchip', 'fdc', 'models'],
         cpu.initialise().then(function () {
             return disc.ssdLoad("discs/" + discName + ".ssd");
         }).then(function (data) {
-            cpu.fdc.loadDisc(0, disc.ssdFor(cpu.fdc, data));
+            cpu.fdc.loadDisc(0, disc.ssdFor(cpu.fdc, false, data));
             cpu.sysvia.keyDown(16);
             cpu.execute(10 * 1000 * 1000);
             cpu.sysvia.keyUp(16);

--- a/fdc.js
+++ b/fdc.js
@@ -22,7 +22,7 @@ define(['utils'], function (utils) {
         return result;
     }
 
-    function ssdFor(fdc, stringData) {
+    function ssdFor(fdc, isDsd, stringData) {
         var data;
         if (typeof(stringData) !== "string") {
             data = stringData;
@@ -31,7 +31,7 @@ define(['utils'], function (utils) {
             data = new Uint8Array(len);
             for (var i = 0; i < len; ++i) data[i] = stringData.charCodeAt(i) & 0xff;
         }
-        return baseSsd(fdc, data);
+        return baseSsd(fdc, isDsd, data);
     }
 
     function localDisc(fdc, name) {
@@ -50,17 +50,17 @@ define(['utils'], function (utils) {
             data = new Uint8Array(len);
             for (i = 0; i < len; ++i) data[i] = dataString.charCodeAt(i) & 0xff;
         }
-        return baseSsd(fdc, data, function () {
+        return baseSsd(fdc, false, data, function () {
             var str = "";
             for (var i = 0; i < data.length; ++i) str += String.fromCharCode(data[i]);
             localStorage[discName] = str;
         });
     }
 
-    function baseSsd(fdc, data, flusher) {
+    function baseSsd(fdc, isDsd, data, flusher) {
         if (data === null || data === undefined) throw new Error("Bad disc data");
         return {
-            dsd: false,
+            dsd: isDsd,
             inRead: false,
             inWrite: false,
             inFormat: false,

--- a/google-drive.js
+++ b/google-drive.js
@@ -159,7 +159,7 @@ define(['jquery', 'utils', 'fdc'], function ($, utils, fdc) {
             } else {
                 console.log("Making read-only disc");
             }
-            return baseSsd(fdc, data, flusher);
+            return baseSsd(fdc, false, data, flusher);
         }
 
         self.load = function (fdc, fileId) {

--- a/index.html
+++ b/index.html
@@ -352,11 +352,11 @@
                     <li class="template"><a href="#"><span class="name"></span></a> - <span
                             class="description"></span></li>
                 </ul>
-                To load a custom disc image, get an SSD file and load it below. Search the web, or check somewhere
+                To load a custom disc image, get an SSD or DSD file and load it below. Search the web, or check somewhere
                 like <a href="http://www.bbcmicrogames.com/GettingStarted.html">here</a> for these. Be aware the
                 images are usually stored in a ZIP file, and you'll need to unzip first.
                 <div class="disc">
-                    <label>Load local SSD file: <input type="file" id="disc_load" accept=".ssd,image/*"></label>
+                    <label>Load local SSD or DSD file: <input type="file" id="disc_load" accept=".ssd,.dsd,image/*"></label>
                 </div>
             </div>
             <div class="modal-footer">

--- a/main.js
+++ b/main.js
@@ -722,7 +722,7 @@ require(['jquery', 'utils', 'video', 'soundchip', 'debug', '6502', 'cmos', 'sth'
             }
             if (schema === "|" || schema === "sth") {
                 return discSth.fetch(discImage).then(function (discData) {
-                    return disc.ssdFor(processor.fdc, discData);
+                    return disc.ssdFor(processor.fdc, false, discData);
                 });
             }
             if (schema === "gd") {
@@ -736,12 +736,12 @@ require(['jquery', 'utils', 'video', 'soundchip', 'debug', '6502', 'cmos', 'sth'
             }
             if (schema === "http" || schema === "https") {
                 return utils.loadData(schema + "://" + discImage).then(function (discData) {
-                    return disc.ssdFor(processor.fdc, discData);
+                    return disc.ssdFor(processor.fdc, /\.dsd$/i.test(discImage), discData);
                 });
             }
 
             return disc.ssdLoad("discs/" + discImage).then(function (discData) {
-                return disc.ssdFor(processor.fdc, discData);
+                return disc.ssdFor(processor.fdc, /\.dsd$/i.test(discImage), discData);
             });
         }
 
@@ -765,7 +765,7 @@ require(['jquery', 'utils', 'video', 'soundchip', 'debug', '6502', 'cmos', 'sth'
             var reader = new FileReader();
             utils.noteEvent('local', 'click'); // NB no filename here
             reader.onload = function (e) {
-                processor.fdc.loadDisc(0, disc.ssdFor(processor.fdc, e.target.result));
+                processor.fdc.loadDisc(0, disc.ssdFor(processor.fdc, /\.dsd$/i.test(file.name), e.target.result));
                 delete parsedQuery.disc;
                 updateUrl();
                 $('#discs').modal("hide");

--- a/tests/test.js
+++ b/tests/test.js
@@ -186,7 +186,7 @@ define(['video', 'soundchip', '6502', 'fdc', 'utils', 'models', 'cmos'],
                 0x0000, 0x00, 0x00,
             ];
             return fdc.ssdLoad("discs/TestTimings.ssd").then(function (data) {
-                processor.fdc.loadDisc(0, fdc.ssdFor(processor.fdc, data));
+                processor.fdc.loadDisc(0, fdc.ssdFor(processor.fdc, false, data));
                 return runUntilInput();
             }).then(function () {
                 return type('CHAIN "TEST"');
@@ -208,7 +208,7 @@ define(['video', 'soundchip', '6502', 'fdc', 'utils', 'models', 'cmos'],
             var output = "";
             var hook;
             return fdc.ssdLoad("discs/bcdtest.ssd").then(function (data) {
-                processor.fdc.loadDisc(0, fdc.ssdFor(processor.fdc, data));
+                processor.fdc.loadDisc(0, fdc.ssdFor(processor.fdc, false, data));
                 return runUntilInput();
             }).then(function () {
                 return type("*BCDTEST");
@@ -231,7 +231,7 @@ define(['video', 'soundchip', '6502', 'fdc', 'utils', 'models', 'cmos'],
 
         function testKevinEdwards(name) { // Well, at least his protection system...
             return fdc.ssdLoad("discs/Protection.ssd").then(function (data) {
-                processor.fdc.loadDisc(0, fdc.ssdFor(processor.fdc, data));
+                processor.fdc.loadDisc(0, fdc.ssdFor(processor.fdc, false, data));
                 return runUntilInput();
             }).then(function () {
                 return type('CHAIN "B.' + name + '"');

--- a/tests/test.js
+++ b/tests/test.js
@@ -185,7 +185,7 @@ define(['video', 'soundchip', '6502', 'fdc', 'utils', 'models', 'cmos'],
                 0x45A6, 0xC0, 0x00,
                 0x0000, 0x00, 0x00,
             ];
-            return fdc.ssdLoad("/discs/TestTimings.ssd").then(function (data) {
+            return fdc.ssdLoad("discs/TestTimings.ssd").then(function (data) {
                 processor.fdc.loadDisc(0, fdc.ssdFor(processor.fdc, data));
                 return runUntilInput();
             }).then(function () {
@@ -207,7 +207,7 @@ define(['video', 'soundchip', '6502', 'fdc', 'utils', 'models', 'cmos'],
         function testBCD() {
             var output = "";
             var hook;
-            return fdc.ssdLoad("/discs/bcdtest.ssd").then(function (data) {
+            return fdc.ssdLoad("discs/bcdtest.ssd").then(function (data) {
                 processor.fdc.loadDisc(0, fdc.ssdFor(processor.fdc, data));
                 return runUntilInput();
             }).then(function () {
@@ -230,7 +230,7 @@ define(['video', 'soundchip', '6502', 'fdc', 'utils', 'models', 'cmos'],
         }
 
         function testKevinEdwards(name) { // Well, at least his protection system...
-            return fdc.ssdLoad("/discs/Protection.ssd").then(function (data) {
+            return fdc.ssdLoad("discs/Protection.ssd").then(function (data) {
                 processor.fdc.loadDisc(0, fdc.ssdFor(processor.fdc, data));
                 return runUntilInput();
             }).then(function () {


### PR DESCRIPTION
Internally, the `baseSsd` method in fdc.js supports dsd images if the `dsd` member is true, however this isn't exposed in the UI or via URL parameters.

This PR adds transparent handling of a disc image as dsd if it has the extension `.dsd` and is loaded via a URL parameter or using the UI to load a local image.

What I'm not sure about is if the functions I've changed (`ssdFor` and `baseSsd`) should be renamed to reflect that they don't just support SSDs - e.g. `diskFor` and `baseDisk`, or if they should be left as-is for compatibility?  Let me know if they should be renamed and I'll update this PR.

Also included is a fix for a bug running the tests via a browser if the application isn't located in the root of a web server (which I discovered along the way).