### PR TITLE
chore: update jQuery to 4.0 and Electron to 40.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "bootswatch": "^5.3.8",
         "event-emitter-es6": "^1.1.5",
         "fflate": "^0.8.2",
-        "jquery": "^3.7.1",
+        "jquery": "^4.0.0",
         "pako": "^2.1.0",
         "smoothie": "^1.36.1",
         "underscore": "^1.13.7"
@@ -38,7 +38,7 @@
         "node": "22"
       },
       "optionalDependencies": {
-        "electron": "^39.5.1",
+        "electron": "^40.1.0",
         "electron-builder": "^26.7.0",
         "electron-store": "^11.0.2"
       }
@@ -2478,13 +2478,13 @@
       "optional": true
     },
     "node_modules/@types/node": {
-      "version": "22.19.8",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.8.tgz",
-      "integrity": "sha512-ebO/Yl+EAvVe8DnMfi+iaAyIqYdK0q/q0y0rw82INWEKJOBe6b/P3YWE8NW7oOlF/nXFNrHwhARrN/hdgDkraA==",
+      "version": "24.10.10",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.10.10.tgz",
+      "integrity": "sha512-+0/4J266CBGPUq/ELg7QUHhN25WYjE0wYTPSQJn1xeu8DOlIOPxXxrNGiLmfAWl7HMMgWFWXpt9IDjMWrF5Iow==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "undici-types": "~6.21.0"
+        "undici-types": "~7.16.0"
       }
     },
     "node_modules/@types/plist": {
@@ -4344,15 +4344,15 @@
       }
     },
     "node_modules/electron": {
-      "version": "39.5.1",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-39.5.1.tgz",
-      "integrity": "sha512-6s/sBQar+bbW59XSqohZj04MPic+kdVUAWjLbfQB/uLOeNw9jWX5FHaTxpHK29Xp3mKOHef7wErsjwMyCuWltg==",
+      "version": "40.1.0",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-40.1.0.tgz",
+      "integrity": "sha512-2j/kvw7uF0H1PnzYBzw2k2Q6q16J8ToKrtQzZfsAoXbbMY0l5gQi2DLOauIZLzwp4O01n8Wt/74JhSRwG0yj9A==",
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
         "@electron/get": "^2.0.0",
-        "@types/node": "^22.7.7",
+        "@types/node": "^24.9.0",
         "extract-zip": "^2.0.1"
       },
       "bin": {
@@ -6546,9 +6546,9 @@
       }
     },
     "node_modules/jquery": {
-      "version": "3.7.1",
-      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.7.1.tgz",
-      "integrity": "sha512-m4avr8yL8kmFN8psrbFFFmB/If14iN5o9nw/NgnnM+kybDJpRsAynV2BsfpTYrTRysYUdADVD7CkUUizgkpLfg==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jquery/-/jquery-4.0.0.tgz",
+      "integrity": "sha512-TXCHVR3Lb6TZdtw1l3RTLf8RBWVGexdxL6AC8/e0xZKEpBflBsjh9/8LXw+dkNFuOyW9B7iB3O1sP7hS0Kiacg==",
       "license": "MIT"
     },
     "node_modules/js-tokens": {
@@ -10013,9 +10013,9 @@
       "license": "MIT"
     },
     "node_modules/undici-types": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
-      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
       "license": "MIT",
       "optional": true
     },

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "bootswatch": "^5.3.8",
     "event-emitter-es6": "^1.1.5",
     "fflate": "^0.8.2",
-    "jquery": "^3.7.1",
+    "jquery": "^4.0.0",
     "pako": "^2.1.0",
     "smoothie": "^1.36.1",
     "underscore": "^1.13.7"
@@ -41,7 +41,7 @@
     "vitest": "^4.0.10"
   },
   "optionalDependencies": {
-    "electron": "^39.5.1",
+    "electron": "^40.1.0",
     "electron-builder": "^26.7.0",
     "electron-store": "^11.0.2"
   },

--- a/src/main.js
+++ b/src/main.js
@@ -287,7 +287,7 @@ function sbBind(div, url, onload) {
     const img = div.find("img");
     img.hide();
     if (!url) return;
-    img.attr("src", url).bind("load", function () {
+    img.attr("src", url).on("load", function () {
         onload(div, img);
         img.show();
     });

--- a/src/web/debug.js
+++ b/src/web/debug.js
@@ -22,7 +22,7 @@ class MemoryView {
         }
         template.remove();
 
-        widget.bind("wheel", (evt) => {
+        widget.on("wheel", (evt) => {
             const deltaY = evt.originalEvent.deltaY;
             if (deltaY === 0) return;
             const steps = (deltaY / 20) | 0;
@@ -111,7 +111,7 @@ export class Debugger {
 
         this.disass.find(".bp_gutter").click(this.bpClick.bind(this));
 
-        this.disass.bind("wheel", (evt) => {
+        this.disass.on("wheel", (evt) => {
             let deltaY = evt.originalEvent.deltaY;
             if (deltaY === 0) return;
             let addr = this.disassPc;


### PR DESCRIPTION
## Summary
- Update jQuery from 3.7.1 to 4.0.0
- Update Electron from 39.5.1 to 40.1.0
- Replace deprecated `.bind()` with `.on()` for jQuery event handlers

## Breaking Changes Reviewed

**jQuery 4.0**: No issues - the codebase doesn't use any removed APIs (`jQuery.isArray`, `jQuery.parseJSON`, `jQuery.trim`, etc.)

**Electron 40**: No issues - already uses `contextBridge` in preload.js for secure IPC

## Test plan
- [x] Unit tests pass
- [x] Build succeeds
- [x] Manual testing of debugger wheel scrolling, modals, configuration changes

🤖 Generated with [Claude Code](https://claude.ai/code)