### PR TITLE
Implement 0x1B, read sector IDs, for i8271.

### DIFF
--- a/fdc.js
+++ b/fdc.js
@@ -568,6 +568,20 @@ define(['./utils'], function (utils) {
                     self.drives[self.curDrive].read(self.curSector, self.params[0], density(), 0);
                     break;
 
+                case 0x1b: // Read ID
+                    if (!self.phase) {
+                        self.curTrack[self.curDrive] = self.params[0];
+                        self.phase = 1;
+                        self.drives[self.curDrive].address(self.params[0], density(), 0);
+                        return;
+                    }
+                    if (--self.sectorsLeft === 0) {
+                        done();
+                        return;
+                    }
+                    self.drives[self.curDrive].address(self.params[0], density(), 0);
+                    break;
+
                 case 0x23: // Format
                     switch (self.phase) {
                         case 0:


### PR DESCRIPTION
Fixes #198 

Used by the Dragonsoft Explorer loader.