### PR TITLE
Fix hardware scrolling lookup table bug from PR #522

### DIFF
--- a/src/video.js
+++ b/src/video.js
@@ -153,7 +153,7 @@ export class Video {
                 0xff000000, 0xff0000ff, 0xff00ff00, 0xff00ffff, 0xffff0000, 0xffff00ff, 0xffffff00, 0xffffffff,
             ]),
         );
-        this.screenAddrSubtract = new Uint8Array([8, 10, 4, 5]);
+        this.screenAddrSubtract = new Uint8Array([8, 4, 10, 5]);
         this.cursorTable = new Uint8Array([0x00, 0x00, 0x00, 0x80, 0x40, 0x20, 0x20]);
         this.cursorFlashMask = new Uint8Array([0x00, 0x00, 0x08, 0x10]);
         this.regs = new Uint8Array(32);

--- a/tests/unit/test-video.js
+++ b/tests/unit/test-video.js
@@ -285,4 +285,51 @@ describe("Video", () => {
             expect(mockTeletext.render).not.toHaveBeenCalled();
         });
     });
+
+    describe("Hardware scrolling address translation", () => {
+        beforeEach(() => {
+            // Set up for graphics mode (non-teletext)
+            video.ula.write(0, 0);
+            video.addr = 0x1000; // Set MA12 to trigger translation
+            video.scanlineCounter = 0;
+        });
+
+        it("should apply mode 0-2 scroll offset (subtract 10)", () => {
+            video.setScreenHwScroll(2); // C1=1, C0=0 -> MODE 0-2, subtract 0x5000 (10 from MA11-MA8)
+            mockCpu.videoRead.mockReturnValue(0x42);
+
+            const result = video.readVideoMem();
+
+            // MA=0x1000: MA12=1 (trigger), MA11-MA8=0x0, MA7-MA0=0x00
+            // adjustedHigh = (0x0 - 10) & 0x0f = 0x6
+            // Expected: ((0x6 << 11) | (0x00 << 3) | 0x0) = 0x3000
+            // Matches beebjit: (0x1000 * 8) - 0x5000 = 0x8000 - 0x5000 = 0x3000
+            expect(mockCpu.videoRead).toHaveBeenCalledWith(0x3000);
+            expect(result).toBe(0x42);
+        });
+
+        it("should not affect addresses when MA12 is clear", () => {
+            video.setScreenHwScroll(2);
+            video.addr = 0x0500; // MA12 clear
+
+            video.readVideoMem();
+
+            // No translation: ((0x5 << 11) | (0x00 << 3) | 0x0) = 0x2800
+            expect(mockCpu.videoRead).toHaveBeenCalledWith(0x2800);
+        });
+
+        it("should handle scanlineCounter offset correctly", () => {
+            video.setScreenHwScroll(0); // C1=0, C0=0 -> MODE 3, subtract 0x4000 (8 from MA11-MA8)
+            video.addr = 0x1000;
+            video.scanlineCounter = 5; // RA = 5
+
+            video.readVideoMem();
+
+            // MA=0x1000: MA12=1 (trigger), MA11-MA8=0x0, MA7-MA0=0x00, RA=5
+            // adjustedHigh = (0x0 - 8) & 0x0f = 0x8
+            // Expected: ((0x8 << 11) | (0x00 << 3) | 0x5) = 0x4005
+            // Matches beebjit: (0x1000 * 8) - 0x4000 + 5 = 0x8000 - 0x4000 + 5 = 0x4005
+            expect(mockCpu.videoRead).toHaveBeenCalledWith(0x4005);
+        });
+    });
 });


### PR DESCRIPTION
## Summary

PR #522 introduced proper hardware scrolling address translation, but had a bug in the `screenAddrSubtract` lookup table where **indices 1 and 2 were swapped**. This PR fixes the bug and adds comprehensive tests.

## The Bug

```diff
- this.screenAddrSubtract = new Uint8Array([8, 10, 4, 5]);
+ this.screenAddrSubtract = new Uint8Array([8, 4, 10, 5]);
```

## Root Cause Analysis

The PR author was correct to be suspicious! After cross-referencing with BeebWiki and beebjit, I found the issue.

### BeebWiki Documentation

According to [BeebWiki Address Translation](http://beebwiki.mdfs.net/Address_translation), the hardware decoder outputs B4-B1 values that are **one's complemented**:

| Index | C1 | C0 | B4-B1 (raw) | ~B4-B1 (subtract) | Full Amount | Modes |
|-------|----|----|-------------|-------------------|-------------|-------|
| 0     | 0  | 0  | 0111 (7)    | **8**            | 0x4000      | 3     |
| 1     | 0  | 1  | 1011 (11)   | **4**            | 0x2000      | 6     |
| 2     | 1  | 0  | 0101 (5)    | **10**           | 0x5000      | 0,1,2 |
| 3     | 1  | 1  | 1010 (10)   | **5**            | 0x2800      | 4,5   |

The actual subtraction values are the one's complement of the B4-B1 decoder outputs.

### Cross-Reference with beebjit

Verified against [beebjit](https://github.com/scarybeasts/beebjit) (another BBC Micro emulator):
```c
// beebjit/video.c uses full address subtraction:
switch (size_id) {
  case 0: screen_wrap_add = 0x4000; break;  // 0x4000 >> 11 = 8
  case 1: screen_wrap_add = 0x2000; break;  // 0x2000 >> 11 = 4
  case 2: screen_wrap_add = 0x5000; break;  // 0x5000 >> 11 = 10
  case 3: screen_wrap_add = 0x2800; break;  // 0x2800 >> 11 = 5
}
```

Converting these to 4-bit MA11-MA8 values: **[8, 4, 10, 5]** ✓

## Changes

### Fixed Code
- **src/video.js line 156**: Corrected `screenAddrSubtract` array

### New Tests
Added 3 comprehensive hardware scrolling tests to `tests/unit/test-video.js`:
1. **MODE 0-2 scroll offset** - Verifies index 2 (subtract 10) works correctly
2. **MA12 clear** - Ensures no translation when MA12 bit is not set
3. **Scanline counter integration** - Tests MODE 3 (index 0, subtract 8) with RA offset

All 244 tests pass.

## Test Plan

- ✅ All unit tests pass (244/244)
- ✅ Pre-commit hooks pass (linting, formatting, related tests)
- ✅ Cross-referenced with BeebWiki hardware documentation
- ✅ Cross-referenced with beebjit implementation

Fixes the bug introduced in #522.