### PR TITLE
refactor: extract AtomSoundChip subclass from SoundChip

### DIFF
--- a/src/soundchip.js
+++ b/src/soundchip.js
@@ -344,6 +344,9 @@ export class AtomSoundChip extends SoundChip {
 
         // Replace the BBC tone/noise generators with just sine + speaker.
         this.generators = [this.sineChannel.bind(this), this.speakerChannel.bind(this)];
+        // Recompute sine attenuation for the Atom's 2-channel mix
+        // (parent computed it for 5 BBC channels).
+        this.sineTable = makeSineTable(1 / this.generators.length);
 
         this.speakerGenerator = {
             mute: () => {

--- a/src/soundchip.js
+++ b/src/soundchip.js
@@ -21,7 +21,7 @@ function makeSineTable(attenuation) {
 }
 
 export class SoundChip {
-    constructor(onBuffer, { cpuSpeed = 2000000, isAtom = false } = {}) {
+    constructor(onBuffer) {
         this._onBuffer = onBuffer;
         // 4MHz input signal. Internal divide-by-8
         this.soundchipFreq = 4000000.0 / 8;
@@ -32,7 +32,7 @@ export class SoundChip {
         // we generate a sample, we need to decrement the counters by this amount:
         this.sampleDecrement = this.waveDecrementPerSecond / sampleRate;
         // How many samples are generated per CPU cycle.
-        this.samplesPerCycle = sampleRate / cpuSpeed;
+        this.samplesPerCycle = sampleRate / 2000000;
         this.minCyclesWELow = 14; // Somewhat empirically derived; Repton 2 has only 14 cycles between WE low and WE high (@0x2caa)
 
         this.registers = new Uint16Array(4);
@@ -45,7 +45,6 @@ export class SoundChip {
             this.toneChannel.bind(this),
             this.noiseChannel.bind(this),
             this.sineChannel.bind(this),
-            this.speakerChannel.bind(this), // Acorn Atom 1-bit speaker
         ];
 
         this.sineTable = makeSineTable(1 / this.generators.length);
@@ -80,31 +79,6 @@ export class SoundChip {
                 this.sineStep = (freq / sampleRate) * this.sineTable.length;
             },
         };
-
-        // Atom 1-bit speaker support.
-        // The PPIA drives this via pushBit() on each speaker bit transition.
-        this.isAtom = !!isAtom;
-        this.speakerGenerator = {
-            mute: () => {
-                this.catchUp();
-                this.speakerReset();
-            },
-            pushBit: (bit, cycles, seconds) => {
-                this.catchUp();
-                this.updateSpeaker(bit, cycles, seconds);
-            },
-        };
-        this.secondsPerCycle = 1 / cpuSpeed;
-        this.bitChange = [];
-        this.currentSpeakerBit = 0.0;
-        // DC-blocking high-pass filter state
-        this._speakerPrevIn = 0;
-        this._speakerPrevOut = 0;
-    }
-
-    setCPUSpeed(cpuSpeed) {
-        this.secondsPerCycle = 1 / cpuSpeed;
-        this.samplesPerCycle = this.soundchipFreq * this.secondsPerCycle;
     }
 
     sineChannel(channel, out, offset, length) {
@@ -198,11 +172,6 @@ export class SoundChip {
         }
         if (!this.enabled) return;
         for (let i = 0; i < this.generators.length; ++i) {
-            // TODO: consider an AtomSoundChip subclass that overrides generate()
-            // instead of branching on isAtom here. Would cleanly separate BBC
-            // (tone/noise/sine) from Atom (sine/speaker) channel sets.
-            if (this.isAtom && i < 4) continue;
-            if (!this.isAtom && i === 5) continue;
             this.generators[i](i, out, offset, length);
         }
     }
@@ -346,7 +315,6 @@ export class SoundChip {
             this.volume[i] = volumeTable[8];
         }
         this.noisePoked();
-        this.speakerReset();
         this.lastRunEpoch = this.scheduler.epoch;
     }
 
@@ -361,11 +329,44 @@ export class SoundChip {
     unmute() {
         this.enabled = true;
     }
+}
 
-    // Atom speaker: bit-transition FIFO queue.
-    // The CPU toggles a speaker bit via PPIA port C. Each transition is
-    // recorded with its cycle timestamp. speakerChannel then converts
-    // these transitions into audio samples at the output sample rate.
+/**
+ * AtomSoundChip -- Acorn Atom sound via a 1-bit speaker driven by the PPIA.
+ * Uses only the sine channel (shared with BBC for tape tones) and a speaker
+ * channel with DC-blocking filter.
+ */
+export class AtomSoundChip extends SoundChip {
+    constructor(onBuffer, { cpuSpeed = 1000000 } = {}) {
+        super(onBuffer);
+        this.samplesPerCycle = this.soundchipFreq / cpuSpeed;
+        this.secondsPerCycle = 1 / cpuSpeed;
+
+        // Replace the BBC tone/noise generators with just sine + speaker.
+        this.generators = [this.sineChannel.bind(this), this.speakerChannel.bind(this)];
+
+        this.speakerGenerator = {
+            mute: () => {
+                this.catchUp();
+                this.speakerReset();
+            },
+            pushBit: (bit, cycles, seconds) => {
+                this.catchUp();
+                this.updateSpeaker(bit, cycles, seconds);
+            },
+        };
+
+        this.bitChange = [];
+        this.currentSpeakerBit = 0.0;
+        this._speakerPrevIn = 0;
+        this._speakerPrevOut = 0;
+    }
+
+    reset(hard) {
+        super.reset(hard);
+        if (hard) this.speakerReset();
+    }
+
     speakerReset() {
         this.bitChange = [];
         this.currentSpeakerBit = 0.0;

--- a/src/web/audio-handler.js
+++ b/src/web/audio-handler.js
@@ -1,4 +1,4 @@
-import { FakeSoundChip, SoundChip } from "../soundchip.js";
+import { FakeSoundChip, SoundChip, AtomSoundChip } from "../soundchip.js";
 import { DdNoise, FakeDdNoise } from "../ddnoise.js";
 import { RelayNoise, FakeRelayNoise } from "../relaynoise.js";
 import { Music5000, FakeMusic5000 } from "../music5000.js";
@@ -28,10 +28,10 @@ export class AudioHandler {
         this._jsAudioNode = null;
         if (this.audioContext && this.audioContext.audioWorklet) {
             this.audioContext.onstatechange = () => this.checkStatus();
-            this.soundChip = new SoundChip((buffer, time) => this._onBuffer(buffer, time), {
-                cpuSpeed: this.cpuSpeed,
-                isAtom: this.isAtom,
-            });
+            const onBuffer = (buffer, time) => this._onBuffer(buffer, time);
+            this.soundChip = this.isAtom
+                ? new AtomSoundChip(onBuffer, { cpuSpeed: this.cpuSpeed })
+                : new SoundChip(onBuffer);
             // Master gain node for all sample-based audio (disc, relay, etc.).
             this.masterGain = this.audioContext.createGain();
             this.masterGain.connect(this.audioContext.destination);

--- a/tests/unit/test-soundchip.js
+++ b/tests/unit/test-soundchip.js
@@ -1,10 +1,17 @@
 import { describe, it, expect } from "vitest";
-import { SoundChip } from "../../src/soundchip.js";
+import { SoundChip, AtomSoundChip } from "../../src/soundchip.js";
 import { Scheduler } from "../../src/scheduler.js";
 
 function makeSoundChip() {
     const scheduler = new Scheduler();
     const chip = new SoundChip(() => {});
+    chip.setScheduler(scheduler);
+    return { chip, scheduler };
+}
+
+function makeAtomSoundChip() {
+    const scheduler = new Scheduler();
+    const chip = new AtomSoundChip(() => {});
     chip.setScheduler(scheduler);
     return { chip, scheduler };
 }
@@ -144,29 +151,21 @@ describe("SoundChip snapshotState / restoreState", () => {
     });
 });
 
-describe("Atom speaker support", () => {
+describe("AtomSoundChip", () => {
     it("should have speakerGenerator with mute and pushBit", () => {
-        const { chip } = makeSoundChip();
+        const { chip } = makeAtomSoundChip();
         expect(chip.speakerGenerator).toBeDefined();
         expect(typeof chip.speakerGenerator.mute).toBe("function");
         expect(typeof chip.speakerGenerator.pushBit).toBe("function");
     });
 
-    it("should default isAtom to false", () => {
-        const { chip } = makeSoundChip();
-        expect(chip.isAtom).toBe(false);
-    });
-
-    it("setCPUSpeed should adjust samplesPerCycle", () => {
-        const { chip } = makeSoundChip();
-        const before = chip.samplesPerCycle;
-        chip.setCPUSpeed(1000000); // 1 MHz (Atom)
-        expect(chip.samplesPerCycle).not.toBe(before);
+    it("should use 1 MHz samplesPerCycle by default", () => {
+        const { chip } = makeAtomSoundChip();
         expect(chip.samplesPerCycle).toBeCloseTo(chip.soundchipFreq / 1000000);
     });
 
     it("speakerReset should clear the bit change queue", () => {
-        const { chip } = makeSoundChip();
+        const { chip } = makeAtomSoundChip();
         chip.bitChange.push({ bit: 1.0, cycles: 100 });
         chip.speakerReset();
         expect(chip.bitChange).toHaveLength(0);
@@ -174,7 +173,7 @@ describe("Atom speaker support", () => {
     });
 
     it("updateSpeaker should record bit transitions", () => {
-        const { chip } = makeSoundChip();
+        const { chip } = makeAtomSoundChip();
         chip.updateSpeaker(1, 100, 0);
         chip.updateSpeaker(0, 200, 0);
         expect(chip.bitChange).toHaveLength(2);
@@ -182,47 +181,32 @@ describe("Atom speaker support", () => {
         expect(chip.bitChange[1].bit).toBe(0.0);
     });
 
-    it("BBC channels should be skipped when isAtom is true", () => {
-        const { chip } = makeSoundChip();
-        chip.isAtom = true;
-        // Set BBC tone channel to produce sound
+    it("should not run BBC tone/noise channels", () => {
+        const { chip } = makeAtomSoundChip();
         chip.registers[0] = 100;
         chip.volume[0] = 0.25;
         const out = new Float32Array(32);
         chip.generate(out, 0, 32);
-        // BBC tone channel should be silent (skipped)
-        const allZeroOrSpeaker = out.every((v) => Math.abs(v) < 0.01);
-        expect(allZeroOrSpeaker).toBe(true);
+        // No BBC tone output (only sine + speaker generators)
+        expect(out.every((v) => Math.abs(v) < 0.01)).toBe(true);
     });
 
-    it("speaker channel should be skipped when isAtom is false", () => {
-        // Generate baseline output without any speaker transition queued
-        const { chip: baseline } = makeSoundChip();
-        baseline.isAtom = false;
-        const baselineOut = new Float32Array(32);
-        baseline.generate(baselineOut, 0, 32);
-
-        // Generate with a speaker transition queued — should be identical
+    it("BBC SoundChip should not have speaker channel", () => {
         const { chip } = makeSoundChip();
-        chip.isAtom = false;
-        chip.bitChange.push({ bit: 1.0, cycles: 0 });
-        const out = new Float32Array(32);
-        chip.generate(out, 0, 32);
-
-        expect(Array.from(out)).toEqual(Array.from(baselineOut));
+        // BBC SoundChip has 5 generators (3 tone + noise + sine), no speaker
+        expect(chip.generators).toHaveLength(5);
+        expect(chip.speakerGenerator).toBeUndefined();
     });
 
     it("speakerChannel should produce output from bit transitions and consume them", () => {
-        const { chip, scheduler } = makeSoundChip();
+        const { chip, scheduler } = makeAtomSoundChip();
         chip.speakerReset();
-        // Push transitions at known cycle timestamps
         chip.bitChange.push({ bit: 1.0, cycles: 5 });
         chip.bitChange.push({ bit: 0.0, cycles: 10 });
-        // Set epoch so the transitions fall within the render window
         scheduler.epoch = 16;
 
         const out = new Float32Array(16);
-        chip.speakerChannel(5, out, 0, 16);
+        chip.speakerChannel(1, out, 0, 16);
 
         // Before cycle 5: silence (no transitions yet)
         expect(out[0]).toBeCloseTo(0.0, 2);


### PR DESCRIPTION
## Summary

Move all Atom speaker code out of the base SoundChip into a clean AtomSoundChip subclass. The base SoundChip is now purely BBC-focused with no `isAtom` flag or conditional channel skipping.

### What moved to AtomSoundChip
- Speaker state (`bitChange`, `currentSpeakerBit`, DC filter state)
- `speakerGenerator` interface (for PPIA to drive)
- `speakerChannel` / `speakerReset` / `updateSpeaker` methods
- `secondsPerCycle` and CPU speed handling
- Generator list overridden to just sine + speaker (no BBC tone/noise)

### What's left in SoundChip
- BBC tone channels (0-2), noise channel, sine channel
- `toneGenerator` interface (shared, used by Atom for tape tones too)
- Snapshot/restore, scheduling, rendering
- No Atom-specific code or `isAtom` flag

### AudioHandler
Creates `AtomSoundChip` or `SoundChip` based on the `isAtom` option.

Closes #646.

🤖 Generated with [Claude Code](https://claude.com/claude-code)