### PR TITLE
Improve accuracy of when key registers are checked.

### DIFF
--- a/debug.js
+++ b/debug.js
@@ -115,8 +115,8 @@ define(['jquery', 'underscore', './utils'], function ($, _, utils) {
             var stateNode = node.find('.crtc_state');
             var others = [
                 'bitmapX', 'bitmapY', 'dispEnabled',
-                'horizCounter', 'inHSync', 'scanlineCounter', 'vertCounter', 'inVSync',
-                'vertAdjustPending', 'inVertAdjust', 'dummyRasterPending', 'inDummyRaster',
+                'horizCounter', 'inHSync', 'scanlineCounter', 'vertAdjustCounter', 'vertCounter',
+                'inVSync', 'endOfMainLatched', 'endOfVertAdjustLatched', 'inVertAdjust', 'inDummyRaster',
                 'addr', 'lineStartAddr', 'nextLineStartAddr'];
             $.each(others, function (_, elem) {
                 var value = makeRow(stateNode, elem);


### PR DESCRIPTION
- Enables removal of a couple of ugly special cases.
- Emulates R0=0 a little better.
- Matches real hardware for when R4/R9 and R5 are read, to the clock.