### PR TITLE
Remove the 'content' class from outer monitor div

### DIFF
--- a/index.html
+++ b/index.html
@@ -135,7 +135,7 @@
     </div>
 </div>
 
-<div class="container">
+<div>
     <div id="cub-monitor">
         <div>
             <img id="#cub-monitor-pic" width="921" height="682" src="images/cub-monitor.png">


### PR DESCRIPTION
This prevents the emulated screen unexpectedly jumping to the right (and so partially off-screen) if the window size is less than 992px wide, but doesn't otherwise affect the layout.