### PR TITLE
feat: add Atom hostname detection and MMC URL parameter

### DIFF
--- a/src/url-params.js
+++ b/src/url-params.js
@@ -240,6 +240,7 @@ export function processAutobootParams(parsedQuery) {
 export function guessModelFromHostname(hostname) {
     if (hostname.startsWith("bbc")) return "B-DFS1.2";
     if (hostname.startsWith("master")) return "Master";
+    if (hostname.startsWith("atom")) return "Atom";
     return "B-DFS1.2";
 }
 
@@ -247,10 +248,14 @@ export function guessModelFromHostname(hostname) {
  * Parse disc or tape images from the query parameters
  * @param {Object} parsedQuery - The query parameters
  * @returns {Object} Object containing disc and tape information
+ *   - discImage: disc image URL (?disc= or ?disc1=)
+ *   - secondDiscImage: second disc URL (?disc2=)
+ *   - tapeImage: tape image URL (?tape=)
+ *   - mmcImage: MMC/SD card image URL (?mmc=, Atom only)
  */
 export function parseMediaParams(parsedQuery) {
-    const { disc, disc1, disc2, tape } = parsedQuery;
+    const { disc, disc1, disc2, tape, mmc } = parsedQuery;
     const discImage = disc || disc1;
 
-    return { discImage, secondDiscImage: disc2, tapeImage: tape };
+    return { discImage, secondDiscImage: disc2, tapeImage: tape, mmcImage: mmc };
 }

--- a/tests/unit/test-url-params.js
+++ b/tests/unit/test-url-params.js
@@ -313,12 +313,23 @@ describe("URL Parameters", () => {
                 discImage: "elite.ssd",
                 secondDiscImage: "games.ssd",
                 tapeImage: "welcome.uef",
+                mmcImage: undefined,
             });
 
             expect(parseMediaParams({ disc1: "disc1.ssd" })).toEqual({
                 discImage: "disc1.ssd",
                 secondDiscImage: undefined,
                 tapeImage: undefined,
+                mmcImage: undefined,
+            });
+        });
+
+        it("should extract mmc image for Atom", () => {
+            expect(parseMediaParams({ mmc: "sdcard.zip" })).toEqual({
+                discImage: undefined,
+                secondDiscImage: undefined,
+                tapeImage: undefined,
+                mmcImage: "sdcard.zip",
             });
         });
     });
@@ -332,6 +343,11 @@ describe("URL Parameters", () => {
         it("should return Master for hostnames starting with 'master'", () => {
             expect(guessModelFromHostname("master.example.com")).toBe("Master");
             expect(guessModelFromHostname("mastercompact.local")).toBe("Master");
+        });
+
+        it("should return Atom for hostnames starting with 'atom'", () => {
+            expect(guessModelFromHostname("atom.example.com")).toBe("Atom");
+            expect(guessModelFromHostname("atomulator.local")).toBe("Atom");
         });
 
         it("should return default model for other hostnames", () => {


### PR DESCRIPTION
## Summary

Extend URL parameter handling for Atom support:
- `guessModelFromHostname`: recognise `atom*` hostnames → default to Atom model
- `parseMediaParams`: add `mmcImage` from `?mmc=` query parameter for Atom SD card images

Both are backward-compatible — existing BBC parameters and hostname detection unchanged.

Part of the incremental merge of Acorn Atom support from PR #505 by @CommanderCoder.

### New URL parameters
- `?mmc=<url>` — load an MMC/SD card image (ZIP) for the Atom. Will be wired into main.js in the integration PR.

### Hostname detection
- `atom.example.com` or `atomulator.local` → selects Atom model by default

### Notes
- The `?mmc=` param needs to be added to `ParamTypes` in main.js (PR 12) to be parsed from the query string. Until then, `mmcImage` will be `undefined`.
- The `?restore=` param from the original PR was not included — the existing snapshot system handles state loading differently.

Co-Authored-By: CommanderCoder <CommanderCoder.2011@gmail.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)