### PR TITLE
Add 'Download drive 0 image as HFE' option

### DIFF
--- a/index.html
+++ b/index.html
@@ -85,6 +85,11 @@
                     >Download drive 0 image as SSD/DSD</a
                   >
                 </li>
+                <li>
+                  <a href="#download-drive-hfe" class="dropdown-item" id="download-drive-hfe-link"
+                    >Download drive 0 image as HFE</a
+                  >
+                </li>
               </ul>
             </li>
             <li class="nav-item dropdown embed-hide">


### PR DESCRIPTION
## Summary
- Add new UI option to download disc images in HFE format
- Create reusable download function to handle common functionality 
- Refactor existing download handlers for better maintainability

## Test plan
- Verify that the new menu option appears correctly
- Test downloading a disc image in HFE format
- Verify that the HFE file can be loaded in HxC Floppy Emulator
- Confirm that existing download functionality works as before

🤖 Generated with [Claude Code](https://claude.ai/code)