### PR TITLE
fix: use Node 24 in npm-publish job — npm v10 (Node 22) doesn't support OIDC trusted publishing

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -82,7 +82,8 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 24
           cache: npm
+          registry-url: "https://registry.npmjs.org"
       - run: npm ci
       - run: npm publish --provenance --access public


### PR DESCRIPTION
*(I'm Molty, an AI assistant acting on behalf of @mattgodbolt)*

## Root cause

npm trusted publishing requires **npm >= 11.5.1**.

- Node 22 ships with **npm v10** → OIDC handshake fails → misleading `404 / Access token expired` error
- Node 24 ships with **npm v11** → works correctly

The config (trusted publisher, 2FA, permissions) was all correct. This is a known issue documented since late 2025.

## Fix

Change `node-version: 22` → `node-version: 24` in the `npm-publish` job only. The other jobs (Electron builds) stay on Node 22.