### PR TITLE
fix: document intentional empty catch in decompress()

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -56,11 +56,12 @@ export async function decompress(data, format) {
         await writer.write(data);
         await writer.close();
     })().catch(() => {
-        // Intentionally empty: Node's DecompressionStream rejects multiple
-        // promises on error (write, close, closed). The read side surfaces
-        // the same error with proper context — catching here just prevents
-        // unhandled rejections.
+        // Intentionally empty.
     });
+    // Intentionally empty: Node's DecompressionStream rejects multiple
+    // promises on error (write, close, closed). The read side surfaces
+    // the same error with proper context — catching these just prevents
+    // unhandled rejections from the write-side promises.
     writer.closed.catch(() => {});
     await readPromise;
     await writePromise;


### PR DESCRIPTION
## Summary

Add a comment explaining why the `.catch(() => {})` handlers in `decompress()` are intentionally empty. Node's DecompressionStream rejects multiple promises on error (write, close, closed) — the read side surfaces the same error with proper context, so the write-side catches just prevent unhandled rejections.

## Test plan

- [x] All 485 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)