### PR TITLE
update to the 'tiny screen' fix

### DIFF
--- a/main.js
+++ b/main.js
@@ -1504,6 +1504,7 @@ function stop(debug) {
     }
 
     window.onresize = resizeTv;
+    window.setTimeout(resizeTv, 1);
     window.setTimeout(resizeTv, 500);
 })();
 


### PR DESCRIPTION
Changes to the `window.setTimeout` logic as per conversation with Matt.

** I was originally using a delay of `, 1` but moved to `, 500` to improve the success from ~95% to 100%. 
So if you agree I have included two bites at the resize at both 1 and 500 intervals as you suggested in order to avoid any initial delay.
(NB: The other change to move the read of the navbar height into the resize function is still needed).