### PR TITLE
feat: add cassette play/stop control for Atom tape models

### DIFF
--- a/index.html
+++ b/index.html
@@ -258,6 +258,7 @@
           <thead>
             <tr>
               <th>cassette<br />motor</th>
+              <th id="tape-control-header" class="initially-hidden">tape<br />control</th>
               <th>caps<br />lock</th>
               <th>shift<br />lock</th>
               <th>drive<br />0/2</th>
@@ -270,6 +271,9 @@
             <tr>
               <td>
                 <div class="red led" id="motorlight"></div>
+              </td>
+              <td id="tape-control-cell" class="initially-hidden">
+                <button id="tape-play-stop" class="tape-btn" title="Play/Stop cassette">&#9654;</button>
               </td>
               <td>
                 <div class="red led" id="capslight"></div>
@@ -628,7 +632,7 @@
             <div class="tape">
               <label
                 >Load local UEF file:
-                <input type="file" id="tape_load" accept=".uef,application/binary" />
+                <input type="file" id="tape_load" accept=".uef,.zip,application/binary" />
               </label>
             </div>
           </div>

--- a/index.html
+++ b/index.html
@@ -273,7 +273,9 @@
                 <div class="red led" id="motorlight"></div>
               </td>
               <td id="tape-control-cell" class="initially-hidden">
-                <button id="tape-play-stop" class="tape-btn" title="Play/Stop cassette">&#9654;</button>
+                <button id="tape-play-stop" class="tape-btn" title="Play cassette" aria-label="Play cassette">
+                  &#9654;
+                </button>
               </td>
               <td class="bbc-only">
                 <div class="red led" id="capslight"></div>

--- a/index.html
+++ b/index.html
@@ -259,11 +259,11 @@
             <tr>
               <th>cassette<br />motor</th>
               <th id="tape-control-header" class="initially-hidden">tape<br />control</th>
-              <th>caps<br />lock</th>
-              <th>shift<br />lock</th>
-              <th>drive<br />0/2</th>
-              <th>drive<br />1/3</th>
-              <th>econet<br />tx/rx</th>
+              <th class="bbc-only">caps<br />lock</th>
+              <th class="bbc-only">shift<br />lock</th>
+              <th class="bbc-only">drive<br />0/2</th>
+              <th class="bbc-only">drive<br />1/3</th>
+              <th class="bbc-only">econet<br />tx/rx</th>
               <th id="virtual-mhz-header">virtual<br />MHz</th>
             </tr>
           </thead>
@@ -275,19 +275,19 @@
               <td id="tape-control-cell" class="initially-hidden">
                 <button id="tape-play-stop" class="tape-btn" title="Play/Stop cassette">&#9654;</button>
               </td>
-              <td>
+              <td class="bbc-only">
                 <div class="red led" id="capslight"></div>
               </td>
-              <td>
+              <td class="bbc-only">
                 <div class="red led" id="shiftlight"></div>
               </td>
-              <td>
+              <td class="bbc-only">
                 <div class="yellow led" id="drive0"></div>
               </td>
-              <td>
+              <td class="bbc-only">
                 <div class="yellow led" id="drive1"></div>
               </td>
-              <td>
+              <td class="bbc-only">
                 <div class="yellow led" id="networklight"></div>
               </td>
               <td>

--- a/src/jsbeeb.css
+++ b/src/jsbeeb.css
@@ -188,6 +188,29 @@ div.led {
   background-image: url(/images/yellow-on-16.png);
 }
 
+.tape-btn {
+  background: #333;
+  color: #ccc;
+  border: 1px solid #666;
+  border-radius: 3px;
+  font-size: 10px;
+  width: 20px;
+  height: 18px;
+  padding: 0;
+  line-height: 18px;
+  cursor: pointer;
+  text-align: center;
+}
+
+.tape-btn:hover {
+  background: #555;
+  color: #fff;
+}
+
+.tape-btn.playing {
+  color: #4c4;
+}
+
 #pages {
   margin-top: 10px;
 }

--- a/src/main.js
+++ b/src/main.js
@@ -14,7 +14,7 @@ import { Cmos } from "./cmos.js";
 import { StairwayToHell } from "./sth.js";
 import { GamePad } from "./gamepads.js";
 import * as disc from "./fdc.js";
-import { loadTape, loadTapeFromData } from "./tapes.js";
+import { loadTapeFromData } from "./tapes.js";
 import { GoogleDriveLoader } from "./google-drive.js";
 import * as tokeniser from "./basic-tokenise.js";
 import * as canvasLib from "./canvas.js";
@@ -1230,8 +1230,17 @@ async function loadTapeImage(tapeImage) {
             return await loadTapeFromData(tapeImage, tapeData, isAtom);
         }
 
-        default:
-            return await loadTape("tapes/" + tapeImage, isAtom);
+        default: {
+            const tapePath = "tapes/" + tapeImage;
+            let tapeData = await utils.loadData(tapePath);
+            let tapeName = tapeImage;
+            if (/\.zip/i.test(tapeName)) {
+                const unzipped = await utils.unzipDiscImage(tapeData);
+                tapeData = unzipped.data;
+                tapeName = unzipped.name;
+            }
+            return await loadTapeFromData(tapeName, tapeData, isAtom);
+        }
     }
 }
 
@@ -1256,8 +1265,14 @@ document.getElementById("tape_load").addEventListener("change", async function (
     const file = evt.target.files[0];
     utils.noteEvent("local", "clickTape"); // NB no filename here
 
-    const binaryData = await readFileAsBinaryString(file);
-    setProcessorTape(await loadTapeFromData("local file", binaryData, model.isAtom));
+    let tapeData = await readFileAsBinaryString(file);
+    let tapeName = file.name;
+    if (/\.zip/i.test(tapeName)) {
+        const unzipped = await utils.unzipDiscImage(tapeData);
+        tapeData = unzipped.data;
+        tapeName = unzipped.name;
+    }
+    setProcessorTape(await loadTapeFromData(tapeName, tapeData, model.isAtom));
     delete parsedQuery.tape;
     updateUrl();
     bootstrap.Modal.getInstance(document.getElementById("tapes"))?.hide();
@@ -1598,12 +1613,47 @@ for (const link of document.querySelectorAll("#tape-menu a")) {
 
         if (type === "rewind") {
             console.log("Rewinding tape to the start");
-            processor.acia.rewindTape();
+            if (model.isAtom) {
+                processor.atomppia.stopTape();
+                processor.atomppia.rewindTape();
+                updateTapeButton();
+            } else {
+                processor.acia.rewindTape();
+            }
         } else {
             console.log("unknown type", type);
         }
     });
 }
+
+const tapePlayStopBtn = document.getElementById("tape-play-stop");
+const tapeControlHeader = document.getElementById("tape-control-header");
+const tapeControlCell = document.getElementById("tape-control-cell");
+
+function updateTapeButton() {
+    if (!model.isAtom) return;
+    const playing = processor.atomppia.motorOn;
+    tapePlayStopBtn.innerHTML = playing ? "\u25A0" : "\u25B6";
+    tapePlayStopBtn.title = playing ? "Stop cassette" : "Play cassette";
+    tapePlayStopBtn.classList.toggle("playing", playing);
+}
+
+function showTapeControl(visible) {
+    const display = visible ? "" : "none";
+    tapeControlHeader.style.display = display;
+    tapeControlCell.style.display = display;
+}
+
+showTapeControl(model.isAtom);
+
+tapePlayStopBtn.addEventListener("click", () => {
+    if (processor.atomppia.motorOn) {
+        processor.atomppia.stopTape();
+    } else {
+        processor.atomppia.playTape();
+    }
+    updateTapeButton();
+});
 
 function Light(name) {
     const dom = document.getElementById(name);
@@ -1623,13 +1673,17 @@ const drive1 = new Light("drive1");
 const network = new Light("networklight");
 
 syncLights = function () {
-    caps.update(processor.sysvia.capsLockLight);
-    shift.update(processor.sysvia.shiftLockLight);
-    drive0.update(processor.fdc.motorOn[0]);
-    drive1.update(processor.fdc.motorOn[1]);
-    cassette.update(processor.acia.motorOn);
-    if (model.hasEconet) {
-        network.update(processor.econet.activityLight());
+    if (model.isAtom) {
+        cassette.update(processor.atomppia.motorOn);
+    } else {
+        caps.update(processor.sysvia.capsLockLight);
+        shift.update(processor.sysvia.shiftLockLight);
+        drive0.update(processor.fdc.motorOn[0]);
+        drive1.update(processor.fdc.motorOn[1]);
+        cassette.update(processor.acia.motorOn);
+        if (model.hasEconet) {
+            network.update(processor.econet.activityLight());
+        }
     }
 };
 

--- a/src/main.js
+++ b/src/main.js
@@ -1644,7 +1644,15 @@ function showTapeControl(visible) {
     tapeControlCell.style.display = display;
 }
 
-showTapeControl(model.isAtom);
+function updateLedVisibility() {
+    const bbcDisplay = model.isAtom ? "none" : "";
+    for (const el of document.querySelectorAll(".bbc-only")) {
+        el.style.display = bbcDisplay;
+    }
+    showTapeControl(model.isAtom);
+}
+
+updateLedVisibility();
 
 tapePlayStopBtn.addEventListener("click", () => {
     if (processor.atomppia.motorOn) {

--- a/src/main.js
+++ b/src/main.js
@@ -1633,7 +1633,7 @@ const tapeControlCell = document.getElementById("tape-control-cell");
 function updateTapeButton() {
     if (!model.isAtom) return;
     const playing = processor.atomppia.motorOn;
-    tapePlayStopBtn.innerHTML = playing ? "\u25A0" : "\u25B6";
+    tapePlayStopBtn.textContent = playing ? "\u25A0" : "\u25B6";
     tapePlayStopBtn.title = playing ? "Stop cassette" : "Play cassette";
     tapePlayStopBtn.classList.toggle("playing", playing);
 }

--- a/src/main.js
+++ b/src/main.js
@@ -1268,7 +1268,7 @@ document.getElementById("tape_load").addEventListener("change", async function (
     let tapeData = await readFileAsBinaryString(file);
     let tapeName = file.name;
     if (/\.zip/i.test(tapeName)) {
-        const unzipped = await utils.unzipDiscImage(tapeData);
+        const unzipped = await utils.unzipDiscImage(utils.stringToUint8Array(tapeData));
         tapeData = unzipped.data;
         tapeName = unzipped.name;
     }
@@ -1633,8 +1633,10 @@ const tapeControlCell = document.getElementById("tape-control-cell");
 function updateTapeButton() {
     if (!model.isAtom) return;
     const playing = processor.atomppia.motorOn;
+    const label = playing ? "Stop cassette" : "Play cassette";
     tapePlayStopBtn.textContent = playing ? "\u25A0" : "\u25B6";
-    tapePlayStopBtn.title = playing ? "Stop cassette" : "Play cassette";
+    tapePlayStopBtn.title = label;
+    tapePlayStopBtn.setAttribute("aria-label", label);
     tapePlayStopBtn.classList.toggle("playing", playing);
 }
 

--- a/src/ppia.js
+++ b/src/ppia.js
@@ -171,6 +171,12 @@ class PPIA {
                 const rept_key = (!this.keys[1][6] << 6) & 0x40;
                 val = (val & ~0x40) | rept_key;
 
+                // Track cassette input transitions. The Atom ROM tape routines:
+                //   0xfc0a - OSBGET: get byte from tape (every 3.34ms)
+                //   0xfcd2 - test tape input pulse (every 0.033ms / 33 cycles)
+                //   0xfcc2 - count duration of tape pulse (<8 loops = '1', >=8 = '0')
+                //   0xfe6e, 0xfe9d, 0xfe69 - flyback/VSync routines
+                // Between each receiveBit, fcd2 is called ~6 times (33 cycles each).
                 return val;
             }
             default:

--- a/src/ppia.js
+++ b/src/ppia.js
@@ -171,12 +171,6 @@ class PPIA {
                 const rept_key = (!this.keys[1][6] << 6) & 0x40;
                 val = (val & ~0x40) | rept_key;
 
-                // Track cassette input transitions. The Atom ROM tape routines:
-                //   0xfc0a - OSBGET: get byte from tape (every 3.34ms)
-                //   0xfcd2 - test tape input pulse (every 0.033ms / 33 cycles)
-                //   0xfcc2 - count duration of tape pulse (<8 loops = '1', >=8 = '0')
-                //   0xfe6e, 0xfe9d, 0xfe69 - flyback/VSync routines
-                // Between each receiveBit, fcd2 is called ~6 times (33 cycles each).
                 return val;
             }
             default:
@@ -235,6 +229,7 @@ export class AtomPPIA extends PPIA {
         this.shiftLockLight = false;
         this.tapeCarrierCount = 0;
         this.tapeDcdLineLevel = false;
+        this.motorOn = false;
 
         this.reset();
 
@@ -417,14 +412,15 @@ export class AtomPPIA extends PPIA {
 
     playTape() {
         if (this.tape) {
-            //start
+            this.motorOn = true;
             this.runTape();
         }
     }
 
     stopTape() {
+        this.motorOn = false;
         if (this.tape) {
-            let toneGen = this.cpu.soundChip.toneGenerator;
+            const toneGen = this.cpu.soundChip.toneGenerator;
             toneGen.mute();
             this.runTapeTask.cancel();
             this.setTapeCarrier(false);

--- a/src/tapes.js
+++ b/src/tapes.js
@@ -215,7 +215,7 @@ class UefTape {
                     this.count = this.curChunk.stream.readInt16();
                     // Each Atom carrier cycle expands to 16 wavebits, so
                     // divide the count to avoid 16x too many cycles.
-                    if (this.isAtom) this.count = (this.count / 16) | 0;
+                    if (this.isAtom) this.count = Math.max(1, (this.count / 16) | 0);
                 }
                 acia.setTapeCarrier(true);
                 acia.tone(2 * this.baseFrequency);
@@ -310,9 +310,4 @@ export async function loadTapeFromData(name, data, isAtom = false) {
     }
     console.log("Unknown tape format");
     return null;
-}
-
-export async function loadTape(name, isAtom = false) {
-    console.log("Loading tape from " + name);
-    return loadTapeFromData(name, await utils.loadData(name), isAtom);
 }

--- a/src/tapes.js
+++ b/src/tapes.js
@@ -70,13 +70,14 @@ class UefTape {
     poll(acia) {
         if (!this.curChunk) return;
 
-        // Atom: drain the wavebits queue first (one bit per poll)
+        // Atom: drain the wavebits queue first (one bit per poll).
+        // Each wavebit represents one half-period of 2×baseFrequency (2400 Hz),
+        // so the delay is 1/(4×baseFrequency) seconds ≈ 208 cycles at 1 MHz.
+        // AtomBit1Pattern [0,1,0,1,...] toggles every wavebit → 208-cycle transitions → ROM counts ~6 → '1'.
+        // AtomBit0Pattern [0,0,1,1,...] toggles every 2 wavebits → 416-cycle transitions → ROM counts ~13 → '0'.
         if (this.isAtom && this.wavebits.length > 0) {
             acia.receiveBit(this.wavebits.shift());
-            // ~53 cycles at 1 MHz between individual bit transitions.
-            // 16 bits per byte × 53 ≈ 848 cycles per byte character,
-            // with ~3340 cycles between complete bytes (including gaps).
-            return secsToClocks(1.0 / 15.5136 / this.baseFrequency, this.cpuSpeed);
+            return secsToClocks(0.25 / this.baseFrequency, this.cpuSpeed);
         }
 
         if (this.state === -1) {
@@ -181,11 +182,14 @@ class UefTape {
                 if (this.state === 0) {
                     acia.setTapeCarrier(true);
                     acia.tone(2 * this.baseFrequency);
+                    if (this.isAtom) this.wavebits = Array.from(AtomBit1Pattern);
                     this.carrierBefore--;
                     if (this.carrierBefore <= 0) this.state = 1;
                 } else if (this.state < 11) {
                     acia.setTapeCarrier(false);
                     acia.tone(this.dummyData[this.state - 1] ? this.baseFrequency : 2 * this.baseFrequency);
+                    if (this.isAtom)
+                        this.wavebits = Array.from(this.dummyData[this.state - 1] ? AtomBit0Pattern : AtomBit1Pattern);
                     if (this.state === 10) {
                         acia.receive(0xaa);
                     }
@@ -193,9 +197,11 @@ class UefTape {
                 } else {
                     acia.setTapeCarrier(true);
                     acia.tone(2 * this.baseFrequency);
+                    if (this.isAtom) this.wavebits = Array.from(AtomBit1Pattern);
                     this.carrierAfter--;
                     if (this.carrierAfter <= 0) this.state = -1;
                 }
+                if (this.isAtom) return 0;
                 return this.cycles(1);
             case 0x0114:
                 console.log("Ignoring security cycles");
@@ -207,11 +213,16 @@ class UefTape {
                 if (this.state === -1) {
                     this.state = 0;
                     this.count = this.curChunk.stream.readInt16();
+                    // Each Atom carrier cycle expands to 16 wavebits, so
+                    // divide the count to avoid 16x too many cycles.
+                    if (this.isAtom) this.count = (this.count / 16) | 0;
                 }
                 acia.setTapeCarrier(true);
                 acia.tone(2 * this.baseFrequency);
+                if (this.isAtom) this.wavebits = Array.from(AtomBit1Pattern);
                 this.count--;
                 if (this.count <= 0) this.state = -1;
+                if (this.isAtom) return 0;
                 return this.cycles(1);
             case 0x0113:
                 this.baseFrequency = this.curChunk.stream.readFloat32();


### PR DESCRIPTION
## Summary

- Adds a play/stop button to the LED cluster for Atom models (the Atom has no hardware motor control unlike the BBC's ACIA)
- Tracks `motorOn` state in PPIA so the cassette motor LED works
- Fixes tape menu rewind to route through PPIA for Atom
- Fixes zip tape loading from local files and `?tape=` URL parameters
- Fixes Atom carrier tone wavebits (chunks 0x0110/0x0111 were missing Atom-specific bit patterns)
- Fixes wavebit timing from ~54 to ~208 cycles per sample

Partially addresses #661 and #673.

## Test plan

- [ ] Select an Atom Tape model, verify play/stop button appears in LED cluster
- [ ] Click play → button changes to stop icon, motor LED lights up
- [ ] Click stop → button reverts to play icon, motor LED turns off
- [ ] Select a BBC model → play/stop button column is hidden
- [ ] Load a zip tape via URL param (`?model=Atom-Tape&tape=atom%2FTangledUEFhq.zip`)
- [ ] Load a zip tape via Cassette → From local file
- [ ] Rewind from Cassette menu stops tape and rewinds

> **Note:** Tape byte decoding does not work end-to-end yet — see #676 for investigation details.

🤖 Generated with [Claude Code](https://claude.com/claude-code)