### PR TITLE
fix: pad SSD/DSD disc images that aren't a multiple of sector size

### DIFF
--- a/src/disc.js
+++ b/src/disc.js
@@ -535,7 +535,10 @@ export function loadSsd(disc, data, isDsd, onChange) {
     const blankSector = new Uint8Array(SsdFormat.sectorSize);
     const numSides = isDsd ? 2 : 1;
     if (data.length % SsdFormat.sectorSize !== 0) {
-        throw new Error("SSD file size is not a multiple of sector size");
+        const paddedLength = Math.ceil(data.length / SsdFormat.sectorSize) * SsdFormat.sectorSize;
+        const padded = new Uint8Array(paddedLength);
+        padded.set(data);
+        data = padded;
     }
     const maxSize = SsdFormat.sectorSize * SsdFormat.sectorsPerTrack * SsdFormat.tracksPerDisc * numSides;
     if (data.length > maxSize) {

--- a/tests/unit/test-disc.js
+++ b/tests/unit/test-disc.js
@@ -203,6 +203,23 @@ describe(
                 expect(ssdSaved[i]).toBe(0);
             }
         });
+        it("should load an SSD whose size is not a multiple of sector size", () => {
+            // Create data that's not a multiple of 256 bytes (e.g., 2.5 sectors worth)
+            const sectorSize = 256;
+            const oddSize = sectorSize * 2 + 100;
+            const oddData = new Uint8Array(oddSize);
+            for (let i = 0; i < oddSize; i++) oddData[i] = i & 0xff;
+
+            const disc = new Disc(true, new DiscConfig(), "test.ssd");
+            loadSsd(disc, oddData, false);
+
+            const sectors = disc.getTrack(false, 0).findSectors();
+            expect(sectors.length).toBe(10);
+            for (const sector of sectors) {
+                expect(sector.hasHeaderCrcError).toBe(false);
+                expect(sector.hasDataCrcError).toBe(false);
+            }
+        });
         it("should have sane tracks", () => {
             const disc = new Disc(true, new DiscConfig(), "test.ssd");
             loadSsd(disc, data, false);


### PR DESCRIPTION
## Summary

- Fixes #601: `loadSsd` no longer throws when an SSD/DSD file size isn't an exact multiple of the 256-byte sector size
- Instead of erroring, pads the data with zeros to the next sector boundary (matching b2's approach)
- Adds a test verifying that odd-sized disc images load successfully with valid sectors

## Test plan

- [x] Unit tests pass (`npm run test:unit` — 402 tests)
- [ ] Verify with real-world odd-sized disc images from bbcmicro.co.uk

🤖 Generated with [Claude Code](https://claude.com/claude-code)