### PR TITLE
Minor LED panel fixes

### DIFF
--- a/jsbeeb.css
+++ b/jsbeeb.css
@@ -110,6 +110,10 @@ span.accesskey {
     #leds thead {
         display: none;
     }
+
+    div.led {
+        vertical-align: middle;
+    }
 }
 
 #leds td, th {

--- a/jsbeeb.css
+++ b/jsbeeb.css
@@ -96,6 +96,7 @@ span.accesskey {
     box-shadow: 3px 3px 5px #000;
     border-radius: 6px;
     border: 1px solid #555555;
+    background-color: #181818;
     margin: 2px;
     padding: 2px;
     font-size: 8pt;


### PR DESCRIPTION
Just a couple of small commits to fix two minor LED panel niggles:

The first makes the background of the LED panel fully opaque - currently there is a transparent inner border between the `div` border and `table` which doesn't show up on the dark background, but is visible sometimes with a custom footer.  I've set a partially white background in the below before and after for maximum visibility:

![before](https://cloud.githubusercontent.com/assets/961548/13440249/078c0804-dfe9-11e5-9da4-6e490a934cf0.png) ![after](https://cloud.githubusercontent.com/assets/961548/13440250/0791a1d8-dfe9-11e5-8cde-2f557c306216.png)

The second evens up the spacing around the LED images when the text is hidden on small screens or in an `iframe` - here's another before and after:

![before_vert](https://cloud.githubusercontent.com/assets/961548/13440344/8706899c-dfe9-11e5-8851-dde70d36b0b7.png) ![after_vert](https://cloud.githubusercontent.com/assets/961548/13440345/870ae0b4-dfe9-11e5-81a1-03d89aa7c244.png)