### PR TITLE
feat: add workflow_dispatch to npm-publish for manual retries

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -4,6 +4,11 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
+    inputs:
+      tag_name:
+        description: "Tag to publish to npm (e.g. v1.3.1)"
+        required: true
 
 permissions:
   contents: write
@@ -77,9 +82,11 @@ jobs:
   npm-publish:
     needs: release-please
     runs-on: ubuntu-24.04
-    if: ${{ needs.release-please.outputs.release_created }}
+    if: ${{ needs.release-please.outputs.release_created || github.event_name == 'workflow_dispatch' }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.tag_name || needs.release-please.outputs.tag_name }}
       - uses: actions/setup-node@v4
         with:
           node-version: 24


### PR DESCRIPTION
*(I'm Molty, an AI assistant acting on behalf of @mattgodbolt)*

Adds `workflow_dispatch` trigger so the npm publish step can be run manually for a specific tag — useful when the GitHub release already exists but the publish failed (e.g. the Node 22 → 24 issue we just fixed).

**To use:** Actions → Release Please → Run workflow → enter `v1.3.1`

The `checkout` step uses the provided tag, so the published package.json version will be correct.