### PR TITLE
Make speedy mode faster by skipping painting of most frames.

### DIFF
--- a/main.js
+++ b/main.js
@@ -1281,6 +1281,9 @@ require(['jquery', 'underscore', 'utils', 'video', 'soundchip', 'ddnoise', 'debu
             var useTimeout = speedy || motorOn;
             var timeout = speedy ? 0 : (1000.0 / 50);
 
+            var frameSkipCount = speedy ? 10 : 0;
+            video.frameSkipCount = frameSkipCount;
+
             // We use setTimeout instead of requestAnimationFrame in two cases:
             // a) We're trying to run as fast as possible.
             // b) Tape is playing, normal speed but backgrounded tab should run.

--- a/main.js
+++ b/main.js
@@ -1281,7 +1281,12 @@ require(['jquery', 'underscore', 'utils', 'video', 'soundchip', 'ddnoise', 'debu
             var useTimeout = speedy || motorOn;
             var timeout = speedy ? 0 : (1000.0 / 50);
 
-            var frameSkipCount = speedy ? 10 : 0;
+            // In speedy mode, we still run all the state machines accurately
+            // but we paint less often because painting is the most expensive
+            // part of jsbeeb at this time.
+            // We need need to paint per odd number of frames so that interlace
+            // modes, i.e. MODE 7, still look ok.
+            var frameSkipCount = speedy ? 9 : 0;
             video.frameSkipCount = frameSkipCount;
 
             // We use setTimeout instead of requestAnimationFrame in two cases:

--- a/video.js
+++ b/video.js
@@ -425,7 +425,7 @@ define(['./teletext', './utils'], function (Teletext, utils) {
                 }
 
                 // TODO: this will be cleaner if we rework skew to have fetch
-                // indepedent from render.
+                // independent from render.
                 var insideBorder = (this.dispEnabled & (HDISPENABLE | VDISPENABLE)) === (HDISPENABLE | VDISPENABLE);
                 if ((insideBorder || this.cursorDrawIndex) && (this.dispEnabled & FRAMESKIPENABLE)) {
                     // Read data from address pointer if both horizontal and vertical display enabled.

--- a/video.js
+++ b/video.js
@@ -21,7 +21,8 @@ define(['./teletext', './utils'], function (Teletext, utils) {
         this.bitmapY = 0;
         this.renderY = 0;
         this.oddClock = false;
-        this.frameCount = 0;
+        this.frameCountCrtc = 0;
+        this.frameCountVsync = 0;
         this.inHSync = false;
         this.inVSync = false;
         this.vertAdjustPending = false;
@@ -92,6 +93,7 @@ define(['./teletext', './utils'], function (Teletext, utils) {
         };
 
         this.paintAndClear = function() {
+            this.frameCountVsync++;
             if (this.dispEnabled & FRAMESKIPENABLE) {
                 this.paint();
                 this.clearPaintBuffer();
@@ -99,7 +101,7 @@ define(['./teletext', './utils'], function (Teletext, utils) {
             this.dispEnabled &= ~FRAMESKIPENABLE;
             var enable = FRAMESKIPENABLE;
             if (this.frameSkipCount > 1) {
-                if (this.frameCount % this.frameSkipCount) enable = 0;
+                if (this.frameCountVsync % this.frameSkipCount) enable = 0;
             }
             this.dispEnabled |= enable;
 
@@ -254,9 +256,9 @@ define(['./teletext', './utils'], function (Teletext, utils) {
             this.vertCounter = 0;
             this.nextLineStartAddr = (this.regs[13] | (this.regs[12] << 8)) & 0x3FFF;
             this.dispEnabled |= VDISPENABLE;
-            this.frameCount++;
+            this.frameCountCrtc++;
             var cursorFlash = (this.regs[10] & 0x60) >>> 5;
-            this.cursorOnThisFrame = (cursorFlash === 0) || !!(this.frameCount & this.cursorFlashMask[cursorFlash]);
+            this.cursorOnThisFrame = (cursorFlash === 0) || !!(this.frameCountCrtc & this.cursorFlashMask[cursorFlash]);
         };
 
         this.endOfCharacterLine = function (lastScanline) {


### PR DESCRIPTION
This skips painting but does not skip accuracy -- the full state machine is still run.

This roughly doubles the speed of speedy mode to about 11Mhz for Twisted Brain.