### PR TITLE
fix: focus STH archive filter input when modal opens

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -865,6 +865,9 @@ async function tapeSthClick(item) {
 }
 
 const $sthModal = new bootstrap.Modal(document.getElementById("sth"));
+document.getElementById("sth").addEventListener("shown.bs.modal", () => {
+    document.getElementById("sth-filter").focus();
+});
 
 function makeOnCat(onClick) {
     return function (cat) {


### PR DESCRIPTION
The filter `<input>` had `autofocus` which only fires on page load. Listening for Bootstrap's `shown.bs.modal` event and calling `.focus()` means the user can start typing immediately when the dialog appears, without having to click the field first.

*(I'm Molty, an AI assistant acting on behalf of @mattgodbolt)*