### PR TITLE
fix: add debounce gap between paste key releases on Atom

### DIFF
--- a/src/keyboard.js
+++ b/src/keyboard.js
@@ -394,7 +394,10 @@ export class Keyboard extends EventTarget {
             return;
         }
 
-        let delayMs = 50;
+        // Atom ROM polls the keyboard once per VSync (~20ms at 50 Hz).
+        // 50ms is only 2.5 scan cycles; 80ms gives the ROM a comfortable
+        // margin to detect, debounce, and process each keypress.
+        let delayMs = this.processor.model.isAtom ? 80 : 50;
         if (typeof this._pasteLastChar === "number") {
             delayMs = this._pasteLastChar;
             this._pasteLastChar = undefined;

--- a/src/keyboard.js
+++ b/src/keyboard.js
@@ -376,6 +376,15 @@ export class Keyboard extends EventTarget {
             return;
         }
 
+        // Atom's PPIA keyboard is polled, not interrupt-driven like the BBC's
+        // SysVIA. Insert a debounce gap after every key release so the ROM
+        // sees the key-up before the next key-down arrives.
+        if (this._pasteLastChar && this._pasteLastChar !== this._shiftKey && this.processor.model.isAtom) {
+            this._pasteLastChar = undefined;
+            this._pasteTask.schedule(30 * this._pasteClocksPerMs);
+            return;
+        }
+
         const ch = this._pasteKeys[0];
         const debounce = this._pasteLastChar === ch;
         this._pasteLastChar = ch;

--- a/src/keyboard.js
+++ b/src/keyboard.js
@@ -394,9 +394,9 @@ export class Keyboard extends EventTarget {
             return;
         }
 
-        // Atom ROM polls the keyboard once per VSync (~20ms at 50 Hz).
-        // 50ms is only 2.5 scan cycles; 80ms gives the ROM a comfortable
-        // margin to detect, debounce, and process each keypress.
+        // Atom ROM polls the keyboard once per VSync (~16ms at 60 Hz).
+        // 80ms gives the ROM ~5 scan cycles to detect, debounce, and
+        // process each keypress.
         let delayMs = this.processor.model.isAtom ? 80 : 50;
         if (typeof this._pasteLastChar === "number") {
             delayMs = this._pasteLastChar;

--- a/src/utils_atom.js
+++ b/src/utils_atom.js
@@ -115,21 +115,18 @@ export const ATOM = {
 export function stringToATOMKeys(str) {
     const array = [];
     let shiftState = false;
-    let capsLockState = true;
     for (let i = 0; i < str.length; ++i) {
         const c = str.charCodeAt(i);
         let charStr = str.charAt(i);
         let atomKey = null;
         let needsShift = false;
-        let needsCapsLock = true;
         if (c >= 65 && c <= 90) {
             // A-Z
             atomKey = ATOM[charStr];
         } else if (c >= 97 && c <= 122) {
-            // a-z
+            // a-z → A-Z (Atom character set is uppercase only)
             charStr = String.fromCharCode(c - 32);
             atomKey = ATOM[charStr];
-            needsCapsLock = false;
         } else if (c >= 48 && c <= 57) {
             // 0-9
             atomKey = ATOM["K" + charStr];
@@ -156,30 +153,15 @@ export function stringToATOMKeys(str) {
                     atomKey = ATOM.MINUS_EQUALS;
                     needsShift = true;
                     break;
-                // case '^':
-                //     atomKey = ATOM.HAT_TILDE;
-                //     break;
-                // case '~':
-                //     atomKey = ATOM.HAT_TILDE; needsShift = true;
-                //     break;
                 case "\\":
                     atomKey = ATOM.BACKSLASH;
                     break;
-                // case '|':
-                //     atomKey = ATOM.PIPE_BACKSLASH; needsShift = true;
-                //     break;
                 case "@":
                     atomKey = ATOM.AT;
                     break;
                 case "[":
                     atomKey = ATOM.LEFT_SQUARE_BRACKET;
                     break;
-                // case '{':
-                //     atomKey = ATOM.LEFT_SQUARE_BRACKET; needsShift = true;
-                //     break;
-                // case '_':
-                //     atomKey = ATOM.UNDERSCORE_POUND;
-                //     break;
                 case ";":
                     atomKey = ATOM.SEMICOLON_PLUS;
                     break;
@@ -197,9 +179,6 @@ export function stringToATOMKeys(str) {
                 case "]":
                     atomKey = ATOM.RIGHT_SQUARE_BRACKET;
                     break;
-                // case '}':
-                //     atomKey = ATOM.RIGHT_SQUARE_BRACKET; needsShift = true;
-                //     break;
                 case ",":
                     atomKey = ATOM.COMMA_LESSTHAN;
                     break;
@@ -230,15 +209,10 @@ export function stringToATOMKeys(str) {
             array.push(ATOM.SHIFT);
             shiftState = !shiftState;
         }
-        if ((needsCapsLock && !capsLockState) || (!needsCapsLock && capsLockState)) {
-            array.push(ATOM.LOCK);
-            capsLockState = !capsLockState;
-        }
         array.push(atomKey);
     }
 
     if (shiftState) array.push(ATOM.SHIFT);
-    if (!capsLockState) array.push(ATOM.LOCK);
     return array;
 }
 

--- a/src/utils_atom.js
+++ b/src/utils_atom.js
@@ -121,10 +121,13 @@ export function stringToATOMKeys(str) {
         let charStr = str.charAt(i);
         let atomKey = null;
         let needsShift = false;
-        let needsCapsLock = true;
+        // Only letters care about caps lock state; non-letter characters
+        // leave it wherever it is to avoid unnecessary LOCK toggles.
+        let needsCapsLock = capsLockState;
         if (c >= 65 && c <= 90) {
             // A-Z
             atomKey = ATOM[charStr];
+            needsCapsLock = true;
         } else if (c >= 97 && c <= 122) {
             // a-z (LOCK toggles the ROM's internal caps lock state)
             charStr = String.fromCharCode(c - 32);

--- a/src/utils_atom.js
+++ b/src/utils_atom.js
@@ -115,18 +115,21 @@ export const ATOM = {
 export function stringToATOMKeys(str) {
     const array = [];
     let shiftState = false;
+    let capsLockState = true;
     for (let i = 0; i < str.length; ++i) {
         const c = str.charCodeAt(i);
         let charStr = str.charAt(i);
         let atomKey = null;
         let needsShift = false;
+        let needsCapsLock = true;
         if (c >= 65 && c <= 90) {
             // A-Z
             atomKey = ATOM[charStr];
         } else if (c >= 97 && c <= 122) {
-            // a-z → A-Z (Atom character set is uppercase only)
+            // a-z (LOCK toggles the ROM's internal caps lock state)
             charStr = String.fromCharCode(c - 32);
             atomKey = ATOM[charStr];
+            needsCapsLock = false;
         } else if (c >= 48 && c <= 57) {
             // 0-9
             atomKey = ATOM["K" + charStr];
@@ -209,10 +212,15 @@ export function stringToATOMKeys(str) {
             array.push(ATOM.SHIFT);
             shiftState = !shiftState;
         }
+        if ((needsCapsLock && !capsLockState) || (!needsCapsLock && capsLockState)) {
+            array.push(ATOM.LOCK);
+            capsLockState = !capsLockState;
+        }
         array.push(atomKey);
     }
 
     if (shiftState) array.push(ATOM.SHIFT);
+    if (!capsLockState) array.push(ATOM.LOCK);
     return array;
 }
 

--- a/tests/integration/atom-keyboard.js
+++ b/tests/integration/atom-keyboard.js
@@ -1,0 +1,61 @@
+import { describe, it, expect } from "vitest";
+import { TestMachine } from "../test-machine.js";
+
+describe("Atom keyboard", () => {
+    let machine;
+
+    async function bootAtom() {
+        machine = new TestMachine("Atom");
+        await machine.initialise();
+        machine.startCapture();
+        await machine.runUntilInput(10);
+        machine.drainText(); // discard boot message
+    }
+
+    async function typeAndCapture(text, runCycles = 2000000) {
+        await machine.type(text);
+        await machine.runFor(runCycles);
+        return machine.drainText();
+    }
+
+    it("should type uppercase text", async () => {
+        await bootAtom();
+        const output = await typeAndCapture("PRINT 42");
+        expect(output).toContain("PRINT 42");
+        expect(output).toContain("42");
+    });
+
+    it("should type mixed case text", async () => {
+        await bootAtom();
+        // P."Hello" should echo "Hello" then print Hello
+        const output = await typeAndCapture('P."Hello"');
+        expect(output).toContain("Hello");
+    });
+
+    it("should type shifted characters", async () => {
+        await bootAtom();
+        const output = await typeAndCapture("PRINT 1+2");
+        expect(output).toContain("PRINT 1+2");
+        expect(output).toContain("3");
+    });
+
+    it("should type text with spaces in lowercase runs", async () => {
+        await bootAtom();
+        // This reproduced the original bug: spaces in lowercase text caused
+        // unnecessary LOCK toggles that the ROM read as character input.
+        // "attempting to unzip" has spaces mid-lowercase — previously each
+        // space triggered 2 extra LOCK presses, garbling the output.
+        const output = await typeAndCapture('P."attempting to unzip"', 3000000);
+        expect(output).toContain("attempting to unzip");
+    });
+
+    it("should preserve caps lock state across commands", async () => {
+        await bootAtom();
+        // Type something with lowercase, then an all-uppercase command.
+        // The trailing LOCK in stringToATOMKeys should restore caps lock.
+        await typeAndCapture('P."hello"');
+        const output = await typeAndCapture("PRINT 99");
+        expect(output).toContain("PRINT 99");
+        expect(output).toContain("99");
+    });
+});

--- a/tests/test-machine.js
+++ b/tests/test-machine.js
@@ -410,7 +410,8 @@ export class TestMachine {
     /** Type text on the Atom using its key mapping and PPIA interface. */
     async _typeAtom(text) {
         // stringToATOMKeys returns a flat array of [col, row] pairs.
-        // SHIFT is inserted as a toggle that stays held until the next toggle.
+        // SHIFT is held across multiple characters; LOCK is tapped to
+        // toggle the ROM's internal caps lock state.
         const keySequence = utils_atom.stringToATOMKeys(text + "\n");
         const ppia = this.processor.atomppia;
         const holdCycles = 80000; // Atom at 1 MHz needs longer hold than BBC at 2 MHz

--- a/tests/test-machine.js
+++ b/tests/test-machine.js
@@ -32,11 +32,11 @@ export class TestMachine {
      * The Atom ROM's main loop waits for VSync (bit 7 of Port C) to
      * toggle before scanning the keyboard.  The MC6847 video chip drives
      * this in the real emulator, but fake6502 doesn't create one, so we
-     * simulate it with a scheduler task at 50 Hz.
+     * simulate it with a scheduler task at ~60 Hz (NTSC).
      */
     _startAtomVSync() {
         const ppia = this.processor.atomppia;
-        const VsyncPeriod = 20000; // 1 MHz / 50 Hz
+        const VsyncPeriod = 16667; // 1 MHz / 60 Hz (NTSC 262-line frame)
         const VsyncPulse = 800;
         let inVsync = false;
         const task = this.processor.scheduler.newTask(() => {

--- a/tests/test-machine.js
+++ b/tests/test-machine.js
@@ -25,6 +25,32 @@ export class TestMachine {
 
     async initialise() {
         await this.processor.initialise();
+        if (this.model.isAtom) this._startAtomVSync();
+    }
+
+    /**
+     * The Atom ROM's main loop waits for VSync (bit 7 of Port C) to
+     * toggle before scanning the keyboard.  The MC6847 video chip drives
+     * this in the real emulator, but fake6502 doesn't create one, so we
+     * simulate it with a scheduler task at 50 Hz.
+     */
+    _startAtomVSync() {
+        const ppia = this.processor.atomppia;
+        const VsyncPeriod = 20000; // 1 MHz / 50 Hz
+        const VsyncPulse = 800;
+        let inVsync = false;
+        const task = this.processor.scheduler.newTask(() => {
+            if (!inVsync) {
+                ppia.setVBlankInt(1);
+                inVsync = true;
+                task.reschedule(VsyncPulse);
+            } else {
+                ppia.setVBlankInt(0);
+                inVsync = false;
+                task.reschedule(VsyncPeriod - VsyncPulse);
+            }
+        });
+        task.schedule(VsyncPeriod);
     }
 
     /**
@@ -35,8 +61,10 @@ export class TestMachine {
     startCapture() {
         if (this._captureHookInstalled) return;
         this._captureHookInstalled = true;
+        // WRCHV is at 0x0208 on Atom, 0x020E on BBC.
+        const wrchvAddr = this.model.isAtom ? 0x0208 : 0x020e;
         this.processor.debugInstruction.add((addr) => {
-            const wrchv = this.readword(0x20e);
+            const wrchv = this.readword(wrchvAddr);
             if (addr === wrchv) {
                 this._capturedChars.push(this.processor.a);
             }
@@ -382,31 +410,28 @@ export class TestMachine {
     /** Type text on the Atom using its key mapping and PPIA interface. */
     async _typeAtom(text) {
         // stringToATOMKeys returns a flat array of [col, row] pairs.
-        // SHIFT and LOCK are inserted as toggle entries that stay held
-        // until the next toggle of the same key.
+        // SHIFT is inserted as a toggle that stays held until the next toggle.
         const keySequence = utils_atom.stringToATOMKeys(text + "\n");
         const ppia = this.processor.atomppia;
         const holdCycles = 80000; // Atom at 1 MHz needs longer hold than BBC at 2 MHz
         const SHIFT = utils_atom.ATOM.SHIFT;
-        const LOCK = utils_atom.ATOM.LOCK;
 
         let index = 0;
         let phase = "idle";
         let nextEventCycle = 0;
         let done = false;
-        const toggleState = new Set();
+        let shiftHeld = false;
 
         const currentCycle = () => this.processor.cycleSeconds * 1000000 + this.processor.currentCycles;
 
-        const isToggle = (entry) =>
-            (entry[0] === SHIFT[0] && entry[1] === SHIFT[1]) || (entry[0] === LOCK[0] && entry[1] === LOCK[1]);
+        const isShift = (entry) => entry[0] === SHIFT[0] && entry[1] === SHIFT[1];
 
         const hook = this.processor.debugInstruction.add(() => {
             if (currentCycle() < nextEventCycle) return;
 
             if (phase === "down") {
                 const entry = keySequence[index];
-                if (!isToggle(entry)) {
+                if (!isShift(entry)) {
                     ppia.keyUpRaw(entry);
                 }
                 index++;
@@ -416,25 +441,20 @@ export class TestMachine {
             }
 
             if (index >= keySequence.length) {
-                // Release any held toggles
-                for (const key of toggleState) {
-                    const [col, row] = key.split(",").map(Number);
-                    ppia.keyUpRaw([col, row]);
-                }
+                if (shiftHeld) ppia.keyUpRaw(SHIFT);
                 hook.remove();
                 done = true;
                 return;
             }
 
             const entry = keySequence[index];
-            if (isToggle(entry)) {
-                const key = `${entry[0]},${entry[1]}`;
-                if (toggleState.has(key)) {
-                    ppia.keyUpRaw(entry);
-                    toggleState.delete(key);
+            if (isShift(entry)) {
+                if (shiftHeld) {
+                    ppia.keyUpRaw(SHIFT);
+                    shiftHeld = false;
                 } else {
-                    ppia.keyDownRaw(entry);
-                    toggleState.add(key);
+                    ppia.keyDownRaw(SHIFT);
+                    shiftHeld = true;
                 }
                 index++;
                 nextEventCycle = currentCycle() + holdCycles;
@@ -449,10 +469,7 @@ export class TestMachine {
             const stopped = await this.runFor(holdCycles);
             if (stopped) {
                 hook.remove();
-                for (const key of toggleState) {
-                    const [col, row] = key.split(",").map(Number);
-                    ppia.keyUpRaw([col, row]);
-                }
+                if (shiftHeld) ppia.keyUpRaw(SHIFT);
                 break;
             }
         }

--- a/tests/unit/test-keyboard.js
+++ b/tests/unit/test-keyboard.js
@@ -646,25 +646,30 @@ describe("Keyboard Atom adapter", () => {
 });
 
 describe("stringToATOMKeys", () => {
-    test("should not produce LOCK key entries", () => {
-        const keys = stringToATOMKeys("Hello World");
-        const hasLock = keys.some((k) => k[0] === ATOM.LOCK[0] && k[1] === ATOM.LOCK[1]);
-        expect(hasLock).toBe(false);
+    test("should insert LOCK toggles for case transitions", () => {
+        // "Hello" = H (caps on), LOCK off, e, l, l, o, LOCK on
+        const keys = stringToATOMKeys("Hello");
+        expect(keys).toEqual([ATOM.H, ATOM.LOCK, ATOM.E, ATOM.L, ATOM.L, ATOM.O, ATOM.LOCK]);
     });
 
-    test("should convert lowercase to uppercase", () => {
-        const keys = stringToATOMKeys("abc");
+    test("should not insert LOCK for all-uppercase", () => {
+        const keys = stringToATOMKeys("ABC");
         expect(keys).toEqual([ATOM.A, ATOM.B, ATOM.C]);
-    });
-
-    test("should produce identical keys for mixed case", () => {
-        expect(stringToATOMKeys("Ab")).toEqual([ATOM.A, ATOM.B]);
-        expect(stringToATOMKeys("hELLO")).toEqual(stringToATOMKeys("Hello"));
     });
 
     test("should handle shifted characters with SHIFT toggles", () => {
         const keys = stringToATOMKeys("a'b");
-        // ' is SHIFT+7 on the Atom
-        expect(keys).toEqual([ATOM.A, ATOM.SHIFT, ATOM.K7, ATOM.SHIFT, ATOM.B]);
+        // ' is SHIFT+7 on the Atom. LOCK toggles surround the lowercase text.
+        expect(keys).toEqual([
+            ATOM.LOCK,
+            ATOM.A,
+            ATOM.SHIFT,
+            ATOM.LOCK,
+            ATOM.K7,
+            ATOM.SHIFT,
+            ATOM.LOCK,
+            ATOM.B,
+            ATOM.LOCK,
+        ]);
     });
 });

--- a/tests/unit/test-keyboard.js
+++ b/tests/unit/test-keyboard.js
@@ -606,31 +606,27 @@ describe("Keyboard Atom adapter", () => {
     });
 
     test("paste should insert debounce gap between key release and next key press", () => {
-        const ATOM_A = [3, 3]; // Atom 'A' key position
-        const ATOM_B = [3, 4]; // Atom 'B' key position
-        keyboard.sendRawKeyboard([ATOM_A, ATOM_B], false);
+        keyboard.sendRawKeyboard([ATOM.A, ATOM.B], false);
         const clocksPerMs = Math.floor(mockProcessor.cpuMultiplier * mockProcessor.peripheralCyclesPerSecond) / 1000;
 
         // First fire: press A
         mockProcessor.scheduler.polltime(1);
         expect(mockAtomPPIA.keyToggleRaw).toHaveBeenCalledTimes(1);
-        expect(mockAtomPPIA.keyToggleRaw).toHaveBeenCalledWith(ATOM_A);
+        expect(mockAtomPPIA.keyToggleRaw).toHaveBeenCalledWith(ATOM.A);
 
         // After 80ms (Atom uses longer hold): release A, then debounce gap
         mockProcessor.scheduler.polltime(80 * clocksPerMs);
         expect(mockAtomPPIA.keyToggleRaw).toHaveBeenCalledTimes(2); // release A only
-        expect(mockAtomPPIA.keyToggleRaw).toHaveBeenLastCalledWith(ATOM_A); // toggle off
+        expect(mockAtomPPIA.keyToggleRaw).toHaveBeenLastCalledWith(ATOM.A); // toggle off
 
         // After 30ms debounce: press B
         mockProcessor.scheduler.polltime(30 * clocksPerMs);
         expect(mockAtomPPIA.keyToggleRaw).toHaveBeenCalledTimes(3);
-        expect(mockAtomPPIA.keyToggleRaw).toHaveBeenLastCalledWith(ATOM_B);
+        expect(mockAtomPPIA.keyToggleRaw).toHaveBeenLastCalledWith(ATOM.B);
     });
 
     test("paste should not insert debounce gap after SHIFT key", () => {
-        const ATOM_A = [3, 3];
-        // Simulate a shifted character: SHIFT held, then A pressed
-        keyboard.sendRawKeyboard([ATOM.SHIFT, ATOM_A], false);
+        keyboard.sendRawKeyboard([ATOM.SHIFT, ATOM.A], false);
         const clocksPerMs = Math.floor(mockProcessor.cpuMultiplier * mockProcessor.peripheralCyclesPerSecond) / 1000;
 
         // First fire: press SHIFT
@@ -641,12 +637,11 @@ describe("Keyboard Atom adapter", () => {
         // be pressed immediately — no debounce gap for SHIFT.
         mockProcessor.scheduler.polltime(80 * clocksPerMs);
         expect(mockAtomPPIA.keyToggleRaw).toHaveBeenCalledTimes(2);
-        expect(mockAtomPPIA.keyToggleRaw).toHaveBeenLastCalledWith(ATOM_A);
+        expect(mockAtomPPIA.keyToggleRaw).toHaveBeenLastCalledWith(ATOM.A);
     });
 
     test("paste should handle repeated characters with Atom debounce", () => {
-        const ATOM_A = [3, 3];
-        keyboard.sendRawKeyboard([ATOM_A, ATOM_A], false);
+        keyboard.sendRawKeyboard([ATOM.A, ATOM.A], false);
         const clocksPerMs = Math.floor(mockProcessor.cpuMultiplier * mockProcessor.peripheralCyclesPerSecond) / 1000;
 
         // Press first A
@@ -662,13 +657,11 @@ describe("Keyboard Atom adapter", () => {
         // The Atom debounce cleared _pasteLastChar, so same-key debounce
         // doesn't trigger — second A is pressed directly.
         expect(mockAtomPPIA.keyToggleRaw).toHaveBeenCalledTimes(3);
-        expect(mockAtomPPIA.keyToggleRaw).toHaveBeenLastCalledWith(ATOM_A);
+        expect(mockAtomPPIA.keyToggleRaw).toHaveBeenLastCalledWith(ATOM.A);
     });
 
     test("paste should debounce LOCK key like regular keys", () => {
-        const ATOM_A = [3, 3];
-        // Sequence: LOCK (toggle caps off), A, LOCK (toggle caps on)
-        keyboard.sendRawKeyboard([ATOM.LOCK, ATOM_A, ATOM.LOCK], false);
+        keyboard.sendRawKeyboard([ATOM.LOCK, ATOM.A, ATOM.LOCK], false);
         const clocksPerMs = Math.floor(mockProcessor.cpuMultiplier * mockProcessor.peripheralCyclesPerSecond) / 1000;
 
         // Press LOCK
@@ -683,7 +676,7 @@ describe("Keyboard Atom adapter", () => {
         // After 30ms debounce: press A
         mockProcessor.scheduler.polltime(30 * clocksPerMs);
         expect(mockAtomPPIA.keyToggleRaw).toHaveBeenCalledTimes(3);
-        expect(mockAtomPPIA.keyToggleRaw).toHaveBeenLastCalledWith(ATOM_A);
+        expect(mockAtomPPIA.keyToggleRaw).toHaveBeenLastCalledWith(ATOM.A);
     });
 });
 

--- a/tests/unit/test-keyboard.js
+++ b/tests/unit/test-keyboard.js
@@ -616,8 +616,8 @@ describe("Keyboard Atom adapter", () => {
         expect(mockAtomPPIA.keyToggleRaw).toHaveBeenCalledTimes(1);
         expect(mockAtomPPIA.keyToggleRaw).toHaveBeenCalledWith(ATOM_A);
 
-        // After 50ms: release A, then Atom debounce gap (don't press B yet)
-        mockProcessor.scheduler.polltime(50 * clocksPerMs);
+        // After 80ms (Atom uses longer hold): release A, then debounce gap
+        mockProcessor.scheduler.polltime(80 * clocksPerMs);
         expect(mockAtomPPIA.keyToggleRaw).toHaveBeenCalledTimes(2); // release A only
         expect(mockAtomPPIA.keyToggleRaw).toHaveBeenLastCalledWith(ATOM_A); // toggle off
 
@@ -637,17 +637,17 @@ describe("Keyboard Atom adapter", () => {
         mockProcessor.scheduler.polltime(1);
         expect(mockAtomPPIA.keyToggleRaw).toHaveBeenCalledTimes(1);
 
-        // After 50ms: SHIFT is not released (it's the shift key), and A should
+        // After 80ms: SHIFT is not released (it's the shift key), and A should
         // be pressed immediately — no debounce gap for SHIFT.
-        mockProcessor.scheduler.polltime(50 * clocksPerMs);
+        mockProcessor.scheduler.polltime(80 * clocksPerMs);
         expect(mockAtomPPIA.keyToggleRaw).toHaveBeenCalledTimes(2);
         expect(mockAtomPPIA.keyToggleRaw).toHaveBeenLastCalledWith(ATOM_A);
     });
 });
 
 describe("stringToATOMKeys", () => {
-    test("should insert LOCK toggles for case transitions", () => {
-        // "Hello" = H (caps on), LOCK off, e, l, l, o, LOCK on
+    test("should insert LOCK toggles only for case transitions", () => {
+        // "Hello" = H (caps on), LOCK off, e, l, l, o, LOCK on (restore)
         const keys = stringToATOMKeys("Hello");
         expect(keys).toEqual([ATOM.H, ATOM.LOCK, ATOM.E, ATOM.L, ATOM.L, ATOM.O, ATOM.LOCK]);
     });
@@ -657,19 +657,16 @@ describe("stringToATOMKeys", () => {
         expect(keys).toEqual([ATOM.A, ATOM.B, ATOM.C]);
     });
 
-    test("should handle shifted characters with SHIFT toggles", () => {
+    test("should not toggle LOCK for non-letter characters", () => {
+        // Space and digits should not force LOCK back on between lowercase runs
+        const keys = stringToATOMKeys("a b");
+        expect(keys).toEqual([ATOM.LOCK, ATOM.A, ATOM.SPACE, ATOM.B, ATOM.LOCK]);
+    });
+
+    test("should handle shifted characters without extra LOCK toggles", () => {
+        // ' is SHIFT+7. Apostrophe doesn't care about caps lock state,
+        // so no LOCK toggle between the lowercase letters and the punctuation.
         const keys = stringToATOMKeys("a'b");
-        // ' is SHIFT+7 on the Atom. LOCK toggles surround the lowercase text.
-        expect(keys).toEqual([
-            ATOM.LOCK,
-            ATOM.A,
-            ATOM.SHIFT,
-            ATOM.LOCK,
-            ATOM.K7,
-            ATOM.SHIFT,
-            ATOM.LOCK,
-            ATOM.B,
-            ATOM.LOCK,
-        ]);
+        expect(keys).toEqual([ATOM.LOCK, ATOM.A, ATOM.SHIFT, ATOM.K7, ATOM.SHIFT, ATOM.B, ATOM.LOCK]);
     });
 });

--- a/tests/unit/test-keyboard.js
+++ b/tests/unit/test-keyboard.js
@@ -2,7 +2,7 @@ import { expect, describe, test, beforeEach, vi } from "vitest";
 import { Keyboard } from "../../src/keyboard.js";
 import { Scheduler } from "../../src/scheduler.js";
 import * as utils from "../../src/utils.js";
-import { ATOM } from "../../src/utils_atom.js";
+import { ATOM, stringToATOMKeys } from "../../src/utils_atom.js";
 
 describe("Keyboard", () => {
     let keyboard;
@@ -642,5 +642,29 @@ describe("Keyboard Atom adapter", () => {
         mockProcessor.scheduler.polltime(50 * clocksPerMs);
         expect(mockAtomPPIA.keyToggleRaw).toHaveBeenCalledTimes(2);
         expect(mockAtomPPIA.keyToggleRaw).toHaveBeenLastCalledWith(ATOM_A);
+    });
+});
+
+describe("stringToATOMKeys", () => {
+    test("should not produce LOCK key entries", () => {
+        const keys = stringToATOMKeys("Hello World");
+        const hasLock = keys.some((k) => k[0] === ATOM.LOCK[0] && k[1] === ATOM.LOCK[1]);
+        expect(hasLock).toBe(false);
+    });
+
+    test("should convert lowercase to uppercase", () => {
+        const keys = stringToATOMKeys("abc");
+        expect(keys).toEqual([ATOM.A, ATOM.B, ATOM.C]);
+    });
+
+    test("should produce identical keys for mixed case", () => {
+        expect(stringToATOMKeys("Ab")).toEqual([ATOM.A, ATOM.B]);
+        expect(stringToATOMKeys("hELLO")).toEqual(stringToATOMKeys("Hello"));
+    });
+
+    test("should handle shifted characters with SHIFT toggles", () => {
+        const keys = stringToATOMKeys("a'b");
+        // ' is SHIFT+7 on the Atom
+        expect(keys).toEqual([ATOM.A, ATOM.SHIFT, ATOM.K7, ATOM.SHIFT, ATOM.B]);
     });
 });

--- a/tests/unit/test-keyboard.js
+++ b/tests/unit/test-keyboard.js
@@ -643,6 +643,48 @@ describe("Keyboard Atom adapter", () => {
         expect(mockAtomPPIA.keyToggleRaw).toHaveBeenCalledTimes(2);
         expect(mockAtomPPIA.keyToggleRaw).toHaveBeenLastCalledWith(ATOM_A);
     });
+
+    test("paste should handle repeated characters with Atom debounce", () => {
+        const ATOM_A = [3, 3];
+        keyboard.sendRawKeyboard([ATOM_A, ATOM_A], false);
+        const clocksPerMs = Math.floor(mockProcessor.cpuMultiplier * mockProcessor.peripheralCyclesPerSecond) / 1000;
+
+        // Press first A
+        mockProcessor.scheduler.polltime(1);
+        expect(mockAtomPPIA.keyToggleRaw).toHaveBeenCalledTimes(1);
+
+        // After 80ms: release A, Atom debounce gap
+        mockProcessor.scheduler.polltime(80 * clocksPerMs);
+        expect(mockAtomPPIA.keyToggleRaw).toHaveBeenCalledTimes(2); // release only
+
+        // After 30ms Atom debounce: same-key debounce fires (not a double press)
+        mockProcessor.scheduler.polltime(30 * clocksPerMs);
+        // The Atom debounce cleared _pasteLastChar, so same-key debounce
+        // doesn't trigger — second A is pressed directly.
+        expect(mockAtomPPIA.keyToggleRaw).toHaveBeenCalledTimes(3);
+        expect(mockAtomPPIA.keyToggleRaw).toHaveBeenLastCalledWith(ATOM_A);
+    });
+
+    test("paste should debounce LOCK key like regular keys", () => {
+        const ATOM_A = [3, 3];
+        // Sequence: LOCK (toggle caps off), A, LOCK (toggle caps on)
+        keyboard.sendRawKeyboard([ATOM.LOCK, ATOM_A, ATOM.LOCK], false);
+        const clocksPerMs = Math.floor(mockProcessor.cpuMultiplier * mockProcessor.peripheralCyclesPerSecond) / 1000;
+
+        // Press LOCK
+        mockProcessor.scheduler.polltime(1);
+        expect(mockAtomPPIA.keyToggleRaw).toHaveBeenCalledTimes(1);
+        expect(mockAtomPPIA.keyToggleRaw).toHaveBeenLastCalledWith(ATOM.LOCK);
+
+        // After 80ms: release LOCK, Atom debounce (LOCK is not SHIFT)
+        mockProcessor.scheduler.polltime(80 * clocksPerMs);
+        expect(mockAtomPPIA.keyToggleRaw).toHaveBeenCalledTimes(2);
+
+        // After 30ms debounce: press A
+        mockProcessor.scheduler.polltime(30 * clocksPerMs);
+        expect(mockAtomPPIA.keyToggleRaw).toHaveBeenCalledTimes(3);
+        expect(mockAtomPPIA.keyToggleRaw).toHaveBeenLastCalledWith(ATOM_A);
+    });
 });
 
 describe("stringToATOMKeys", () => {

--- a/tests/unit/test-keyboard.js
+++ b/tests/unit/test-keyboard.js
@@ -2,6 +2,7 @@ import { expect, describe, test, beforeEach, vi } from "vitest";
 import { Keyboard } from "../../src/keyboard.js";
 import { Scheduler } from "../../src/scheduler.js";
 import * as utils from "../../src/utils.js";
+import { ATOM } from "../../src/utils_atom.js";
 
 describe("Keyboard", () => {
     let keyboard;
@@ -602,5 +603,44 @@ describe("Keyboard Atom adapter", () => {
     test("setKeyLayout should call PPIA setKeyLayout", () => {
         keyboard.setKeyLayout("natural");
         expect(mockAtomPPIA.setKeyLayout).toHaveBeenCalledWith("natural");
+    });
+
+    test("paste should insert debounce gap between key release and next key press", () => {
+        const ATOM_A = [3, 3]; // Atom 'A' key position
+        const ATOM_B = [3, 4]; // Atom 'B' key position
+        keyboard.sendRawKeyboard([ATOM_A, ATOM_B], false);
+        const clocksPerMs = Math.floor(mockProcessor.cpuMultiplier * mockProcessor.peripheralCyclesPerSecond) / 1000;
+
+        // First fire: press A
+        mockProcessor.scheduler.polltime(1);
+        expect(mockAtomPPIA.keyToggleRaw).toHaveBeenCalledTimes(1);
+        expect(mockAtomPPIA.keyToggleRaw).toHaveBeenCalledWith(ATOM_A);
+
+        // After 50ms: release A, then Atom debounce gap (don't press B yet)
+        mockProcessor.scheduler.polltime(50 * clocksPerMs);
+        expect(mockAtomPPIA.keyToggleRaw).toHaveBeenCalledTimes(2); // release A only
+        expect(mockAtomPPIA.keyToggleRaw).toHaveBeenLastCalledWith(ATOM_A); // toggle off
+
+        // After 30ms debounce: press B
+        mockProcessor.scheduler.polltime(30 * clocksPerMs);
+        expect(mockAtomPPIA.keyToggleRaw).toHaveBeenCalledTimes(3);
+        expect(mockAtomPPIA.keyToggleRaw).toHaveBeenLastCalledWith(ATOM_B);
+    });
+
+    test("paste should not insert debounce gap after SHIFT key", () => {
+        const ATOM_A = [3, 3];
+        // Simulate a shifted character: SHIFT held, then A pressed
+        keyboard.sendRawKeyboard([ATOM.SHIFT, ATOM_A], false);
+        const clocksPerMs = Math.floor(mockProcessor.cpuMultiplier * mockProcessor.peripheralCyclesPerSecond) / 1000;
+
+        // First fire: press SHIFT
+        mockProcessor.scheduler.polltime(1);
+        expect(mockAtomPPIA.keyToggleRaw).toHaveBeenCalledTimes(1);
+
+        // After 50ms: SHIFT is not released (it's the shift key), and A should
+        // be pressed immediately — no debounce gap for SHIFT.
+        mockProcessor.scheduler.polltime(50 * clocksPerMs);
+        expect(mockAtomPPIA.keyToggleRaw).toHaveBeenCalledTimes(2);
+        expect(mockAtomPPIA.keyToggleRaw).toHaveBeenLastCalledWith(ATOM_A);
     });
 });


### PR DESCRIPTION
## Summary

Fixes Atom paste character loss — three interrelated issues:

- **Paste debounce**: Added 30ms debounce gap after each key release during paste on Atom (SHIFT excluded). The Atom's PPIA keyboard is polled by the ROM, not interrupt-driven like the BBC's SysVIA, so the ROM needs time to see each key-up before the next key-down.
- **Longer hold time**: Increased Atom paste key hold from 50ms to 80ms. The ROM polls keyboard once per VSync (~16ms at 60 Hz NTSC); 50ms gave only ~3 scan cycles per key.
- **Fewer LOCK toggles**: Non-letter characters (space, digits, punctuation) no longer force caps lock state, eliminating unnecessary LOCK key presses between lowercase runs. E.g., "attempting to unzip" went from 6 LOCKs to 2.
- **LOCK preserved for case**: LOCK toggles the ROM's internal caps lock, producing lowercase ASCII codes (0x61-0x7A) — needed for BASIC string operations. The MC6847 can't display lowercase, but the codes matter.
- **Test infrastructure**: Fixed TestMachine for Atom — simulate VSync at ~60 Hz NTSC (fake6502 has no MC6847), use correct WRCHV address (0x0208 vs BBC's 0x020E) for text capture. Integration tests verify paste end-to-end through the real Atom ROM.

Fixes #672

## Test plan

- [x] Paste mixed-case text into Atom — characters appear correctly
- [x] Paste text with shifted characters (apostrophes, parentheses) — correct output
- [x] Paste into BBC emulator — no change in behavior
- [x] `npm run test:unit` passes (566 tests)
- [x] `npm run test:integration` passes (58 tests including 5 new Atom keyboard tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)