### PR TITLE
Add BaseDiscDrive interface for disc drive abstraction

### DIFF
--- a/src/disc-drive.js
+++ b/src/disc-drive.js
@@ -12,7 +12,127 @@ class StepEvent extends Event {
     }
 }
 
-export class DiscDrive extends EventTarget {
+/**
+ * Abstract base class defining the interface for disc drives.
+ * All disc drive implementations must extend this class.
+ */
+export class BaseDiscDrive extends EventTarget {
+    /** @returns {Disc|undefined} */
+    get disc() {
+        throw new Error("Not implemented: disc getter");
+    }
+
+    /** @returns {number} */
+    get track() {
+        throw new Error("Not implemented: track getter");
+    }
+
+    /** @returns {number} */
+    get headPosition() {
+        throw new Error("Not implemented: headPosition getter");
+    }
+
+    /** @returns {boolean} */
+    get indexPulse() {
+        throw new Error("Not implemented: indexPulse getter");
+    }
+
+    /** @returns {boolean} */
+    get spinning() {
+        throw new Error("Not implemented: spinning getter");
+    }
+
+    /** @returns {boolean} */
+    get writeProtect() {
+        throw new Error("Not implemented: writeProtect getter");
+    }
+
+    /** @returns {number} */
+    get trackLength() {
+        throw new Error("Not implemented: trackLength getter");
+    }
+
+    /** @returns {number} */
+    get positionFraction() {
+        throw new Error("Not implemented: positionFraction getter");
+    }
+
+    /** @returns {number} */
+    get positionTime() {
+        throw new Error("Not implemented: positionTime getter");
+    }
+
+    /**
+     * @param {Disc|undefined} disc
+     */
+    setDisc() {
+        throw new Error("Not implemented: setDisc");
+    }
+
+    /**
+     * @param {function(number, number): void} callback
+     */
+    setPulsesCallback() {
+        throw new Error("Not implemented: setPulsesCallback");
+    }
+
+    startSpinning() {
+        throw new Error("Not implemented: startSpinning");
+    }
+
+    stopSpinning() {
+        throw new Error("Not implemented: stopSpinning");
+    }
+
+    /**
+     * @param {boolean} isSideUpper
+     */
+    selectSide() {
+        throw new Error("Not implemented: selectSide");
+    }
+
+    /**
+     * @param {number} delta
+     */
+    seekOneTrack() {
+        throw new Error("Not implemented: seekOneTrack");
+    }
+
+    /**
+     * @param {number} newTrack
+     */
+    notifySeek() {
+        throw new Error("Not implemented: notifySeek");
+    }
+
+    /**
+     * @param {number} delta
+     */
+    notifySeekAmount() {
+        throw new Error("Not implemented: notifySeekAmount");
+    }
+
+    /**
+     * @param {boolean} isDoubleDensity
+     */
+    set32usMode() {
+        throw new Error("Not implemented: set32usMode");
+    }
+
+    /**
+     * @param {number} pulses
+     */
+    writePulses() {
+        throw new Error("Not implemented: writePulses");
+    }
+
+    /** @returns {number} */
+    getQuasiRandomPulses() {
+        throw new Error("Not implemented: getQuasiRandomPulses");
+    }
+}
+
+export class DiscDrive extends BaseDiscDrive {
     static get TicksPerRevolution() {
         // 300 rpm
         return 400000;

--- a/src/disc-drive.js
+++ b/src/disc-drive.js
@@ -63,16 +63,18 @@ export class BaseDiscDrive extends EventTarget {
     }
 
     /**
-     * @param {Disc|undefined} disc
+     * @param {Disc|undefined} _disc
      */
-    setDisc() {
+    // eslint-disable-next-line no-unused-vars
+    setDisc(_disc) {
         throw new Error("Not implemented: setDisc");
     }
 
     /**
-     * @param {function(number, number): void} callback
+     * @param {function(number, number): void} _callback
      */
-    setPulsesCallback() {
+    // eslint-disable-next-line no-unused-vars
+    setPulsesCallback(_callback) {
         throw new Error("Not implemented: setPulsesCallback");
     }
 
@@ -85,44 +87,50 @@ export class BaseDiscDrive extends EventTarget {
     }
 
     /**
-     * @param {boolean} isSideUpper
+     * @param {boolean} _isSideUpper
      */
-    selectSide() {
+    // eslint-disable-next-line no-unused-vars
+    selectSide(_isSideUpper) {
         throw new Error("Not implemented: selectSide");
     }
 
     /**
-     * @param {number} delta
+     * @param {number} _delta
      */
-    seekOneTrack() {
+    // eslint-disable-next-line no-unused-vars
+    seekOneTrack(_delta) {
         throw new Error("Not implemented: seekOneTrack");
     }
 
     /**
-     * @param {number} newTrack
+     * @param {number} _newTrack
      */
-    notifySeek() {
+    // eslint-disable-next-line no-unused-vars
+    notifySeek(_newTrack) {
         throw new Error("Not implemented: notifySeek");
     }
 
     /**
-     * @param {number} delta
+     * @param {number} _delta
      */
-    notifySeekAmount() {
+    // eslint-disable-next-line no-unused-vars
+    notifySeekAmount(_delta) {
         throw new Error("Not implemented: notifySeekAmount");
     }
 
     /**
-     * @param {boolean} isDoubleDensity
+     * @param {boolean} _isDoubleDensity
      */
-    set32usMode() {
+    // eslint-disable-next-line no-unused-vars
+    set32usMode(_isDoubleDensity) {
         throw new Error("Not implemented: set32usMode");
     }
 
     /**
-     * @param {number} pulses
+     * @param {number} _pulses
      */
-    writePulses() {
+    // eslint-disable-next-line no-unused-vars
+    writePulses(_pulses) {
         throw new Error("Not implemented: writePulses");
     }
 

--- a/src/intel-fdc.js
+++ b/src/intel-fdc.js
@@ -5,7 +5,8 @@ import { Cpu6502 } from "./6502.js";
 // eslint-disable-next-line no-unused-vars
 import { Disc, IbmDiscFormat } from "./disc.js";
 
-import { DiscDrive } from "./disc-drive.js";
+// eslint-disable-next-line no-unused-vars
+import { BaseDiscDrive, DiscDrive } from "./disc-drive.js";
 // eslint-disable-next-line no-unused-vars
 import { Scheduler } from "./scheduler.js";
 import * as utils from "./utils.js";
@@ -285,14 +286,14 @@ export class IntelFdc {
     /**
      * @param {Cpu6502} cpu
      * @param {Scheduler} scheduler
-     * @param {DiscDrive[] | undefined} drives
+     * @param {BaseDiscDrive[] | undefined} drives
      * @param {*} debugFlags
      */
     constructor(cpu, scheduler, drives, debugFlags) {
         this._cpu = cpu;
         if (drives) this._drives = drives;
         else this._drives = [new DiscDrive(0, scheduler), new DiscDrive(1, scheduler)];
-        /** @type {DiscDrive} */
+        /** @type {BaseDiscDrive} */
         this._currentDrive = null;
 
         this._paramCallback = ParamAccept.none;

--- a/src/wd-fdc.js
+++ b/src/wd-fdc.js
@@ -2,7 +2,8 @@
 // https://github.com/scarybeasts/beebjit
 // eslint-disable-next-line no-unused-vars
 import { Cpu6502 } from "./6502.js";
-import { DiscDrive } from "./disc-drive.js";
+// eslint-disable-next-line no-unused-vars
+import { BaseDiscDrive, DiscDrive } from "./disc-drive.js";
 import { IbmDiscFormat } from "./disc.js";
 // eslint-disable-next-line no-unused-vars
 import { Scheduler } from "./scheduler.js";
@@ -126,7 +127,7 @@ export class WdFdc {
     /**
      * @param {Cpu6502} cpu
      * @param {Scheduler} scheduler
-     * @param {DiscDrive[] | undefined} drives
+     * @param {BaseDiscDrive[] | undefined} drives
      * @param {*} debugFlags
      */
     constructor(cpu, scheduler, drives, debugFlags) {
@@ -148,7 +149,7 @@ export class WdFdc {
         this._isDrq = false;
         this._doRaiseIntRq = false;
 
-        /** @type {DiscDrive|null} */
+        /** @type {BaseDiscDrive|null} */
         this._currentDrive = null;
         this._isIndexPulse = false;
         this._isInterruptOnIndexPulse = false;


### PR DESCRIPTION
## Summary
- Introduce abstract base class to define the disc drive interface
- Enable support for different disc drive implementations
- Maintain backwards compatibility with existing FDC code

## Changes
1. Added `BaseDiscDrive` abstract class with all required methods that throw "Not implemented" errors
2. Refactored `DiscDrive` to extend `BaseDiscDrive`
3. Updated FDC constructors to accept arrays of `BaseDiscDrive` instances
4. Fixed linting issues related to unused parameters in base class

## Test plan
- [x] All existing unit tests pass
- [x] ESLint passes without errors
- [x] No functional changes to existing code
- [ ] Manual testing with emulator (if needed)

🤖 Generated with [Claude Code](https://claude.ai/code)