### PR TITLE
fix: enable window scaling in Electron and modernize event handlers

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,9 +75,10 @@ jsbeeb can also run as a standalone desktop application using Electron:
 ### Running in Development
 
 ```sh
-npm run build
 npm run electron
 ```
+
+This automatically builds the latest code before launching Electron.
 
 ### Building Distributable Packages
 

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "coverage:unit": "vitest run tests/unit --coverage",
     "coverage:all-tests": "vitest run --coverage",
     "benchmark": "node app-bench.js",
-    "electron": "ELECTRON_DISABLE_SANDBOX=1 electron .",
+    "electron": "npm run build && ELECTRON_DISABLE_SANDBOX=1 electron .",
     "electron:build": "electron-builder"
   },
   "lint-staged": {

--- a/src/main.js
+++ b/src/main.js
@@ -522,22 +522,24 @@ $debugPlay.click(() => {
 
 // To lower chance of data loss, only accept drop events in the drop
 // zone in the menu bar.
-document.ondragover = function (event) {
+document.addEventListener("dragover", function (event) {
     event.preventDefault();
     event.dataTransfer.dropEffect = "none";
-};
-document.ondrop = function (event) {
+});
+document.addEventListener("drop", function (event) {
     event.preventDefault();
-};
+});
 
-window.onbeforeunload = function () {
+window.addEventListener("beforeunload", function (event) {
     if (running && processor.sysvia.hasAnyKeyDown()) {
-        return (
+        const message =
             "It seems like you're still using the emulator. If you're in Chrome, it's impossible for jsbeeb to prevent some shortcuts (like ctrl-W) from performing their default behaviour (e.g. closing the window).\n" +
-            "As a workarond, create an 'Application Shortcut' from the Tools menu.  When jsbeeb runs as an application, it *can* prevent ctrl-W from closing the window."
-        );
+            "As a workarond, create an 'Application Shortcut' from the Tools menu.  When jsbeeb runs as an application, it *can* prevent ctrl-W from closing the window.";
+        event.preventDefault();
+        event.returnValue = message;
+        return message;
     }
-};
+});
 
 if (model.hasEconet) {
     econet = new Econet(stationId);
@@ -752,13 +754,13 @@ keyboard.registerKeyHandler(
 );
 
 // Setup key handlers
-document.onkeydown = (evt) => {
+document.addEventListener("keydown", (evt) => {
     audioHandler.tryResume().then(() => {});
     ensureMicrophoneRunning().then(() => {});
     keyboard.keyDown(evt);
-};
-document.onkeypress = (evt) => keyboard.keyPress(evt);
-document.onkeyup = (evt) => keyboard.keyUp(evt);
+});
+document.addEventListener("keypress", (evt) => keyboard.keyPress(evt));
+document.addEventListener("keyup", (evt) => keyboard.keyUp(evt));
 
 function setDisc1Image(name) {
     delete parsedQuery.disc;
@@ -1665,7 +1667,7 @@ function stop(debug) {
         const minWidth = imageOrigWidth / 4;
         const minHeight = imageOrigHeight / 4;
 
-        let navbarHeight = $("#header-bar").outerHeight();
+        let navbarHeight = $("#header-bar").outerHeight() || 0;
         let width = Math.max(minWidth, window.innerWidth - borderReservedSize * 2);
         let height = Math.max(minHeight, window.innerHeight - navbarHeight - bottomReservedSize);
         if (width / height <= desiredAspectRatio) {
@@ -1697,7 +1699,7 @@ function stop(debug) {
         $screen.css("top", canvasOrigTop * containerScale + "px");
     }
 
-    window.onresize = resizeTv;
+    window.addEventListener("resize", resizeTv);
     window.setTimeout(resizeTv, 1);
     window.setTimeout(resizeTv, 500);
 })();


### PR DESCRIPTION
## Summary
- Fixes Electron window not scaling with BrowserWindow resize
- Modernizes event handlers from old-style assignments to addEventListener
- Simplifies developer workflow by auto-building on `npm run electron`

## Changes

### Window Scaling Fix
- Replace `window.onresize` with `addEventListener` for better Electron compatibility
- Add fallback for undefined `navbarHeight` (`|| 0`)
- The Electron view now properly scales when the window is resized

### Development Workflow
- `npm run electron` now automatically runs `npm run build` first
- Updated README to reflect simplified workflow (no need to run build separately)
- Ensures developers always test the latest code

### Code Modernization
- Converted all old-style event handlers to `addEventListener`:
  - `document.onkeydown` → `addEventListener("keydown")`
  - `document.onkeypress` → `addEventListener("keypress")`
  - `document.onkeyup` → `addEventListener("keyup")`
  - `document.ondragover` → `addEventListener("dragover")`
  - `document.ondrop` → `addEventListener("drop")`
  - `window.onbeforeunload` → `addEventListener("beforeunload")` with proper event handling

## Testing
- [x] Verified window scaling works in Electron
- [x] Pre-commit hooks passed (ESLint, Prettier, tests)
- [x] README updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)