### PR TITLE
Updated Tube ULA implementation

### DIFF
--- a/tube.js
+++ b/tube.js
@@ -128,9 +128,6 @@ export class Tube {
         this.parasiteCpu.resetHeldLow = (this.internalStatusRegister & TUBE_ULA_FLAG_STATUS_PARASITE_RESET_ACTIVE_LOW);
     }
     hostRead(address) {
-        //  Not implemented - needs to be integrated with the parasite CPU code:
-        //  Boot mode is terminated by the software when it selects any one of the Tube addresses.
-        //  This deselects the ROM
         let result = 0xfe;
         switch (address & 7) {
             case TUBE_ULA_R1_STATUS_ADDRESS:
@@ -253,6 +250,9 @@ export class Tube {
         this.updateInterrupts();
     }
     parasiteRead(address) {
+        //  Not implemented - needs to be integrated with the parasite CPU code:
+        //  Boot mode is terminated by the software when it selects any one of the Tube addresses.
+        //  This deselects the ROM
         let result = 0;
         switch (address & 7) {
             case TUBE_ULA_R1_STATUS_ADDRESS:
@@ -301,6 +301,9 @@ export class Tube {
         return result;
     }
     parasiteWrite(address, value) {
+        //  Not implemented - needs to be integrated with the parasite CPU code:
+        //  Boot mode is terminated by the software when it selects any one of the Tube addresses.
+        //  This deselects the ROM
         if (this.debug) {
             console.log("TUBE ULA: parasite write " + utils.hexword(address) + " = " + utils.hexbyte(value));
         }

--- a/tube.js
+++ b/tube.js
@@ -128,6 +128,9 @@ export class Tube {
         this.parasiteCpu.resetHeldLow = (this.internalStatusRegister & TUBE_ULA_FLAG_STATUS_PARASITE_RESET_ACTIVE_LOW);
     }
     hostRead(address) {
+        //  Not implemented - needs to be integrated with the parasite CPU code:
+        //  Boot mode is terminated by the software when it selects any one of the Tube addresses.
+        //  This deselects the ROM
         let result = 0xfe;
         switch (address & 7) {
             case TUBE_ULA_R1_STATUS_ADDRESS:

--- a/tube.js
+++ b/tube.js
@@ -16,25 +16,25 @@ const TUBE_ULA_R3_STATUS_ADDRESS = 4;
 const TUBE_ULA_R3_DATA_ADDRESS = 5;
 const TUBE_ULA_R4_STATUS_ADDRESS = 6;
 const TUBE_ULA_R4_DATA_ADDRESS = 7;
-const TUBE_FLAG_DATA_AVAILABLE = 0x80;
-const TUBE_FLAG_DATA_REGISTER_NOT_FULL = 0x40;
-const TUBE_FLAG_STATUS_Q = 0x01;
-const TUBE_FLAG_STATUS_I = 0x02;
-const TUBE_FLAG_STATUS_J = 0x04;
-const TUBE_FLAG_STATUS_M = 0x08;
-const TUBE_FLAG_STATUS_V = 0x10;
-const TUBE_FLAG_STATUS_P = 0x20;
-const TUBE_FLAG_STATUS_T = 0x40;
-const TUBE_FLAG_STATUS_S = 0x80;
+const TUBE_ULA_FLAG_DATA_AVAILABLE = 0x80;
+const TUBE_ULA_FLAG_DATA_REGISTER_NOT_FULL = 0x40;
+const TUBE_ULA_FLAG_STATUS_Q = 0x01;
+const TUBE_ULA_FLAG_STATUS_I = 0x02;
+const TUBE_ULA_FLAG_STATUS_J = 0x04;
+const TUBE_ULA_FLAG_STATUS_M = 0x08;
+const TUBE_ULA_FLAG_STATUS_V = 0x10;
+const TUBE_ULA_FLAG_STATUS_P = 0x20;
+const TUBE_ULA_FLAG_STATUS_T = 0x40;
+const TUBE_ULA_FLAG_STATUS_S = 0x80;
 //  human-readable aliases for the above flags
-const TUBE_FLAG_STATUS_ENABLE_HOST_IRQ_FROM_R4_DATA = TUBE_FLAG_STATUS_Q;
-const TUBE_FLAG_STATUS_ENABLE_PARASITE_IRQ_FROM_R1_DATA = TUBE_FLAG_STATUS_I;
-const TUBE_FLAG_STATUS_ENABLE_PARASITE_IRQ_FROM_R4_DATA = TUBE_FLAG_STATUS_J;
-const TUBE_FLAG_STATUS_ENABLE_PARASITE_NMI_FROM_R3_DATA = TUBE_FLAG_STATUS_M;
-const TUBE_FLAG_STATUS_ENABLE_2_BYTE_R3_DATA = TUBE_FLAG_STATUS_V;
-const TUBE_FLAG_STATUS_PARASITE_RESET_ACTIVE_LOW = TUBE_FLAG_STATUS_P;
-const TUBE_FLAG_STATUS_CLEAR_ALL_TUBE_REGISTERS = TUBE_FLAG_STATUS_T;
-const TUBE_FLAG_STATUS_SET_CONTROL_FLAGS = TUBE_FLAG_STATUS_S;
+const TUBE_ULA_FLAG_STATUS_ENABLE_HOST_IRQ_FROM_R4_DATA = TUBE_ULA_FLAG_STATUS_Q;
+const TUBE_ULA_FLAG_STATUS_ENABLE_PARASITE_IRQ_FROM_R1_DATA = TUBE_ULA_FLAG_STATUS_I;
+const TUBE_ULA_FLAG_STATUS_ENABLE_PARASITE_IRQ_FROM_R4_DATA = TUBE_ULA_FLAG_STATUS_J;
+const TUBE_ULA_FLAG_STATUS_ENABLE_PARASITE_NMI_FROM_R3_DATA = TUBE_ULA_FLAG_STATUS_M;
+const TUBE_ULA_FLAG_STATUS_ENABLE_2_BYTE_R3_DATA = TUBE_ULA_FLAG_STATUS_V;
+const TUBE_ULA_FLAG_STATUS_PARASITE_RESET_ACTIVE_LOW = TUBE_ULA_FLAG_STATUS_P;
+const TUBE_ULA_FLAG_STATUS_CLEAR_ALL_TUBE_REGISTERS = TUBE_ULA_FLAG_STATUS_T;
+const TUBE_ULA_FLAG_STATUS_SET_CONTROL_FLAGS = TUBE_ULA_FLAG_STATUS_S;
 const TUBE_ULA_R1_PARASITE_BYTE_COUNT = 24;
 
 export class Tube {
@@ -66,11 +66,11 @@ export class Tube {
             this.internalStatusRegister = 0;
         }
         for (let i = 0; i < 4; i++) {
-            this.hostStatus[i] = TUBE_FLAG_DATA_REGISTER_NOT_FULL;
-            this.parasiteStatus[i] = TUBE_FLAG_DATA_REGISTER_NOT_FULL;
+            this.hostStatus[i] = TUBE_ULA_FLAG_DATA_REGISTER_NOT_FULL;
+            this.parasiteStatus[i] = TUBE_ULA_FLAG_DATA_REGISTER_NOT_FULL;
             if (i == TUBE_ULA_R3) {
                 //  register 3 has one valid but insignificant byte in the parasite to host FIFO (this is to prevent an immediate PNMI state after PRST)
-                this.hostStatus[i] |= TUBE_FLAG_DATA_AVAILABLE;
+                this.hostStatus[i] |= TUBE_ULA_FLAG_DATA_AVAILABLE;
                 this.parasiteToHostData[i][0] = 0;
             }
         }
@@ -83,8 +83,8 @@ export class Tube {
     updateInterrupts() {
         //  host IRQ
         if (
-            (this.hostStatus[TUBE_ULA_R4] & TUBE_FLAG_DATA_AVAILABLE) &&
-            (this.internalStatusRegister & TUBE_FLAG_STATUS_ENABLE_HOST_IRQ_FROM_R4_DATA)
+            (this.hostStatus[TUBE_ULA_R4] & TUBE_ULA_FLAG_DATA_AVAILABLE) &&
+            (this.internalStatusRegister & TUBE_ULA_FLAG_STATUS_ENABLE_HOST_IRQ_FROM_R4_DATA)
         ) {
             this.hostCpu.interrupt |= HOST_CPU_FLAG_IRQ_TUBE_ULA;
         } else {
@@ -93,12 +93,12 @@ export class Tube {
         //  parasite IRQ
         if (
             (
-                (this.parasiteStatus[TUBE_ULA_R1] & TUBE_FLAG_DATA_AVAILABLE) &&
-                (this.internalStatusRegister & TUBE_FLAG_STATUS_ENABLE_PARASITE_IRQ_FROM_R1_DATA)
+                (this.parasiteStatus[TUBE_ULA_R1] & TUBE_ULA_FLAG_DATA_AVAILABLE) &&
+                (this.internalStatusRegister & TUBE_ULA_FLAG_STATUS_ENABLE_PARASITE_IRQ_FROM_R1_DATA)
             ) ||
             (
-                (this.parasiteStatus[TUBE_ULA_R4] & TUBE_FLAG_DATA_AVAILABLE) &&
-                (this.internalStatusRegister & TUBE_FLAG_STATUS_ENABLE_PARASITE_IRQ_FROM_R4_DATA)
+                (this.parasiteStatus[TUBE_ULA_R4] & TUBE_ULA_FLAG_DATA_AVAILABLE) &&
+                (this.internalStatusRegister & TUBE_ULA_FLAG_STATUS_ENABLE_PARASITE_IRQ_FROM_R4_DATA)
             )
         ) {
             this.parasiteCpu.interrupt = true;
@@ -112,9 +112,9 @@ export class Tube {
         //  register 3)
         //  or: M = 1, V = 1, 2 bytes in host to parasite register 3 FIFO or 0 bytes in parasite to host
         //  register 3 FIFO. (this allows two byte transfers across register 3)
-        const r3Size = (this.internalStatusRegister & TUBE_FLAG_STATUS_ENABLE_2_BYTE_R3_DATA) ? 2 : 1;
+        const r3Size = (this.internalStatusRegister & TUBE_ULA_FLAG_STATUS_ENABLE_2_BYTE_R3_DATA) ? 2 : 1;
         if (
-            (this.internalStatusRegister & TUBE_FLAG_STATUS_ENABLE_PARASITE_NMI_FROM_R3_DATA) &&
+            (this.internalStatusRegister & TUBE_ULA_FLAG_STATUS_ENABLE_PARASITE_NMI_FROM_R3_DATA) &&
             (
                 (this.hostToParasiteFifoByteCount3 >= r3Size) ||
                 (this.parasiteToHostFifoByteCount3 === 0)
@@ -125,25 +125,25 @@ export class Tube {
             this.parasiteCpu.nmi = false;
         }
         //  parasite CPU RESET held low - not implemented in the CPU - the CPU should be frozen until this signal is released
-        this.parasiteCpu.resetHeldLow = (this.internalStatusRegister & TUBE_FLAG_STATUS_PARASITE_RESET_ACTIVE_LOW);
+        this.parasiteCpu.resetHeldLow = (this.internalStatusRegister & TUBE_ULA_FLAG_STATUS_PARASITE_RESET_ACTIVE_LOW);
     }
     hostRead(address) {
         let result = 0xfe;
         switch (address & 7) {
             case TUBE_ULA_R1_STATUS_ADDRESS:
-                result = (this.hostStatus[TUBE_ULA_R1] & (TUBE_FLAG_DATA_AVAILABLE | TUBE_FLAG_DATA_REGISTER_NOT_FULL)) |
-                    (this.internalStatusRegister & ~(TUBE_FLAG_DATA_AVAILABLE | TUBE_FLAG_DATA_REGISTER_NOT_FULL));
+                result = (this.hostStatus[TUBE_ULA_R1] & (TUBE_ULA_FLAG_DATA_AVAILABLE | TUBE_ULA_FLAG_DATA_REGISTER_NOT_FULL)) |
+                    (this.internalStatusRegister & ~(TUBE_ULA_FLAG_DATA_AVAILABLE | TUBE_ULA_FLAG_DATA_REGISTER_NOT_FULL));
                 break;
             case TUBE_ULA_R1_DATA_ADDRESS:
                 result = this.parasiteToHostData[TUBE_ULA_R1][0];
-                if (this.hostStatus[TUBE_ULA_R1] & TUBE_FLAG_DATA_AVAILABLE) {
+                if (this.hostStatus[TUBE_ULA_R1] & TUBE_ULA_FLAG_DATA_AVAILABLE) {
                     for (let i = 1; i < TUBE_ULA_R1_PARASITE_BYTE_COUNT; i++) {
                         this.parasiteToHostData[TUBE_ULA_R1][i - 1] = this.parasiteToHostData[TUBE_ULA_R1][i];
                     }
-                    this.parasiteStatus[TUBE_ULA_R1] |= TUBE_FLAG_DATA_REGISTER_NOT_FULL;
+                    this.parasiteStatus[TUBE_ULA_R1] |= TUBE_ULA_FLAG_DATA_REGISTER_NOT_FULL;
                     this.parasiteToHostFifoByteCount1--;
                     if (this.parasiteToHostFifoByteCount1 === 0) {
-                        this.hostStatus[TUBE_ULA_R1] &= ~TUBE_FLAG_DATA_AVAILABLE;
+                        this.hostStatus[TUBE_ULA_R1] &= ~TUBE_ULA_FLAG_DATA_AVAILABLE;
                     }
                 }
                 break;
@@ -152,20 +152,20 @@ export class Tube {
                 break;
             case TUBE_ULA_R2_DATA_ADDRESS:
                 result = this.parasiteToHostData[TUBE_ULA_R2][0];
-                this.parasiteStatus[TUBE_ULA_R2] |= TUBE_FLAG_DATA_REGISTER_NOT_FULL;
-                this.hostStatus[TUBE_ULA_R2] &= ~TUBE_FLAG_DATA_AVAILABLE;
+                this.parasiteStatus[TUBE_ULA_R2] |= TUBE_ULA_FLAG_DATA_REGISTER_NOT_FULL;
+                this.hostStatus[TUBE_ULA_R2] &= ~TUBE_ULA_FLAG_DATA_AVAILABLE;
                 break;
             case TUBE_ULA_R3_STATUS_ADDRESS:
                 result = this.hostStatus[TUBE_ULA_R3];
                 break;
             case TUBE_ULA_R3_DATA_ADDRESS:
                 result = this.parasiteToHostData[TUBE_ULA_R3][0];
-                if (this.hostStatus[TUBE_ULA_R3] & TUBE_FLAG_DATA_AVAILABLE) {
+                if (this.hostStatus[TUBE_ULA_R3] & TUBE_ULA_FLAG_DATA_AVAILABLE) {
                     this.parasiteToHostData[TUBE_ULA_R3][0] = this.parasiteToHostData[TUBE_ULA_R3][1];
-                    this.parasiteStatus[TUBE_ULA_R3] |= TUBE_FLAG_DATA_REGISTER_NOT_FULL;
+                    this.parasiteStatus[TUBE_ULA_R3] |= TUBE_ULA_FLAG_DATA_REGISTER_NOT_FULL;
                     this.parasiteToHostFifoByteCount3--;
                     if (this.parasiteToHostFifoByteCount3 === 0) {
-                        this.hostStatus[TUBE_ULA_R3] &= ~TUBE_FLAG_DATA_AVAILABLE;
+                        this.hostStatus[TUBE_ULA_R3] &= ~TUBE_ULA_FLAG_DATA_AVAILABLE;
                     }
                 }
                 break;
@@ -174,8 +174,8 @@ export class Tube {
                 break;
             case TUBE_ULA_R4_DATA_ADDRESS:
                 result = this.parasiteToHostData[TUBE_ULA_R4][0];
-                this.parasiteStatus[TUBE_ULA_R4] |= TUBE_FLAG_DATA_REGISTER_NOT_FULL;
-                this.hostStatus[TUBE_ULA_R4] &= ~TUBE_FLAG_DATA_AVAILABLE;
+                this.parasiteStatus[TUBE_ULA_R4] |= TUBE_ULA_FLAG_DATA_REGISTER_NOT_FULL;
+                this.hostStatus[TUBE_ULA_R4] &= ~TUBE_ULA_FLAG_DATA_AVAILABLE;
                 break;
         }
         this.updateInterrupts();
@@ -190,60 +190,60 @@ export class Tube {
         }
         switch (address & 7) {
             case TUBE_ULA_R1_STATUS_ADDRESS:
-                if (value & TUBE_FLAG_STATUS_SET_CONTROL_FLAGS) {
-                    this.internalStatusRegister |= (value & ~(TUBE_FLAG_DATA_AVAILABLE | TUBE_FLAG_DATA_REGISTER_NOT_FULL));
+                if (value & TUBE_ULA_FLAG_STATUS_SET_CONTROL_FLAGS) {
+                    this.internalStatusRegister |= (value & ~(TUBE_ULA_FLAG_DATA_AVAILABLE | TUBE_ULA_FLAG_DATA_REGISTER_NOT_FULL));
                 } else {
-                    this.internalStatusRegister &= ~(value & ~(TUBE_FLAG_DATA_AVAILABLE | TUBE_FLAG_DATA_REGISTER_NOT_FULL));
+                    this.internalStatusRegister &= ~(value & ~(TUBE_ULA_FLAG_DATA_AVAILABLE | TUBE_ULA_FLAG_DATA_REGISTER_NOT_FULL));
                 }
-                if (value & TUBE_FLAG_STATUS_CLEAR_ALL_TUBE_REGISTERS) {
+                if (value & TUBE_ULA_FLAG_STATUS_CLEAR_ALL_TUBE_REGISTERS) {
                     this.reset(false);
                 }
-                if (value & TUBE_FLAG_STATUS_PARASITE_RESET_ACTIVE_LOW) {
+                if (value & TUBE_ULA_FLAG_STATUS_PARASITE_RESET_ACTIVE_LOW) {
                     //  there is still an issue with the parasite OS that runs after this happens
                     //  it prints the startup banner but then seems to stop responding when a R3 data
                     //  transfer (based on Advanced User Guide example) is attempted
-                    if (this.internalStatusRegister & TUBE_FLAG_STATUS_PARASITE_RESET_ACTIVE_LOW) {
+                    if (this.internalStatusRegister & TUBE_ULA_FLAG_STATUS_PARASITE_RESET_ACTIVE_LOW) {
                         this.parasiteCpu.reset(true);   //  this in turn calls our this.reset(true)
                     }
                 }
                 break;
             case TUBE_ULA_R1_DATA_ADDRESS:
-                if (this.hostStatus[TUBE_ULA_R1] & TUBE_FLAG_DATA_REGISTER_NOT_FULL) {
+                if (this.hostStatus[TUBE_ULA_R1] & TUBE_ULA_FLAG_DATA_REGISTER_NOT_FULL) {
                     this.hostToParasiteData[TUBE_ULA_R1][0] = value;
-                    this.parasiteStatus[TUBE_ULA_R1] |= TUBE_FLAG_DATA_AVAILABLE;
-                    this.hostStatus[TUBE_ULA_R1] &= ~TUBE_FLAG_DATA_REGISTER_NOT_FULL;
+                    this.parasiteStatus[TUBE_ULA_R1] |= TUBE_ULA_FLAG_DATA_AVAILABLE;
+                    this.hostStatus[TUBE_ULA_R1] &= ~TUBE_ULA_FLAG_DATA_REGISTER_NOT_FULL;
                 }
                 break;
             case TUBE_ULA_R2_DATA_ADDRESS:
-                if (this.hostStatus[TUBE_ULA_R2] & TUBE_FLAG_DATA_REGISTER_NOT_FULL) {
+                if (this.hostStatus[TUBE_ULA_R2] & TUBE_ULA_FLAG_DATA_REGISTER_NOT_FULL) {
                     this.hostToParasiteData[TUBE_ULA_R2][0] = value;
-                    this.parasiteStatus[TUBE_ULA_R2] |= TUBE_FLAG_DATA_AVAILABLE;
-                    this.hostStatus[TUBE_ULA_R2] &= ~TUBE_FLAG_DATA_REGISTER_NOT_FULL;
+                    this.parasiteStatus[TUBE_ULA_R2] |= TUBE_ULA_FLAG_DATA_AVAILABLE;
+                    this.hostStatus[TUBE_ULA_R2] &= ~TUBE_ULA_FLAG_DATA_REGISTER_NOT_FULL;
                 }
                 break;
             case TUBE_ULA_R3_DATA_ADDRESS:
-                if (this.hostStatus[TUBE_ULA_R3] & TUBE_FLAG_DATA_REGISTER_NOT_FULL) {
-                    if (this.internalStatusRegister & TUBE_FLAG_STATUS_ENABLE_2_BYTE_R3_DATA) {
+                if (this.hostStatus[TUBE_ULA_R3] & TUBE_ULA_FLAG_DATA_REGISTER_NOT_FULL) {
+                    if (this.internalStatusRegister & TUBE_ULA_FLAG_STATUS_ENABLE_2_BYTE_R3_DATA) {
                         if (this.hostToParasiteFifoByteCount3 < 2) {
                             this.hostToParasiteData[this.hostToParasiteFifoByteCount3++] = value;
                         }
                         if (this.hostToParasiteFifoByteCount3 === 2) {
-                            this.parasiteStatus[TUBE_ULA_R3] |= TUBE_FLAG_DATA_AVAILABLE;
-                            this.hostStatus[TUBE_ULA_R3] &= ~TUBE_FLAG_DATA_REGISTER_NOT_FULL;
+                            this.parasiteStatus[TUBE_ULA_R3] |= TUBE_ULA_FLAG_DATA_AVAILABLE;
+                            this.hostStatus[TUBE_ULA_R3] &= ~TUBE_ULA_FLAG_DATA_REGISTER_NOT_FULL;
                         }
                     } else {
                         this.hostToParasiteData[TUBE_ULA_R3][0] = value;
                         this.hostToParasiteFifoByteCount3 = 1;
-                        this.parasiteStatus[TUBE_ULA_R3] |= TUBE_FLAG_DATA_AVAILABLE;
-                        this.hostStatus[TUBE_ULA_R3] &= ~TUBE_FLAG_DATA_REGISTER_NOT_FULL;
+                        this.parasiteStatus[TUBE_ULA_R3] |= TUBE_ULA_FLAG_DATA_AVAILABLE;
+                        this.hostStatus[TUBE_ULA_R3] &= ~TUBE_ULA_FLAG_DATA_REGISTER_NOT_FULL;
                     }
                 }
                 break;
             case TUBE_ULA_R4_DATA_ADDRESS:
-                if (this.hostStatus[TUBE_ULA_R4] & TUBE_FLAG_DATA_REGISTER_NOT_FULL) {
+                if (this.hostStatus[TUBE_ULA_R4] & TUBE_ULA_FLAG_DATA_REGISTER_NOT_FULL) {
                     this.hostToParasiteData[TUBE_ULA_R4][0] = value;
-                    this.parasiteStatus[TUBE_ULA_R4] |= TUBE_FLAG_DATA_AVAILABLE;
-                    this.hostStatus[TUBE_ULA_R4] &= ~TUBE_FLAG_DATA_REGISTER_NOT_FULL;
+                    this.parasiteStatus[TUBE_ULA_R4] |= TUBE_ULA_FLAG_DATA_AVAILABLE;
+                    this.hostStatus[TUBE_ULA_R4] &= ~TUBE_ULA_FLAG_DATA_REGISTER_NOT_FULL;
                 }
                 break;
         }
@@ -257,28 +257,28 @@ export class Tube {
                 break;
             case TUBE_ULA_R1_DATA_ADDRESS:
                 result = this.hostToParasiteData[TUBE_ULA_R1][0];
-                this.hostStatus[TUBE_ULA_R1] |= TUBE_FLAG_DATA_REGISTER_NOT_FULL;
-                this.parasiteStatus[TUBE_ULA_R1] &= ~TUBE_FLAG_DATA_AVAILABLE;
+                this.hostStatus[TUBE_ULA_R1] |= TUBE_ULA_FLAG_DATA_REGISTER_NOT_FULL;
+                this.parasiteStatus[TUBE_ULA_R1] &= ~TUBE_ULA_FLAG_DATA_AVAILABLE;
                 break;
             case TUBE_ULA_R2_STATUS_ADDRESS:
                 result = this.parasiteStatus[TUBE_ULA_R2];
                 break;
             case TUBE_ULA_R2_DATA_ADDRESS:
                 result = this.hostToParasiteData[TUBE_ULA_R2][0];
-                this.hostStatus[TUBE_ULA_R2] |= TUBE_FLAG_DATA_REGISTER_NOT_FULL;
-                this.parasiteStatus[TUBE_ULA_R2] &= ~TUBE_FLAG_DATA_AVAILABLE;
+                this.hostStatus[TUBE_ULA_R2] |= TUBE_ULA_FLAG_DATA_REGISTER_NOT_FULL;
+                this.parasiteStatus[TUBE_ULA_R2] &= ~TUBE_ULA_FLAG_DATA_AVAILABLE;
                 break;
             case TUBE_ULA_R3_STATUS_ADDRESS:
                 result = this.parasiteStatus[TUBE_ULA_R3];
                 break;
             case TUBE_ULA_R3_DATA_ADDRESS:
                 result = this.hostToParasiteData[TUBE_ULA_R3][0];
-                if (this.parasiteStatus[TUBE_ULA_R3] & TUBE_FLAG_DATA_AVAILABLE) {
+                if (this.parasiteStatus[TUBE_ULA_R3] & TUBE_ULA_FLAG_DATA_AVAILABLE) {
                     this.hostToParasiteData[TUBE_ULA_R3][0] = this.hostToParasiteData[TUBE_ULA_R3][1];
                     this.hostToParasiteFifoByteCount3--;
                     if (this.hostToParasiteFifoByteCount3 === 0) {
-                        this.hostStatus[TUBE_ULA_R3] |= TUBE_FLAG_DATA_REGISTER_NOT_FULL;
-                        this.parasiteStatus[TUBE_ULA_R3] &= ~TUBE_FLAG_DATA_AVAILABLE;
+                        this.hostStatus[TUBE_ULA_R3] |= TUBE_ULA_FLAG_DATA_REGISTER_NOT_FULL;
+                        this.parasiteStatus[TUBE_ULA_R3] &= ~TUBE_ULA_FLAG_DATA_AVAILABLE;
                     }
                 }
                 break;
@@ -287,8 +287,8 @@ export class Tube {
                 break;
             case TUBE_ULA_R4_DATA_ADDRESS:
                 result = this.hostToParasiteData[TUBE_ULA_R4][0];
-                this.hostStatus[TUBE_ULA_R4] |= TUBE_FLAG_DATA_REGISTER_NOT_FULL;
-                this.parasiteStatus[TUBE_ULA_R4] &= ~TUBE_FLAG_DATA_AVAILABLE;
+                this.hostStatus[TUBE_ULA_R4] |= TUBE_ULA_FLAG_DATA_REGISTER_NOT_FULL;
+                this.parasiteStatus[TUBE_ULA_R4] &= ~TUBE_ULA_FLAG_DATA_AVAILABLE;
                 break;
         }
         this.updateInterrupts();
@@ -303,44 +303,44 @@ export class Tube {
         }
         switch (address & 7) {
             case TUBE_ULA_R1_DATA_ADDRESS:
-                if (this.parasiteStatus[TUBE_ULA_R1] & TUBE_FLAG_DATA_REGISTER_NOT_FULL) {
+                if (this.parasiteStatus[TUBE_ULA_R1] & TUBE_ULA_FLAG_DATA_REGISTER_NOT_FULL) {
                     this.parasiteToHostData[TUBE_ULA_R1][this.parasiteToHostFifoByteCount1++] = value;
-                    this.hostStatus[TUBE_ULA_R1] |= TUBE_FLAG_DATA_AVAILABLE;
+                    this.hostStatus[TUBE_ULA_R1] |= TUBE_ULA_FLAG_DATA_AVAILABLE;
                     if (this.parasiteToHostFifoByteCount1 === TUBE_ULA_R1_PARASITE_BYTE_COUNT) {
-                        this.parasiteStatus[TUBE_ULA_R1] &= ~TUBE_FLAG_DATA_REGISTER_NOT_FULL;
+                        this.parasiteStatus[TUBE_ULA_R1] &= ~TUBE_ULA_FLAG_DATA_REGISTER_NOT_FULL;
                     }
                 }
                 break;
             case TUBE_ULA_R2_DATA_ADDRESS:
-                if (this.parasiteStatus[TUBE_ULA_R2] & TUBE_FLAG_DATA_REGISTER_NOT_FULL) {
+                if (this.parasiteStatus[TUBE_ULA_R2] & TUBE_ULA_FLAG_DATA_REGISTER_NOT_FULL) {
                     this.parasiteToHostData[TUBE_ULA_R2][0] = value;
-                    this.hostStatus[TUBE_ULA_R2] |= TUBE_FLAG_DATA_AVAILABLE;
-                    this.parasiteStatus[TUBE_ULA_R2] &= ~TUBE_FLAG_DATA_REGISTER_NOT_FULL;
+                    this.hostStatus[TUBE_ULA_R2] |= TUBE_ULA_FLAG_DATA_AVAILABLE;
+                    this.parasiteStatus[TUBE_ULA_R2] &= ~TUBE_ULA_FLAG_DATA_REGISTER_NOT_FULL;
                 }
                 break;
             case TUBE_ULA_R3_DATA_ADDRESS:
-                if (this.parasiteStatus[TUBE_ULA_R3] & TUBE_FLAG_DATA_REGISTER_NOT_FULL) {
-                    if (this.internalStatusRegister & TUBE_FLAG_STATUS_ENABLE_2_BYTE_R3_DATA) {
+                if (this.parasiteStatus[TUBE_ULA_R3] & TUBE_ULA_FLAG_DATA_REGISTER_NOT_FULL) {
+                    if (this.internalStatusRegister & TUBE_ULA_FLAG_STATUS_ENABLE_2_BYTE_R3_DATA) {
                         if (this.parasiteToHostFifoByteCount3 < 2) {
                             this.parasiteToHostData[this.parasiteToHostFifoByteCount3++] = value;
                         }
                         if (this.parasiteToHostFifoByteCount3 === 2) {
-                            this.hostStatus[TUBE_ULA_R3] |= TUBE_FLAG_DATA_AVAILABLE;
-                            this.parasiteStatus[TUBE_ULA_R3] &= ~TUBE_FLAG_DATA_REGISTER_NOT_FULL;
+                            this.hostStatus[TUBE_ULA_R3] |= TUBE_ULA_FLAG_DATA_AVAILABLE;
+                            this.parasiteStatus[TUBE_ULA_R3] &= ~TUBE_ULA_FLAG_DATA_REGISTER_NOT_FULL;
                         }
                     } else {
                         this.parasiteToHostData[0] = value;
                         this.parasiteToHostFifoByteCount3 = 1;
-                        this.hostStatus[TUBE_ULA_R3] |= TUBE_FLAG_DATA_AVAILABLE;
-                        this.parasiteStatus[TUBE_ULA_R3] &= ~TUBE_FLAG_DATA_REGISTER_NOT_FULL;
+                        this.hostStatus[TUBE_ULA_R3] |= TUBE_ULA_FLAG_DATA_AVAILABLE;
+                        this.parasiteStatus[TUBE_ULA_R3] &= ~TUBE_ULA_FLAG_DATA_REGISTER_NOT_FULL;
                     }
                 }
                 break;
             case TUBE_ULA_R4_DATA_ADDRESS:
-                if (this.parasiteStatus[TUBE_ULA_R4] & TUBE_FLAG_DATA_REGISTER_NOT_FULL) {
+                if (this.parasiteStatus[TUBE_ULA_R4] & TUBE_ULA_FLAG_DATA_REGISTER_NOT_FULL) {
                     this.parasiteToHostData[TUBE_ULA_R4][0] = value;
-                    this.hostStatus[TUBE_ULA_R4] |= TUBE_FLAG_DATA_AVAILABLE;
-                    this.parasiteStatus[TUBE_ULA_R4] &= ~TUBE_FLAG_DATA_REGISTER_NOT_FULL;
+                    this.hostStatus[TUBE_ULA_R4] |= TUBE_ULA_FLAG_DATA_AVAILABLE;
+                    this.parasiteStatus[TUBE_ULA_R4] &= ~TUBE_ULA_FLAG_DATA_REGISTER_NOT_FULL;
                 }
                 break;
         }

--- a/tube.js
+++ b/tube.js
@@ -1,231 +1,347 @@
 "use strict";
 import * as utils from "./utils.js";
 
+//  this one should be declared more globally
+const HOST_CPU_FLAG_IRQ_TUBE_ULA = 8;
+
+const TUBE_ULA_R1 = 0;
+const TUBE_ULA_R2 = 1;
+const TUBE_ULA_R3 = 2;
+const TUBE_ULA_R4 = 3;
+const TUBE_ULA_R1_STATUS_ADDRESS = 0;
+const TUBE_ULA_R1_DATA_ADDRESS = 1;
+const TUBE_ULA_R2_STATUS_ADDRESS = 2;
+const TUBE_ULA_R2_DATA_ADDRESS = 3;
+const TUBE_ULA_R3_STATUS_ADDRESS = 4;
+const TUBE_ULA_R3_DATA_ADDRESS = 5;
+const TUBE_ULA_R4_STATUS_ADDRESS = 6;
+const TUBE_ULA_R4_DATA_ADDRESS = 7;
+const TUBE_FLAG_DATA_AVAILABLE = 0x80;
+const TUBE_FLAG_DATA_REGISTER_NOT_FULL = 0x40;
+const TUBE_FLAG_STATUS_Q = 0x01;
+const TUBE_FLAG_STATUS_I = 0x02;
+const TUBE_FLAG_STATUS_J = 0x04;
+const TUBE_FLAG_STATUS_M = 0x08;
+const TUBE_FLAG_STATUS_V = 0x10;
+const TUBE_FLAG_STATUS_P = 0x20;
+const TUBE_FLAG_STATUS_T = 0x40;
+const TUBE_FLAG_STATUS_S = 0x80;
+//  human-readable aliases for the above flags
+const TUBE_FLAG_STATUS_ENABLE_HOST_IRQ_FROM_R4_DATA = TUBE_FLAG_STATUS_Q;
+const TUBE_FLAG_STATUS_ENABLE_PARASITE_IRQ_FROM_R1_DATA = TUBE_FLAG_STATUS_I;
+const TUBE_FLAG_STATUS_ENABLE_PARASITE_IRQ_FROM_R4_DATA = TUBE_FLAG_STATUS_J;
+const TUBE_FLAG_STATUS_ENABLE_PARASITE_NMI_FROM_R3_DATA = TUBE_FLAG_STATUS_M;
+const TUBE_FLAG_STATUS_ENABLE_2_BYTE_R3_DATA = TUBE_FLAG_STATUS_V;
+const TUBE_FLAG_STATUS_PARASITE_RESET_ACTIVE_LOW = TUBE_FLAG_STATUS_P;
+const TUBE_FLAG_STATUS_CLEAR_ALL_TUBE_REGISTERS = TUBE_FLAG_STATUS_T;
+const TUBE_FLAG_STATUS_SET_CONTROL_FLAGS = TUBE_FLAG_STATUS_S;
+const TUBE_ULA_R1_PARASITE_BYTE_COUNT = 24;
+
 export class Tube {
     constructor(hostCpu, parasiteCpu) {
         this.hostCpu = hostCpu;
         this.parasiteCpu = parasiteCpu;
-        this.ph1 = new Uint8Array(24);
-        this.ph2 = 0;
-        this.ph3 = new Uint8Array(2);
-        this.ph4 = 0;
-        this.hp1 = 0;
-        this.hp2 = 0;
-        this.hp3 = new Uint8Array(2);
-        this.hp4 = 0;
-        this.hstat = new Uint8Array(4);
-        this.pstat = new Uint8Array(4);
-        this.r1stat = 0;
-        this.ph1pos = 0;
-        this.ph3pos = 0;
-        this.hp3pos = 0;
+        this.internalStatusRegister = 0;
+        this.hostStatus = new Uint8Array(4);
+        this.parasiteStatus = new Uint8Array(4);
+        this.parasiteToHostData = [
+            new Uint8Array(TUBE_ULA_R1_PARASITE_BYTE_COUNT),
+            new Uint8Array(1),
+            new Uint8Array(2),
+            new Uint8Array(1)
+        ];
+        this.hostToParasiteData = [
+            new Uint8Array(1),
+            new Uint8Array(1),
+            new Uint8Array(2),
+            new Uint8Array(1)
+        ];
+        this.parasiteToHostFifoByteCount1 = 0;
+        this.parasiteToHostFifoByteCount3 = 0;
+        this.hostToParasiteFifoByteCount3 = 0;
         this.debug = false;
     }
+    reset(updateInternalStatusRegister = true) {
+        if (updateInternalStatusRegister) {
+            this.internalStatusRegister = 0;
+        }
+        for (let i = 0; i < 4; i++) {
+            this.hostStatus[i] = TUBE_FLAG_DATA_REGISTER_NOT_FULL;
+            this.parasiteStatus[i] = TUBE_FLAG_DATA_REGISTER_NOT_FULL;
+            if (i == TUBE_ULA_R3) {
+                //  register 3 has one valid but insignificant byte in the parasite to host FIFO (this is to prevent an immediate PNMI state after PRST)
+                this.hostStatus[i] |= TUBE_FLAG_DATA_AVAILABLE;
+                this.parasiteToHostData[i][0] = 0;
+            }
+        }
+        this.parasiteToHostFifoByteCount1 = 0;
+        //  see info in the loop above from Tube Application Note about R3
+        this.parasiteToHostFifoByteCount3 = 1;
+        this.hostToParasiteFifoByteCount3 = 0;
+        this.updateInterrupts();
+    }
     updateInterrupts() {
-        // Host interrupt
-        this.hostCpu.interrupt &= ~8;
-        if (this.r1stat & 0x01 && this.hstat[3] & 0x80) this.hostCpu.interrupt |= 8;
-
-        // Parasite interrupts
-        this.parasiteCpu.interrupt = !!(
-            (this.r1stat & 0x02 && this.pstat[0] & 0x80) ||
-            (this.r1stat & 0x04 && this.pstat[3] & 0x80)
-        );
-
-        const hp3Size = this.r1stat & 0x10 ? 1 : 0;
-        this.parasiteCpu.nmi = !!(this.r1stat & 0x08 && this.hp3pos > hp3Size);
+        //  host IRQ
+        if (
+            (this.hostStatus[TUBE_ULA_R4] & TUBE_FLAG_DATA_AVAILABLE) &&
+            (this.internalStatusRegister & TUBE_FLAG_STATUS_ENABLE_HOST_IRQ_FROM_R4_DATA)
+        ) {
+            this.hostCpu.interrupt |= HOST_CPU_FLAG_IRQ_TUBE_ULA;
+        } else {
+            this.hostCpu.interrupt &= ~HOST_CPU_FLAG_IRQ_TUBE_ULA;
+        }
+        //  parasite IRQ
+        if (
+            (
+                (this.parasiteStatus[TUBE_ULA_R1] & TUBE_FLAG_DATA_AVAILABLE) &&
+                (this.internalStatusRegister & TUBE_FLAG_STATUS_ENABLE_PARASITE_IRQ_FROM_R1_DATA)
+            ) ||
+            (
+                (this.parasiteStatus[TUBE_ULA_R4] & TUBE_FLAG_DATA_AVAILABLE) &&
+                (this.internalStatusRegister & TUBE_FLAG_STATUS_ENABLE_PARASITE_IRQ_FROM_R4_DATA)
+            )
+        ) {
+            this.parasiteCpu.interrupt = true;
+        } else {
+            this.parasiteCpu.interrupt = false;
+        }
+        //  parasite NMI
+        //  (from Tube Application Note)
+        //  either: M = 1, V = 0, 1 or 2 bytes in host to parasite register 3 FIFO or 0 bytes in parasite
+        //  to host register 3 FIFO (this allows single byte transfers across
+        //  register 3)
+        //  or: M = 1, V = 1, 2 bytes in host to parasite register 3 FIFO or 0 bytes in parasite to host
+        //  register 3 FIFO. (this allows two byte transfers across register 3)
+        const r3Size = (this.internalStatusRegister & TUBE_FLAG_STATUS_ENABLE_2_BYTE_R3_DATA) ? 2 : 1;
+        if (
+            (this.internalStatusRegister & TUBE_FLAG_STATUS_ENABLE_PARASITE_NMI_FROM_R3_DATA) &&
+            (
+                (this.hostToParasiteFifoByteCount3 >= r3Size) ||
+                (this.parasiteToHostFifoByteCount3 === 0)
+            )
+        ) {
+            this.parasiteCpu.nmi = true;
+        } else {
+            this.parasiteCpu.nmi = false;
+        }
+        //  parasite CPU RESET held low - not implemented in the CPU - the CPU should be frozen until this signal is released
+        this.parasiteCpu.resetHeldLow = (this.internalStatusRegister & TUBE_FLAG_STATUS_PARASITE_RESET_ACTIVE_LOW);
     }
-    reset() {
-        this.ph1pos = this.hp3pos = 0;
-        this.ph3pos = 1;
-        this.r1stat = 0;
-        this.hstat[0] = this.hstat[1] = this.hstat[3] = 0x40;
-        this.hstat[2] = 0xc0;
-
-        this.pstat[0] = 0x40;
-        this.pstat[1] = this.pstat[2] = this.pstat[3] = 0x7f;
-        this.updateInterrupts();
-    }
-    hostRead(addr) {
+    hostRead(address) {
         let result = 0xfe;
-        switch (addr & 7) {
-            case 0:
-                result = (this.hstat[0] & 0xc0) | this.r1stat;
+        switch (address & 7) {
+            case TUBE_ULA_R1_STATUS_ADDRESS:
+                result = (this.hostStatus[TUBE_ULA_R1] & (TUBE_FLAG_DATA_AVAILABLE | TUBE_FLAG_DATA_REGISTER_NOT_FULL)) |
+                    (this.internalStatusRegister & ~(TUBE_FLAG_DATA_AVAILABLE | TUBE_FLAG_DATA_REGISTER_NOT_FULL));
                 break;
-            case 1:
-                result = this.ph1[0];
-                for (let i = 0; i < 23; ++i) this.ph1[i] = this.ph1[i + 1];
-                this.pstat[0] |= 0x40;
-                if (!--this.ph1pos) {
-                    this.hstat[0] &= ~0x80;
+            case TUBE_ULA_R1_DATA_ADDRESS:
+                result = this.parasiteToHostData[TUBE_ULA_R1][0];
+                if (this.hostStatus[TUBE_ULA_R1] & TUBE_FLAG_DATA_AVAILABLE) {
+                    for (let i = 1; i < TUBE_ULA_R1_PARASITE_BYTE_COUNT; i++) {
+                        this.parasiteToHostData[TUBE_ULA_R1][i - 1] = this.parasiteToHostData[TUBE_ULA_R1][i];
+                    }
+                    this.parasiteStatus[TUBE_ULA_R1] |= TUBE_FLAG_DATA_REGISTER_NOT_FULL;
+                    this.parasiteToHostFifoByteCount1--;
+                    if (this.parasiteToHostFifoByteCount1 === 0) {
+                        this.hostStatus[TUBE_ULA_R1] &= ~TUBE_FLAG_DATA_AVAILABLE;
+                    }
                 }
                 break;
-            case 2:
-                result = this.hstat[1];
+            case TUBE_ULA_R2_STATUS_ADDRESS:
+                result = this.hostStatus[TUBE_ULA_R2];
                 break;
-            case 3:
-                result = this.ph2;
-                if (this.hstat[1] & 0x80) {
-                    this.hstat[1] &= ~0x80;
-                    this.pstat[1] |= 0x40;
+            case TUBE_ULA_R2_DATA_ADDRESS:
+                result = this.parasiteToHostData[TUBE_ULA_R2][0];
+                this.parasiteStatus[TUBE_ULA_R2] |= TUBE_FLAG_DATA_REGISTER_NOT_FULL;
+                this.hostStatus[TUBE_ULA_R2] &= ~TUBE_FLAG_DATA_AVAILABLE;
+                break;
+            case TUBE_ULA_R3_STATUS_ADDRESS:
+                result = this.hostStatus[TUBE_ULA_R3];
+                break;
+            case TUBE_ULA_R3_DATA_ADDRESS:
+                result = this.parasiteToHostData[TUBE_ULA_R3][0];
+                if (this.hostStatus[TUBE_ULA_R3] & TUBE_FLAG_DATA_AVAILABLE) {
+                    this.parasiteToHostData[TUBE_ULA_R3][0] = this.parasiteToHostData[TUBE_ULA_R3][1];
+                    this.parasiteStatus[TUBE_ULA_R3] |= TUBE_FLAG_DATA_REGISTER_NOT_FULL;
+                    this.parasiteToHostFifoByteCount3--;
+                    if (this.parasiteToHostFifoByteCount3 === 0) {
+                        this.hostStatus[TUBE_ULA_R3] &= ~TUBE_FLAG_DATA_AVAILABLE;
+                    }
                 }
                 break;
-            case 4:
-                result = this.hstat[2];
+            case TUBE_ULA_R4_STATUS_ADDRESS:
+                result = this.hostStatus[TUBE_ULA_R4];
                 break;
-            case 5:
-                result = this.ph3[0];
-                if (this.ph3pos > 0) {
-                    this.ph3[0] = this.ph3[1];
-                    this.pstat[2] |= 0xc0;
-                    if (!--this.ph3pos) this.hstat[2] &= ~0x80;
-                }
-                break;
-            case 6:
-                result = this.hstat[3];
-                break;
-            case 7:
-                result = this.ph4;
-                if (this.hstat[3] & 0x80) {
-                    this.hstat[3] &= ~0x80;
-                    this.pstat[3] |= 0x40;
-                }
+            case TUBE_ULA_R4_DATA_ADDRESS:
+                result = this.parasiteToHostData[TUBE_ULA_R4][0];
+                this.parasiteStatus[TUBE_ULA_R4] |= TUBE_FLAG_DATA_REGISTER_NOT_FULL;
+                this.hostStatus[TUBE_ULA_R4] &= ~TUBE_FLAG_DATA_AVAILABLE;
                 break;
         }
         this.updateInterrupts();
-        if (this.debug) console.log("host read " + utils.hexword(addr) + " = " + utils.hexbyte(result));
+        if (this.debug) {
+            console.log("TUBE ULA: host read " + utils.hexword(address) + " = " + utils.hexbyte(result));
+        }
         return result;
     }
-    hostWrite(addr, b) {
-        if (this.debug) console.log("host write " + utils.hexword(addr) + " = " + utils.hexbyte(b));
-        switch (addr & 7) {
-            case 0:
-                if (b & 0x80) {
-                    this.r1stat |= b & 0x3f;
-                } else if (this.r1stat & 0x20) {
-                    this.reset();
-                    this.parasiteCpu.reset();
+    hostWrite(address, value) {
+        if (this.debug) {
+            console.log("TUBE ULA: host write " + utils.hexword(address) + " = " + utils.hexbyte(value));
+        }
+        switch (address & 7) {
+            case TUBE_ULA_R1_STATUS_ADDRESS:
+                if (value & TUBE_FLAG_STATUS_SET_CONTROL_FLAGS) {
+                    this.internalStatusRegister |= (value & ~(TUBE_FLAG_DATA_AVAILABLE | TUBE_FLAG_DATA_REGISTER_NOT_FULL));
                 } else {
-                    this.r1stat &= ~(b & 0x3f);
+                    this.internalStatusRegister &= ~(value & ~(TUBE_FLAG_DATA_AVAILABLE | TUBE_FLAG_DATA_REGISTER_NOT_FULL));
                 }
-                this.hstat[0] = (this.hstat[0] & 0xc0) | (b & 0x3f);
-                break;
-            case 1:
-                this.hp1 = b;
-                this.pstat[0] |= 0x80;
-                this.hstat[0] &= ~0x40;
-                break;
-            case 3:
-                this.hp2 = b;
-                this.pstat[1] |= 0x80;
-                this.hstat[1] &= ~0x40;
-                break;
-            case 5:
-                if (this.r1stat & 0x10) {
-                    if (this.hp3pos < 2) this.hp3[this.hp3pos++] = b;
-                    if (this.hp3pos === 2) {
-                        this.pstat[2] |= 0x80;
-                        this.hstat[2] &= ~0x40;
+                if (value & TUBE_FLAG_STATUS_CLEAR_ALL_TUBE_REGISTERS) {
+                    this.reset(false);
+                }
+                if (value & TUBE_FLAG_STATUS_PARASITE_RESET_ACTIVE_LOW) {
+                    //  there is still an issue with the parasite OS that runs after this happens
+                    //  it prints the startup banner but then seems to stop responding when a R3 data
+                    //  transfer (based on Advanced User Guide example) is attempted
+                    if (this.internalStatusRegister & TUBE_FLAG_STATUS_PARASITE_RESET_ACTIVE_LOW) {
+                        this.parasiteCpu.reset(true);   //  this in turn calls our this.reset(true)
                     }
-                } else {
-                    this.hp3[0] = b;
-                    this.hp3pos = 1;
-                    this.pstat[2] |= 0x80;
-                    this.hstat[2] &= ~0x40;
                 }
                 break;
-            case 7:
-                this.hp4 = b;
-                this.pstat[3] |= 0x80;
-                this.hstat[3] &= ~0x40;
+            case TUBE_ULA_R1_DATA_ADDRESS:
+                if (this.hostStatus[TUBE_ULA_R1] & TUBE_FLAG_DATA_REGISTER_NOT_FULL) {
+                    this.hostToParasiteData[TUBE_ULA_R1][0] = value;
+                    this.parasiteStatus[TUBE_ULA_R1] |= TUBE_FLAG_DATA_AVAILABLE;
+                    this.hostStatus[TUBE_ULA_R1] &= ~TUBE_FLAG_DATA_REGISTER_NOT_FULL;
+                }
+                break;
+            case TUBE_ULA_R2_DATA_ADDRESS:
+                if (this.hostStatus[TUBE_ULA_R2] & TUBE_FLAG_DATA_REGISTER_NOT_FULL) {
+                    this.hostToParasiteData[TUBE_ULA_R2][0] = value;
+                    this.parasiteStatus[TUBE_ULA_R2] |= TUBE_FLAG_DATA_AVAILABLE;
+                    this.hostStatus[TUBE_ULA_R2] &= ~TUBE_FLAG_DATA_REGISTER_NOT_FULL;
+                }
+                break;
+            case TUBE_ULA_R3_DATA_ADDRESS:
+                if (this.hostStatus[TUBE_ULA_R3] & TUBE_FLAG_DATA_REGISTER_NOT_FULL) {
+                    if (this.internalStatusRegister & TUBE_FLAG_STATUS_ENABLE_2_BYTE_R3_DATA) {
+                        if (this.hostToParasiteFifoByteCount3 < 2) {
+                            this.hostToParasiteData[this.hostToParasiteFifoByteCount3++] = value;
+                        }
+                        if (this.hostToParasiteFifoByteCount3 === 2) {
+                            this.parasiteStatus[TUBE_ULA_R3] |= TUBE_FLAG_DATA_AVAILABLE;
+                            this.hostStatus[TUBE_ULA_R3] &= ~TUBE_FLAG_DATA_REGISTER_NOT_FULL;
+                        }
+                    } else {
+                        this.hostToParasiteData[TUBE_ULA_R3][0] = value;
+                        this.hostToParasiteFifoByteCount3 = 1;
+                        this.parasiteStatus[TUBE_ULA_R3] |= TUBE_FLAG_DATA_AVAILABLE;
+                        this.hostStatus[TUBE_ULA_R3] &= ~TUBE_FLAG_DATA_REGISTER_NOT_FULL;
+                    }
+                }
+                break;
+            case TUBE_ULA_R4_DATA_ADDRESS:
+                if (this.hostStatus[TUBE_ULA_R4] & TUBE_FLAG_DATA_REGISTER_NOT_FULL) {
+                    this.hostToParasiteData[TUBE_ULA_R4][0] = value;
+                    this.parasiteStatus[TUBE_ULA_R4] |= TUBE_FLAG_DATA_AVAILABLE;
+                    this.hostStatus[TUBE_ULA_R4] &= ~TUBE_FLAG_DATA_REGISTER_NOT_FULL;
+                }
                 break;
         }
         this.updateInterrupts();
     }
-    parasiteRead(addr) {
+    parasiteRead(address) {
         let result = 0;
-        switch (addr & 7) {
-            case 0: // Stat
-                result = this.pstat[0] | this.r1stat;
+        switch (address & 7) {
+            case TUBE_ULA_R1_STATUS_ADDRESS:
+                result = this.parasiteStatus[TUBE_ULA_R1];
                 break;
-            case 1:
-                result = this.hp1;
-                if (this.pstat[0] & 0x80) {
-                    this.pstat[0] &= ~0x80;
-                    this.hstat[0] |= 0x40;
-                }
+            case TUBE_ULA_R1_DATA_ADDRESS:
+                result = this.hostToParasiteData[TUBE_ULA_R1][0];
+                this.hostStatus[TUBE_ULA_R1] |= TUBE_FLAG_DATA_REGISTER_NOT_FULL;
+                this.parasiteStatus[TUBE_ULA_R1] &= ~TUBE_FLAG_DATA_AVAILABLE;
                 break;
-            case 2:
-                result = this.pstat[1];
+            case TUBE_ULA_R2_STATUS_ADDRESS:
+                result = this.parasiteStatus[TUBE_ULA_R2];
                 break;
-            case 3:
-                result = this.hp2;
-                if (this.pstat[1] & 0x80) {
-                    this.pstat[1] &= ~0x80;
-                    this.hstat[1] |= 0x40;
-                }
+            case TUBE_ULA_R2_DATA_ADDRESS:
+                result = this.hostToParasiteData[TUBE_ULA_R2][0];
+                this.hostStatus[TUBE_ULA_R2] |= TUBE_FLAG_DATA_REGISTER_NOT_FULL;
+                this.parasiteStatus[TUBE_ULA_R2] &= ~TUBE_FLAG_DATA_AVAILABLE;
                 break;
-            case 4:
-                result = this.pstat[2];
+            case TUBE_ULA_R3_STATUS_ADDRESS:
+                result = this.parasiteStatus[TUBE_ULA_R3];
                 break;
-            case 5:
-                result = this.hp3[0];
-                if (this.hp3pos > 0) {
-                    this.hp3[0] = this.hp3[1];
-                    if (!--this.hp3pos) {
-                        this.pstat[2] &= ~0x80;
-                        this.hstat[2] |= 0x40;
+            case TUBE_ULA_R3_DATA_ADDRESS:
+                result = this.hostToParasiteData[TUBE_ULA_R3][0];
+                if (this.parasiteStatus[TUBE_ULA_R3] & TUBE_FLAG_DATA_AVAILABLE) {
+                    this.hostToParasiteData[TUBE_ULA_R3][0] = this.hostToParasiteData[TUBE_ULA_R3][1];
+                    this.hostToParasiteFifoByteCount3--;
+                    if (this.hostToParasiteFifoByteCount3 === 0) {
+                        this.hostStatus[TUBE_ULA_R3] |= TUBE_FLAG_DATA_REGISTER_NOT_FULL;
+                        this.parasiteStatus[TUBE_ULA_R3] &= ~TUBE_FLAG_DATA_AVAILABLE;
                     }
                 }
                 break;
-            case 6:
-                result = this.pstat[3];
+            case TUBE_ULA_R4_STATUS_ADDRESS:
+                result = this.parasiteStatus[TUBE_ULA_R4];
                 break;
-            case 7:
-                result = this.hp4;
-                if (this.pstat[3] & 0x80) {
-                    this.pstat[3] &= ~0x80;
-                    this.hstat[3] |= 0x40;
-                }
+            case TUBE_ULA_R4_DATA_ADDRESS:
+                result = this.hostToParasiteData[TUBE_ULA_R4][0];
+                this.hostStatus[TUBE_ULA_R4] |= TUBE_FLAG_DATA_REGISTER_NOT_FULL;
+                this.parasiteStatus[TUBE_ULA_R4] &= ~TUBE_FLAG_DATA_AVAILABLE;
                 break;
         }
         this.updateInterrupts();
-        if (this.debug) console.log("parasite read " + utils.hexword(addr) + " = " + utils.hexbyte(result));
+        if (this.debug) {
+            console.log("TUBE ULA: parasite read " + utils.hexword(address) + " = " + utils.hexbyte(result));
+        }
         return result;
     }
-    parasiteWrite(addr, b) {
-        if (this.debug) console.log("parasite write " + utils.hexword(addr) + " = " + utils.hexbyte(b));
-        switch (addr & 7) {
-            case 1:
-                if (this.ph1pos < 24) {
-                    this.ph1[this.ph1pos++] = b;
-                    this.hstat[0] |= 0x80;
-                    if (this.ph1pos === 24) this.pstat[0] &= ~0x40;
-                }
-                break;
-            case 3:
-                this.ph2 = b;
-                this.hstat[1] |= 0x80;
-                this.pstat[1] &= ~0x40;
-                break;
-            case 5:
-                if (this.r1stat & 0x10) {
-                    if (this.ph3pos < 2) this.ph3[this.ph3pos++] = b;
-                    if (this.ph3pos === 2) {
-                        this.hstat[2] |= 0x80;
-                        this.pstat[2] &= ~0x40;
+    parasiteWrite(address, value) {
+        if (this.debug) {
+            console.log("TUBE ULA: parasite write " + utils.hexword(address) + " = " + utils.hexbyte(value));
+        }
+        switch (address & 7) {
+            case TUBE_ULA_R1_DATA_ADDRESS:
+                if (this.parasiteStatus[TUBE_ULA_R1] & TUBE_FLAG_DATA_REGISTER_NOT_FULL) {
+                    this.parasiteToHostData[TUBE_ULA_R1][this.parasiteToHostFifoByteCount1++] = value;
+                    this.hostStatus[TUBE_ULA_R1] |= TUBE_FLAG_DATA_AVAILABLE;
+                    if (this.parasiteToHostFifoByteCount1 === TUBE_ULA_R1_PARASITE_BYTE_COUNT) {
+                        this.parasiteStatus[TUBE_ULA_R1] &= ~TUBE_FLAG_DATA_REGISTER_NOT_FULL;
                     }
-                } else {
-                    this.ph3[0] = b;
-                    this.ph3pos = 1;
-                    this.hstat[2] |= 0x80;
-                    this.pstat[2] &= ~0x40;
                 }
                 break;
-            case 7:
-                this.ph4 = b;
-                this.hstat[3] |= 0x80;
-                this.pstat[3] &= ~0x40;
+            case TUBE_ULA_R2_DATA_ADDRESS:
+                if (this.parasiteStatus[TUBE_ULA_R2] & TUBE_FLAG_DATA_REGISTER_NOT_FULL) {
+                    this.parasiteToHostData[TUBE_ULA_R2][0] = value;
+                    this.hostStatus[TUBE_ULA_R2] |= TUBE_FLAG_DATA_AVAILABLE;
+                    this.parasiteStatus[TUBE_ULA_R2] &= ~TUBE_FLAG_DATA_REGISTER_NOT_FULL;
+                }
+                break;
+            case TUBE_ULA_R3_DATA_ADDRESS:
+                if (this.parasiteStatus[TUBE_ULA_R3] & TUBE_FLAG_DATA_REGISTER_NOT_FULL) {
+                    if (this.internalStatusRegister & TUBE_FLAG_STATUS_ENABLE_2_BYTE_R3_DATA) {
+                        if (this.parasiteToHostFifoByteCount3 < 2) {
+                            this.parasiteToHostData[this.parasiteToHostFifoByteCount3++] = value;
+                        }
+                        if (this.parasiteToHostFifoByteCount3 === 2) {
+                            this.hostStatus[TUBE_ULA_R3] |= TUBE_FLAG_DATA_AVAILABLE;
+                            this.parasiteStatus[TUBE_ULA_R3] &= ~TUBE_FLAG_DATA_REGISTER_NOT_FULL;
+                        }
+                    } else {
+                        this.parasiteToHostData[0] = value;
+                        this.parasiteToHostFifoByteCount3 = 1;
+                        this.hostStatus[TUBE_ULA_R3] |= TUBE_FLAG_DATA_AVAILABLE;
+                        this.parasiteStatus[TUBE_ULA_R3] &= ~TUBE_FLAG_DATA_REGISTER_NOT_FULL;
+                    }
+                }
+                break;
+            case TUBE_ULA_R4_DATA_ADDRESS:
+                if (this.parasiteStatus[TUBE_ULA_R4] & TUBE_FLAG_DATA_REGISTER_NOT_FULL) {
+                    this.parasiteToHostData[TUBE_ULA_R4][0] = value;
+                    this.hostStatus[TUBE_ULA_R4] |= TUBE_FLAG_DATA_AVAILABLE;
+                    this.parasiteStatus[TUBE_ULA_R4] &= ~TUBE_FLAG_DATA_REGISTER_NOT_FULL;
+                }
                 break;
         }
         this.updateInterrupts();


### PR DESCRIPTION
Hello.

I've updated the Tube ULA implementation again.

It's now much more readable, making it easier to understand, and (hopefully never have to, but...) work out what's going on if it turns out I've missed something.

Added the functionality for two bits when writing to the R1 status register.

Re-added the incorrectly removed check for parasite to host R3 being empty when deciding whether a parasite NMI should be asserted.

Adjusted a few bits of logic as well to match observed behaviour on real hardware, and information in the Tube Application Note.

Please let me know your thoughts.

:)