### PR TITLE
Speech chip is not present so don't interfere with data bus

### DIFF
--- a/via.js
+++ b/via.js
@@ -486,12 +486,6 @@ define(['./utils'], function (utils) {
             if (!(self.IC32 & 8) && !self.keys[self.keycol][keyrow]) {
                 self.sdbval &= 0x7f;
             }
-            if (!isMaster && !(self.IC32 & 4)) {
-                self.sdbval = 0xff; // unsure; taken from beebem
-            }
-            if (!isMaster && !(self.IC32 & 2)) {
-                self.sdbval = 0x00;  // no speech
-            }
         };
 
         self.writeIC32 = function (val) { // addressable latch


### PR DESCRIPTION
Fixes #93 

For some reason, the alternative Repton 2 images are latching the speech chip read enable (active low):
[ITRP] 4160: SEI
[ITRP] 4161: LDA #$01
[ITRP] 4163: STA $FE40

I don't think this should do anything since we're not emulating the speech chip. Surely a chip that isn't present shouldn't be able to affect the slow data bus?

The removed code includes a comment "no speech" which raises the question: is the speech chip still correctly detected as not present? The answer is yes. This is handled by self.readPortB returning the high bit set (it returns 0xFF). This can be confirmed with:
P. ?&27B
Which returns 0 for no speech chip detected by MOS.

Simplified behavior matches b-em.
