### PR TITLE
fix: work around Chrome 150 V8 bug that wedged the emulator after ~1 minute

### DIFF
--- a/src/soundchip.js
+++ b/src/soundchip.js
@@ -2,6 +2,9 @@
 // The BBC volumeTable[0] (loudest) is 0.25 (1.0 / 4 channels).
 const speakerVolume = 0.5;
 
+// Samples per output chunk handed to the onBuffer callback.
+export const SoundBufferSamples = 512;
+
 const volumeTable = new Float32Array(16);
 (() => {
     let f = 1.0;
@@ -21,6 +24,13 @@ function makeSineTable(attenuation) {
 }
 
 export class SoundChip {
+    /**
+     * @param {function(Float32Array): void} onBuffer called with each full
+     *     SoundBufferSamples-sized buffer of output. The chip passes the same
+     *     buffer every call and overwrites its contents immediately afterwards:
+     *     copy it if it is kept (a structured clone via postMessage suffices),
+     *     and never transfer/detach it — see the note in advance().
+     */
     constructor(onBuffer) {
         this._onBuffer = onBuffer;
         // 4MHz input signal. Internal divide-by-8
@@ -62,7 +72,7 @@ export class SoundChip {
 
         this.residual = 0;
         this.position = 0;
-        this.buffer = new Float32Array(512);
+        this.buffer = new Float32Array(SoundBufferSamples);
 
         this.latchedRegister = 0;
         this.slowDataBus = 0;
@@ -211,17 +221,26 @@ export class SoundChip {
         const num = cycles * this.samplesPerCycle + this.residual;
         let rounded = num | 0;
         this.residual = num - rounded;
-        const bufferLength = this.buffer.length;
+        // The single buffer is reused for the chip's whole life and is never
+        // transferred, detached, or reallocated. This is deliberate: the
+        // transfer-then-reallocate pattern used previously is miscompiled by a
+        // V8 optimiser bug (Chrome 150, crbug.com/537801199) that allocates the
+        // replacement with length 0, wedging this loop forever — and reordering
+        // the reallocation before the transfer did not avoid it. The guard below
+        // turns any recurrence into an error rather than a frozen page.
         while (rounded > 0) {
-            const leftInBuffer = bufferLength - this.position;
+            const leftInBuffer = SoundBufferSamples - this.position;
             const numSamplesToGenerate = Math.min(rounded, leftInBuffer);
+            if (numSamplesToGenerate <= 0)
+                throw new Error(
+                    `Sound buffer accounting error (buffer=${this.buffer.length}, position=${this.position}, rounded=${rounded})`,
+                );
             this.generate(this.buffer, this.position, numSamplesToGenerate);
             this.position += numSamplesToGenerate;
             rounded -= numSamplesToGenerate;
 
-            if (this.position === bufferLength) {
+            if (this.position === SoundBufferSamples) {
                 this._onBuffer(this.buffer);
-                this.buffer = new Float32Array(bufferLength);
                 this.position = 0;
             }
         }

--- a/src/soundchip.js
+++ b/src/soundchip.js
@@ -26,10 +26,8 @@ function makeSineTable(attenuation) {
 export class SoundChip {
     /**
      * @param {function(Float32Array): void} onBuffer called with each full
-     *     SoundBufferSamples-sized buffer of output. The chip passes the same
-     *     buffer every call and overwrites its contents immediately afterwards:
-     *     copy it if it is kept (a structured clone via postMessage suffices),
-     *     and never transfer/detach it — see the note in advance().
+     *     SoundBufferSamples-sized buffer of output. Receives the same buffer
+     *     every call, overwritten afterwards: copy the contents if they are kept.
      */
     constructor(onBuffer) {
         this._onBuffer = onBuffer;
@@ -221,17 +219,18 @@ export class SoundChip {
         const num = cycles * this.samplesPerCycle + this.residual;
         let rounded = num | 0;
         this.residual = num - rounded;
-        // The single buffer is reused for the chip's whole life and is never
-        // transferred, detached, or reallocated. This is deliberate: the
-        // transfer-then-reallocate pattern used previously is miscompiled by a
-        // V8 optimiser bug (Chrome 150, crbug.com/537801199) that allocates the
-        // replacement with length 0, wedging this loop forever — and reordering
-        // the reallocation before the transfer did not avoid it. The guard below
-        // turns any recurrence into an error rather than a frozen page.
+        // The buffer is deliberately reused for the chip's whole life: the
+        // previous transfer-then-reallocate pattern is miscompiled by a V8
+        // optimiser bug (Chrome 150, crbug.com/537801199) which allocates the
+        // replacement with length 0, even when the reallocation is reordered
+        // before the transfer, wedging this loop forever. Reuse is also
+        // cheaper, so this needn't be reverted once the crbug is fixed. The
+        // guard fails loudly if the buffer is ever detached or the accounting
+        // goes bad.
         while (rounded > 0) {
             const leftInBuffer = SoundBufferSamples - this.position;
             const numSamplesToGenerate = Math.min(rounded, leftInBuffer);
-            if (numSamplesToGenerate <= 0)
+            if (numSamplesToGenerate <= 0 || this.buffer.length !== SoundBufferSamples)
                 throw new Error(
                     `Sound buffer accounting error (buffer=${this.buffer.length}, position=${this.position}, rounded=${rounded})`,
                 );

--- a/src/web/audio-handler.js
+++ b/src/web/audio-handler.js
@@ -123,7 +123,11 @@ export class AudioHandler {
     }
 
     _onBuffer(buffer) {
-        if (this._jsAudioNode) this._jsAudioNode.port.postMessage({ time: Date.now(), buffer }, [buffer.buffer]);
+        // The sound chip reuses this buffer, so the worklet must get a copy:
+        // deliberately no transfer list, which would detach the chip's buffer
+        // and trip a V8 optimiser bug that wedges the emulator — see
+        // SoundChip.advance() and crbug.com/537801199 before "optimising" this.
+        if (this._jsAudioNode) this._jsAudioNode.port.postMessage({ time: Date.now(), buffer });
     }
 
     // Recent browsers, particularly Safari and Chrome, require a user interaction in order to enable sound playback.

--- a/src/web/audio-handler.js
+++ b/src/web/audio-handler.js
@@ -123,10 +123,9 @@ export class AudioHandler {
     }
 
     _onBuffer(buffer) {
-        // The sound chip reuses this buffer, so the worklet must get a copy:
-        // deliberately no transfer list, which would detach the chip's buffer
-        // and trip a V8 optimiser bug that wedges the emulator — see
-        // SoundChip.advance() and crbug.com/537801199 before "optimising" this.
+        // No transfer list, deliberately: the chip reuses this buffer, and
+        // transferring would detach it and trip crbug.com/537801199. The clone
+        // costs little (512 floats per 1.024ms of chip output, ~2MB/s).
         if (this._jsAudioNode) this._jsAudioNode.port.postMessage({ time: Date.now(), buffer });
     }
 

--- a/tests/unit/test-soundchip.js
+++ b/tests/unit/test-soundchip.js
@@ -17,25 +17,40 @@ function makeAtomSoundChip() {
 }
 
 describe("SoundChip advance", () => {
-    it("should reuse one full buffer for every onBuffer callback", () => {
-        // Pins the buffer-reuse contract that works around crbug.com/537801199
-        // — see the comment in SoundChip.advance().
+    it("should reuse one buffer for every onBuffer callback, never reallocating", () => {
+        // Pins the buffer-reuse contract that works around crbug.com/537801199;
+        // see the comment in SoundChip.advance(). Cross-call identity is the
+        // key assertion: the old code handed out a fresh buffer per callback.
         let callbackCount = 0;
+        let firstBuffer = null;
         const { chip } = makeSoundChip((buffer) => {
+            if (firstBuffer === null) firstBuffer = buffer;
+            expect(buffer).toBe(firstBuffer);
             callbackCount++;
-            expect(buffer).toBe(chip.buffer);
         });
 
+        // samplesPerCycle divides SoundBufferSamples exactly, so this fills the
+        // buffer exactly three times and leaves position at zero.
         const cyclesToFillBufferThrice = Math.round((3 * SoundBufferSamples) / chip.samplesPerCycle);
         chip.advance(cyclesToFillBufferThrice);
         expect(callbackCount).toBe(3);
+        expect(chip.buffer).toBe(firstBuffer);
         expect(chip.buffer.length).toBe(SoundBufferSamples);
         expect(chip.position).toBe(0);
     });
 
+    // The guard states are unreachable through the public API (that's the
+    // point), so these tests corrupt internal state to simulate a miscompile
+    // or a reintroduced buffer transfer.
     it("should throw rather than spin if the buffer position goes bad", () => {
         const { chip } = makeSoundChip();
-        chip.position = SoundBufferSamples; // can never legitimately be at/past the end on entry
+        chip.position = SoundBufferSamples;
+        expect(() => chip.advance(1024)).toThrow("Sound buffer accounting error");
+    });
+
+    it("should throw rather than fall silent if the buffer is detached or replaced", () => {
+        const { chip } = makeSoundChip();
+        chip.buffer = new Float32Array(0); // what a detached buffer reports
         expect(() => chip.advance(1024)).toThrow("Sound buffer accounting error");
     });
 });

--- a/tests/unit/test-soundchip.js
+++ b/tests/unit/test-soundchip.js
@@ -1,10 +1,10 @@
 import { describe, it, expect } from "vitest";
-import { SoundChip, AtomSoundChip } from "../../src/soundchip.js";
+import { SoundChip, AtomSoundChip, SoundBufferSamples } from "../../src/soundchip.js";
 import { Scheduler } from "../../src/scheduler.js";
 
-function makeSoundChip() {
+function makeSoundChip(onBuffer = () => {}) {
     const scheduler = new Scheduler();
-    const chip = new SoundChip(() => {});
+    const chip = new SoundChip(onBuffer);
     chip.setScheduler(scheduler);
     return { chip, scheduler };
 }
@@ -15,6 +15,30 @@ function makeAtomSoundChip() {
     chip.setScheduler(scheduler);
     return { chip, scheduler };
 }
+
+describe("SoundChip advance", () => {
+    it("should reuse one full buffer for every onBuffer callback", () => {
+        // Pins the buffer-reuse contract that works around crbug.com/537801199
+        // — see the comment in SoundChip.advance().
+        let callbackCount = 0;
+        const { chip } = makeSoundChip((buffer) => {
+            callbackCount++;
+            expect(buffer).toBe(chip.buffer);
+        });
+
+        const cyclesToFillBufferThrice = Math.round((3 * SoundBufferSamples) / chip.samplesPerCycle);
+        chip.advance(cyclesToFillBufferThrice);
+        expect(callbackCount).toBe(3);
+        expect(chip.buffer.length).toBe(SoundBufferSamples);
+        expect(chip.position).toBe(0);
+    });
+
+    it("should throw rather than spin if the buffer position goes bad", () => {
+        const { chip } = makeSoundChip();
+        chip.position = SoundBufferSamples; // can never legitimately be at/past the end on entry
+        expect(() => chip.advance(1024)).toThrow("Sound buffer accounting error");
+    });
+});
 
 describe("SoundChip snapshotState / restoreState", () => {
     it("should snapshot and restore tone channel registers", () => {


### PR DESCRIPTION
## Summary

Chrome 150 ships a V8 optimiser bug ([crbug.com/537801199](https://issues.chromium.org/issues/537801199)) that miscompiles the sound chip's buffer hand-off. `advance()` posted each 512-sample buffer to the audio worklet with a transfer list (detaching it) and immediately reallocated a replacement. After JIT warm-up the replacement is allocated with length 0, leaving `advance()` in an infinite loop and freezing the page about a minute after startup. Reordering the reallocation before the transfer did not help, so this removes the pattern instead:

- The chip reuses a single buffer for its whole life: never transferred, detached, or reallocated. The worklet receives a structured clone (about 2MB/s, negligible), matching the existing Music 5000 path.
- The copy-don't-keep contract is documented on the `SoundChip` constructor; `512` becomes the exported constant `SoundBufferSamples`.
- A guard throws `Sound buffer accounting error` if the buffer is ever detached, replaced, or the loop accounting goes bad, so any regression fails loudly instead of wedging or falling silent.

## Verification

- Reproduced standalone (minimal test case attached to the crbug): wedges in 5-15s on Chrome 150.0.7871.114/.182; clean without the transfer list, with `--js-flags="--no-turbofan --no-maglev"`, and on Firefox.
- Soak-tested the fix in the real app; `npm run test:unit` (598 tests) and lint pass. Three new tests pin the reuse contract and the guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)