### PR TITLE
Fix reading of IRA and port contention.

### DIFF
--- a/cmos.js
+++ b/cmos.js
@@ -13,11 +13,10 @@ define([], function () {
             ];
             save();
         }
-        var readWrite = false;
-        var oldStrobe = false;
-        var data = 0;
         var enabled = false;
-        var addressStrobe = false;
+        var isRead = false;
+        var addressSelect = false;
+        var dataSelect = false;
         var cmosAddr = 0;
 
         function save() {
@@ -27,40 +26,32 @@ define([], function () {
         }
 
         function cmosRead(IC32) {
+            if (!enabled) return 0xff;
             // To drive the bus we need:
             // - CMOS enabled.
-            // - Address Strobe low.
-            // - Data Strobe high.
-            // - Read/write high (read).
-            if (enabled && !addressStrobe && (IC32 & 0x04) && readWrite) return data & 0xff;
+            // - Address Select low.
+            // - Data Select high.
+            // - Read high.
+            if (!addressSelect && dataSelect && isRead) return store[cmosAddr] & 0xff;
             return 0xff;
         }
 
-        function cmosWrite(IC32, sdbval) {
-            readWrite = !!(IC32 & 2);
-            var strobe = !!(IC32 & 4) ^ oldStrobe;
-            oldStrobe = !!(IC32 & 4);
-            if (strobe && enabled && !addressStrobe) {
-                if (!readWrite && cmosAddr > 0xb && !(IC32 & 4)) {
-                    // Write triggered on low to high D
-                    store[cmosAddr] = sdbval;
-                    save();
-                }
-                if (readWrite && (IC32 & 4)) {
-                    // Read data output while D is high
-                    data = store[cmosAddr] & 0xff;
-                }
+        function cmosWriteControl(portbpins, portapins, IC32) {
+            enabled = !!(portbpins & 0x40);
+            if (!enabled) return;
+            var oldDataSelect = dataSelect;
+            var oldAddressSelect = addressSelect;
+            isRead = !!(IC32 & 2);
+            dataSelect = !!(IC32 & 4);
+            addressSelect = !!(portbpins & 0x80);
+            if (oldAddressSelect && !addressSelect) cmosAddr = portapins & 0x3f;
+            if (oldDataSelect && !dataSelect && !addressSelect && !isRead && cmosAddr > 0xb) {
+                store[cmosAddr] = portapins;
+                save();
             }
         }
 
-        function cmosWriteAddr(val, sdbval) {
-            addressStrobe = !!(val & 0x80);
-            if (addressStrobe) cmosAddr = sdbval & 0x3f;
-            enabled = !!(val & 0x40);
-        }
-
         this.read = cmosRead;
-        this.write = cmosWrite;
-        this.writeAddr = cmosWriteAddr;
+        this.writeControl = cmosWriteControl;
     };
 });

--- a/debug.js
+++ b/debug.js
@@ -64,7 +64,7 @@ define(['jquery', 'underscore', './utils'], function ($, _, utils) {
             if (!via) return utils.noop;
             var regs = ["ora", "orb", "ira", "irb", "ddra", "ddrb",
                 "acr", "pcr", "ifr", "ier",
-                "t1c", "t1l", "t2c", "t2l", "IC32", "sdbval", "sdbout"];
+                "t1c", "t1l", "t2c", "t2l", "portapins", "portbpins", "IC32"];
             $.each(regs, function (_, elem) {
                 if (via[elem] === undefined) return;
                 var row = node.find(".template").clone().removeClass("template").appendTo(node);

--- a/soundchip.js
+++ b/soundchip.js
@@ -239,8 +239,13 @@ define(['./utils'], function (utils) {
         this.updateSlowDataBus = function (slowDataBus, active) {
             this.slowDataBus = slowDataBus;
             this.active = active;
+            // TODO: this probably isn't modeled correctly. Currently the
+            // sound chip "notices" a new data bus value some fixed number of
+            // cycles after WE (write enable) is triggered.
+            // In reality, the sound chip likely pulls data off the bus at a
+            // fixed point in its cycle, iff WE is active.
             if (active) {
-                activeTask.reschedule(minCyclesWELow);
+                activeTask.ensureScheduled(true, minCyclesWELow);
             }
         };
         this.reset = function (hard) {

--- a/via.js
+++ b/via.js
@@ -242,10 +242,12 @@ define(['./utils'], function (utils) {
                         // Reading ORA reads pin levels regardless of DDRA.
                         // Of the various 6522 datasheets, this one is clear:
                         // http://archive.6502.org/datasheets/wdc_w65c22s_mar_2004.pdf
-                        if (self.acr & 1)
+                        if (self.acr & 1) {
                             return self.ira;
-                        else
+                        } else {
+                            self.recalculatePortAPins();
                             return self.portapins;
+                        }
                         break;
 
                     case ORB:
@@ -254,6 +256,7 @@ define(['./utils'], function (utils) {
                             self.ifr &= ~INT_CB2;
                         self.updateIFR();
 
+                        self.recalculatePortBPins();
                         temp = self.orb & self.ddrb;
                         if (self.acr & 2)
                             temp |= (self.irb & ~self.ddrb);


### PR DESCRIPTION
- Reading of IRA now matches the datasheet by reading pin levels, not output bits.
- Handle output pin 1 vs. bus level 0 contention (bus level 0 wins).
- Handle CMOS vs. keyboard contention (keyboard wins).
- These changes exposed CMOS bugs; fix them all and simplify.