### PR TITLE
Clear decimal flag on IRQ for 65c12.

### DIFF
--- a/6502.js
+++ b/6502.js
@@ -337,6 +337,8 @@ define(['./utils', './6502.opcodes', './via', './acia', './serial', './tube', '.
                         this.pc = this.readmem(0xfffe) | (this.readmem(0xffff) << 8);
                         this.p.i = true;
                         this.polltime(7);
+                        if (!model.nmos)
+                            this.p.d = false;
                     }
                     if (this.nmi) {
                         this.push(this.pc >>> 8);
@@ -959,6 +961,8 @@ define(['./utils', './6502.opcodes', './via', './acia', './serial', './tube', '.
                 this.pc = this.readmem(0xfffe) | (this.readmem(0xffff) << 8);
                 this.p.i = true;
                 this.polltime(7);
+                if (!model.nmos)
+                    this.p.d = false;
             };
 
             this.handleNmi = function () {


### PR DESCRIPTION
All documentation does seem consistent that the CMOS 6502s clear the D flags on all of: BRK, NMI, IRQ. Currently, jsbeeb is clearing for BRK and NMI but not IRQ.

http://wilsonminesco.com/NMOS-CMOSdif/

Seems like this could be a source of tricky, intermittent bugs, although I don't have any concrete failure cases.

I did write a test that spins around a SED while leaving IRQs enabled. MOS 3.20 issues CLD for the BRK path but _not_ the IRQ path. Stepping through the IRQ path, it does seem to hit some ADC instructions while the D flag is still a hangover from "user space", and get incorrect results.