### PR TITLE
Allow loading discs and tapes from data embedded in the URI. Also allow # instead of ? for query strings: no reason to pass this information to the server.

### DIFF
--- a/main.js
+++ b/main.js
@@ -29,7 +29,7 @@ require(['jquery', 'underscore', 'utils', 'video', 'soundchip', 'ddnoise', 'debu
                 discImage = availableImages[0].file;
             }
         }
-        var queryString = document.location.search;
+        var queryString = document.location.search.substring(1)+"&"+window.location.hash.substring(1);
         var secondDiscImage = null;
         var parsedQuery = {};
         var needsAutoboot = false;
@@ -41,7 +41,6 @@ require(['jquery', 'underscore', 'utils', 'video', 'soundchip', 'ddnoise', 'debu
         var cpuMultiplier = 1;
 
         if (queryString) {
-            queryString = queryString.substring(1);
             if (queryString[queryString.length - 1] === '/')  // workaround for shonky python web server
                 queryString = queryString.substring(0, queryString.length - 1);
             queryString.split("&").forEach(function (keyval) {
@@ -723,6 +722,13 @@ require(['jquery', 'underscore', 'utils', 'video', 'soundchip', 'ddnoise', 'debu
                 }
                 return gdLoad({title: title, id: discImage});
             }
+            if (schema === "data") {
+		var arr = Array.prototype.map.call(atob(discImage), (x)=>x.charCodeAt(0));
+                var unzipped = utils.unzipDiscImage(arr);
+                var discData = unzipped.data;
+                var discImage = unzipped.name;
+                return Promise.resolve(disc.discFor(processor.fdc, /\.dsd$/i.test(discImage), discData));
+	    }
             if (schema === "http" || schema === "https") {
                 return utils.loadData(schema + "://" + discImage).then(function (discData) {
                     if (/\.zip/i.test(discImage)) {
@@ -749,6 +755,11 @@ require(['jquery', 'underscore', 'utils', 'video', 'soundchip', 'ddnoise', 'debu
                     processor.acia.setTape(tapes.loadTapeFromData(tapeImage, image));
                 });
             }
+            if (schema === "data") {
+		var arr = Array.prototype.map.call(atob(tapeImage), (x)=>x.charCodeAt(0));
+                var unzipped = utils.unzipDiscImage(arr);
+                return Promise.resolve(processor.acia.setTape(tapes.loadTapeFromData(unzipped.name, unzipped.data)));
+	    }
 
             if (schema === "http" || schema === "https") {
                 return utils.loadData(schema + "://" + tapeImage).then(function (tapeData) {


### PR DESCRIPTION
Test with 

#disc=data:UEsDBBQAAAAIAOEKlkxfovpswwAAAAAKAAAIABwAc3VuZi5zc2RVVAkAA+bV21ru1dtadXgLAAEE9AEAAAToAwAAY2CAAEUnf/8QBQWV4FA/BSBQYRhBgEXAAEj+/8/JcICZge95QyvDGaaBdhO9AC8DF9trA14Gfo4QVduJvAwiiu+NjHWMjEx0zAx0jExNwRjIhEJeBjmh90BBSx0zEwNrU0Mja14GDaHHCp62hjsMDQwMOoz0THgZjGRcbA3NtLZ5Wr1RcNGa7anjorXV0+o90FReBhvWt7wMbmzvgcwAzo8TdUNUef8PoP+dPfSUgGleiXcA3TAKRsEoGAWjYBTQGwAAUEsBAh4DFAAAAAgA4QqWTF+i+mzDAAAAAAoAAAgAGAAAAAAAAAAAALSBAAAAAHN1bmYuc3NkVVQFAAPm1dtadXgLAAEE9AEAAAToAwAAUEsFBgAAAAABAAEATgAAAAUBAAAAAA%3D%3D&autoboot

and 

#tape=data:UEsDBBQAAAAIAJcDZDbbvxZnCAMAAHwGAAALABwAcHVnd2FzaC51ZWZVVAkAA74S6kV1s2xcdXgLAAEE9AEAAAToAwAArVJNaBNBFJ5UKyKsiC2CFxm3mZJNduP+5HfSLWw2m3jpD01DwVPbZOsPtYhafxCh6k1EaIXiUeihNBREwUtBkB57Vi9WUC89eBCtwVOIb3abbZo2VsE32Znvfe/NmzffpGBlcfbipH0aHUEIHYfPvGqPXbdLePw2Ttv2uHUZIZ8P+PIxXxssr9p2uHfOIB8GPzhYyI0Y+bMInazVumZqNYixNIRycxw6cgL/xMGdxqHOLRYPTp+/OXbtAnbYU3vmBvL4a5x+f5gUo0LqtRJRUvyD+rbh6Smbh0isRUSRxbiQ4ufEBuM5pHbib6qWSqiympKdwaGeDlz5RX9ccffT6gKHsu2YQ4OH8CcOnWOwdPQjridwaOrdF0VURNkZijNisihFRElhP0WVxeSN0dFRV62ewy3U8tXVWn4h07Rf502cwfA0OWzgdBGXsD3BUxP4KJgC5q5sjoEBimgq83lqQVYCLA7mrmxOgsWNREKLspmnGchSVC0Sj4aNcCIWDoeTPB0mepKmiR6jm4Zf7Ce0f2BEn6V9RJdpgegLdIjoaRKKBBczfvGN6RcVQeDQrceVjT7So8uQ10dCGt1YMv1vuxWmxRCRAnkiDREhWCAgCAVeFZUZcPIkBBAoqLxcIF7tlysrK65aeiu12upq3as0dELzjd1ZLgearUIYOgoViMDEWYXIkuW4HLo/6TQtwV1NopsOgBY1aN0pFVhMQy3DqSUFFgHwXbzQKwvQu8CaZwrBF+onwWFCK9XZXvDoJnb1qxogcwn+g/Qzhx49X8dZKLxj0sTdnCriIkMGQ1kPOdxEU9RcW1vbR60DdbUuvWf7zOZJ24OD0jmGLIZMDzmc0bUrzKH5uf9yOW1rm9PBBONshkoMFRmCw+tbct4hhrfPqOdw6Nniulu1YeqQJGkftQ7W1fpwlxVsrsC4EjvE9l7DQaXtiznyGNuw2DKe8zSwPNTEOdpnGLLYpcpP/lLmf+Baaj1fLpe31cqiPdRqR91ohqn1tPqnl4lB2SlblLlaPJVKuTUHlN9QSwECHgMUAAAACACXA2Q2278WZwgDAAB8BgAACwAYAAAAAAAAAAAApIEAAAAAcHVnd2FzaC51ZWZVVAUAA74S6kV1eAsAAQT0AQAABOgDAABQSwUGAAAAAAEAAQBRAAAATQMAAAAA&autochain