### PR TITLE
Add tests to ensure submodules are present and fail with a more explicit error message if not

### DIFF
--- a/tests/integration/ensure-submodules.js
+++ b/tests/integration/ensure-submodules.js
@@ -1,0 +1,21 @@
+import { describe, it } from "vitest";
+import assert from "assert";
+import * as fs from "fs";
+
+describe("ensure git submodules are present", function () {
+    it("should have functional tests", function () {
+        try {
+            fs.accessSync("tests/6502_65C02_functional_tests/README.md");
+        } catch {
+            assert.fail("Functional tests submodule missing. Ensure git submodules are fetched.");
+        }
+    });
+
+    it("should have timing tests", function () {
+        try {
+            fs.accessSync("tests/integration/dp111_6502Timing/README.md");
+        } catch {
+            assert.fail("Timing tests submodule missing. Ensure git submodules are fetched.");
+        }
+    });
+});


### PR DESCRIPTION
See #461 