### PR TITLE
fix: use process.defaultApp to detect packaged Electron app

### DIFF
--- a/src/app/app.js
+++ b/src/app/app.js
@@ -5,6 +5,8 @@ import * as fs from "fs";
 import * as path from "path";
 import { ArgumentParser } from "argparse";
 
+import { getArguments } from "./args.js";
+
 const store = new Store();
 
 ipcMain.on("set-title", (event, title) => {
@@ -19,21 +21,6 @@ ipcMain.on("save-settings", (event, settings) => {
 });
 
 const isMac = process.platform === "darwin";
-
-function getArguments() {
-    // Heinous hack to get "built" versions working
-    let args;
-    if (path.basename(process.argv[0]) === "jsbeeb")
-        // Is this ia "built" version?
-        args = process.argv.slice(1);
-    else args = process.argv.slice(2);
-
-    // Filter out Chrome switches that appear in process.argv. The snap wrapper
-    // adds --no-sandbox for compatibility, and `--disable-gpu` might be useful.
-    // Note that we don't support snap any more, but these seemed useful to leave.
-    const ignoredChromeFlags = ["--no-sandbox", "--disable-gpu"];
-    return args.filter((arg) => !ignoredChromeFlags.includes(arg));
-}
 
 const parser = new ArgumentParser({
     prog: "jsbeeb",

--- a/src/app/args.js
+++ b/src/app/args.js
@@ -1,0 +1,26 @@
+"use strict";
+
+/**
+ * Returns the command-line arguments the user actually passed to jsbeeb, with
+ * the Electron binary path(s) and known runtime-injected flags stripped.
+ *
+ * @param {string[]} [argv=process.argv] Full argv array.
+ * @param {boolean} [defaultApp=process.defaultApp]
+ *   True when running under `electron .` (dev). Electron only sets
+ *   process.defaultApp in that case, so we use it instead of comparing
+ *   basename(argv[0]) === "jsbeeb" (the previous check), which failed on
+ *   Windows where the binary is jsbeeb.exe, silently dropping the first
+ *   user argument. See issue #684.
+ * @returns {string[]}
+ */
+export function getArguments(argv = process.argv, defaultApp = process.defaultApp) {
+    // In a packaged Electron app argv is [appBinary, ...userArgs]; when running
+    // under `electron .` (dev) it is [electronBinary, appPath, ...userArgs].
+    const args = defaultApp ? argv.slice(2) : argv.slice(1);
+
+    // Filter out Chrome switches that appear in argv. The snap wrapper adds
+    // --no-sandbox for compatibility, and --disable-gpu might be useful. We
+    // don't support snap any more, but these seemed useful to leave.
+    const ignoredChromeFlags = ["--no-sandbox", "--disable-gpu"];
+    return args.filter((arg) => !ignoredChromeFlags.includes(arg));
+}

--- a/tests/unit/test-app-args.js
+++ b/tests/unit/test-app-args.js
@@ -1,0 +1,39 @@
+import { describe, it, expect } from "vitest";
+
+import { getArguments } from "../../src/app/args.js";
+
+// Regression tests for issue #684: on Windows the packaged binary is jsbeeb.exe,
+// so basename(argv[0]) === "jsbeeb" was always false and the first user argument
+// (e.g. --noboot) was silently dropped via slice(2). Now we key off Electron's
+// process.defaultApp so the dev/packaged distinction is reliable on every OS.
+describe("getArguments", () => {
+    it("strips only the binary path for a packaged Electron app on Linux", () => {
+        const argv = ["/opt/jsbeeb/jsbeeb", "--noboot", "foo.dsd"];
+        expect(getArguments(argv, undefined)).toEqual(["--noboot", "foo.dsd"]);
+    });
+
+    it("strips only the binary path for a packaged Electron app on Windows (issue #684)", () => {
+        const argv = ["C:\\Program Files\\jsbeeb\\jsbeeb.exe", "--noboot", "foo.dsd"];
+        expect(getArguments(argv, undefined)).toEqual(["--noboot", "foo.dsd"]);
+    });
+
+    it("strips only the binary path for a packaged Electron app on macOS", () => {
+        const argv = ["/Applications/jsbeeb.app/Contents/MacOS/jsbeeb", "--noboot", "foo.dsd"];
+        expect(getArguments(argv, undefined)).toEqual(["--noboot", "foo.dsd"]);
+    });
+
+    it("skips electron binary and app path in development mode", () => {
+        const argv = ["/usr/bin/electron", "/home/user/jsbeeb", "--noboot", "foo.dsd"];
+        expect(getArguments(argv, true)).toEqual(["--noboot", "foo.dsd"]);
+    });
+
+    it("preserves a bare disc image when running as a packaged app", () => {
+        const argv = ["C:\\Program Files\\jsbeeb\\jsbeeb.exe", "foo.dsd"];
+        expect(getArguments(argv, undefined)).toEqual(["foo.dsd"]);
+    });
+
+    it("filters out Chrome flags injected by the runtime", () => {
+        const argv = ["/opt/jsbeeb/jsbeeb", "--no-sandbox", "--disable-gpu", "--noboot", "foo.dsd"];
+        expect(getArguments(argv, undefined)).toEqual(["--noboot", "foo.dsd"]);
+    });
+});


### PR DESCRIPTION
Fixes #684.

In getArguments the basename(argv[0]) === "jsbeeb" check never matched on Windows (the packaged binary is jsbeeb.exe), so the function fell through to argv.slice(2) and silently dropped the first user argument. That made "jsbeeb --noboot foo.dsd" appear to autoboot (--noboot was discarded and foo.dsd became disc1) and "jsbeeb foo.dsd" appear to do nothing (foo.dsd was discarded).

Switched to process.defaultApp, which Electron sets only when running `electron .` in development, so the dev/packaged distinction is reliable across Linux, macOS, and Windows. Extracted getArguments into src/app/args.js so it can be unit-tested without booting Electron, and added tests/unit/test-app-args.js covering the Windows .exe case, the macOS .app/.../jsbeeb path, the Linux packaged path, dev mode, and the Chrome-flag filter.