### PR TITLE
fix: correct paste timing and SHIFT key for Atom

### DIFF
--- a/src/keyboard.js
+++ b/src/keyboard.js
@@ -234,7 +234,7 @@ export class Keyboard extends EventTarget {
         const isSpecialHandled = this._handleSpecialKeys(code);
         if (isSpecialHandled) return;
 
-        // Check for registered handlers first; if one fires, don't also send to the BBC.
+        // Check for registered handlers first; if one fires, don't pass to the emulator.
         // This lets Alt+key and Ctrl+key handlers cleanly own their keys without the
         // underlying key leaking through to the emulated machine.
         const handler = this._findKeyHandler(code, evt.altKey, evt.ctrlKey);
@@ -243,7 +243,7 @@ export class Keyboard extends EventTarget {
             return;
         }
 
-        // No handler claimed the key — pass it to the BBC Micro.
+        // No handler claimed the key; pass it to the emulated machine.
         this.keyInterface.keyDown(code, evt.shiftKey);
     }
 
@@ -333,11 +333,11 @@ export class Keyboard extends EventTarget {
     }
 
     /**
-     * Send raw keyboard input to the BBC
-     * @param {Array} keysToSend - Array of keys to send
+     * Send raw keyboard input to the emulated machine (for paste/autotype).
+     * @param {Array} keysToSend - Array of machine-specific key codes to send
      * @param {boolean} checkCapsAndShiftLocks - Whether to check caps and shift locks
      */
-    sendRawKeyboardToBBC(keysToSend, checkCapsAndShiftLocks) {
+    sendRawKeyboard(keysToSend, checkCapsAndShiftLocks) {
         if (this.isPasting) this.cancelPaste();
 
         this.keyInterface.disableKeyboard();

--- a/src/main.js
+++ b/src/main.js
@@ -511,7 +511,7 @@ const pastetext = document.getElementById("paste-text");
 pastetext.closest("form").addEventListener("submit", (event) => event.preventDefault());
 pastetext.addEventListener("paste", function (event) {
     const text = event.clipboardData.getData("text/plain");
-    sendRawKeyboardToBBC(stringToMachineKeys(text), true);
+    sendRawKeyboard(stringToMachineKeys(text), true);
 });
 pastetext.addEventListener("dragover", function (event) {
     event.preventDefault();
@@ -1035,9 +1035,9 @@ const sthFilter = document.getElementById("sth-filter");
 sthFilter.addEventListener("change", () => setSthFilter(sthFilter.value));
 sthFilter.addEventListener("keyup", () => setSthFilter(sthFilter.value));
 
-function sendRawKeyboardToBBC(keysToSend, checkCapsAndShiftLocks) {
+function sendRawKeyboard(keysToSend, checkCapsAndShiftLocks) {
     if (keyboard) {
-        keyboard.sendRawKeyboardToBBC(keysToSend, checkCapsAndShiftLocks);
+        keyboard.sendRawKeyboard(keysToSend, checkCapsAndShiftLocks);
     } else {
         console.warn("Tried to send keys before keyboard was initialised");
     }
@@ -1050,7 +1050,7 @@ function autoboot(image) {
     utils.noteEvent("init", "autoboot", image);
 
     // Shift-break simulation, hold SHIFT for 1000ms.
-    sendRawKeyboardToBBC([BBC.SHIFT, 1000], false);
+    sendRawKeyboard([BBC.SHIFT, 1000], false);
 }
 
 function autoBootType(keys) {
@@ -1058,7 +1058,7 @@ function autoBootType(keys) {
     utils.noteEvent("init", "autochain");
 
     const bbcKeys = stringToMachineKeys(keys);
-    sendRawKeyboardToBBC([1000].concat(bbcKeys), false);
+    sendRawKeyboard([1000].concat(bbcKeys), false);
 }
 
 function autoChainTape() {
@@ -1066,7 +1066,7 @@ function autoChainTape() {
     utils.noteEvent("init", "autochain");
 
     const bbcKeys = stringToMachineKeys('*TAPE\nCH.""\n');
-    sendRawKeyboardToBBC([1000].concat(bbcKeys), false);
+    sendRawKeyboard([1000].concat(bbcKeys), false);
 }
 
 function autoRunTape() {
@@ -1074,7 +1074,7 @@ function autoRunTape() {
     utils.noteEvent("init", "autorun");
 
     const bbcKeys = stringToMachineKeys("*TAPE\n*/\n");
-    sendRawKeyboardToBBC([1000].concat(bbcKeys), false);
+    sendRawKeyboard([1000].concat(bbcKeys), false);
 }
 
 function autoRunBasic() {
@@ -1082,7 +1082,7 @@ function autoRunBasic() {
     utils.noteEvent("init", "autorunbasic");
 
     const bbcKeys = stringToMachineKeys("RUN\n");
-    sendRawKeyboardToBBC([1000].concat(bbcKeys), false);
+    sendRawKeyboard([1000].concat(bbcKeys), false);
 }
 
 function updateUrl() {

--- a/tests/unit/test-keyboard.js
+++ b/tests/unit/test-keyboard.js
@@ -390,15 +390,15 @@ describe("Keyboard", () => {
         expect(mockHandler).toHaveBeenCalledWith(true, utils.keyCodes.E);
     });
 
-    test("sendRawKeyboardToBBC should disable keyboard and schedule paste task", () => {
-        keyboard.sendRawKeyboardToBBC([utils.BBC.A], false);
+    test("sendRawKeyboard should disable keyboard and schedule paste task", () => {
+        keyboard.sendRawKeyboard([utils.BBC.A], false);
 
         expect(mockSysvia.disableKeyboard).toHaveBeenCalled();
         expect(keyboard.isPasting).toBe(true);
     });
 
-    test("sendRawKeyboardToBBC should deliver keys via scheduler and re-enable keyboard", () => {
-        keyboard.sendRawKeyboardToBBC([utils.BBC.A], false);
+    test("sendRawKeyboard should deliver keys via scheduler and re-enable keyboard", () => {
+        keyboard.sendRawKeyboard([utils.BBC.A], false);
 
         // First scheduler fire: presses the key
         mockProcessor.scheduler.polltime(1);
@@ -414,7 +414,7 @@ describe("Keyboard", () => {
     });
 
     test("cancelPaste should stop paste and re-enable keyboard", () => {
-        keyboard.sendRawKeyboardToBBC([utils.BBC.A, utils.BBC.B, utils.BBC.C], false);
+        keyboard.sendRawKeyboard([utils.BBC.A, utils.BBC.B, utils.BBC.C], false);
         mockProcessor.scheduler.polltime(1); // deliver first key
 
         keyboard.cancelPaste();
@@ -424,7 +424,7 @@ describe("Keyboard", () => {
     });
 
     test("Escape should cancel paste during keyDown", () => {
-        keyboard.sendRawKeyboardToBBC([utils.BBC.A, utils.BBC.B], false);
+        keyboard.sendRawKeyboard([utils.BBC.A, utils.BBC.B], false);
         keyboard.setRunning(true);
 
         const escEvent = {
@@ -441,8 +441,8 @@ describe("Keyboard", () => {
         expect(mockSysvia.enableKeyboard).toHaveBeenCalled();
     });
 
-    test("sendRawKeyboardToBBC should handle numeric delay entries", () => {
-        keyboard.sendRawKeyboardToBBC([1000, utils.BBC.A], false);
+    test("sendRawKeyboard should handle numeric delay entries", () => {
+        keyboard.sendRawKeyboard([1000, utils.BBC.A], false);
         const clocksPerMs = Math.floor(mockProcessor.cpuMultiplier * mockProcessor.peripheralCyclesPerSecond) / 1000;
 
         // First fire: numeric delay consumed, no key toggled yet
@@ -455,8 +455,8 @@ describe("Keyboard", () => {
         expect(mockSysvia.keyToggleRaw).toHaveBeenCalledWith(utils.BBC.A);
     });
 
-    test("sendRawKeyboardToBBC should debounce consecutive identical keys", () => {
-        keyboard.sendRawKeyboardToBBC([utils.BBC.A, utils.BBC.A], false);
+    test("sendRawKeyboard should debounce consecutive identical keys", () => {
+        keyboard.sendRawKeyboard([utils.BBC.A, utils.BBC.A], false);
         const clocksPerMs = Math.floor(mockProcessor.cpuMultiplier * mockProcessor.peripheralCyclesPerSecond) / 1000;
 
         // First fire: press A
@@ -474,12 +474,12 @@ describe("Keyboard", () => {
         expect(mockSysvia.keyToggleRaw).toHaveBeenCalledTimes(3);
     });
 
-    test("sendRawKeyboardToBBC while already pasting should cancel previous paste", () => {
-        keyboard.sendRawKeyboardToBBC([utils.BBC.A, utils.BBC.B, utils.BBC.C], false);
+    test("sendRawKeyboard while already pasting should cancel previous paste", () => {
+        keyboard.sendRawKeyboard([utils.BBC.A, utils.BBC.B, utils.BBC.C], false);
         mockProcessor.scheduler.polltime(1); // deliver first key
 
         // Start a new paste mid-stream
-        keyboard.sendRawKeyboardToBBC([utils.BBC.X], false);
+        keyboard.sendRawKeyboard([utils.BBC.X], false);
 
         // Old paste should be cancelled, new one in progress
         expect(keyboard.isPasting).toBe(true);
@@ -587,13 +587,13 @@ describe("Keyboard Atom adapter", () => {
         expect(mockAtomPPIA.keyUp).toHaveBeenCalledWith(65);
     });
 
-    test("sendRawKeyboardToBBC should not inject lock toggles for Atom", () => {
+    test("sendRawKeyboard should not inject lock toggles for Atom", () => {
         // PPIA reports capsLockLight=true, shiftLockLight=false,
         // so the paste logic should not prepend/append any lock keys.
         mockAtomPPIA.capsLockLight = true;
         mockAtomPPIA.shiftLockLight = false;
         const keys = [utils.BBC.A];
-        keyboard.sendRawKeyboardToBBC(keys, true);
+        keyboard.sendRawKeyboard(keys, true);
         expect(mockAtomPPIA.disableKeyboard).toHaveBeenCalled();
         // The keys array should not have been modified with lock toggles
         expect(keys).toEqual([utils.BBC.A]);


### PR DESCRIPTION
## Summary

Two bugs in the paste/autotype path when running on the Atom:

1. **Paste timing was hard-coded to 2 MHz (BBC).** Now uses `processor.peripheralCyclesPerSecond` so the Atom gets correct 1 MHz timing. Without this, paste delays were double what they should be.

2. **SHIFT key sentinel comparison failed on Atom.** The paste code checks `_pasteLastChar !== BBC.SHIFT` to avoid toggling shift off between shifted characters. But `stringToATOMKeys` pushes `ATOM.SHIFT` (`[0,7]`), which is a different array reference from `BBC.SHIFT` (`[0,0]`), so the `!==` always passed. This caused SHIFT to be toggled off after every shifted character, breaking shifted symbol input during paste. Now stores the correct SHIFT key reference per machine at construction time.

Closes #657.

🤖 Generated with [Claude Code](https://claude.com/claude-code)