### PR TITLE
ISSUE-397-tube-ula-fixes

### DIFF
--- a/tube.js
+++ b/tube.js
@@ -33,7 +33,7 @@ export class Tube {
         );
 
         const hp3Size = this.r1stat & 0x10 ? 1 : 0;
-        this.parasiteCpu.nmi = !!(this.r1stat & 0x08 && (this.hp3pos > hp3Size || this.ph3pos === 0));
+        this.parasiteCpu.nmi = !!(this.r1stat & 0x08 && (this.hp3pos > hp3Size));
     }
     reset() {
         this.ph1pos = this.hp3pos = 0;
@@ -41,7 +41,10 @@ export class Tube {
         this.r1stat = 0;
         this.hstat[0] = this.hstat[1] = this.hstat[3] = 0x40;
         this.hstat[2] = 0xc0;
-        this.pstat[0] = this.pstat[1] = this.pstat[2] = this.pstat[3] = 0x40;
+
+        this.pstat[0] = 0x40;
+        this.pstat[1] = this.pstat[2] = this.pstat[3] = 0x7f;
+        this.updateInterrupts();
     }
     hostRead(addr) {
         let result = 0xfe;
@@ -97,9 +100,15 @@ export class Tube {
         if (this.debug) console.log("host write " + utils.hexword(addr) + " = " + utils.hexbyte(b));
         switch (addr & 7) {
             case 0:
-                if (b & 0x80) this.r1stat |= b & 0x3f;
-                else this.r1stat &= ~(b & 0x3f);
-                this.hstat[0] = (this.hstat[0] & 0xc0) | (b & 0x3f);
+                if (b & 0x80)
+                this.r1stat |= b & 0x3f;
+                else if (this.r1stat & 0x20) {
+                    this.reset();
+                    this.parasiteCpu.reset();
+                }
+                else
+                    this.r1stat &= ~(b & 0x3f);
+                    this.hstat[0] = (this.hstat[0] & 0xc0) | (b & 0x3f);
                 break;
             case 1:
                 this.hp1 = b;
@@ -210,7 +219,7 @@ export class Tube {
                     this.ph3[0] = b;
                     this.ph3pos = 1;
                     this.hstat[2] |= 0x80;
-                    this.pstat[2] &= ~0xc0;
+                    this.pstat[2] &= ~0x40;
                 }
                 break;
             case 7:

--- a/tube.js
+++ b/tube.js
@@ -110,7 +110,6 @@ export class Tube {
                 else {
                     this.r1stat &= ~(b & 0x3f);
                 }
-
                 this.hstat[0] = (this.hstat[0] & 0xc0) | (b & 0x3f);
                 break;
             case 1:

--- a/tube.js
+++ b/tube.js
@@ -101,14 +101,15 @@ export class Tube {
         switch (addr & 7) {
             case 0:
                 if (b & 0x80)
-                this.r1stat |= b & 0x3f;
+                    this.r1stat |= b & 0x3f;
                 else if (this.r1stat & 0x20) {
                     this.reset();
                     this.parasiteCpu.reset();
                 }
                 else
                     this.r1stat &= ~(b & 0x3f);
-                    this.hstat[0] = (this.hstat[0] & 0xc0) | (b & 0x3f);
+
+                this.hstat[0] = (this.hstat[0] & 0xc0) | (b & 0x3f);
                 break;
             case 1:
                 this.hp1 = b;

--- a/tube.js
+++ b/tube.js
@@ -100,14 +100,16 @@ export class Tube {
         if (this.debug) console.log("host write " + utils.hexword(addr) + " = " + utils.hexbyte(b));
         switch (addr & 7) {
             case 0:
-                if (b & 0x80)
+                if (b & 0x80) {
                     this.r1stat |= b & 0x3f;
+                }
                 else if (this.r1stat & 0x20) {
                     this.reset();
                     this.parasiteCpu.reset();
                 }
-                else
+                else {
                     this.r1stat &= ~(b & 0x3f);
+                }
 
                 this.hstat[0] = (this.hstat[0] & 0xc0) | (b & 0x3f);
                 break;


### PR DESCRIPTION
Hey people. None of this is intended to be "narky". If it can be taken a lighter way, it should be. :)

Unsure what this was about. Can't see how it would be relevant to the behaviour of the ULA.

`|| this.ph3pos === 0`
in
`this.parasiteCpu.nmi = !!(this.r1stat & 0x08 && (this.hp3pos > hp3Size || this.ph3pos === 0));
`

This also needs a further mechanical test on one aspect. Documentation seems unclear whether the NMI would fire when the first byte is added host side, regardless of whether R3 is in one- or two-byte mode.

Expanded out the `reset` function to match b-Em's latest, although it still needs a proper look over what's actually going on in it vs real hardware.

`hostRead` has been updated in b-Em as a partial success, so copying that mod here for now.

This is closer to what actually happens on real hardware, but still not completely correct.
It does at least allow the start-up banner to be transferred to the host when the /RESET pin is engaged after BREAK.
Still unsure why the ULA/parasite refuses to respond to certain (esp the ones I want to use) subsequent ULA changes and signals

```
if (b & 0x80)
this.r1stat |= b & 0x3f;
else if (this.r1stat & 0x20) {
this.reset();
this.parasiteCpu.reset();
}
,,,

```

Unsure why this would be 0xc0 and not 0x40. Possibly a typo. :)

`this.pstat[2] &= ~0xc0;`

The issue is NOT closed by accepting this first PR although, arguably. I should raise another issue for each of the still-not-completely-right bits. Up to the primary dev team. What works best for you?

Please let me know your thoughts.