### PR TITLE
Use a 2d canvas in preference to WebGL CPU fallback.

### DIFF
--- a/canvas.js
+++ b/canvas.js
@@ -25,11 +25,15 @@ define(['webgl-debug'], function (webglDebug) {
     };
 
     function GlCanvas(canvas) {
+        // failIfMajorPerformanceCaveat prevents the use of CPU based WebGL
+        // rendering, which is much worse than simply using a 2D canvas for
+        // rendering.
         var glAttrs = { alpha: false,
                         antialias: false,
                         depth: false,
                         preserveDrawingBuffer: false,
-                        stencil: false };
+                        stencil: false,
+                        failIfMajorPerformanceCaveat: true };
         var gl = canvas.getContext('webgl', glAttrs) || canvas.getContext('experimental-webgl', glAttrs);
         this.gl = gl;
         if (!gl) {


### PR DESCRIPTION
For some reason my GPU driver has wedged and Chrome's WebGL fallback to CPU based rendering is slow. We already have a 2d canvas fallback so use it in this case, it is well over 2x faster.