### PR TITLE
Use a callback for CB2 changes rather than direct queries.

### DIFF
--- a/via.js
+++ b/via.js
@@ -35,6 +35,7 @@ define(['./utils'], function (utils) {
             porta: 0, portb: 0,
             ca1: false, ca2: false,
             cb1: false, cb2: false,
+            cb2changecallback: null,
             justhit: 0,
             t1_pb7: 0,
 
@@ -348,7 +349,9 @@ define(['./utils'], function (utils) {
             setcb2: function (level) {
                 if (level === self.cb2) return;
                 self.cb2 = level;
-                if (self.pcr & 0x80) return; // output
+                var output = !!(self.pcr & 0x80);
+                if (self.cb2changecallback) self.cb2changecallback(level, output);
+                if (output) return;
                 var pcrSet = !!(self.pcr & 0x40);
                 if (pcrSet === level) {
                     self.ifr |= INT_CB2;

--- a/video.js
+++ b/video.js
@@ -374,7 +374,7 @@ define(['./teletext', './utils'], function (Teletext, utils) {
                 this.regs[16] = (this.addr >> 8) & 0x3f;
                 this.regs[17] = this.addr & 0xff;
             }
-        }
+        };
 
         ////////////////////
         // Main drawing routine


### PR DESCRIPTION
No functional change, but a cleaner way of handling CB2 changes that influence light pen behavior. This enables the light pen handling to only fire on (rare) CB2 changes, and avoids extra checks in the performance sensitive polltime().