### PR TITLE
feat: add Atom keyboard mapping utilities

### DIFF
--- a/src/utils_atom.js
+++ b/src/utils_atom.js
@@ -456,7 +456,7 @@ export function getKeyMapAtom(keyLayout) {
         // Like a real ATOM
         // mainly the CTRL key is still CTRL (as CAPSLOCK locks on the MAC)
         // UP/DOWN/LEFT/RIGHT are using arrow keys
-        // REPT is using the RIGHT_ALT
+        // REPT is using RIGHT_SHIFT
         // note: LOCK is on LEFT_ALT
         map(keyCodes.K1, ATOM.K1);
         map(keyCodes.K2, ATOM.K2);


### PR DESCRIPTION
## Summary

Add standalone Acorn Atom keyboard mapping utilities. Not yet wired into the emulator — this is a standalone module for future integration.

Part of the incremental merge of Acorn Atom support from PR #505 by @CommanderCoder.

### File
- `src/utils_atom.js` — Atom keyboard matrix, key conversion, and gamepad mapping

### What the module provides
- `ATOM` constant — keyboard matrix mapping each key to its [row, column] pair
- `stringToATOMKeys(text)` — converts a text string into a sequence of Atom key events (for paste/autotype). Follows ASCII order for shifted digits (Shift+1=!, Shift+9=)), which differs from US keyboard conventions.
- `getKeyMapAtom(layout)` — returns PC-to-Atom key mappings for three layouts:
  - **natural**: typed characters match labels (Shift=Shift, Ctrl=Ctrl)
  - **gaming**: optimised for gameplay (DELETE=UP, BACKSPACE=BACKSLASH, etc.)
  - **physical**: matches real Atom layout (PC Ctrl→Atom Shift, PC Shift→Atom Ctrl)
- `remapGamepad(gamepad)` — sets default gamepad button→Atom key mappings
- Common mappings (DELETE, ESCAPE, TAB→COPY, F10→REPT) are set once, then each layout overrides as needed

### Design notes
- `detectKeyboardLayout()` is duplicated locally from utils.js because utils.js doesn't export `isUKlayout`. Behaviour matches (including localStorage check).
- The host Tab key maps to ATOM.COPY (useful physical mapping), while `\t` in `stringToATOMKeys` maps to ATOM.SPACE (the Atom has no tab concept) — different contexts, different intent.

## Test plan

- [x] `npm run lint` passes
- [x] `npm run test:unit` passes
- [x] File not imported by existing code — no existing functionality affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)