### PR TITLE
Fix jsbeeb hang when refocusing browser tab after a while.

### DIFF
--- a/main.js
+++ b/main.js
@@ -1246,12 +1246,14 @@ require(['jquery', 'underscore', 'utils', 'video', 'soundchip', 'ddnoise', 'debu
             if (last !== 0) {
                 var cycles;
                 if (!speedy) {
+                    // Now and last are DOMHighResTimeStamp, just a double.
                     var sinceLast = now - last;
-                    cycles = (sinceLast * clocksPerSecond / 1000) | 0;
+                    cycles = sinceLast * clocksPerSecond / 1000;
                     cycles = Math.min(cycles, MaxCyclesPerFrame);
                 } else {
                     cycles = clocksPerSecond / 50;
                 }
+                cycles |= 0;
                 try {
                     var begin = performance.now();
                     if (!processor.execute(cycles)) {


### PR DESCRIPTION
Since forever, jsbeeb can be found totally hung when returning to a jsbeeb tab after a while without it focused.

This is a speculative fix based on review but it does fix an issue that can cause a hang. Modern browsers can suspect requestAnimationFrame() callbacks indefinitely while a tab is not the foreground. So when refocusing jsbeeb, a large time delta is possible here in sinceLast, where sinceLast is a quantity in miliseconds.

cycles = (sinceLast * clocksPerSecond / 1000) | 0;

What I think is happening is that any number of elapsed seconds greater than 1080 or so can cause an integer overflow when forced to an int32 via the "| 0". e.g.

((1080 * 1000) * 2000000 / 1000) | 0
= -2134967296
(havoc ensues)

Amusingly, once the threshold has crossed, you might get lucky -- presumably after a very long time, you're at a 50% chance of a positive and 50% chance of a negative.