### PR TITLE
fix: add DC-blocking filter to Atom speaker output

### DIFF
--- a/src/soundchip.js
+++ b/src/soundchip.js
@@ -1,6 +1,6 @@
 // Atom speaker volume, scaled to be comparable with BBC tone channels.
 // The BBC volumeTable[0] (loudest) is 0.25 (1.0 / 4 channels).
-const SpeakerVolume = 0.5;
+const speakerVolume = 0.5;
 
 const volumeTable = new Float32Array(16);
 (() => {
@@ -376,17 +376,17 @@ export class SoundChip {
     speakerChannel(channel, out, offset, length) {
         let fromTime = this.scheduler.epoch - length;
         let bitIndex = 0;
-        // DC-blocking high-pass filter coefficient.
-        // y[n] = x[n] - x[n-1] + alpha * y[n-1]
-        // alpha close to 1 = very low cutoff (passes most audio, blocks DC).
-        const alpha = 0.995;
+        // DC-blocking high-pass filter: y[n] = x[n] - x[n-1] + alpha * y[n-1]
+        // The SoundChip runs at 500 kHz (4 MHz / 8). For a ~20 Hz cutoff:
+        // alpha = 1 - 2*pi*fc/fs = 1 - 2*pi*20/500000 ≈ 0.99975
+        const alpha = 0.99975;
 
         for (let i = 0; i < length; ++i) {
             while (bitIndex < this.bitChange.length && this.bitChange[bitIndex].cycles <= fromTime + i) {
                 this.currentSpeakerBit = this.bitChange[bitIndex].bit;
                 bitIndex++;
             }
-            const input = this.currentSpeakerBit * SpeakerVolume;
+            const input = this.currentSpeakerBit * speakerVolume;
             this._speakerPrevOut = input - this._speakerPrevIn + alpha * this._speakerPrevOut;
             this._speakerPrevIn = input;
             out[i + offset] += this._speakerPrevOut;

--- a/src/soundchip.js
+++ b/src/soundchip.js
@@ -1,3 +1,7 @@
+// Atom speaker volume, scaled to be comparable with BBC tone channels.
+// The BBC volumeTable[0] (loudest) is 0.25 (1.0 / 4 channels).
+const SpeakerVolume = 0.5;
+
 const volumeTable = new Float32Array(16);
 (() => {
     let f = 1.0;
@@ -93,6 +97,9 @@ export class SoundChip {
         this.secondsPerCycle = 1 / cpuSpeed;
         this.bitChange = [];
         this.currentSpeakerBit = 0.0;
+        // DC-blocking high-pass filter state
+        this._speakerPrevIn = 0;
+        this._speakerPrevOut = 0;
     }
 
     setCPUSpeed(cpuSpeed) {
@@ -362,18 +369,27 @@ export class SoundChip {
     speakerReset() {
         this.bitChange = [];
         this.currentSpeakerBit = 0.0;
+        this._speakerPrevIn = 0;
+        this._speakerPrevOut = 0;
     }
 
     speakerChannel(channel, out, offset, length) {
         let fromTime = this.scheduler.epoch - length;
         let bitIndex = 0;
+        // DC-blocking high-pass filter coefficient.
+        // y[n] = x[n] - x[n-1] + alpha * y[n-1]
+        // alpha close to 1 = very low cutoff (passes most audio, blocks DC).
+        const alpha = 0.995;
 
         for (let i = 0; i < length; ++i) {
             while (bitIndex < this.bitChange.length && this.bitChange[bitIndex].cycles <= fromTime + i) {
                 this.currentSpeakerBit = this.bitChange[bitIndex].bit;
                 bitIndex++;
             }
-            out[i + offset] += this.currentSpeakerBit;
+            const input = this.currentSpeakerBit * SpeakerVolume;
+            this._speakerPrevOut = input - this._speakerPrevIn + alpha * this._speakerPrevOut;
+            this._speakerPrevIn = input;
+            out[i + offset] += this._speakerPrevOut;
         }
 
         if (bitIndex > 0) {

--- a/tests/unit/test-soundchip.js
+++ b/tests/unit/test-soundchip.js
@@ -224,13 +224,15 @@ describe("Atom speaker support", () => {
         const out = new Float32Array(16);
         chip.speakerChannel(5, out, 0, 16);
 
-        // Before cycle 5: 0, from 5-9: 1.0, from 10+: 0
-        expect(out[0]).toBe(0.0);
-        expect(out[4]).toBe(0.0);
-        expect(out[5]).toBe(1.0);
-        expect(out[9]).toBe(1.0);
-        expect(out[10]).toBe(0.0);
-        expect(out[15]).toBe(0.0);
+        // Before cycle 5: silence (no transitions yet)
+        expect(out[0]).toBeCloseTo(0.0, 2);
+        expect(out[4]).toBeCloseTo(0.0, 2);
+        // At cycle 5: bit goes high, output jumps positive (DC-blocked)
+        expect(out[5]).toBeGreaterThan(0);
+        // At cycle 10: bit goes low, output changes sign
+        expect(out[10]).toBeLessThan(out[9]);
+        // After all transitions consumed, output decays toward 0
+        expect(Math.abs(out[15])).toBeLessThan(Math.abs(out[10]));
         // Transitions should be consumed
         expect(chip.bitChange).toHaveLength(0);
     });


### PR DESCRIPTION
## Summary

The Atom speaker outputs a 1-bit signal (0 or 1). When the speaker bit is static (common during idle), this produced a constant DC offset added to every audio sample, causing loud noise/buzzing that overwhelmed browser audio.

### The fix

Add a first-order DC-blocking high-pass filter to the speaker channel:

```
y[n] = x[n] - x[n-1] + alpha * y[n-1]   (alpha = 0.995)
```

This is the standard approach for AC-coupling a digital speaker signal. It removes the DC component (static speaker level) while preserving the audio waveform (speaker toggling). The filter naturally decays to silence when the speaker stops toggling.

Also attenuates the speaker output to 0.5x to be comparable with BBC tone channel volume levels.

Fixes #664.

🤖 Generated with [Claude Code](https://claude.com/claude-code)