### PR TITLE
Allow tokenising longer input lines

### DIFF
--- a/basic-tokenise.js
+++ b/basic-tokenise.js
@@ -19,13 +19,34 @@ define(['utils', 'models', 'fake6502', 'promise'],
                 }
                 cpu.writemem(offset + line.length, 0x0d);
                 var safety = 20 * 1000 * 1000;
+                var result = "";
                 while (cpu.s <= 0xf0) {
                     cpu.execute(1);
                     if (--safety === 0) {
                         break;
                     }
+                    if (cpu.pc === 0x8ea1) {
+                        // Intercept the subroutine in the BASIC ROM which replaces a keyword
+                        // with a token and copies down the tail of the line.  The 6502 code
+                        // uses the Y register to index the copy and fails if the untokenised
+                        // tail is longer than 255 bytes.  It also makes tokenisation O(n²)
+                        // for a line with a lot of tokens.
+                        //
+                        // Instead we copy out the newly processed part and advance the pointer
+                        // in 0x37/0x38 to the unprocessed part.
+                        let to = cpu.readmemZpStack(0x38) << 8 | cpu.readmemZpStack(0x37);
+                        while (offset < to) {
+                            result += String.fromCharCode(cpu.readmem(offset));
+                            offset++;
+                        }
+                        result += String.fromCharCode(cpu.a);
+                        offset += cpu.y;
+                        cpu.writememZpStack(0x37, offset & 0xff);
+                        cpu.writememZpStack(0x38, (offset >>> 8) & 0xff);
+                        ++offset;
+                        cpu.pc = 0x8ea4;
+                    }
                 }
-                var result = "";
                 for (i = offset; cpu.readmem(i) !== 0x0d; ++i) {
                     result += String.fromCharCode(cpu.readmem(i));
                 }
@@ -39,6 +60,9 @@ define(['utils', 'models', 'fake6502', 'promise'],
                 var lineSplit = line.match(lineRe);
                 var lineNum = lineSplit[1] ? parseInt(lineSplit[1]) : lineNumIfNotSpec;
                 var tokens = callTokeniser(lineSplit[2]);
+                if (tokens.length > 251) {
+                    throw new Error("Line " + lineNum + " tokenised length " + tokens.length + " > 251 bytes");
+                }
                 return '\r' +
                     String.fromCharCode((lineNum >>> 8) & 0xff) +
                     String.fromCharCode(lineNum & 0xff) +

--- a/basic-tokenise.js
+++ b/basic-tokenise.js
@@ -5,14 +5,29 @@ define(['utils', 'models', 'fake6502', 'promise'],
         function create() {
             var cpu = Fake6502.fake6502(models.basicOnly);
             var callTokeniser = function (line) {
+                // Address of the tokenisation subroutine in the Master's BASIC ROM.
                 // With thanks to http://8bs.com/basic/basic4-8db2.htm
-                cpu.pc = 0x8db2;
-                cpu.s = 0xf0;
-                var offset = 0x1000;
+                const tokeniseBASIC = 0x8db2;
+                // Address of the instruction to intercept where the tail is copied down.
+                const copyIntercept = 0x8ea1;
+                // Set the stack top to this, then execute until the CPU pops past this.
+                const stackTop = 0xf0;
+                // Address to inject the BASIC program text at.
+                const workSpace = 0x1000;
+                // Pointer to the program text.
+                const textPtrLo = 0x37;
+                const textPtrHi = 0x38;
+
+                cpu.pc = tokeniseBASIC;
+                cpu.s = stackTop;
+                var offset = workSpace;
+                // Set flags to indicate that we're at the start of a statement
+                // but have already processed the line number.
                 cpu.writemem(0x3b, 0x00);
                 cpu.writemem(0x3c, 0x00);
-                cpu.writemem(0x37, offset & 0xff);
-                cpu.writemem(0x38, (offset >>> 8) & 0xff);
+                cpu.writemem(textPtrLo, offset & 0xff);
+                cpu.writemem(textPtrHi, (offset >>> 8) & 0xff);
+                // Set the paged ROM latch to page in the BASIC.
                 cpu.writemem(0xfe30, 12);
                 for (var i = 0; i < line.length; ++i) {
                     cpu.writemem(offset + i, line.charCodeAt(i));
@@ -20,12 +35,12 @@ define(['utils', 'models', 'fake6502', 'promise'],
                 cpu.writemem(offset + line.length, 0x0d);
                 var safety = 20 * 1000 * 1000;
                 var result = "";
-                while (cpu.s <= 0xf0) {
+                while (cpu.s <= stackTop) {
                     cpu.execute(1);
                     if (--safety === 0) {
                         break;
                     }
-                    if (cpu.pc === 0x8ea1) {
+                    if (cpu.pc === copyIntercept) {
                         // Intercept the subroutine in the BASIC ROM which replaces a keyword
                         // with a token and copies down the tail of the line.  The 6502 code
                         // uses the Y register to index the copy and fails if the untokenised
@@ -33,18 +48,19 @@ define(['utils', 'models', 'fake6502', 'promise'],
                         // for a line with a lot of tokens.
                         //
                         // Instead we copy out the newly processed part and advance the pointer
-                        // in 0x37/0x38 to the unprocessed part.
-                        let to = cpu.readmemZpStack(0x38) << 8 | cpu.readmemZpStack(0x37);
+                        // to the unprocessed part.
+                        let to = cpu.readmemZpStack(textPtrHi) << 8 | cpu.readmemZpStack(textPtrLo);
                         while (offset < to) {
                             result += String.fromCharCode(cpu.readmem(offset));
                             offset++;
                         }
                         result += String.fromCharCode(cpu.a);
                         offset += cpu.y;
-                        cpu.writememZpStack(0x37, offset & 0xff);
-                        cpu.writememZpStack(0x38, (offset >>> 8) & 0xff);
+                        cpu.writememZpStack(textPtrLo, offset & 0xff);
+                        cpu.writememZpStack(textPtrHi, (offset >>> 8) & 0xff);
                         ++offset;
-                        cpu.pc = 0x8ea4;
+                        // Skip over the JSR instruction.
+                        cpu.pc += 3;
                     }
                 }
                 for (i = offset; cpu.readmem(i) !== 0x0d; ++i) {

--- a/tests/unit/test-tokenise.js
+++ b/tests/unit/test-tokenise.js
@@ -17,6 +17,18 @@ describe('Tokeniser', function () {
         });
     }
 
+    function checkThrows(done, text, expectedError) {
+        tokeniser.then(function (t) {
+            t.tokenise(text);
+            console.log("Failed to give exeception with message:", expectedError);
+            assert.strictEqual(false, true);
+            done();
+        }).catch(function (e) {
+            assert.strictEqual(e.message, expectedError);
+            done();
+        });
+    }
+
     it('handles a simple program', function (done) {
         check(done, "10 PRINT \"hello\"\n20 GOTO 10\n",
             "\r\x00\x0a\x0e \xf1 \"hello\"\r\x00\x14\x0b \xe5 \x8d\x54\x4a\x40\r\xff");
@@ -42,5 +54,11 @@ describe('Tokeniser', function () {
     });
     it('handles REM', function (done) {
         check(done, "10REM I am a monkey", "\r\x00\x0a\x13\xf4 I am a monkey\r\xff");
+    });
+    it('handles extra long input', function (done) {
+        check(done, "10" + "ENVELOPE".repeat(251), "\r\x00\x0a\xff" + "\xe2".repeat(251) + "\r\xff");
+    });
+    it('gives error for overlong input', function (done) {
+        checkThrows(done, "10" + "ENVELOPE".repeat(252), 'Line 10 tokenised length 252 > 251 bytes');
     });
 });


### PR DESCRIPTION
The code in the BASIC ROM we use copies down the tail of the line
after substituting a token with a loop indexed on Y, which limits
the untokenised tail to 255 bytes (plus a terminating CR).

Intercept this copy loop and perform the copying in JS to allow
longer inputs to be tokenised.  The output still has to fit in the BASIC
line length limit.

I would flag this as WIP but I can't seem to see how to in github.  Still to resolve is that I've attempted to add a test that an overlong input gives a suitable exception, but the testharness seems to complain this takes more than 2 seconds.  I think I'm out of the javascript depth here so pointers appreciated.