### PR TITLE
fix: remove invalid package-name parameter from release-please action

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -20,7 +20,6 @@ jobs:
         id: release
         with:
           release-type: node
-          package-name: jsbeeb
 
   upload-electron-packages:
     needs: release-please


### PR DESCRIPTION
## Summary
Fixes the release-please action warning about invalid `package-name` parameter.

## Issue
The `package-name` parameter was valid in release-please-action@v3 but was removed in v4. This caused the warning:
```
Warning: Unexpected input(s) 'package-name', valid inputs are...
```

## Changes
- Removed `package-name: jsbeeb` from the workflow
- Package name is now inferred automatically from package.json

## Testing
- This should eliminate the warning in the next workflow run
- The .release-please-manifest.json already exists with the correct version

🤖 Generated with [Claude Code](https://claude.com/claude-code)