### PR TITLE
Fix SSD loading

### DIFF
--- a/disc.js
+++ b/disc.js
@@ -538,8 +538,6 @@ export function loadSsd(disc, data, isDsd, onChange) {
 
     let offset = 0;
     for (let track = 0; track < SsdFormat.tracksPerDisc; ++track) {
-        if (offset >= data.length) break;
-
         for (let side = 0; side < numSides; ++side) {
             const trackBuilder = disc.buildTrack(side === 1, track);
             // Sync pattern at start of track, as the index pulse starts, aka GAP 5.

--- a/tests/unit/test-disc.js
+++ b/tests/unit/test-disc.js
@@ -181,7 +181,7 @@ describe("SSD loader tests", function () {
     it("should load Elite", () => {
         const disc = new Disc(true, new DiscConfig(), "test.ssd");
         loadSsd(disc, data, false);
-        assert.equal(disc.tracksUsed, 46);
+        assert.equal(disc.tracksUsed, 80);
     });
     it("should roundtrip Elite", () => {
         const disc = new Disc(true, new DiscConfig(), "test.ssd");


### PR DESCRIPTION
Don't stop "formatting" tracks beyond the end of the SSD; else we leave unformatted blank space into which we can't save or do anything useful. Closes #428