### PR TITLE
Fix precision problems in PAL mode

### DIFF
--- a/src/video-filters/shaders/pal-composite.vert.glsl
+++ b/src/video-filters/shaders/pal-composite.vert.glsl
@@ -1,11 +1,8 @@
 attribute vec2 pos;
 attribute vec2 uvIn;
 varying vec2 vTexCoord;
-varying vec2 vPixelCoord;
-uniform vec2 uResolution;
 
 void main() {
     vTexCoord = uvIn;
-    vPixelCoord = uvIn * uResolution;
     gl_Position = vec4(pos * 2.0 - 1.0, 0.0, 1.0);
 }


### PR DESCRIPTION
- `precision highp float;` - we need more than 10 bits for the
   maths we're doing. My laptop defaulted to "23 bits" for medium
   precision, so that hid the issues until I tried it on latest
   NVidia drivers on my desktop.
- Using gl_FragCoord instead of a varying. Probably unnecessary
  but we can avoid a varying this way. Claude reckons:
  "Avoids barycentric interpolation artifacts" but that might be
  FUD honestly, we experimented a bunch to work out what was going
  on and this didn't seem like a _bad_ change, so we left it in.