### PR TITLE
Enable browser sound upon key or mouse down, plus warning message.

### DIFF
--- a/ddnoise.js
+++ b/ddnoise.js
@@ -55,7 +55,7 @@ define(['./utils', 'underscore', 'promise'], function (utils, _) {
     DdNoise.prototype.oneShot = function (sound) {
         var duration = sound.duration;
         var context = this.context;
-        if (context.state != "running") return duration;
+        if (context.state !== "running") return duration;
         var source = context.createBufferSource();
         source.buffer = sound;
         source.connect(this.gain);
@@ -66,7 +66,7 @@ define(['./utils', 'underscore', 'promise'], function (utils, _) {
     DdNoise.prototype.play = function (sound, loop) {
         var self = this;
         var context = self.context;
-        if (context.state != "running") return null;
+        if (context.state !== "running") return null;
         return new Promise(function (resolve, reject) {
             var source = context.createBufferSource();
             source.loop = !!loop;

--- a/ddnoise.js
+++ b/ddnoise.js
@@ -64,11 +64,10 @@ define(['./utils', 'underscore', 'promise'], function (utils, _) {
     };
 
     DdNoise.prototype.play = function (sound, loop) {
+        if (this.context.state !== "running") return Promise.reject();
         var self = this;
-        var context = self.context;
-        if (context.state !== "running") return null;
         return new Promise(function (resolve, reject) {
-            var source = context.createBufferSource();
+            var source = self.context.createBufferSource();
             source.loop = !!loop;
             source.buffer = sound;
             source.connect(self.gain);
@@ -88,14 +87,12 @@ define(['./utils', 'underscore', 'promise'], function (utils, _) {
         if (this.state === SPINNING || this.state === SPIN_UP) return;
         this.state = SPIN_UP;
         var self = this;
-        var promise = self.play(self.sounds.motorOn);
-        if (promise === null) return;
-        promise.then(function () {
+        this.play(this.sounds.motorOn).then(function () {
             self.play(self.sounds.motor, true).then(function (source) {
                 self.motor = source;
                 self.state = SPINNING;
             });
-        });
+        }, function () {});
     };
 
     DdNoise.prototype.spinDown = function () {

--- a/debug.js
+++ b/debug.js
@@ -39,7 +39,6 @@ define(['jquery', 'underscore', './utils'], function ($, _, utils) {
         };
 
         enable(false);
-        $('.initially-hidden').removeClass('initially-hidden');
 
         var numToShow = 16;
         var i;

--- a/index.html
+++ b/index.html
@@ -99,6 +99,10 @@
     </div>
 </div>
 
+<div id="audio-warning" class="alert alert-warning initially-hidden">
+Your browser has suspended audio -- mouse click or key press for sound.
+</div>
+
 <div>
     <div id="outer">
         <div id="cub-monitor">

--- a/main.js
+++ b/main.js
@@ -201,13 +201,13 @@ require(['jquery', 'underscore', 'utils', 'video', 'soundchip', 'ddnoise', 'debu
         });
 
         function checkAudioSuspended() {
-            if (audioContext.state == "suspended") $audioWarningNode.fadeIn();
+            if (audioContext.state === "suspended") $audioWarningNode.fadeIn();
         }
 
         if (audioContext) {
             audioContext.onstatechange = function () {
-                if (audioContext.state == "running") $audioWarningNode.fadeOut();
-            }
+                if (audioContext.state === "running") $audioWarningNode.fadeOut();
+            };
             soundChip = new SoundChip.SoundChip(audioContext.sampleRate);
             // NB must be assigned to some kind of object else it seems to get GC'd by
             // Safari...

--- a/main.js
+++ b/main.js
@@ -186,11 +186,28 @@ require(['jquery', 'underscore', 'utils', 'video', 'soundchip', 'ddnoise', 'debu
         if (parsedQuery.fakeVideo !== undefined)
             video = new Video.FakeVideo();
 
+        // Recent browsers, particularly Safari and Chrome, require a user
+        // interaction in order to enable sound playback.
+        function userInteraction() {
+            if (audioContext) audioContext.resume();
+        }
+
         var audioContext = typeof AudioContext !== 'undefined' ? new AudioContext() // jshint ignore:line
             : typeof webkitAudioContext !== 'undefined' ? new webkitAudioContext() // jshint ignore:line
                 : null;
+        var $audioWarningNode = $('#audio-warning');
+        $audioWarningNode.on('mousedown', function () {
+            userInteraction();
+        });
+
+        function checkAudioSuspended() {
+            if (audioContext.state == "suspended") $audioWarningNode.fadeIn();
+        }
 
         if (audioContext) {
+            audioContext.onstatechange = function () {
+                if (audioContext.state == "running") $audioWarningNode.fadeOut();
+            }
             soundChip = new SoundChip.SoundChip(audioContext.sampleRate);
             // NB must be assigned to some kind of object else it seems to get GC'd by
             // Safari...
@@ -202,6 +219,12 @@ require(['jquery', 'underscore', 'utils', 'video', 'soundchip', 'ddnoise', 'debu
             };
             soundChip.jsAudioNode.connect(audioContext.destination);
             if (!noSeek) ddNoise = new DdNoise.DdNoise(audioContext);
+
+            $audioWarningNode.toggle(false);
+            // Firefox will report that audio is suspended even when it will
+            // start playing without user interaction, so we need to delay a
+            // little to get a reliable indication.
+            window.setTimeout(checkAudioSuspended, 1000);
         }
         if (!soundChip) soundChip = new SoundChip.FakeSoundChip();
         if (!ddNoise) ddNoise = new DdNoise.FakeDdNoise();
@@ -211,6 +234,8 @@ require(['jquery', 'underscore', 'utils', 'video', 'soundchip', 'ddnoise', 'debu
         var lastAltLocation = 1;
 
         dbgr = new Debugger(video);
+
+        $('.initially-hidden').removeClass('initially-hidden');
 
         function keyCode(evt) {
             var ret = evt.which || evt.charCode || evt.keyCode;
@@ -322,6 +347,7 @@ require(['jquery', 'underscore', 'utils', 'video', 'soundchip', 'ddnoise', 'debu
         };
 
         function keyDown(evt) {
+            userInteraction();
             if (!running) return;
             var code = keyCode(evt);
             if (evt.altKey) {
@@ -365,6 +391,7 @@ require(['jquery', 'underscore', 'utils', 'video', 'soundchip', 'ddnoise', 'debu
 
         var $cub = $('#cub-monitor');
         $cub.on('mousemove mousedown mouseup', function (evt) {
+            userInteraction();
             var cubOffset = $cub.offset();
             var screenOffset = $screen.offset();
             var x = (evt.offsetX - cubOffset.left + screenOffset.left) / $screen.width();


### PR DESCRIPTION
Fixes #184 
Fixes #186 

Hook user interactions, and enable audio.
If audio is detected as suspended, fade in a warning UI and fade it out again when the audio state changes to running.

Tested in Chrome and Firefox.