### PR TITLE
Don't trigger hsync if we're inside hsync.

### DIFF
--- a/video.js
+++ b/video.js
@@ -398,7 +398,7 @@ define(['./teletext', './utils'], function (Teletext, utils) {
                         this.dispEnabled &= ~(HDISPENABLE | SKEWDISPENABLE);
 
                     // Initiate HSync
-                    if (this.horizCounter === this.regs[2]) {
+                    if (this.horizCounter === this.regs[2] && !this.inHSync) {
                         this.inHSync = true;
                         this.hpulseCounter = 0;
                     }


### PR DESCRIPTION
Fixes #109 

See the issue for a detailed description of how this condition triggers.

There are a couple of different ways we could handle hsync while the hsync pulse is active. For now, we do the same as b2 which doesn't reset the hsync pulse counter.