### PR TITLE
Swapped key codes for mac users.

### DIFF
--- a/utils.js
+++ b/utils.js
@@ -290,6 +290,14 @@ define(['jsunzip', 'promise'], function (jsunzip) {
         keyCodes.BACK_QUOTE = isUKlayout ? 223 : 192;
     }
 
+    // Swap APOSTROPHE and BACK_QUOTE keys around for Mac users.  They are the opposite to what jsbeeb expects.
+    // Swap them to what jsbeeb expects, and tidy up the hash key to prevent duplicate key mappings.
+    if (window && window.navigator.userAgent.indexOf("Mac") !== -1) {
+        keyCodes.BACK_QUOTE = 192;
+        keyCodes.APOSTROPHE = 222;
+        keyCodes.HASH = 223;
+    }
+
     exports.getKeyMap = function (keyLayout) {
         var keys2 = [];
 
@@ -554,12 +562,6 @@ define(['jsunzip', 'promise'], function (jsunzip) {
             map(keyCodes.APOSTROPHE, BBC.COLON_STAR);
             map(keyCodes.HASH, BBC.RIGHT_SQUARE_BRACKET);
             map(keyCodes.BACK_QUOTE, BBC.AT);
-        }
-
-        // Swap APOSTROPHE and BACK_QUOTE key codes around for Mac users.
-        if (window.navigator.userAgent.indexOf("Mac") !== -1) {
-            map(keyCodes.BACK_QUOTE, BBC.COLON_STAR);
-            map(keyCodes.APOSTROPHE, BBC.AT);
         }
 
         // Master

--- a/utils.js
+++ b/utils.js
@@ -556,6 +556,12 @@ define(['jsunzip', 'promise'], function (jsunzip) {
             map(keyCodes.BACK_QUOTE, BBC.AT);
         }
 
+        // Swap APOSTROPHE and BACK_QUOTE key codes around for Mac users.
+        if (window.navigator.userAgent.indexOf("Mac") !== -1) {
+            map(keyCodes.BACK_QUOTE, BBC.COLON_STAR);
+            map(keyCodes.APOSTROPHE, BBC.AT);
+        }
+
         // Master
         map(keyCodes.NUMPAD0, BBC.NUMPAD0);
         map(keyCodes.NUMPAD1, BBC.NUMPAD1);

--- a/utils.js
+++ b/utils.js
@@ -292,10 +292,12 @@ define(['jsunzip', 'promise'], function (jsunzip) {
 
     // Swap APOSTROPHE and BACK_QUOTE keys around for Mac users.  They are the opposite to what jsbeeb expects.
     // Swap them to what jsbeeb expects, and tidy up the hash key to prevent duplicate key mappings.
-    if (window && window.navigator.userAgent.indexOf("Mac") !== -1) {
-        keyCodes.BACK_QUOTE = 192;
-        keyCodes.APOSTROPHE = 222;
-        keyCodes.HASH = 223;
+    if (window) {
+        if (window.navigator.userAgent.indexOf("Mac") !== -1) {
+            keyCodes.BACK_QUOTE = 192;
+            keyCodes.APOSTROPHE = 222;
+            keyCodes.HASH = 223;
+        }
     }
 
     exports.getKeyMap = function (keyLayout) {


### PR DESCRIPTION
For Mac users, the key codes for APOSTROPHE and BACK_QUOTE seem to be the wrong way around compared what jsbeeb expects.  This makes it almost impossible to play games where the BBC.COLON_STAR key is used for “up”.  This fix checks to see if the user has a Mac operating system and if so, swaps the key codes around so that they match what jsbeeb expects.