### PR TITLE
Model sound chip write enable closer to real hardware.

### DIFF
--- a/soundchip.js
+++ b/soundchip.js
@@ -239,10 +239,10 @@ define(['./utils'], function (utils) {
         this.slowDataBus = 0;
         this.updateSlowDataBus = function (slowDataBus, active) {
             this.slowDataBus = slowDataBus;
-            if (active && !this.active) {
+            this.active = active;
+            if (active) {
                 activeTask.reschedule(minCyclesWELow);
             }
-            this.active = active;
         };
         this.reset = function (hard) {
             if (!hard) return;

--- a/soundchip.js
+++ b/soundchip.js
@@ -67,12 +67,6 @@ define(['./utils'], function (utils) {
         function toneChannel(channel, out, offset, length) {
             var i;
             var reg = register[channel], vol = volume[channel];
-            if (reg === 1) {
-                for (i = 0; i < length; ++i) {
-                    out[i + offset] += vol;
-                }
-                return;
-            }
             if (reg === 0) reg = 1024;
             for (i = 0; i < length; ++i) {
                 counter[channel] -= sampleDecrement;
@@ -80,7 +74,7 @@ define(['./utils'], function (utils) {
                     counter[channel] += reg;
                     outputBit[channel] = !outputBit[channel];
                 }
-                out[i + offset] += outputBit[channel] ? vol : -vol;
+                out[i + offset] += (outputBit[channel] * vol);
             }
         }
 
@@ -126,7 +120,7 @@ define(['./utils'], function (utils) {
                     outputBit[channel] = !outputBit[channel];
                     if (outputBit[channel]) shiftLfsr();
                 }
-                out[i + offset] += (lfsr & 1) ? vol : -vol;
+                out[i + offset] += ((lfsr & 1) * vol);
             }
         }
 

--- a/via.js
+++ b/via.js
@@ -486,6 +486,7 @@ define(['./utils'], function (utils) {
             if (!(self.IC32 & 8) && !self.keys[self.keycol][keyrow]) {
                 self.sdbval &= 0x7f;
             }
+            soundChip.updateSlowDataBus(self.sdbval, !(self.IC32 & 1));
         };
 
         self.writeIC32 = function (val) { // addressable latch
@@ -495,7 +496,6 @@ define(['./utils'], function (utils) {
                 self.IC32 &= ~(1 << (val & 7));
 
             self.updateSdb();
-            soundChip.updateSlowDataBus(self.sdbval, !(self.IC32 & 1));
 
             self.capsLockLight = !(self.IC32 & 0x40);
             self.shiftLockLight = !(self.IC32 & 0x80);

--- a/video.js
+++ b/video.js
@@ -458,8 +458,18 @@ define(['./teletext', './utils'], function (Teletext, utils) {
         }
 
         Crtc.prototype.read = function (addr) {
-            if (addr & 1) return this.video.regs[this.curReg];
-            return this.curReg;
+            if (!(addr & 1))
+                return 0;
+            switch (this.curReg) {
+                case 12:
+                case 13:
+                case 14:
+                case 15:
+                case 16:
+                case 17:
+                    return this.video.regs[this.curReg];
+            }
+            return 0;
         };
         Crtc.prototype.write = function (addr, val) {
             if (addr & 1) {
@@ -496,9 +506,6 @@ define(['./teletext', './utils'], function (Teletext, utils) {
             this.video = video;
         }
 
-        Ula.prototype.read = function () {
-            return 0xff;
-        };
         Ula.prototype.write = function (addr, val) {
             addr |= 0;
             val |= 0;


### PR DESCRIPTION
Fixes #96 
Fixes #193 

There's a great, concise summary of our latest understanding of hardware behavior from Rich here:
https://stardot.org.uk/forums/viewtopic.php?f=4&t=17537#p243442

This patch takes us closer to that behavior while being minimally invasive. I think it's a good balance for now and I no longer know of any sampled (or other) sound that jsbeeb cannot play.

Now works:
Speech.dsd
Repton 2

Tested still ok:
Exile
Enjoy the Silence
Spy Hunter
Reet Petite
Citadel