### PR TITLE
Support drop of image files to load them.

### DIFF
--- a/app-bench.js
+++ b/app-bench.js
@@ -29,7 +29,7 @@ requirejs(['fake6502', 'fdc', 'models'],
         cpu.initialise().then(function () {
             return disc.load("discs/" + discName + ".ssd");
         }).then(function (data) {
-            cpu.fdc.loadDisc(0, disc.discFor(cpu.fdc, false, data));
+            cpu.fdc.loadDisc(0, disc.discFor(cpu.fdc, '', data));
             cpu.sysvia.keyDown(16);
             cpu.execute(10 * 1000 * 1000);
             cpu.sysvia.keyUp(16);

--- a/app-frogman.js
+++ b/app-frogman.js
@@ -56,7 +56,7 @@ requirejs(['video', 'fake6502', 'soundchip', 'fdc', 'models', 'tests/test.js', '
         cpu.initialise().then(function () {
             return disc.load("discs/" + discName + ".ssd");
         }).then(function (data) {
-            cpu.fdc.loadDisc(0, disc.discFor(cpu.fdc, false, data));
+            cpu.fdc.loadDisc(0, disc.discFor(cpu.fdc, '', data));
             var trace = false;
             cpu.debugInstruction.add(function (addr) {
                 //if (addr === 0x11ae) {

--- a/app.js
+++ b/app.js
@@ -54,7 +54,7 @@ requirejs(['video', 'fake6502', 'fdc', 'models'],
         cpu.initialise().then(function () {
             return disc.load("discs/" + discName + ".ssd");
         }).then(function (data) {
-            cpu.fdc.loadDisc(0, disc.discFor(cpu.fdc, false, data));
+            cpu.fdc.loadDisc(0, disc.discFor(cpu.fdc, '', data));
             cpu.sysvia.keyDown(16);
             cpu.execute(10 * 1000 * 1000);
             cpu.sysvia.keyUp(16);

--- a/d8js-bench.js
+++ b/d8js-bench.js
@@ -51,7 +51,7 @@ requirejs(['fake6502', 'fdc', 'models'],
         cpu.initialise().then(function () {
             return disc.load("discs/" + discName + ".ssd");
         }).then(function (data) {
-            cpu.fdc.loadDisc(0, disc.discFor(cpu.fdc, false, data));
+            cpu.fdc.loadDisc(0, disc.discFor(cpu.fdc, '', data));
             cpu.sysvia.keyDown(16);
             cpu.execute(10 * 1000 * 1000);
             cpu.sysvia.keyUp(16);

--- a/google-drive.js
+++ b/google-drive.js
@@ -147,15 +147,6 @@ define(['jquery', 'utils', 'fdc', 'underscore', 'promise'], function ($, utils, 
         function makeDisc(fdc, data, meta) {
             var flusher = null;
             var name = meta.title;
-            var nameDetails = utils.discImageSize(name);
-            var isDsd = nameDetails.isDsd;
-            var byteSize = nameDetails.byteSize;
-            if (data.length === 100 * 1024) {
-                // Old images were stored too small so convert them.
-                data = utils.resizeUint8Array(data, byteSize);
-            } else if (data.length !== byteSize) {
-                throw new Error("Google Drive: Invalid disc data for '" + name + "': found " + data.length + " byte image)");
-            }
             if (meta.editable) {
                 console.log("Making editable disc");
                 flusher = _.debounce(function () {
@@ -166,7 +157,7 @@ define(['jquery', 'utils', 'fdc', 'underscore', 'promise'], function ($, utils, 
             } else {
                 console.log("Making read-only disc");
             }
-            return new BaseSsd(fdc, isDsd, data, flusher);
+            return new BaseSsd(fdc, name, data, flusher);
         }
 
         self.load = function (fdc, fileId) {

--- a/index.html
+++ b/index.html
@@ -95,7 +95,7 @@
                 </li>
             </ul>
             <div style="float:left; padding-top:12px; padding-left:32px;">
-                <input id="paste-text" type="text" maxlength="0" placeholder="Paste to BBC here..."></input>
+                <input id="paste-text" type="text" maxlength="0" placeholder="Paste text or drop files here..." style="width:200px;"></input>
             </div>
         </div>
         <!--/.nav-collapse -->


### PR DESCRIPTION
Fixes #146 

- Drop of disc image files to the paste/drop field loads them.
- Rest of the page desensitized to drop events (previously it typically would navigate, with potential data loss).
- Further centralize SSD vs. DSD size logic.
- Fixes failure to load DSDs from STH.