### PR TITLE
feat: add non-cycle-accurate mode for Tube 6502 instruction generation

### DIFF
--- a/src/6502.js
+++ b/src/6502.js
@@ -101,12 +101,12 @@ class Flags {
 }
 
 class Base6502 {
-    constructor(model) {
+    constructor(model, { cycleAccurate = true } = {}) {
         this.model = model;
         this.a = this.x = this.y = this.s = 0;
         this.p = new Flags();
         this.pc = 0;
-        this.opcodes = model.opcodesFactory(this);
+        this.opcodes = model.opcodesFactory(this, { cycleAccurate });
         this.disassembler = this.opcodes.disassembler;
         this.forceTracing = false;
         this.runner = this.opcodes.runInstruction;
@@ -405,7 +405,7 @@ class Base6502 {
 
 class Tube6502 extends Base6502 {
     constructor(model, cpu) {
-        super(model);
+        super(model, { cycleAccurate: false });
 
         this.cycles = 0;
         this.cpuMultiplier = 2;
@@ -571,8 +571,19 @@ function is1MHzAccess(addr) {
 }
 
 export class Cpu6502 extends Base6502 {
-    constructor(model, dbgr, video_, soundChip_, ddNoise_, music5000_, cmos, config, econet_) {
-        super(model);
+    constructor(
+        model,
+        dbgr,
+        video_,
+        soundChip_,
+        ddNoise_,
+        music5000_,
+        cmos,
+        config,
+        econet_,
+        { cycleAccurate = true } = {},
+    ) {
+        super(model, { cycleAccurate });
         this.config = fixUpConfig(config);
         this.debugFlags = this.config.debugFlags;
         this.cmos = cmos;

--- a/src/6502.opcodes.js
+++ b/src/6502.opcodes.js
@@ -41,8 +41,9 @@ function push(reg) {
 }
 
 class InstructionGen {
-    constructor(is65c12) {
+    constructor(is65c12, cycleAccurate = true) {
         this.is65c12 = is65c12;
+        this.cycleAccurate = cycleAccurate;
         this.ops = {};
         this.cycle = 0;
     }
@@ -106,6 +107,10 @@ class InstructionGen {
     }
 
     spuriousOp(addr, reg) {
+        if (!this.cycleAccurate) {
+            this.cycle++;
+            return;
+        }
         if (this.is65c12) {
             this.readOp(addr, "", true);
         } else {
@@ -122,7 +127,7 @@ class InstructionGen {
                 toSkip++;
                 continue;
             }
-            if (toSkip && this.ops[i].exact) {
+            if (this.cycleAccurate && toSkip && this.ops[i].exact) {
                 if (this.ops[i].addr) {
                     out.push(`cpu.polltimeAddr(${toSkip}, ${this.ops[i].addr});`);
                 } else {
@@ -134,7 +139,7 @@ class InstructionGen {
             toSkip++;
         }
         if (toSkip) {
-            if (this.ops[this.cycle] && this.ops[this.cycle].addr) {
+            if (this.cycleAccurate && this.ops[this.cycle] && this.ops[this.cycle].addr) {
                 out.push(`cpu.polltimeAddr(${toSkip}, ${this.ops[this.cycle].addr});`);
             } else {
                 out.push(`cpu.polltime(${toSkip});`);
@@ -145,17 +150,17 @@ class InstructionGen {
     }
 
     split(condition) {
-        return new SplitInstruction(this, condition, this.is65c12);
+        return new SplitInstruction(this, condition, this.is65c12, this.cycleAccurate);
     }
 }
 
 class SplitInstruction {
-    constructor(preamble, condition, is65c12) {
+    constructor(preamble, condition, is65c12, cycleAccurate = true) {
         this.preamble = preamble;
         this.condition = condition;
-        this.ifTrue = new InstructionGen(is65c12);
+        this.ifTrue = new InstructionGen(is65c12, cycleAccurate);
         this.ifTrue.tick(preamble.cycle);
-        this.ifFalse = new InstructionGen(is65c12);
+        this.ifFalse = new InstructionGen(is65c12, cycleAccurate);
         this.ifFalse.tick(preamble.cycle);
 
         ["append", "prepend", "readOp", "writeOp", "spuriousOp"].forEach((op) => {
@@ -1052,7 +1057,7 @@ class Disassemble6502 {
     }
 }
 
-function makeCpuFunctions(cpu, opcodes, is65c12) {
+function makeCpuFunctions(cpu, opcodes, is65c12, cycleAccurate = true) {
     function getInstruction(opcodeString, needsReg) {
         const split = opcodeString.split(" ");
         const opcode = split[0];
@@ -1060,7 +1065,7 @@ function makeCpuFunctions(cpu, opcodes, is65c12) {
         const op = getOp(opcode, arg);
         if (!op) return null;
 
-        let ig = new InstructionGen(is65c12);
+        let ig = new InstructionGen(is65c12, cycleAccurate);
         if (needsReg) ig.append("let REG = 0|0;");
 
         switch (arg) {
@@ -1398,14 +1403,14 @@ ${indent}`)
     };
 }
 
-export function Cpu6502(cpu) {
-    return makeCpuFunctions(cpu, opcodes6502, false);
+export function Cpu6502(cpu, { cycleAccurate = true } = {}) {
+    return makeCpuFunctions(cpu, opcodes6502, false, cycleAccurate);
 }
 
-export function Cpu65c12(cpu) {
-    return makeCpuFunctions(cpu, opcodes65c12, true);
+export function Cpu65c12(cpu, { cycleAccurate = true } = {}) {
+    return makeCpuFunctions(cpu, opcodes65c12, true, cycleAccurate);
 }
 
-export function Cpu65c02(cpu) {
-    return makeCpuFunctions(cpu, opcodes65c02, true);
+export function Cpu65c02(cpu, { cycleAccurate = true } = {}) {
+    return makeCpuFunctions(cpu, opcodes65c02, true, cycleAccurate);
 }

--- a/src/fake6502.js
+++ b/src/fake6502.js
@@ -20,7 +20,19 @@ export function fake6502(model, opts) {
     const video = opts.video || fakeVideo;
     model = model || TEST_6502;
     if (opts.tube) model.tube = findModel("Tube65c02");
-    return new Cpu6502(model, dbgr, video, soundChip, new FakeDdNoise(), new FakeMusic5000(), new Cmos());
+    const cpuOpts = opts.cycleAccurate !== undefined ? { cycleAccurate: opts.cycleAccurate } : {};
+    return new Cpu6502(
+        model,
+        dbgr,
+        video,
+        soundChip,
+        new FakeDdNoise(),
+        new FakeMusic5000(),
+        new Cmos(),
+        undefined,
+        undefined,
+        cpuOpts,
+    );
 }
 
 export function fake65C02() {

--- a/tests/integration/dormann.js
+++ b/tests/integration/dormann.js
@@ -4,6 +4,7 @@ import _ from "underscore";
 import { describe, it } from "vitest";
 import * as utils from "../../src/utils.js";
 import { fake6502, fake65C02, fake65C12 } from "../../src/fake6502.js";
+import { TEST_65C02, TEST_65C12 } from "../../src/models.js";
 
 import assert from "assert";
 
@@ -97,5 +98,23 @@ describe("dormann tests", { timeout: 30000 }, function () {
         const cpu = fake65C12();
         await cpu.initialise();
         assert(await runTest(cpu, "65C12_extended_opcodes_test", "65C12"));
+    });
+});
+
+describe("dormann tests (non-cycle-accurate)", { timeout: 30000 }, function () {
+    it("should pass 6502 functional tests", async () => {
+        const cpu = fake6502(undefined, { cycleAccurate: false });
+        await cpu.initialise();
+        assert(await runTest(cpu, "6502_functional_test", "6502 (non-cycle-accurate)"));
+    });
+    it("should pass 65c02 extended opcode tests", async () => {
+        const cpu = fake6502(TEST_65C02, { cycleAccurate: false });
+        await cpu.initialise();
+        assert(await runTest(cpu, "65C02_extended_opcodes_test", "65C02 (non-cycle-accurate)"));
+    });
+    it("should pass 65c12 extended opcode tests", async () => {
+        const cpu = fake6502(TEST_65C12, { cycleAccurate: false });
+        await cpu.initialise();
+        assert(await runTest(cpu, "65C12_extended_opcodes_test", "65C12 (non-cycle-accurate)"));
     });
 });


### PR DESCRIPTION
The Tube second processor's polltime just decrements a counter, so intra-instruction cycle-accurate timing is unnecessary overhead. Add a cycleAccurate option to InstructionGen (default true) that, when false:
- Emits a single polltime(N) per instruction instead of multiple calls
- Skips spurious read/write operations (bus activity with no side effects)
- Replaces polltimeAddr with plain polltime (no 1MHz bus slowdown on Tube)

Tube6502 now uses cycleAccurate: false. Verified with Dormann functional tests for all three CPU types (6502, 65C02, 65C12).