### PR TITLE
Use a more compatible set of default SWRAM banks.

### DIFF
--- a/models.js
+++ b/models.js
@@ -15,10 +15,10 @@ define(['./fdc'], function (fdc) {
 
     // TODO: semi-bplus-style to get swram for exile hardcoded here
     var beebSwram = [
-        true, true, false, false,
+        true, true, true, true,      // Dunjunz variants. Exile (not picky).
+        true, true, true, true,      // Crazee Rider.
         false, false, false, false,
-        false, false, false, false,
-        true, true, false, false];
+        false, false, false, false];
     var masterSwram = [
         false, false, false, false,
         true, true, true, true,


### PR DESCRIPTION
Fixes #199 

Everything significant I know of works "out of the box" now. It's a lot of SWRAM but there are still 6 slots left for extra ROMs which should suffice.

Now works:
- Crazee Rider.
- Dunjunz (2x different variants with different needs).

Still works:
- Exile.
- Enjoy the Silence demo.