### PR TITLE
fix: add snapshotState/restoreState to FakeVideo and FakeSoundChip

### DIFF
--- a/src/soundchip.js
+++ b/src/soundchip.js
@@ -424,4 +424,10 @@ export class FakeSoundChip {
             tone: () => {},
         };
     }
+
+    snapshotState() {
+        return {};
+    }
+
+    restoreState() {}
 }

--- a/src/video.js
+++ b/src/video.js
@@ -1106,4 +1106,10 @@ export class FakeVideo {
     polltime() {}
 
     setScreenHwScroll() {}
+
+    snapshotState() {
+        return {};
+    }
+
+    restoreState() {}
 }


### PR DESCRIPTION
## Summary
- Add `snapshotState()`/`restoreState()` no-ops to `FakeVideo` and `FakeSoundChip`
- These stubs are used in headless/test mode but lacked the snapshot interface, causing `TestMachine.snapshot()` to throw `TypeError: this.video.snapshotState is not a function`

## Testing
- All 458 jsbeeb tests pass
- Tested with 80 XMOS ROM tests using `TestMachine.snapshot()`/`restore()` for per-test state reset

🤖 Generated with [Claude Code](https://claude.com/claude-code)