### PR TITLE
Add ability to load a BASIC program stored in a URL parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ URL parameters
 * `tape=sth:ZZZ` - loads tape ZZZ from the Stairway to Hell archive
 * `patch=P` - applies a memory patch `P`. See below.
 * `loadBasic=X` - loads 'X' (a resource on the webserver) as text, tokenises it and puts it in `PAGE` as if you'd typed it in to the emulator
+* `embedBasic=X` - loads 'X' (a URI-encoded string) as text, tokenises it and puts it in `PAGE` as if you'd typed it in to the emulator
 * `autorun` - types `*TAPE` then `*/` to run from tape. In conjunction with `loadBasic` it types `RUN`.
 * `autochain` - types `*TAPE` then `CH.""` to run from tape.a
 * `embed` - Adjust the navigation entries to make the page clearer within a 921x733 iframe in a third-party site.


### PR DESCRIPTION
Hello! I just discovered this emulator via the Twitter BBC Micro Bot, and in looking at the tiny gif previews produced by the bot from submitted programs, I thought "wouldn't it be nice if I could see the full execution without having to manually copy-and-paste the source tweet (especially on mobile)"... and then I thought, that shouldn't be too hard to get working!

This change would allow any sufficiently-short program to be embedded directly into the URL without needing any external files anywhere, which would allow (for example) twitter bots to provide their own content for the emulator without either party having to bother with hosting a static file somewhere!

An example URL would be something like this: https://bbc.godbolt.org/?embedBasic=10%20PRINT%20%22Computers!!!%20%22;%0A20%20GOTO%2010

I think there aren't any browsers (let alone widely-used ones) that cap URLs at any less than several thousand characters, which should be plenty of room for twitter code golf programs, and maybe even some larger ones too!