### PR TITLE
Implement an embed mode for use within an iframe

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ URL parameters
 * `loadBasic=X` - loads 'X' (a resource on the webserver) as text, tokenises it and puts it in `PAGE` as if you'd typed it in to the emulator
 * `autorun` - types `*TAPE` then `*/` to run from tape. In conjunction with `loadBasic` it types `RUN`.
 * `autochain` - types `*TAPE` then `CH.""` to run from tape.a
+* `embed` - Adjust the navigation entries to make the page clearer within a 921x733 iframe in a third-party site.
 
 Patches
 -------

--- a/index.html
+++ b/index.html
@@ -57,7 +57,7 @@
                 <span class="icon-bar"></span>
                 <span class="icon-bar"></span>
             </button>
-            <a class="navbar-brand" href="#">jsbeeb - a Javascript BBC micro emulator</a>
+            <a class="navbar-brand" href="http://bbc.godbolt.org/" target="_top">jsbeeb - a Javascript BBC micro emulator</a>
         </div>
         <div class="collapse navbar-collapse">
             <ul class="nav navbar-nav">
@@ -79,7 +79,7 @@
                         <li><a href="#" data-target="gaming">Gaming: handy for games like Zalaga</a></li>
                     </ul>
                 </li>
-                <li class="dropdown">
+                <li class="dropdown embed-hide">
                     <a href="#" class="dropdown-toggle" data-toggle="dropdown">Discs<b class="caret"></b></a>
                     <ul class="dropdown-menu">
                         <li><a href="#sth" class="sth" data-id="discs" data-toggle="modal" data-target="#sth">From STH
@@ -90,7 +90,7 @@
                         </li>
                     </ul>
                 </li>
-                <li class="dropdown">
+                <li class="dropdown embed-hide">
                     <a href="#" class="dropdown-toggle" data-toggle="dropdown">Cassettes<b class="caret"></b></a>
                     <ul class="dropdown-menu" id="tape-menu">
                         <li><a href="#sth" class="sth" data-toggle="modal" data-id="tapes" data-target="#sth">From STH
@@ -100,7 +100,7 @@
                         </li>
                     </ul>
                 </li>
-                <li class="dropdown">
+                <li class="dropdown embed-hide">
                     <a href="#" class="dropdown-toggle" data-toggle="dropdown">Share<b class="caret"></b></a>
                     <ul class="dropdown-menu">
                         <li class="social">
@@ -120,7 +120,7 @@
                         </li>
                     </ul>
                 </li>
-                <li class="dropdown">
+                <li class="dropdown embed-hide">
                     <a href="#" class="dropdown-toggle" data-toggle="dropdown">Contact<b class="caret"></b></a>
                     <ul class="dropdown-menu">
                         <li><a href="https://plus.google.com/105166465490735292917" rel="author">About Matt</a></li>
@@ -128,7 +128,7 @@
                     </ul>
                 </li>
                 <li><a href="#help" data-toggle="modal" data-target="#help">Help</a></li>
-                <li><a href="#about" data-toggle="modal" data-target="#info">About</a></li>
+                <li><a href="#about" data-toggle="modal" data-target="#info" id="about">About</a></li>
             </ul>
         </div>
         <!--/.nav-collapse -->

--- a/main.js
+++ b/main.js
@@ -255,6 +255,10 @@ require(['jquery', 'utils', 'video', 'soundchip', 'debug', '6502', 'cmos', 'sth'
                         case "disc2":
                             secondDiscImage = val;
                             break;
+                        case "embed":
+                            $(".embed-hide").hide();
+                            $("#about").append(" jsbeeb");
+                            break;
                     }
                 }
             });


### PR DESCRIPTION
This is somewhere between an RFC and a ready-to-merge PR, so I won't be offended if you don't like the idea or feel it should be implemented in a better or more generally useful way...

Some background: I've been investigating adding embedded instances of jsbeeb to my (long neglected) [online conversion of the 8BS Magazine](http://8bs.nerdoftheherd.com/) as part of an overhaul, so that the programmes contained on the disks can be run without the user having to download the disc image and fire-up an emulator.

----------------------

This PR adds a new URL parameter of `embed`, which adjusts the entries in the top menu to make the application easier to embed in third-party pages using an iframe.

Specifically, the 'Discs', 'Cassettes', 'Share' and 'Contact' drop-downs are hidden: disc and cassette selection as it would be expected that an embedded instance would be pre-loaded with a disk or tape and share and contact as they are rather confusing if the app is embedded in a third-party site.  The 'About' entry is also changed to 'About jsbeeb', again for clarity.

This PR also sets the href of the navbar header to http://bbc.godbolt.org/ so that interested users can easily click through to the main jsbeeb page if they are using an embedded instance.