### PR TITLE
Initialize zero page to 0x00.

### DIFF
--- a/6502.js
+++ b/6502.js
@@ -857,8 +857,18 @@ define(['./utils', './6502.opcodes', './via', './acia', './serial', './tube', '.
                             this.memLook[i] = this.memLook[256 + i] = 0;
                         }
                     }
-                    for (i = 0; i < this.romOffset; ++i)
-                        this.ramRomOs[i] = 0xff;
+                    // DRAM content is not guaranteed to contain any particular
+                    // value on start up, so we choose values that help avoid
+                    // bugs in various games.
+                    for (i = 0; i < this.romOffset; ++i) {
+                        if (i < 0x100) {
+                            // For Clogger.
+                            this.ramRomOs[i] = 0x00;
+                        } else {
+                            // For Eagle Empire.
+                            this.ramRomOs[i] = 0xff;
+                        }
+                    }
                     this.videoDisplayPage = 0;
                     this.scheduler = new scheduler.Scheduler();
                     this.soundChip.setScheduler(this.scheduler);


### PR DESCRIPTION
Fixes #105 

Clogger relies on &9E being zero initialized, otherwise it fails.
Conversely, Eagle Empire is known to rely on &800 being initialized to 0xFF.

We are free to initialize DRAM however we please because it is not defined.

This patch keeps both Clogger and Eagle Empire happy.