### PR TITLE
feat: TestMachine case handling, keyDown/keyUp, loadSidewaysRam

### DIFF
--- a/tests/test-machine.js
+++ b/tests/test-machine.js
@@ -102,6 +102,22 @@ export class TestMachine {
         this.processor.fdc.loadDisc(0, fdc.discFor(this.processor.fdc, "", data));
     }
 
+    /**
+     * Load a disc image from raw data (Uint8Array or Buffer).
+     * @param {Uint8Array|Buffer} data - raw disc image bytes
+     */
+    loadDiscData(data) {
+        this.processor.fdc.loadDisc(0, fdc.discFor(this.processor.fdc, "", data));
+    }
+
+    /**
+     * Reset the machine.
+     * @param {boolean} hard - true for power-on reset, false for soft reset
+     */
+    reset(hard) {
+        this.processor.reset(hard);
+    }
+
     async loadBasic(source) {
         const tokeniser = await Tokeniser.create();
         const tokenised = tokeniser.tokenise(source);


### PR DESCRIPTION
## Summary
Improvements to `TestMachine` for better testing of sideways ROMs (motivated by the XMOS reverse engineering project).

## Changes

### Case-correct typing
`_charToKey` now checks `processor.sysvia.capsLockLight` to determine whether SHIFT is needed for each letter. With CAPS LOCK on (boot default), uppercase needs no shift and lowercase needs shift. With CAPS LOCK off, the reverse.

`type("Hello World")` now produces exactly `Hello World` on screen, regardless of CAPS LOCK state. Previously, lowercase was impossible with CAPS LOCK on.

### New convenience methods
- **`keyDown(code)` / `keyUp(code)`** — direct keyboard access without reaching through `processor.sysvia`
- **`loadSidewaysRam(slot, data)`** — write ROM data directly into a SWRAM slot, bypassing the *SRLOAD + reset dance

## Testing
- All existing jsbeeb tests pass (`npm test`)
- Tested with 75 XMOS ROM tests using `npm link`

🤖 Generated with [Claude Code](https://claude.com/claude-code)