### PR TITLE
Only update the URL and menubar on confirmation of model change

### DIFF
--- a/config.js
+++ b/config.js
@@ -6,7 +6,11 @@ export function Config(onClose) {
     let changed = {};
     this.model = null;
     const $configuration = document.getElementById('configuration');
-    $configuration.addEventListener('show.bs.modal', () => changed = {});
+    $configuration.addEventListener('show.bs.modal', () => {
+        changed = {};
+        setDropdownText(this.model.name);
+    });
+
     $configuration.addEventListener('hide.bs.modal', () => onClose(changed));
 
     this.setModel = function (modelName) {
@@ -18,10 +22,14 @@ export function Config(onClose) {
         $(".keyboard-layout").text(keyLayout[0].toUpperCase() + keyLayout.substr(1));
     };
 
+    function setDropdownText(modelName) {
+        $("#bbc-model-dropdown .bbc-model").text(modelName);
+    }
+
     $('.model-menu a').on("click", function (e) {
         const modelName = $(e.target).attr("data-target");
         changed.model = modelName;
-        this.setModel(modelName);
+        setDropdownText(modelName);
     }.bind(this));
 
     $('.keyboard-menu a').on("click", function (e) {

--- a/main.js
+++ b/main.js
@@ -161,12 +161,12 @@ allModels.forEach(m => {
 var config = new Config(
     function (changed) {
         parsedQuery = _.extend(parsedQuery, changed);
-        updateUrl();
         if (changed.model) {
             areYouSure("Changing model requires a restart of the emulator. Restart now?",
                 "Yes, restart now",
                 "No, thanks",
                 function () {
+                    updateUrl();
                     window.location.reload();
                 });
         }


### PR DESCRIPTION
Fixes #349 

Interaction with config dialog model list now doesn't update any state outside of the dialog until the users clicks `Close` AND confirms their changes.