### PR TITLE
Fix various i8271 bugs including the excessive seeking bug.

### DIFF
--- a/fdc.js
+++ b/fdc.js
@@ -573,9 +573,9 @@ define(['./utils'], function (utils) {
                     break;
 
                 case 0x1b: // Read ID
-                    if (!self.phase) {
+                    if (self.phase == 1) {
                         self.curTrack[self.curDrive] = self.params[0];
-                        self.phase = 1;
+                        self.phase = 2;
                         self.drives[self.curDrive].address(self.params[0], density(), 0);
                         return;
                     }


### PR DESCRIPTION
Fixes #165 

Some of these bugs fixed are pretty overt so I suppose DFS-0.9 doesn't use all the controller functionality.

Bugs fixed:
- Freshly loaded disc + drive started at physical track -1.
- Incorrect value was being written to track registers.
- Report write protect bit correctly instead of always.
- Spinup wasn't always waited for.
- Spindown timer wasn't always set after an operation.
- Spindown should invalidate drive ready status.
- Remove Elite-A workaround (other fixes make it unnecessary).
- Track 0 sensor should report physical track 0 position, not logical.
- Prevent physical seeks out of bounds.
- Drive status queried incorrectly.

After all this, the drive isn't seeking to track 0 all the time, but Elite-A still loads. It relies on spindown occurring before the ship is launched, which is probably how this ever worked on a real beeb. Spindown timer set to 2 second to occur a bit faster to be conservative.