### PR TITLE
Initialize RAM to 0x00, not 0xFF.

### DIFF
--- a/6502.js
+++ b/6502.js
@@ -858,7 +858,7 @@ define(['./utils', './6502.opcodes', './via', './acia', './serial', './tube', '.
                         }
                     }
                     for (i = 0; i < this.romOffset; ++i)
-                        this.ramRomOs[i] = 0xff;
+                        this.ramRomOs[i] = 0x00;
                     this.videoDisplayPage = 0;
                     this.scheduler = new scheduler.Scheduler();
                     this.soundChip.setScheduler(this.scheduler);


### PR DESCRIPTION
Fixes #105 

Clogger relies on &9E being zero initialized, otherwise it fails.

Let's just zero initialize RAM on hard rest instead of setting it to 0xFF. This likely fixes other things too.