### PR TITLE
Fix sampled sound playback to work in more cases.

### DIFF
--- a/soundchip.js
+++ b/soundchip.js
@@ -67,12 +67,6 @@ define(['./utils'], function (utils) {
         function toneChannel(channel, out, offset, length) {
             var i;
             var reg = register[channel], vol = volume[channel];
-            if (reg === 1) {
-                for (i = 0; i < length; ++i) {
-                    out[i + offset] += vol;
-                }
-                return;
-            }
             if (reg === 0) reg = 1024;
             for (i = 0; i < length; ++i) {
                 counter[channel] -= sampleDecrement;
@@ -80,7 +74,7 @@ define(['./utils'], function (utils) {
                     counter[channel] += reg;
                     outputBit[channel] = !outputBit[channel];
                 }
-                out[i + offset] += outputBit[channel] ? vol : -vol;
+                out[i + offset] += (outputBit[channel] * vol);
             }
         }
 
@@ -126,7 +120,7 @@ define(['./utils'], function (utils) {
                     outputBit[channel] = !outputBit[channel];
                     if (outputBit[channel]) shiftLfsr();
                 }
-                out[i + offset] += (lfsr & 1) ? vol : -vol;
+                out[i + offset] += ((lfsr & 1) * vol);
             }
         }
 


### PR DESCRIPTION
Fixes #167 

The root cause is that jsbeeb (as well as most emulators) model sn76489 output voltages in the range +ve, -ve whereas the correct behavior is range +ve, 0. In the former case, very high frequency sounds average out to 0 whereas in the correct case, very high frequency sounds average out to +ve/2. Sampled sounds use volume modulation and will only make significant noise if volume is modulated around an average that is >0.

So why did sample playback work in the first place?
jsbeeb had a tweak to emit constant +ve for tone channels set to a period of 1. Exile and Spy Hunter happen to use this value. However I believe this is just a tweak to get things to work rather than how the digital circuitry on the chip works. Other emulators extend the tweak for perods 1 - 4 inclusive, but this is also not fully correct because there do exist extreme sample playback examples with period 8.
The tweak is removed in this patch to try and finally get a proper emulation.

Does existing sample playback still work?
Yes -- Exile (sideways RAM version), Spy Hunter.

Does extra stuff now work?
Yes, referenced in the bug:
ReetPetite.ssd
tyb-enjoy.ssd

Anything still to do?
Yes, the Speech.dsd disc referenced in the bug fails for a different reason relating to the sound write enable bit. I'll split that into a separate bug.