### PR TITLE
Add InstrumentedSoundChip for headless sound debugging

### DIFF
--- a/src/fake6502.js
+++ b/src/fake6502.js
@@ -22,7 +22,7 @@ export function fake6502(model, opts) {
     return new Cpu6502(model, {
         dbgr,
         video: opts.video || fakeVideo,
-        soundChip,
+        soundChip: opts.soundChip || soundChip,
         ddNoise: new FakeDdNoise(),
         music5000: new FakeMusic5000(),
         cmos: new Cmos(),

--- a/src/machine-session.js
+++ b/src/machine-session.js
@@ -9,6 +9,7 @@ import { readFileSync } from "fs";
 import { fileURLToPath } from "url";
 import path from "path";
 import { TestMachine } from "../tests/test-machine.js";
+import { InstrumentedSoundChip } from "./soundchip.js";
 
 // Resolve the jsbeeb package root from our own location (src/machine-session.js
 // → go up one level).  Passed to setNodeBasePath() so the ROM loader resolves
@@ -53,8 +54,11 @@ export class MachineSession {
             this._completeFb8.set(this._fb8);
         });
 
-        // TestMachine forwards opts.video to fake6502, which uses it instead of FakeVideo
-        this._machine = new TestMachine(modelName, { video: this._video });
+        // Use a real (instrumented) sound chip so we can read registers and capture writes
+        this._soundChip = new InstrumentedSoundChip();
+
+        // TestMachine forwards opts.video and opts.soundChip to fake6502
+        this._machine = new TestMachine(modelName, { video: this._video, soundChip: this._soundChip });
 
         // Accumulated VDU text output — drained by callers
         this._pendingOutput = [];

--- a/src/soundchip.js
+++ b/src/soundchip.js
@@ -288,6 +288,84 @@ export class SoundChip {
     }
 }
 
+/**
+ * InstrumentedSoundChip - wraps a real SoundChip and captures all writes
+ * for debugging purposes. Provides the same interface as SoundChip.
+ */
+export class InstrumentedSoundChip extends SoundChip {
+    constructor() {
+        super(() => {}); // no audio output callback needed in headless mode
+        this._capturedWrites = [];
+        this._capturing = false;
+        this._totalCycles = 0;
+    }
+
+    poke(value) {
+        if (this._capturing) {
+            this._capturedWrites.push({ cycle: this._totalCycles, value });
+        }
+        super.poke(value);
+    }
+
+    /** Start capturing SN76489 writes. Clears any previous capture. */
+    startCapture() {
+        this._capturedWrites = [];
+        this._capturing = true;
+    }
+
+    /** Stop capturing and return the captured writes. */
+    stopCapture() {
+        this._capturing = false;
+        return this._capturedWrites;
+    }
+
+    /** Get the captured writes without stopping. */
+    getCapturedWrites() {
+        return this._capturedWrites;
+    }
+
+    /** Clear captured writes. */
+    clearCapture() {
+        this._capturedWrites = [];
+    }
+
+    /** Track total cycles for timestamps. Called by the scheduler. */
+    advance(cycles) {
+        this._totalCycles += cycles;
+        super.advance(cycles);
+    }
+
+    /** Read current SN76489 register state in a friendly format. */
+    getState() {
+        return {
+            tone: [
+                this.registers[0],
+                this.registers[1],
+                this.registers[2],
+            ],
+            noise: this.registers[3],
+            volume: [
+                this._attenuationFromVolume(0),
+                this._attenuationFromVolume(1),
+                this._attenuationFromVolume(2),
+                this._attenuationFromVolume(3),
+            ],
+            lfsr: this.lfsr,
+            latchedRegister: this.latchedRegister,
+        };
+    }
+
+    /** Convert internal float volume back to 0-15 attenuation. */
+    _attenuationFromVolume(channel) {
+        const v = this.volume[channel];
+        // volumeTable[15] = 0 (silent), volumeTable[0] = loudest
+        for (let i = 0; i < 16; i++) {
+            if (Math.abs(volumeTable[i] - v) < 0.001) return i;
+        }
+        return 15; // silent
+    }
+}
+
 export class FakeSoundChip {
     reset() {}
 


### PR DESCRIPTION
## Summary

- Add `InstrumentedSoundChip` class extending the real `SoundChip` with write capture and state inspection
- Allow `opts.soundChip` override in `fake6502()` (same pattern as existing `opts.video`)
- Wire up `InstrumentedSoundChip` in `MachineSession` so headless sessions get a real sound chip

## Motivation

When debugging music player code via the jsbeeb MCP server, there was no way to inspect what was being written to the SN76489 sound chip — headless mode used `FakeSoundChip` (empty stubs). This made it impossible to diagnose issues like corrupted register data.

The `InstrumentedSoundChip` provides:
- `startCapture()` / `stopCapture()` — log every `poke()` with cycle timestamps
- `getState()` — read current tone periods, volumes, noise register, LFSR state
- Full SN76489 emulation (extends `SoundChip`, not `FakeSoundChip`)

## Usage

Used by jsbeeb-mcp to expose `read_sound_state`, `start_sound_capture`, and `stop_sound_capture` tools.

🤖 Generated with [Claude Code](https://claude.com/claude-code)