### PR TITLE
Make legacy model handling case insensitive too

### DIFF
--- a/config.js
+++ b/config.js
@@ -102,27 +102,26 @@ export function Config(onClose) {
     };
 
     this.mapLegacyModels = function (parsedQuery) {
+        if (!parsedQuery.model) {
+            return;
+        }
+
         // "MasterTurbo" = Master + 6502 second processor
-        if (parsedQuery.model === "MasterTurbo") {
+        if (parsedQuery.model.toLowerCase() === "masterturbo") {
             parsedQuery.model = "Master";
             parsedQuery.coProcessor = true;
         }
 
         // "BMusic5000" = BBC DFS 1.2 + Music 5000
-        if (parsedQuery.model === "BMusic5000") {
+        if (parsedQuery.model.toLowerCase() === "bmusic5000") {
             parsedQuery.model = "B-DFS1.2";
             parsedQuery.hasMusic5000 = true;
         }
 
-        // "MasterTurbo" = BBC DFS 1.2 + Teletext adaptor
-        if (parsedQuery.model === "BTeletext") {
+        // "BTeletext" = BBC DFS 1.2 + Teletext adaptor
+        if (parsedQuery.model.toLowerCase() === "bteletext") {
             parsedQuery.model = "B-DFS1.2";
             parsedQuery.hasTeletextAdaptor = true;
-        }
-
-        // "B" (old default) = BBC DFS 0.9
-        if (parsedQuery.model === "B") {
-            parsedQuery.model = "B-DFS0.9";
         }
     };
 }

--- a/models.js
+++ b/models.js
@@ -65,7 +65,7 @@ export const allModels = [
     ),
     new Model(
         "BBC B with DFS 0.9",
-        ["B-DFS0.9"],
+        ["B-DFS0.9", "B"],
         ["os.rom", "BASIC.ROM", "b/DFS-0.9.rom"],
         true,
         false,


### PR DESCRIPTION
(Only spotted this as it turned out I was using `model=b` for 8bs.nerdoftheherd.com)

Handling of the current model names is case insensitive, e.g. `model=master` is valid as well as `model=Master`.  `mapLegacyModels` is however case sensitive so `model=B` works but `model=b` causes an uncaught `TypeError`.

Resolve this inconsistency by making `mapLegacyModels` case insensitive.  Also took the opportunity to move handling of the legacy `B` model to just be another alias of `BBC B with DFS 0.9` and corrected a comment.