### PR TITLE
Add a noseek parameter which makes disc seeking instant.

### DIFF
--- a/ddnoise.js
+++ b/ddnoise.js
@@ -125,7 +125,7 @@ define(['./utils', 'underscore', 'promise'], function (utils, _) {
     FakeDdNoise.prototype.seek = function () {
         return 0;
     };
-    FakeDdNoise.prototype.initialize = function () {
+    FakeDdNoise.prototype.initialise = function () {
         return Promise.resolve();
     };
 

--- a/fdc.js
+++ b/fdc.js
@@ -315,7 +315,7 @@ define(['./utils'], function (utils) {
             return self.data;
         };
         self.discFinishRead = function () {
-            self.callbackTask.reschedule(200);
+            self.callbackTask.reschedule(DiscTimeSlice);
         };
 
         var paramMap = {
@@ -402,7 +402,7 @@ define(['./utils'], function (utils) {
         }
 
         function spinup() {
-            var time = 200;
+            var time = DiscTimeSlice;
 
             if (!self.motorOn[self.curDrive]) {
                 // Half a second.
@@ -434,7 +434,7 @@ define(['./utils'], function (utils) {
             var diff = self.drives[self.curDrive].seek(realTrack);
             // Let disc noises overlap by ~10%
             var seekLen = (noise.seek(diff) * 0.9 * cpu.peripheralCyclesPerSecond) | 0;
-            self.callbackTask.reschedule(Math.max(200, seekLen));
+            self.callbackTask.reschedule(Math.max(DiscTimeSlice, seekLen));
             self.phase = 1;
         }
 
@@ -780,7 +780,7 @@ define(['./utils'], function (utils) {
     WD1770.prototype.seek = function (addr) {
         var diff = this.curDisc().seek(addr);
         var seekTime = (this.noise.seek(diff) * this.cpu.peripheralCyclesPerSecond) | 0;
-        this.callbackTask.reschedule(Math.max(200, seekTime));
+        this.callbackTask.reschedule(Math.max(DiscTimeSlice, seekTime));
     };
 
     WD1770.prototype.handleCommand = function (command) {
@@ -871,7 +871,7 @@ define(['./utils'], function (utils) {
     };
 
     WD1770.prototype.discFinishRead = function () {
-        this.callbackTask.reschedule(200);
+        this.callbackTask.reschedule(DiscTimeSlice);
     };
 
     WD1770.prototype.notFound = function () {

--- a/main.js
+++ b/main.js
@@ -7,8 +7,8 @@ require(['jquery', 'underscore', 'utils', 'video', 'soundchip', 'ddnoise', 'debu
 
         var processor;
         var video;
-        var soundChip;
-        var ddNoise;
+        var soundChip = null;
+        var ddNoise = null;
         var dbgr;
         var frames = 0;
         var frameSkip = 0;
@@ -41,6 +41,7 @@ require(['jquery', 'underscore', 'utils', 'video', 'soundchip', 'ddnoise', 'debu
         var cpuMultiplier = 1;
         var fastAsPossible = false;
         var fastTape = false;
+        var noSeek = false;
 
         if (queryString) {
             if (queryString[queryString.length - 1] === '/')  // workaround for shonky python web server
@@ -110,6 +111,9 @@ require(['jquery', 'underscore', 'utils', 'video', 'soundchip', 'ddnoise', 'debu
                             break;
                         case "fasttape":
                             fastTape = true;
+                            break;
+                        case "noseek":
+                            noSeek = true;
                             break;
                     }
                 }
@@ -197,11 +201,10 @@ require(['jquery', 'underscore', 'utils', 'video', 'soundchip', 'ddnoise', 'debu
                 soundChip.render(chan, 0, chan.length);
             };
             soundChip.jsAudioNode.connect(audioContext.destination);
-            ddNoise = new DdNoise.DdNoise(audioContext);
-        } else {
-            soundChip = new SoundChip.FakeSoundChip();
-            ddNoise = new DdNoise.FakeDdNoise();
+            if (!noSeek) ddNoise = new DdNoise.DdNoise(audioContext);
         }
+        if (!soundChip) soundChip = new SoundChip.FakeSoundChip();
+        if (!ddNoise) ddNoise = new DdNoise.FakeDdNoise();
 
         var lastShiftLocation = 1;
         var lastCtrlLocation = 1;


### PR DESCRIPTION
The bbcmicro.co.uk admins asked for this. They currently have a noiseless and instant disc seek because they have an old jsbeeb. This UX is deemed preferable by them so they can't readily upgrade their embedded jsbeeb copy.

Since it's pretty trivial to add a noseek parameter to get the old behavior, this patch does so.
