### PR TITLE
Updated configuration screen

### DIFF
--- a/config.js
+++ b/config.js
@@ -5,10 +5,14 @@ import { findModel } from "./models.js";
 export function Config(onClose) {
     let changed = {};
     this.model = null;
+    this.coProcessor = null;
     const $configuration = document.getElementById("configuration");
     $configuration.addEventListener("show.bs.modal", () => {
         changed = {};
         setDropdownText(this.model.name);
+        this.set65c02(this.model.tube);
+        this.setTeletext(this.model.hasTeletextAdaptor);
+        this.setMusic5000(this.model.hasMusic5000);
     });
 
     $configuration.addEventListener("hide.bs.modal", () => onClose(changed));
@@ -22,6 +26,26 @@ export function Config(onClose) {
         $(".keyboard-layout").text(keyLayout[0].toUpperCase() + keyLayout.substr(1));
     };
 
+    this.set65c02 = function (enabled) {
+        enabled = !!enabled;
+        $("#65c02").prop("checked", enabled);
+        this.model.tube = enabled ? findModel("Tube65c02") : null;
+    };
+
+    this.setMusic5000 = function (enabled) {
+        enabled = !!enabled;
+        $("#hasMusic5000").prop("checked", enabled);
+        this.model.hasMusic5000 = enabled;
+        this.addRemoveROM("ample.rom", enabled);
+    };
+
+    this.setTeletext = function (enabled) {
+        enabled = !!enabled;
+        $("#hasTeletextAdaptor").prop("checked", enabled);
+        this.model.hasTeletextAdaptor = enabled;
+        this.addRemoveROM("ats-3.0.rom", enabled);
+    };
+
     function setDropdownText(modelName) {
         $("#bbc-model-dropdown .bbc-model").text(modelName);
     }
@@ -31,7 +55,29 @@ export function Config(onClose) {
         function (e) {
             const modelName = $(e.target).attr("data-target");
             changed.model = modelName;
-            setDropdownText(modelName);
+
+            setDropdownText($(e.target).text());
+        }.bind(this)
+    );
+
+    $("#65c02").on(
+        "click",
+        function () {
+            changed.coProcessor = $("#65c02").prop("checked");
+        }.bind(this)
+    );
+
+    $("#hasTeletextAdaptor").on(
+        "click",
+        function () {
+            changed.hasTeletextAdaptor = $("#hasTeletextAdaptor").prop("checked");
+        }.bind(this)
+    );
+
+    $("#hasMusic5000").on(
+        "click",
+        function () {
+            changed.hasMusic5000 = $("#hasMusic5000").prop("checked");
         }.bind(this)
     );
 
@@ -43,4 +89,40 @@ export function Config(onClose) {
             this.setKeyLayout(keyLayout);
         }.bind(this)
     );
+
+    this.addRemoveROM = function (romName, required) {
+        if (required && !this.model.os.includes(romName)) {
+            this.model.os.push(romName);
+        } else {
+            let pos = this.model.os.indexOf(romName);
+            if (pos != -1) {
+                this.model.os.splice(pos, 1);
+            }
+        }
+    };
+
+    this.mapLegacyModels = function (parsedQuery) {
+        // "MasterTurbo" = Master + 6502 second processor
+        if (parsedQuery.model === "MasterTurbo") {
+            parsedQuery.model = "Master";
+            parsedQuery.coProcessor = true;
+        }
+
+        // "BMusic5000" = BBC DFS 1.2 + Music 5000
+        if (parsedQuery.model === "BMusic5000") {
+            parsedQuery.model = "B-DFS1.2";
+            parsedQuery.hasMusic5000 = true;
+        }
+
+        // "MasterTurbo" = BBC DFS 1.2 + Teletext adaptor
+        if (parsedQuery.model === "BTeletext") {
+            parsedQuery.model = "B-DFS1.2";
+            parsedQuery.hasTeletextAdaptor = true;
+        }
+
+        // "B" (old default) = BBC DFS 0.9
+        if (parsedQuery.model === "B") {
+            parsedQuery.model = "B-DFS0.9";
+        }
+    };
 }

--- a/index.html
+++ b/index.html
@@ -51,7 +51,7 @@
           <ul class="navbar-nav nav mb-2 mb-lg-0">
             <li class="nav-item">
               <a href="#configuration" class="nav-link" data-bs-toggle="modal" data-bs-target="#configuration">
-                Config (<span class="bbc-model">BBC B</span>)</a
+                <span class="bbc-model">BBC B</span></a
               >
             </li>
             <li class="nav-item dropdown embed-hide">
@@ -635,11 +635,14 @@
             <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal" aria-label="Close"></button>
           </div>
           <div class="modal-body">
-            <div class="row g-2 align-items-center">
-              <div class="col-auto">
-                <label for="bbc-model-dropdown" class="col-form-label">Model</label>
+            <div class="row align-items-center">
+              <div class="col-sm-6">
+                <label for="bbc-model-dropdown" class="col-form-label"
+                  >Base model:<br />
+                  <small>(including disk interface)</small>
+                </label>
               </div>
-              <div class="col-auto dropdown">
+              <div class="col-sm-6 dropdown">
                 <button
                   type="button"
                   class="btn btn-secondary dropdown-toggle"
@@ -653,19 +656,26 @@
                   role="menu"
                   aria-labelledby="bbc-model-dropdown"
                 >
-                  <li><a href="#" class="dropdown-item" data-target="B">BBC B</a></li>
-                  <li><a href="#" class="dropdown-item" data-target="BTeletext">BBC B (with Teletext adaptor)</a></li>
-                  <li><a href="#" class="dropdown-item" data-target="BMusic5000">BBC B (with Music 5000)</a></li>
-                  <li><a href="#" class="dropdown-item" data-target="Master">BBC Master 128</a></li>
-                  <li><a href="#" class="dropdown-item" data-target="MasterTurbo">BBC Master Turbo</a></li>
+                  <li>
+                    <a href="#" class="dropdown-item" data-target="B-DFS1.2">BBC B with DFS 1.2</a>
+                  </li>
+                  <li>
+                    <a href="#" class="dropdown-item" data-target="B-DFS0.9">BBC B with DFS 0.9</a>
+                  </li>
+                  <li>
+                    <a href="#" class="dropdown-item" data-target="B1770">BBC B with ADFS</a>
+                  </li>
+                  <li>
+                    <a href="#" class="dropdown-item" data-target="Master">BBC Master 128</a>
+                  </li>
                 </ul>
               </div>
             </div>
-            <div class="row g-2 align-items-center">
-              <div class="col-auto">
-                <label for="keyboardDropdown" class="col-form-label">Keyboard layout</label>
+            <div class="row align-items-center">
+              <div class="col-sm-6">
+                <label for="keyboardDropdown" class="col-form-label">Keyboard layout:</label>
               </div>
-              <div class="col-auto dropdown">
+              <div class="col-sm-6 dropdown">
                 <button
                   type="button"
                   class="btn btn-secondary dropdown-toggle"
@@ -682,11 +692,38 @@
                   <li>
                     <a href="#" class="dropdown-item" data-target="physical">Physical: '*' is next to Enter/Return</a>
                   </li>
-                  <li><a href="#" class="dropdown-item" data-target="natural">Natural: '*' is shift-8</a></li>
+                  <li>
+                    <a href="#" class="dropdown-item" data-target="natural">Natural: '*' is shift-8</a>
+                  </li>
                   <li>
                     <a href="#" class="dropdown-item" data-target="gaming">Gaming: handy for games like Zalaga</a>
                   </li>
                 </ul>
+              </div>
+            </div>
+            <div class="align-items-center">
+              <div class="row">
+                <div class="col-sm-6">
+                  <label for="bbc-peripherals" class="col-form-label"
+                    >Additional peripherals:<br /><small
+                      >(some combinations may cause compatibility issues)</small
+                    ></label
+                  >
+                </div>
+                <div class="col-sm-6">
+                  <div class="form-check">
+                    <input class="form-check-input" type="checkbox" id="65c02" name="65c02" />
+                    <label class="form-check-label" for="65c02">65c02 co-processor</label>
+                  </div>
+                  <div class="form-check">
+                    <input class="form-check-input" type="checkbox" id="hasMusic5000" name="hasMusic5000" />
+                    <label class="form-check-label" for="hasMusic5000">Music 5000 synthesiser</label>
+                  </div>
+                  <div class="form-check">
+                    <input class="form-check-input" type="checkbox" id="hasTeletextAdaptor" name="hasTeletextAdaptor" />
+                    <label class="form-check-label" for="hasTeletextAdaptor">Teletext adaptor</label>
+                  </div>
+                </div>
               </div>
             </div>
           </div>

--- a/jsbeeb.css
+++ b/jsbeeb.css
@@ -324,3 +324,7 @@ div.modal-body > div:not(:first-child) {
   background-color: #440000;
   margin-top: 5px;
 }
+
+small {
+  color: #999;
+}

--- a/main.js
+++ b/main.js
@@ -1483,7 +1483,6 @@ function stop(debug) {
     const cubOrigWidth = $cubMonitorPic.attr("width");
     const cubToScreenHeightRatio = $screen.attr("height") / cubOrigHeight;
     const cubToScreenWidthRatio = $screen.attr("width") / cubOrigWidth;
-    const navbarHeight = $("#header-bar").height();
     const desiredAspectRatio = cubOrigWidth / cubOrigHeight;
     const minWidth = cubOrigWidth / 4;
     const minHeight = cubOrigHeight / 4;
@@ -1491,6 +1490,7 @@ function stop(debug) {
     const bottomReservedSize = 100;
 
     function resizeTv() {
+        let navbarHeight = $("#header-bar").height();
         let width = Math.max(minWidth, window.innerWidth - borderReservedSize * 2);
         let height = Math.max(minHeight, window.innerHeight - navbarHeight - bottomReservedSize);
         if (width / height <= desiredAspectRatio) {
@@ -1504,7 +1504,7 @@ function stop(debug) {
     }
 
     window.onresize = resizeTv;
-    resizeTv();
+    window.setTimeout(resizeTv, 500);
 })();
 
 // Handy shortcuts. bench/profile stuff is delayed so that they can be

--- a/main.js
+++ b/main.js
@@ -21,7 +21,6 @@ import * as canvasLib from "./canvas.js";
 import { Config } from "./config.js";
 import { initialise as electron } from "./app/electron.js";
 import { AudioHandler } from "./web/audio-handler.js";
-import { allModels } from "./models.js";
 
 var processor;
 var video;
@@ -153,14 +152,14 @@ if (queryString) {
 
 if (parsedQuery.frameSkip) frameSkip = parseInt(parsedQuery.frameSkip);
 
-$(".model-menu").empty();
-allModels.forEach((m) => {
-    $(".model-menu").append(`<li><a href="#" class="dropdown-item" data-target="${m.name}">${m.name}</a></li>`);
-});
-
 var config = new Config(function (changed) {
     parsedQuery = _.extend(parsedQuery, changed);
-    if (changed.model) {
+    if (
+        changed.model ||
+        changed.coProcessor !== undefined ||
+        changed.hasMusic5000 !== undefined ||
+        changed.hasTeletextAdaptor !== undefined
+    ) {
         areYouSure(
             "Changing model requires a restart of the emulator. Restart now?",
             "Yes, restart now",
@@ -177,8 +176,16 @@ var config = new Config(function (changed) {
         processor.updateKeyLayout();
     }
 });
+
+// Perform mapping of legacy models to the new format
+config.mapLegacyModels(parsedQuery);
+
 config.setModel(parsedQuery.model || guessModelFromUrl());
 config.setKeyLayout(keyLayout);
+config.set65c02(parsedQuery.coProcessor);
+config.setMusic5000(parsedQuery.hasMusic5000);
+config.setTeletext(parsedQuery.hasTeletextAdaptor);
+
 model = config.model;
 
 function sbBind(div, url, onload) {
@@ -539,6 +546,7 @@ var printerPort = {
 
 var emulationConfig = {
     keyLayout: keyLayout,
+    coProcessor: parsedQuery.coProcessor,
     cpuMultiplier: cpuMultiplier,
     videoCyclesBatch: parsedQuery.videoCyclesBatch,
     extraRoms: extraRoms,
@@ -556,7 +564,7 @@ processor = new Cpu6502(
     video,
     audioHandler.soundChip,
     audioHandler.ddNoise,
-    audioHandler.music5000,
+    model.hasMusic5000 ? audioHandler.music5000 : null,
     cmos,
     emulationConfig
 );
@@ -791,9 +799,10 @@ function updateUrl() {
     var url = window.location.origin + window.location.pathname;
     var sep = "?";
     $.each(parsedQuery, function (key, value) {
-        url += sep + encodeURIComponent(key);
-        if (value) url += "=" + encodeURIComponent(value);
-        sep = "&";
+        if (key.length > 0 && value) {
+            url += sep + encodeURIComponent(key) + "=" + encodeURIComponent(value);
+            sep = "&";
+        }
     });
     window.history.pushState(null, null, url);
 }
@@ -1127,9 +1136,9 @@ $("#soft-reset").click(function (event) {
 });
 
 function guessModelFromUrl() {
-    if (window.location.hostname.indexOf("bbc") === 0) return "B";
+    if (window.location.hostname.indexOf("bbc") === 0) return "B-DFS1.2";
     if (window.location.hostname.indexOf("master") === 0) return "Master";
-    return "B";
+    return "B-DFS1.2";
 }
 
 $("#tape-menu a").on("click", function (e) {
@@ -1160,6 +1169,7 @@ var caps = new Light("capslight");
 var shift = new Light("shiftlight");
 var drive0 = new Light("drive0");
 var drive1 = new Light("drive1");
+
 syncLights = function () {
     caps.update(processor.sysvia.capsLockLight);
     shift.update(processor.sysvia.shiftLockLight);

--- a/models.js
+++ b/models.js
@@ -3,7 +3,7 @@
 import { I8271, WD1770 } from "./fdc.js";
 
 class Model {
-    constructor(name, synonyms, os, nmos, isMaster, swram, fdc, tube, hasTeletextAdaptor, hasMusic5000) {
+    constructor(name, synonyms, os, nmos, isMaster, swram, fdc, tube) {
         this.name = name;
         this.synonyms = synonyms;
         this.os = os;
@@ -13,8 +13,6 @@ class Model {
         this.swram = swram;
         this.isTest = false;
         this.tube = tube;
-        this.hasTeletextAdaptor = hasTeletextAdaptor;
-        this.hasMusic5000 = hasMusic5000;
     }
 }
 
@@ -55,57 +53,27 @@ const masterSwram = [
     false,
     false,
 ];
-const tube65c02 = new Model("Tube65C02", [], ["tube/6502Tube.rom"], false, false);
 export const allModels = [
     new Model(
-        "BBC B",
-        ["B"],
-        ["os.rom", "BASIC.ROM", "b/DFS-0.9.rom"],
-        true,
-        false,
-        beebSwram,
-        I8271,
-        null,
-        false,
-        false
-    ),
-    new Model(
-        "BBC B (with Teletext)",
-        ["BTeletext"],
-        ["os.rom", "BASIC.ROM", "b/DFS-0.9.rom", "ats-3.0.rom"],
-        true,
-        false,
-        beebSwram,
-        I8271,
-        null,
-        true
-    ),
-    new Model(
-        "BBC B (with Music 5000)",
-        ["BMusic5000"],
-        ["os.rom", "BASIC.ROM", "b/DFS-0.9.rom", "ample.rom"],
-        true,
-        false,
-        beebSwram,
-        I8271,
-        null,
-        true,
-        true
-    ),
-    new Model("BBC B (DFS 0.9)", ["B-DFS0.9"], ["os.rom", "BASIC.ROM", "b/DFS-0.9.rom"], true, false, beebSwram, I8271),
-    new Model("BBC B (DFS 1.2)", ["B-DFS1.2"], ["os.rom", "BASIC.ROM", "b/DFS-1.2.rom"], true, false, beebSwram, I8271),
-    new Model(
-        "BBC B (with 65c02 Tube)",
-        ["B-Tube"],
+        "BBC B with DFS 1.2",
+        ["B-DFS1.2"],
         ["os.rom", "BASIC.ROM", "b/DFS-1.2.rom"],
         true,
         false,
         beebSwram,
-        I8271,
-        tube65c02
+        I8271
     ),
     new Model(
-        "BBC B (1770)",
+        "BBC B with DFS 0.9",
+        ["B-DFS0.9"],
+        ["os.rom", "BASIC.ROM", "b/DFS-0.9.rom"],
+        true,
+        false,
+        beebSwram,
+        I8271
+    ),
+    new Model(
+        "BBC B with ADFS",
         ["B1770"],
         ["os.rom", "BASIC.ROM", "b1770/dfs1770.rom", "b1770/zADFS.ROM"],
         true,
@@ -114,7 +82,7 @@ export const allModels = [
         WD1770
     ),
     new Model("BBC Master 128", ["Master"], ["master/mos3.20"], false, true, masterSwram, WD1770),
-    new Model("BBC Master Turbo", ["MasterTurbo"], ["master/mos3.20"], false, true, masterSwram, WD1770, tube65c02),
+    new Model("Tube65C02", [], ["tube/6502Tube.rom"], false, false), // Although this can not be explicitly selected as a model, it is required by the configuration builder later
 ];
 
 export function findModel(name) {


### PR DESCRIPTION
Update for the configuration screen to allow more dynamic configuration options.

The user selects from four base models:
	B-DFS1.2 (default)
	B-DFS0.9
	B1770
	Master

Next, the keyboard layout and any optional peripherals are selected:
	6502 co-processor
	Teletext
	Music 5000

The peripherals selected are exposed via URL params.

The default model shown to the user is now BBC DFS 1.2 (rather than 0.9). DFS 1.2 supports the Tube, and I thought it best that the default model would allow any peripheral to be chosen. 

Some 'legacy' models given in the URL have a custom mapping to the new format:

- “MasterTurbo” becomes “Master” + co-pro
- “BTeletext” becomes “B-DFS1.2” + teletext
- “BMusic5000” becomes “B-DFS1.2” + music 5000
- “B” becomes “B-DFS1.2” ?
