### PR TITLE
feat: add Atom support to MachineSession and emulator skill

### DIFF
--- a/.claude/skills/emulator/SKILL.md
+++ b/.claude/skills/emulator/SKILL.md
@@ -1,0 +1,88 @@
+---
+name: emulator
+description: Boot and interact with a headless BBC Micro or Acorn Atom emulator for testing
+allowed-tools: Bash, Read
+---
+
+# Headless Emulator
+
+Boot a BBC Micro or Acorn Atom emulator and interact with it via typed commands.
+Uses `MachineSession` from `src/machine-session.js`.
+
+## Usage
+
+Run Node.js one-liners from the jsbeeb project root:
+
+```javascript
+import { MachineSession } from "./src/machine-session.js";
+
+const session = new MachineSession("MODEL_NAME");
+await session.initialise();
+await session.boot(10);
+session.drainOutput(); // clear boot text
+
+await session._machine.type("PRINT 1+1");
+await session._machine.runFor(2000000);
+console.log(session.drainOutput().screenText);
+// "\n\n PRINT 1+1\n        2\n>"
+
+session.destroy();
+```
+
+## Text output vs screenshots
+
+**Prefer text output** (`drainOutput().screenText`) -- it's lightweight and easy to parse.
+Only use screenshots when you need to verify graphical output (MODE changes, plotting, character rendering).
+
+```javascript
+// Text (default, preferred):
+const output = session.drainOutput();
+console.log(output.screenText);
+
+// Screenshot (only when visual verification needed):
+import { writeFileSync } from "fs";
+const png = await session.screenshot();
+writeFileSync("/tmp/screen.png", png);
+// Then use Read tool on /tmp/screen.png to view it
+```
+
+## Available models
+
+- **BBC:** `B-DFS1.2`, `B-DFS2.26`, `Master`, `Master-MOS3.20`
+- **Atom:** `Atom-Tape`, `Atom-Tape-FP`, `Atom-MMC`, `Atom-DOS`
+
+## Key differences between BBC and Atom
+
+- **Atom BASIC** needs explicit `END` as the last line of programs
+- **Atom OS commands** use `*` prefix: `*LOAD`, `*SAVE`, `*CAT`
+- Atom runs at 1 MHz (BBC at 2 MHz), so use longer `runFor` values
+
+## Tips
+
+- `runFor(n)` runs n CPU cycles. At 2 MHz (BBC): n/2000000 seconds. At 1 MHz (Atom): n/1000000 seconds.
+- `drainOutput()` returns `{ elements, screenText }` and clears the buffer. Call between commands for clean output.
+- For multi-line programs, type each line separately with `runFor(500000)` between them.
+- `session._machine.readbyte(addr)` / `writebyte(addr, val)` for direct memory access.
+- `session.registers()` returns `{ pc, a, x, y, s, p }`.
+
+## Example: Atom program
+
+```javascript
+const session = new MachineSession("Atom-Tape");
+await session.initialise();
+await session.boot(10);
+session.drainOutput();
+
+for (const line of ['10PRINT"HELLO"', "20END"]) {
+  await session._machine.type(line);
+  await session._machine.runFor(500000);
+}
+session.drainOutput(); // clear line entry echo
+
+await session._machine.type("RUN");
+await session._machine.runFor(2000000);
+console.log(session.drainOutput().screenText);
+// HELLO>
+
+session.destroy();
+```

--- a/src/fake6502.js
+++ b/src/fake6502.js
@@ -6,7 +6,7 @@ import { FakeSoundChip } from "./soundchip.js";
 import { findModel, TEST_6502, TEST_65C02, TEST_65C12 } from "./models.js";
 import { FakeDdNoise } from "./ddnoise.js";
 import { FakeRelayNoise } from "./relaynoise.js";
-import { Cpu6502 } from "./6502.js";
+import { Cpu6502, AtomCpu6502 } from "./6502.js";
 import { Cmos } from "./cmos.js";
 import { FakeMusic5000 } from "./music5000.js";
 
@@ -20,7 +20,8 @@ export function fake6502(model, opts) {
     opts = opts || {};
     model = model || TEST_6502;
     if (opts.tube) model.tube = findModel("Tube65c02");
-    return new Cpu6502(model, {
+    const CpuClass = model.isAtom ? AtomCpu6502 : Cpu6502;
+    return new CpuClass(model, {
         dbgr,
         video: opts.video || fakeVideo,
         soundChip: opts.soundChip || soundChip,

--- a/src/machine-session.js
+++ b/src/machine-session.js
@@ -46,6 +46,7 @@ export class MachineSession {
 
         // Create a real Video instance so we get pixel output
         const modelObj = findModel(modelName);
+        this._isAtom = modelObj.isAtom;
         this._video = new Video(
             modelObj.isMaster,
             this._fb32,
@@ -69,6 +70,7 @@ export class MachineSession {
 
         // Accumulated VDU text output — drained by callers
         this._pendingOutput = [];
+        this._flushCapture = () => {};
 
         // Breakpoint management — persistent hooks that survive across run calls
         this._breakpoints = new Map(); // id → { hook, type, address, hit }
@@ -97,8 +99,9 @@ export class MachineSession {
     /**
      * Install the VDU character-output capture hook.
      *
-     * WRCHV discovery: RAM at 0x20E/0x20F initialises to 0xFFFF before the
-     * OS runs.  We read directly from cpu.ramRomOs (two array lookups — no
+     * WRCHV discovery: RAM at the OS write-character vector (0x20E on BBC,
+     * 0x208 on Atom) initialises to 0x0000 before the OS runs.  We read
+     * directly from cpu.ramRomOs (two array lookups — no
      * readmem() dispatch overhead) on every instruction, waiting for the
      * value to change from its initial 0xFFFF.  Once the OS installs a real
      * handler we use that address for the lifetime of the session.  Programs
@@ -112,7 +115,9 @@ export class MachineSession {
     _installCaptureHook() {
         const cpu = this._machine.processor;
         const ram = cpu.ramRomOs; // direct Uint8Array — no dispatch overhead
-        const initialWrchv = ram[0x20e] | (ram[0x20f] << 8); // 0xFFFF pre-boot
+        // WRCHV vector: BBC at $020E, Atom at $0208.
+        const wrchvAddr = this._isAtom ? 0x208 : 0x20e;
+        const initialWrchv = ram[wrchvAddr] | (ram[wrchvAddr + 1] << 8); // 0xFFFF pre-boot
 
         const attributes = { x: 0, y: 0, text: "", foreground: 7, background: 0, mode: 7 };
         let currentText = "";
@@ -131,6 +136,12 @@ export class MachineSession {
             currentText = "";
         }
 
+        // Expose flush so drainOutput can capture trailing text
+        // that hasn't been terminated by a control character.
+        this._flushCapture = flush;
+
+        const isAtom = this._isAtom;
+
         function onChar(c) {
             if (nextN) {
                 params.push(c);
@@ -142,9 +153,6 @@ export class MachineSession {
                 return;
             }
             switch (c) {
-                case 1: // next char to printer only
-                    nextN = 1;
-                    break;
                 case 10: // LF
                     flush();
                     attributes.y++;
@@ -158,48 +166,58 @@ export class MachineSession {
                     flush();
                     attributes.x = 0;
                     break;
-                case 17: // COLOUR n
-                    nextN = 1;
-                    vduProc = (p) => {
-                        if (p[0] & 0x80) attributes.background = p[0] & 0xf;
-                        else attributes.foreground = p[0] & 0xf;
-                    };
-                    break;
-                case 18: // GCOL
-                    nextN = 2;
-                    break;
-                case 19: // define logical colour
-                    nextN = 5;
-                    break;
-                case 22: // MODE n
-                    nextN = 1;
-                    vduProc = (p) => {
-                        flush();
-                        attributes.mode = p[0];
-                        attributes.x = 0;
-                        attributes.y = 0;
-                        attributes.foreground = 7;
-                        attributes.background = 0;
-                    };
-                    break;
-                case 25: // PLOT
-                    nextN = 5;
-                    break;
-                case 28: // define text window
-                    nextN = 4;
-                    break;
-                case 29: // define graphics origin
-                    nextN = 4;
-                    break;
-                case 31: // TAB(x,y)
-                    nextN = 2;
-                    vduProc = (p) => {
-                        flush();
-                        attributes.x = p[0];
-                        attributes.y = p[1];
-                    };
-                    break;
                 default:
+                    // BBC VDU control codes (multi-byte sequences).
+                    // The Atom doesn't use these; skip them to avoid
+                    // swallowing printable characters.
+                    if (!isAtom) {
+                        switch (c) {
+                            case 1: // next char to printer only
+                                nextN = 1;
+                                return;
+                            case 17: // COLOUR n
+                                nextN = 1;
+                                vduProc = (p) => {
+                                    if (p[0] & 0x80) attributes.background = p[0] & 0xf;
+                                    else attributes.foreground = p[0] & 0xf;
+                                };
+                                return;
+                            case 18: // GCOL
+                                nextN = 2;
+                                return;
+                            case 19: // define logical colour
+                                nextN = 5;
+                                return;
+                            case 22: // MODE n
+                                nextN = 1;
+                                vduProc = (p) => {
+                                    flush();
+                                    attributes.mode = p[0];
+                                    attributes.x = 0;
+                                    attributes.y = 0;
+                                    attributes.foreground = 7;
+                                    attributes.background = 0;
+                                };
+                                return;
+                            case 25: // PLOT
+                                nextN = 5;
+                                return;
+                            case 28: // define text window
+                                nextN = 4;
+                                return;
+                            case 29: // define graphics origin
+                                nextN = 4;
+                                return;
+                            case 31: // TAB(x,y)
+                                nextN = 2;
+                                vduProc = (p) => {
+                                    flush();
+                                    attributes.x = p[0];
+                                    attributes.y = p[1];
+                                };
+                                return;
+                        }
+                    }
                     if (c >= 32 && c < 0x7f) {
                         currentText += String.fromCharCode(c);
                     } else {
@@ -214,7 +232,7 @@ export class MachineSession {
             // Once the OS sets WRCHV (it changes from 0xFFFF), we start
             // capturing.  Programs that install a custom VDU driver mid-run
             // are handled transparently because we re-read on every call.
-            const wrchv = ram[0x20e] | (ram[0x20f] << 8);
+            const wrchv = ram[wrchvAddr] | (ram[wrchvAddr + 1] << 8);
             if (wrchv !== initialWrchv && addr === wrchv) {
                 onChar(cpu.a);
             }
@@ -398,6 +416,7 @@ export class MachineSession {
      * Also includes a flat `screenText` reconstruction.
      */
     drainOutput({ clear = true } = {}) {
+        this._flushCapture();
         const elements = clear ? this._pendingOutput.splice(0) : [...this._pendingOutput];
         return {
             elements,

--- a/src/machine-session.js
+++ b/src/machine-session.js
@@ -9,7 +9,7 @@ import { readFileSync } from "fs";
 import { fileURLToPath } from "url";
 import path from "path";
 import { TestMachine } from "../tests/test-machine.js";
-import { InstrumentedSoundChip } from "./soundchip.js";
+import { InstrumentedSoundChip, FakeSoundChip } from "./soundchip.js";
 
 // Resolve the jsbeeb package root from our own location (src/machine-session.js
 // → go up one level).  Passed to setNodeBasePath() so the ROM loader resolves
@@ -46,16 +46,23 @@ export class MachineSession {
 
         // Create a real Video instance so we get pixel output
         const modelObj = findModel(modelName);
-        this._video = new Video(modelObj.isMaster, this._fb32, (minx, miny, maxx, maxy) => {
-            this._lastPaint = { minx, miny, maxx, maxy };
-            this._frameDirty = true;
-            // Snapshot the complete frame now, before clearPaintBuffer() wipes _fb32.
-            // This mirrors what the browser does: paint_ext fires → canvas updated → fb32 cleared.
-            this._completeFb8.set(this._fb8);
-        });
+        this._video = new Video(
+            modelObj.isMaster,
+            this._fb32,
+            (minx, miny, maxx, maxy) => {
+                this._lastPaint = { minx, miny, maxx, maxy };
+                this._frameDirty = true;
+                // Snapshot the complete frame now, before clearPaintBuffer() wipes _fb32.
+                // This mirrors what the browser does: paint_ext fires → canvas updated → fb32 cleared.
+                this._completeFb8.set(this._fb8);
+            },
+            { isAtom: modelObj.isAtom },
+        );
 
-        // Use a real (instrumented) sound chip so we can read registers and capture writes
-        this._soundChip = new InstrumentedSoundChip();
+        // Use a real (instrumented) sound chip so we can read registers and capture writes.
+        // Atom models use AtomSoundChip which has a different interface (speakerGenerator,
+        // toneGenerator); FakeSoundChip provides compatible no-op stubs for headless mode.
+        this._soundChip = modelObj.isAtom ? new FakeSoundChip() : new InstrumentedSoundChip();
 
         // TestMachine forwards opts.video and opts.soundChip to fake6502
         this._machine = new TestMachine(modelName, { video: this._video, soundChip: this._soundChip });

--- a/tests/test-machine.js
+++ b/tests/test-machine.js
@@ -3,6 +3,7 @@ import { fake6502 } from "../src/fake6502.js";
 import { findModel } from "../src/models.js";
 import assert from "assert";
 import * as utils from "../src/utils.js";
+import * as utils_atom from "../src/utils_atom.js";
 import * as Tokeniser from "../src/basic-tokenise.js";
 
 const MaxCyclesPerIter = 100 * 1000;
@@ -10,9 +11,16 @@ const MaxCyclesPerIter = 100 * 1000;
 export class TestMachine {
     constructor(model, opts) {
         model = model || "B-DFS1.2";
-        this.processor = fake6502(findModel(model), opts || {});
+        const modelObj = findModel(model);
+        this.model = modelObj;
+        this.processor = fake6502(modelObj, opts || {});
         this._capturedChars = [];
         this._captureHookInstalled = false;
+    }
+
+    /** The keyboard interface for this machine (SysVia for BBC, PPIA for Atom). */
+    get _keyInterface() {
+        return this.model.isAtom ? this.processor.atomppia : this.processor.sysvia;
     }
 
     async initialise() {
@@ -130,6 +138,23 @@ export class TestMachine {
     async runUntilInput(secs) {
         if (!secs) secs = 120;
         console.log("Running until keyboard input requested");
+        if (this.model.isAtom) {
+            // The Atom kernel's keyboard read loop at $FE94 is entered when
+            // BASIC (or the OS) waits for a keypress.  We detect entry to
+            // this routine as the idle point.
+            const atomIdleAddr = 0xfe94;
+            let hit = false;
+            const hook = this.processor.debugInstruction.add((addr) => {
+                if (addr === atomIdleAddr) {
+                    hit = true;
+                    return true;
+                }
+            });
+            await this.runFor(secs * 1 * 1000 * 1000); // Atom is 1 MHz
+            hook.remove();
+            assert(hit, "Atom did not reach keyboard input in time");
+            return this.runFor(10 * 1000);
+        }
         const idleAddr = this.processor.model.isMaster ? 0xe7e6 : 0xe581;
         let hit = false;
         const hook = this.processor.debugInstruction.add((addr) => {
@@ -304,6 +329,9 @@ export class TestMachine {
      * resumes.
      */
     async type(text) {
+        if (this.model.isAtom) {
+            return this._typeAtom(text);
+        }
         const fullText = text + "\n"; // append RETURN
         const keys = fullText.split("").map((ch) => this._charToKey(ch));
         const holdCycles = 40000;
@@ -351,20 +379,92 @@ export class TestMachine {
         }
     }
 
-    /**
-     * Press a key on the BBC keyboard.
-     * @param {number} code - BBC key code (e.g. utils.keyCodes.SPACE)
-     */
-    keyDown(code) {
-        this.processor.sysvia.keyDown(code);
+    /** Type text on the Atom using its key mapping and PPIA interface. */
+    async _typeAtom(text) {
+        // stringToATOMKeys returns a flat array of [col, row] pairs.
+        // SHIFT and LOCK are inserted as toggle entries that stay held
+        // until the next toggle of the same key.
+        const keySequence = utils_atom.stringToATOMKeys(text + "\n");
+        const ppia = this.processor.atomppia;
+        const holdCycles = 80000; // Atom at 1 MHz needs longer hold than BBC at 2 MHz
+        const SHIFT = utils_atom.ATOM.SHIFT;
+        const LOCK = utils_atom.ATOM.LOCK;
+
+        let index = 0;
+        let phase = "idle";
+        let nextEventCycle = 0;
+        let done = false;
+        const toggleState = new Set();
+
+        const currentCycle = () => this.processor.cycleSeconds * 1000000 + this.processor.currentCycles;
+
+        const isToggle = (entry) =>
+            (entry[0] === SHIFT[0] && entry[1] === SHIFT[1]) || (entry[0] === LOCK[0] && entry[1] === LOCK[1]);
+
+        const hook = this.processor.debugInstruction.add(() => {
+            if (currentCycle() < nextEventCycle) return;
+
+            if (phase === "down") {
+                const entry = keySequence[index];
+                if (!isToggle(entry)) {
+                    ppia.keyUpRaw(entry);
+                }
+                index++;
+                phase = "idle";
+                nextEventCycle = currentCycle() + holdCycles;
+                return;
+            }
+
+            if (index >= keySequence.length) {
+                // Release any held toggles
+                for (const key of toggleState) {
+                    const [col, row] = key.split(",").map(Number);
+                    ppia.keyUpRaw([col, row]);
+                }
+                hook.remove();
+                done = true;
+                return;
+            }
+
+            const entry = keySequence[index];
+            if (isToggle(entry)) {
+                const key = `${entry[0]},${entry[1]}`;
+                if (toggleState.has(key)) {
+                    ppia.keyUpRaw(entry);
+                    toggleState.delete(key);
+                } else {
+                    ppia.keyDownRaw(entry);
+                    toggleState.add(key);
+                }
+                index++;
+                nextEventCycle = currentCycle() + holdCycles;
+            } else {
+                ppia.keyDownRaw(entry);
+                phase = "down";
+                nextEventCycle = currentCycle() + holdCycles;
+            }
+        });
+
+        while (!done) {
+            const stopped = await this.runFor(holdCycles);
+            if (stopped) break;
+        }
     }
 
     /**
-     * Release a key on the BBC keyboard.
-     * @param {number} code - BBC key code
+     * Press a key on the keyboard.
+     * @param {number} code - key code (BBC keyCode or Atom raw key)
+     */
+    keyDown(code) {
+        this._keyInterface.keyDown(code);
+    }
+
+    /**
+     * Release a key on the keyboard.
+     * @param {number} code - key code
      */
     keyUp(code) {
-        this.processor.sysvia.keyUp(code);
+        this._keyInterface.keyUp(code);
     }
 
     /**

--- a/tests/test-machine.js
+++ b/tests/test-machine.js
@@ -447,7 +447,14 @@ export class TestMachine {
 
         while (!done) {
             const stopped = await this.runFor(holdCycles);
-            if (stopped) break;
+            if (stopped) {
+                hook.remove();
+                for (const key of toggleState) {
+                    const [col, row] = key.split(",").map(Number);
+                    ppia.keyUpRaw([col, row]);
+                }
+                break;
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

- Add Atom model support to `fake6502`, `TestMachine`, and `MachineSession` so headless emulation works for Atom models
- Fix text capture (`drainOutput`) for Atom by hooking the OSWRCH vector at `$0208` (vs BBC's `$020E`)
- Fix `drainOutput` flushing trailing text that hasn't been terminated by a control character (affects both BBC and Atom)
- Gate BBC VDU control codes (COLOUR, MODE, PLOT, etc.) behind `!isAtom` to avoid swallowing Atom printable chars
- Add `/emulator` Claude Code skill for interactive headless testing

### Changes by file

| File | Change |
|------|--------|
| `src/fake6502.js` | Select `AtomCpu6502` when `model.isAtom` |
| `src/machine-session.js` | Atom WRCHV vector, `FakeSoundChip` for Atom, `isAtom` passed to Video, flush capture on drain, VDU code gating |
| `tests/test-machine.js` | Atom keyboard typing via `stringToATOMKeys`/`keyDownRaw`, Atom idle address for `runUntilInput`, `_keyInterface` getter |
| `.claude/skills/emulator/SKILL.md` | Skill with usage docs, model list, BBC/Atom differences |

## Test plan

- [ ] `node -e "import {MachineSession} from './src/machine-session.js'; const s = new MachineSession('Atom-Tape'); await s.initialise(); await s.boot(10); s.drainOutput(); await s._machine.type('PRINT 1+1'); await s._machine.runFor(2000000); console.log(s.drainOutput().screenText); s.destroy()"` -- should output text containing `2>`
- [ ] Same test with `B-DFS1.2` model and `PRINT 6*7` -- should output `42`
- [ ] `npm run test:unit` -- all 556 tests pass
- [ ] `/emulator` skill visible in Claude Code skill list

🤖 Generated with [Claude Code](https://claude.com/claude-code)