### PR TITLE
test: add unit tests for tapes.js

### DIFF
--- a/tests/unit/test-tapes.js
+++ b/tests/unit/test-tapes.js
@@ -35,7 +35,6 @@ function makeUef(chunks) {
 }
 
 // Build a minimal tapefile: 0xFF 0x04 header + padding to 10 bytes + data.
-// The tapefile format starts with carrier (0xFF 0x04), then data follows at offset 10.
 function makeTapefile(data = []) {
     const buf = new Uint8Array(10 + data.length);
     buf[0] = 0xff;
@@ -55,21 +54,38 @@ function mockAcia() {
     };
 }
 
+// Poll a tape until a byte is received or maxPolls is reached.
+function pollUntilReceived(tape, maxPolls = 30) {
+    let received = null;
+    const acia = {
+        setTapeCarrier: () => {},
+        tone: () => {},
+        receive: (b) => {
+            received = b;
+        },
+        cr: 0x00,
+    };
+    for (let i = 0; i < maxPolls && received === null; i++) {
+        tape.poll(acia);
+    }
+    return received;
+}
+
 describe("tapes", () => {
     describe("loadTapeFromData", () => {
         it("should detect UEF format", async () => {
             const uef = makeUef([{ id: 0x0100, data: [0x41] }]);
             const tape = await loadTapeFromData("test.uef", uef);
             expect(tape).not.toBeNull();
-            // UEF tapes have a curChunk from the constructor
-            expect(tape.curChunk).toBeDefined();
+            // Verify it behaves as a UEF tape: poll should not throw
+            expect(() => tape.poll(mockAcia())).not.toThrow();
         });
 
         it("should detect tapefile format", async () => {
             const tapefile = makeTapefile();
             const tape = await loadTapeFromData("test.tape", tapefile);
             expect(tape).not.toBeNull();
-            // Tapefile's first poll reads the 0xFF 0x04 carrier header
+            // First poll reads the 0xFF 0x04 carrier header and returns 5s delay
             expect(tape.poll(mockAcia())).toBe(5 * 2 * 1000 * 1000);
         });
 
@@ -87,59 +103,44 @@ describe("tapes", () => {
     });
 
     describe("UefTape", () => {
-        it("should parse data chunks (0x0100)", async () => {
-            const uef = makeUef([{ id: 0x0100, data: [0x41, 0x42, 0x43] }]);
-            const tape = await loadTapeFromData("test.uef", uef);
-            expect(tape.curChunk).toBeDefined();
-            expect(tape.curChunk.id).toBe(0x0100);
-        });
-
-        it("should parse origin chunks (0x0000)", async () => {
-            const uef = makeUef([
-                { id: 0x0000, data: [0x74, 0x65, 0x73, 0x74, 0x00] },
-                { id: 0x0100, data: [0x41] },
-            ]);
-            const tape = await loadTapeFromData("test.uef", uef);
-            expect(tape).not.toBeNull();
-        });
-
-        it("should support rewind", async () => {
-            const uef = makeUef([{ id: 0x0100, data: [0x41] }]);
-            const tape = await loadTapeFromData("test.uef", uef);
-            tape.rewind();
-            expect(tape.state).toBe(-1);
-            expect(tape.count).toBe(0);
-        });
-
         it("should poll data chunk and receive bytes", async () => {
             // Include a leading chunk because UefTape pre-reads one in the
-            // constructor, and the first poll from the rewound state advances
-            // to the next chunk.
+            // constructor, and the first poll advances to the next chunk.
             const uef = makeUef([
                 { id: 0x0110, data: [0x01, 0x00] }, // carrier tone, count=1
                 { id: 0x0100, data: [0x41] },
             ]);
             const tape = await loadTapeFromData("test.uef", uef);
-            let received = null;
-            const acia = {
-                setTapeCarrier: () => {},
-                tone: () => {},
-                receive: (b) => {
-                    received = b;
-                },
-            };
-            for (let i = 0; i < 30 && received === null; i++) {
-                tape.poll(acia);
-            }
-            expect(received).toBe(0x41);
+            expect(pollUntilReceived(tape)).toBe(0x41);
+        });
+
+        it("should consume origin chunks without error", async () => {
+            const uef = makeUef([
+                { id: 0x0000, data: [0x74, 0x65, 0x73, 0x74, 0x00] }, // "test\0"
+                { id: 0x0100, data: [0x41] },
+            ]);
+            const tape = await loadTapeFromData("test.uef", uef);
+            // Poll past the origin chunk and receive data from the next chunk
+            expect(pollUntilReceived(tape)).toBe(0x41);
+        });
+
+        it("should support rewind and replay", async () => {
+            const uef = makeUef([
+                { id: 0x0110, data: [0x01, 0x00] },
+                { id: 0x0100, data: [0x41] },
+            ]);
+            const tape = await loadTapeFromData("test.uef", uef);
+            expect(pollUntilReceived(tape)).toBe(0x41);
+
+            tape.rewind();
+            expect(pollUntilReceived(tape)).toBe(0x41);
         });
     });
 
     describe("TapefileTape", () => {
         it("should start with carrier from header", async () => {
-            // The first two bytes (0xFF 0x04) are read as the format detection,
-            // but they also serve as the initial carrier signal when polled.
-            // After seek(10), the tape reads from offset 10 onwards.
+            // Format detection uses readByte(0/1) without advancing the stream,
+            // so the first poll still reads the 0xFF 0x04 carrier header.
             const tapefile = makeTapefile([0xff, 0x04]);
             const tape = await loadTapeFromData("test.tape", tapefile);
             let carrierSet = null;
@@ -155,36 +156,17 @@ describe("tapes", () => {
         });
 
         it("should receive regular bytes after rewind", async () => {
-            // After rewind, stream seeks to offset 10 where our test data lives.
             const tapefile = makeTapefile([0x41]);
             const tape = await loadTapeFromData("test.tape", tapefile);
             tape.rewind();
-            let received = null;
-            const acia = {
-                setTapeCarrier: () => {},
-                receive: (b) => {
-                    received = b;
-                },
-                cr: 0x00,
-            };
-            tape.poll(acia);
-            expect(received).toBe(0x41);
+            expect(pollUntilReceived(tape, 1)).toBe(0x41);
         });
 
         it("should escape 0xFF as 0xFF 0xFF after rewind", async () => {
             const tapefile = makeTapefile([0xff, 0xff]);
             const tape = await loadTapeFromData("test.tape", tapefile);
             tape.rewind();
-            let received = null;
-            const acia = {
-                setTapeCarrier: () => {},
-                receive: (b) => {
-                    received = b;
-                },
-                cr: 0x00,
-            };
-            tape.poll(acia);
-            expect(received).toBe(0xff);
+            expect(pollUntilReceived(tape, 1)).toBe(0xff);
         });
 
         it("should handle end of carrier (0xFF 0x00) after rewind", async () => {
@@ -203,33 +185,23 @@ describe("tapes", () => {
             expect(carrierSet).toBe(false);
         });
 
-        it("should support rewind", async () => {
+        it("should support rewind and replay", async () => {
             const tapefile = makeTapefile([0x41, 0x42]);
             const tape = await loadTapeFromData("test.tape", tapefile);
-            const acia = { setTapeCarrier: () => {}, receive: () => {}, cr: 0x00 };
-            tape.poll(acia);
             tape.rewind();
-            let received = null;
-            tape.poll({
-                setTapeCarrier: () => {},
-                receive: (b) => {
-                    received = b;
-                },
-                cr: 0x00,
-            });
-            expect(received).toBe(0x41);
+            expect(pollUntilReceived(tape, 1)).toBe(0x41);
+
+            tape.rewind();
+            expect(pollUntilReceived(tape, 1)).toBe(0x41);
         });
 
         it("should return large cycle count at EOF", async () => {
             const tapefile = makeTapefile([0x41, 0x42, 0x43]);
             const tape = await loadTapeFromData("test.tape", tapefile);
             tape.rewind();
-            // Consume all data
-            while (!tape.stream.eof()) {
-                tape.poll(mockAcia());
-            }
-            const cycles = tape.poll(mockAcia());
-            expect(cycles).toBe(100000);
+            // Consume all bytes
+            for (let i = 0; i < 3; i++) tape.poll(mockAcia());
+            expect(tape.poll(mockAcia())).toBe(100000);
         });
     });
 });


### PR DESCRIPTION
## Summary

Add 13 unit tests for UEF and tapefile tape format parsing, all asserting observable behaviour (poll/receive) rather than internal state.

**Format detection:**
- UEF format detection
- Tapefile format detection (first poll returns carrier delay)
- Unknown format returns null
- Unsupported UEF version throws

**UEF:**
- Polling data chunks receives bytes via ACIA
- Origin chunks consumed without error
- Rewind replays from the start

**Tapefile:**
- Carrier signal (0xFF 0x04)
- End of carrier (0xFF 0x00)
- Regular byte reception
- 0xFF escape (0xFF 0xFF → 0xFF)
- Rewind replays from the start
- EOF returns expected cycle count

## Test plan

- [x] All tests pass (13 new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)