### PR TITLE
fix: speakerChannel epoch wrong when advance() splits into chunks

### DIFF
--- a/src/soundchip.js
+++ b/src/soundchip.js
@@ -363,6 +363,7 @@ export class AtomSoundChip extends SoundChip {
         this.currentSpeakerBit = 0.0;
         this._speakerPrevIn = 0;
         this._speakerPrevOut = 0;
+        this._speakerCycleOffset = 0;
     }
 
     reset(hard) {
@@ -370,15 +371,22 @@ export class AtomSoundChip extends SoundChip {
         if (hard) this.speakerReset();
     }
 
+    catchUp() {
+        this._speakerCycleOffset = 0;
+        super.catchUp();
+    }
+
     speakerReset() {
         this.bitChange = [];
         this.currentSpeakerBit = 0.0;
         this._speakerPrevIn = 0;
         this._speakerPrevOut = 0;
+        this._speakerCycleOffset = 0;
     }
 
     speakerChannel(channel, out, offset, length) {
-        const fromCycle = this.scheduler.epoch - length / this.samplesPerCycle;
+        const fromCycle = this.lastRunEpoch + this._speakerCycleOffset;
+        this._speakerCycleOffset += length / this.samplesPerCycle;
         let bitIndex = 0;
         // DC-blocking high-pass filter: y[n] = x[n] - x[n-1] + alpha * y[n-1]
         // The SoundChip runs at 500 kHz (4 MHz / 8). For a ~20 Hz cutoff:

--- a/src/soundchip.js
+++ b/src/soundchip.js
@@ -524,5 +524,7 @@ export class FakeSoundChip {
         return {};
     }
 
-    restoreState() {}
+    restoreState() {
+        this._speakerCycleOffset = 0;
+    }
 }

--- a/src/soundchip.js
+++ b/src/soundchip.js
@@ -374,6 +374,7 @@ export class AtomSoundChip extends SoundChip {
     catchUp() {
         this._speakerCycleOffset = 0;
         super.catchUp();
+        this._speakerCycleOffset = 0;
     }
 
     speakerReset() {

--- a/tests/unit/test-soundchip.js
+++ b/tests/unit/test-soundchip.js
@@ -198,6 +198,42 @@ describe("AtomSoundChip", () => {
         expect(chip.speakerGenerator).toBeUndefined();
     });
 
+    it("should place transitions correctly when advance() splits into chunks", () => {
+        // The buffer is 512 samples. Advancing 1200 cycles at 0.5 spc =
+        // 600 samples, which splits into chunk 1 (512 samples) and chunk 2
+        // (88 samples). A bit change at cycle 1100 falls in the second
+        // chunk (sample 550 = cycle 1100 * 0.5). If speakerChannel uses
+        // epoch - length for each chunk independently, it miscomputes the
+        // time window and places the transition in the wrong chunk.
+        const { chip, scheduler } = makeAtomSoundChip();
+        chip.speakerReset();
+        chip.enabled = true;
+
+        // Set lastRunEpoch = 0 (start of window), then advance to cycle 1200
+        chip.lastRunEpoch = 0;
+        scheduler.epoch = 1200;
+        chip.bitChange.push({ bit: 1.0, cycles: 1100 });
+
+        // Capture the buffer output callback
+        const buffers = [];
+        chip._onBuffer = (buf) => buffers.push(new Float32Array(buf));
+
+        chip.advance(1200);
+
+        // The bit change at cycle 1100 → sample 550 (in the second chunk).
+        // First buffer (512 samples) should be silent (all zero before DC filter).
+        // If the bug is present, the transition lands in the first chunk instead.
+        const firstBuf = buffers[0];
+        expect(firstBuf).toBeDefined();
+        expect(firstBuf[511]).toBeCloseTo(0.0, 2); // last sample of first chunk: silent
+
+        // Second chunk is in chip.buffer[0..87]. Check the transition is there.
+        // Cycle 1100 → sample 550. Chunk 2 starts at sample 512, so the
+        // transition is at local index 550 - 512 = 38.
+        expect(chip.buffer[37]).toBeCloseTo(0.0, 2); // before transition
+        expect(chip.buffer[38]).toBeGreaterThan(0); // transition happened
+    });
+
     it("speakerChannel should place transitions at the correct sample index", () => {
         // The speaker bug: speakerChannel subtracted sample count from cycle
         // epoch, mixing units. With samplesPerCycle=0.5, a bit change at CPU


### PR DESCRIPTION
## Summary

When `advance()` generates more samples than fit in the 512-sample buffer, it calls `speakerChannel()` multiple times with the same `scheduler.epoch`. Each chunk computed `fromCycle` from `epoch - length/samplesPerCycle` independently, so all chunks processed the same time window — the first chunk consumed all bit changes, leaving silence for subsequent chunks.

Fix: track cumulative cycle offset across chunks using `lastRunEpoch` as the base. Override `catchUp()` to reset the offset before each `advance()`.

Fixes #681

## Test plan

- [x] Failing test: bit change at cycle 1100 (sample 550) in a 600-sample advance — first chunk (512 samples) should be silent, transition should appear in second chunk at local index 38
- [x] `npm run test:unit` — 574 tests pass
- [x] `npm run test:integration` — 65 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)