### PR TITLE
fix: decrement SP by 3 during reset sequence

### DIFF
--- a/src/6502.js
+++ b/src/6502.js
@@ -419,6 +419,7 @@ class Tube6502 extends Base6502 {
         this.romPaged = true;
         this.pc = this.readmem(0xfffc) | (this.readmem(0xfffd) << 8);
         this.p.i = true;
+        this.s = (this.s - 3) & 0xff; // Simulate 3 dummy pushes during reset
         this.tube.reset(hard);
     }
 
@@ -1181,6 +1182,7 @@ export class Cpu6502 extends Base6502 {
         }
         this.pc = this.readmem(0xfffc) | (this.readmem(0xfffd) << 8);
         this.p.i = true;
+        this.s = (this.s - 3) & 0xff; // Simulate 3 dummy pushes during reset
         this._nmiEdge = false;
         this._nmiLevel = false;
         this.halted = false;

--- a/tests/unit/test-sp-reset.js
+++ b/tests/unit/test-sp-reset.js
@@ -1,0 +1,59 @@
+import { describe, it, expect } from "vitest";
+import { fake6502, fake65C12 } from "../../src/fake6502.js";
+
+/**
+ * Tests for 6502 stack pointer behavior during reset.
+ *
+ * The real 6502 reset sequence is 7 cycles and reuses the interrupt/BRK
+ * logic internally. During this sequence, 3 "dummy" stack operations occur
+ * where SP decrements but R/W is held in read mode (no actual writes).
+ * This was a hardware optimization to share logic with BRK/IRQ handling.
+ *
+ * Result: SP decrements 3 times during reset: 0x00 -> 0xFF -> 0xFE -> 0xFD
+ *
+ * References:
+ * - https://www.nesdev.org/wiki/CPU_power_up_state
+ * - https://www.pagetable.com/?p=410
+ */
+
+describe("6502 reset SP behavior", () => {
+    it("should decrement SP by 3 during reset (NMOS 6502)", async () => {
+        const cpu = fake6502();
+        await cpu.initialise();
+        // Real 6502 does 3 dummy pushes: 0x00 -> 0xFF -> 0xFE -> 0xFD
+        expect(cpu.s).toBe(0xfd);
+    });
+
+    it("should decrement SP by 3 during reset (CMOS 65C12)", async () => {
+        const cpu = fake65C12();
+        await cpu.initialise();
+        expect(cpu.s).toBe(0xfd);
+    });
+
+    it("should decrement SP by 3 after explicit hard reset", async () => {
+        const cpu = fake6502();
+        await cpu.initialise();
+        cpu.s = 0x80;
+        // Reset should decrement by 3: 0x80 -> 0x7F -> 0x7E -> 0x7D
+        cpu.reset(true);
+        expect(cpu.s).toBe(0x7d);
+    });
+
+    it("should decrement SP by 3 after explicit soft reset", async () => {
+        const cpu = fake6502();
+        await cpu.initialise();
+        cpu.s = 0x80;
+        // Soft reset should also decrement by 3
+        cpu.reset(false);
+        expect(cpu.s).toBe(0x7d);
+    });
+
+    it("should wrap SP correctly when decrementing near zero", async () => {
+        const cpu = fake6502();
+        await cpu.initialise();
+        cpu.s = 0x01;
+        // 0x01 -> 0x00 -> 0xFF -> 0xFE
+        cpu.reset(true);
+        expect(cpu.s).toBe(0xfe);
+    });
+});


### PR DESCRIPTION
## Summary

Fixes #547

The real 6502 reset sequence reuses the interrupt/BRK logic internally, performing 3 "dummy" stack operations where SP decrements but R/W is held in read mode (no actual writes). This results in SP being 0xFD after reset when starting from 0x00.

This PR adds the missing SP decrement to both `Cpu6502.reset()` and `Tube6502.reset()` methods.

## Changes

- `src/6502.js`: Added `this.s = (this.s - 3) & 0xff` after setting PC and I flag in both reset methods
- `tests/unit/test-sp-reset.js`: New test file covering SP reset behavior

## Test plan

- [x] New unit tests pass (5 tests covering NMOS/CMOS, hard/soft reset, wrap-around)
- [x] Full unit test suite passes (255 tests)
- [x] Integration tests pass (45 tests)
- [x] CPU compatibility test suite passes
- [x] Linting passes