### PR TITLE
Fix various bugs in the Google Drive support.

### DIFF
--- a/fdc.js
+++ b/fdc.js
@@ -31,9 +31,7 @@ define(['./utils'], function (utils) {
         if (typeof stringData !== "string") {
             data = stringData;
         } else {
-            var len = stringData.length;
-            data = new Uint8Array(len);
-            for (var i = 0; i < len; ++i) data[i] = stringData.charCodeAt(i) & 0xff;
+            data = utils.stringToUint8Array(stringData);
         }
         var prevData = new Uint8Array(data);
 
@@ -63,17 +61,16 @@ define(['./utils'], function (utils) {
         var dataString = localStorage[discName];
         var nameDetails = utils.discImageSize(name);
         var isDsd = nameDetails.isDsd;
+        var byteSize = nameDetails.byteSize;
         if (!dataString) {
             console.log("Creating browser-local disc " + name);
-            var numBytes = nameDetails.byteSize;
-            data = new Uint8Array(numBytes);
-            for (i = 0; i < Math.min(12, name.length); ++i)
-                data[i] = name.charCodeAt(i) & 0xff;
+            data = new Uint8Array(byteSize);
+            utils.setDiscName(data, name);
         } else {
             console.log("Loading browser-local disc " + name);
-            var len = dataString.length;
-            data = new Uint8Array(len);
-            for (i = 0; i < len; ++i) data[i] = dataString.charCodeAt(i) & 0xff;
+            data = utils.stringToUint8Array(dataString);
+            if (data.length === 100 * 1024)
+                data = utils.resizeUint8Array(data, byteSize);
         }
         return new BaseDisc(fdc, isDsd, data, function () {
             var str = utils.uint8ArrayToString(data);

--- a/fdc.js
+++ b/fdc.js
@@ -61,12 +61,11 @@ define(['./utils'], function (utils) {
         var data;
         var i;
         var dataString = localStorage[discName];
-        var isDsd = false;
-        if (name.endsWith(".dsd")) isDsd = true;
+        var nameDetails = utils.discImageSize(name);
+        var isDsd = nameDetails.isDsd;
         if (!dataString) {
             console.log("Creating browser-local disc " + name);
-            var numBytes = 256 * 10 * 80;
-            if (isDsd) numBytes *= 2;
+            var numBytes = nameDetails.byteSize;
             data = new Uint8Array(numBytes);
             for (i = 0; i < Math.min(12, name.length); ++i)
                 data[i] = name.charCodeAt(i) & 0xff;
@@ -77,8 +76,7 @@ define(['./utils'], function (utils) {
             for (i = 0; i < len; ++i) data[i] = dataString.charCodeAt(i) & 0xff;
         }
         return new BaseDisc(fdc, isDsd, data, function () {
-            var str = "";
-            for (var i = 0; i < data.length; ++i) str += String.fromCharCode(data[i]);
+            var str = utils.uint8ArrayToString(data);
             try {
                 window.localStorage.setItem(discName, str);
             } catch (e) {

--- a/google-drive.js
+++ b/google-drive.js
@@ -151,7 +151,7 @@ define(['jquery', 'utils', 'fdc', 'underscore', 'promise'], function ($, utils, 
             var nameDetails = utils.discImageSize(name);
             var isDsd = nameDetails.isDsd;
             var byteSize = nameDetails.byteSize;
-            if (data.length != byteSize) {
+            if (data.length !== byteSize) {
                 throw new Error("Google Drive: Invalid disc data for '" + name + "': found " + data.length + " byte image)");
             }
             if (meta.editable) {

--- a/google-drive.js
+++ b/google-drive.js
@@ -108,8 +108,7 @@ define(['jquery', 'utils', 'fdc', 'underscore', 'promise'], function ($, utils, 
             console.log("Google Drive: creating disc image: '" + name + "'");
             var byteSize = utils.discImageSize(name).byteSize;
             var data = new Uint8Array(byteSize);
-            for (var i = 0; i < Math.max(12, name.length); ++i)
-                data[i] = name.charCodeAt(i) & 0xff;
+            utils.setDiscName(data, name);
             return saveFile(name, data)
                 .then(function (response) {
                     var meta = response.result;
@@ -151,7 +150,10 @@ define(['jquery', 'utils', 'fdc', 'underscore', 'promise'], function ($, utils, 
             var nameDetails = utils.discImageSize(name);
             var isDsd = nameDetails.isDsd;
             var byteSize = nameDetails.byteSize;
-            if (data.length !== byteSize) {
+            if (data.length === 100 * 1024) {
+                // Old images were stored too small so convert them.
+                data = utils.resizeUint8Array(data, byteSize);
+            } else if (data.length !== byteSize) {
                 throw new Error("Google Drive: Invalid disc data for '" + name + "': found " + data.length + " byte image)");
             }
             if (meta.editable) {

--- a/main.js
+++ b/main.js
@@ -827,6 +827,7 @@ require(['jquery', 'underscore', 'utils', 'video', 'soundchip', 'ddnoise', 'debu
             reader.onload = function (e) {
                 processor.fdc.loadDisc(0, disc.discFor(processor.fdc, /\.dsd$/i.test(file.name), e.target.result));
                 delete parsedQuery.disc;
+                delete parsedQuery.disc1;
                 updateUrl();
                 $('#discs').modal("hide");
             };

--- a/utils.js
+++ b/utils.js
@@ -939,6 +939,28 @@ define(['jsunzip', 'promise'], function (jsunzip) {
         return {data: uncompressed.data, name: loadedFile};
     };
 
+    exports.discImageSize = function(name) {
+        // SSD, aka. single-sided disc, is:
+        // - 1 side :)
+        // - 80 tracks.
+        // - 10 sectors per track.
+        // - 256 bytes per sector.
+        var isDsd = false;
+        var byteSize = 80 * 10 * 256;
+        // DSD, aka. double-sided disc is twice the size.
+        if (name.toLowerCase().endsWith(".dsd")) {
+            byteSize *= 2;
+            isDsd = true;
+        }
+        return { isDsd: isDsd, byteSize: byteSize };
+    };
+
+    exports.uint8ArrayToString = function(array) {
+        var str = "";
+        for (var i = 0; i < array.length; ++i) str += String.fromCharCode(array[i]);
+        return str;
+    }
+
     function Fifo(capacity) {
         this.buffer = new Uint8Array(capacity);
         this.size = 0;

--- a/utils.js
+++ b/utils.js
@@ -955,10 +955,28 @@ define(['jsunzip', 'promise'], function (jsunzip) {
         return { isDsd: isDsd, byteSize: byteSize };
     };
 
+    exports.setDiscName = function(data, name) {
+        for (var i = 0; i < 8; ++i)
+            data[i] = name.charCodeAt(i) & 0xff;
+    };
+
     exports.uint8ArrayToString = function(array) {
         var str = "";
         for (var i = 0; i < array.length; ++i) str += String.fromCharCode(array[i]);
         return str;
+    };
+
+    exports.stringToUint8Array = function(str) {
+        var len = str.length;
+        var array = new Uint8Array(len);
+        for (var i = 0; i < len; ++i) array[i] = str.charCodeAt(i) & 0xff;
+        return array;
+    };
+
+    exports.resizeUint8Array = function(array, byteSize) {
+        var newArray = new Uint8Array(byteSize);
+        newArray.set(array.subarray(0, byteSize));
+        return newArray;
     };
 
     function Fifo(capacity) {

--- a/utils.js
+++ b/utils.js
@@ -959,7 +959,7 @@ define(['jsunzip', 'promise'], function (jsunzip) {
         var str = "";
         for (var i = 0; i < array.length; ++i) str += String.fromCharCode(array[i]);
         return str;
-    }
+    };
 
     function Fifo(capacity) {
         this.buffer = new Uint8Array(capacity);


### PR DESCRIPTION
Fixes #113 

- Using the gd: pseudo-scheme for any disc, such as disc2, resulted in the URL being modified and "corrupting" the disc parameter.
- Various automatic URL modifications would get confused between disc and disc1, often leaving conflicting parameters even those these are aliases.
- Google Drive discs were being created with size 100KB, leading to corruption when filling the SSD above 100KB (capacity is 200KB).
- Google Drive discs didn't support DSD images.
- The use of Function.prototype.apply() on a large Uint8Array was blowing out the stack, at least on Chrome.