### PR TITLE
feat: allow MachineSession to attach a Tube 65C02 co-processor

### DIFF
--- a/src/fake6502.js
+++ b/src/fake6502.js
@@ -19,7 +19,12 @@ const dbgr = {
 export function fake6502(model, opts) {
     opts = opts || {};
     model = model || TEST_6502;
-    if (opts.tube) model.tube = findModel("Tube65c02");
+    if (opts.tube !== undefined) {
+        // Don't mutate the shared Model from allModels — a later fake6502()
+        // for the same model name would inherit this session's tube setting.
+        model = Object.assign(Object.create(Object.getPrototypeOf(model)), model);
+        model.tube = opts.tube ? findModel("Tube65c02") : null;
+    }
     const CpuClass = model.isAtom ? AtomCpu6502 : Cpu6502;
     return new CpuClass(model, {
         dbgr,

--- a/src/fake6502.js
+++ b/src/fake6502.js
@@ -3,7 +3,7 @@
 
 import { FakeVideo } from "./video.js";
 import { FakeSoundChip } from "./soundchip.js";
-import { findModel, TEST_6502, TEST_65C02, TEST_65C12 } from "./models.js";
+import { TEST_6502, TEST_65C02, TEST_65C12 } from "./models.js";
 import { FakeDdNoise } from "./ddnoise.js";
 import { FakeRelayNoise } from "./relaynoise.js";
 import { Cpu6502, AtomCpu6502 } from "./6502.js";
@@ -19,12 +19,7 @@ const dbgr = {
 export function fake6502(model, opts) {
     opts = opts || {};
     model = model || TEST_6502;
-    if (opts.tube !== undefined) {
-        // Don't mutate the shared Model from allModels — a later fake6502()
-        // for the same model name would inherit this session's tube setting.
-        model = Object.assign(Object.create(Object.getPrototypeOf(model)), model);
-        model.tube = opts.tube ? findModel("Tube65c02") : null;
-    }
+    if (opts.tube) model = model.withTube();
     const CpuClass = model.isAtom ? AtomCpu6502 : Cpu6502;
     return new CpuClass(model, {
         dbgr,

--- a/src/machine-session.js
+++ b/src/machine-session.js
@@ -30,6 +30,7 @@ export class MachineSession {
      * @param {string} modelName - e.g. "B-DFS1.2", "Master"
      * @param {Object} [opts]
      * @param {string} [opts.discImage] - path to an .ssd or .dsd disc image to load on boot
+     * @param {boolean} [opts.tube] - attach a 65C02 second processor (Tube co-processor)
      */
     constructor(modelName = "B-DFS1.2", opts = {}) {
         this.modelName = modelName;
@@ -65,8 +66,12 @@ export class MachineSession {
         // toneGenerator); FakeSoundChip provides compatible no-op stubs for headless mode.
         this._soundChip = modelObj.isAtom ? new FakeSoundChip() : new InstrumentedSoundChip();
 
-        // TestMachine forwards opts.video and opts.soundChip to fake6502
-        this._machine = new TestMachine(modelName, { video: this._video, soundChip: this._soundChip });
+        // TestMachine forwards opts.video, opts.soundChip and opts.tube to fake6502
+        this._machine = new TestMachine(modelName, {
+            video: this._video,
+            soundChip: this._soundChip,
+            tube: !!opts.tube,
+        });
 
         // Accumulated VDU text output — drained by callers
         this._pendingOutput = [];

--- a/src/machine-session.js
+++ b/src/machine-session.js
@@ -70,7 +70,7 @@ export class MachineSession {
         this._machine = new TestMachine(modelName, {
             video: this._video,
             soundChip: this._soundChip,
-            tube: !!opts.tube,
+            tube: opts.tube,
         });
 
         // Accumulated VDU text output — drained by callers

--- a/src/models.js
+++ b/src/models.js
@@ -10,6 +10,10 @@ const CpuModel = Object.freeze({
     CMOS65C12: 2,
 });
 
+// The only second processor jsbeeb emulates. Named here so the one place that
+// knows a "tube" means this particular model is the Model class itself.
+const TubeModelName = "Tube65C02";
+
 class Model {
     constructor({ name, synonyms, os, cpuModel, isMaster, isAtom, swram, fdc, tube, cmosOverride, banks } = {}) {
         this.name = name;
@@ -26,6 +30,21 @@ class Model {
         this.cmosOverride = cmosOverride;
         this.hasEconet = false;
         this.hasMusic5000 = false;
+    }
+
+    /**
+     * Returns a copy of this model with the 65C02 second processor attached,
+     * leaving this model untouched.
+     *
+     * The models in `allModels` are shared singletons, so a machine must never set
+     * `tube` on one in place: a machine created later in the same process would
+     * inherit it. Copying with `Object.create` rather than the constructor keeps
+     * both the prototype getters below and any flags set after construction.
+     *
+     * @returns {Model}
+     */
+    withTube() {
+        return Object.assign(Object.create(Model.prototype), this, { tube: findModel(TubeModelName) });
     }
 
     get nmos() {

--- a/tests/test-machine.js
+++ b/tests/test-machine.js
@@ -11,9 +11,10 @@ const MaxCyclesPerIter = 100 * 1000;
 export class TestMachine {
     constructor(model, opts) {
         model = model || "B-DFS1.2";
-        const modelObj = findModel(model);
-        this.model = modelObj;
-        this.processor = fake6502(modelObj, opts || {});
+        this.processor = fake6502(findModel(model), opts || {});
+        // Read the model back from the processor: fake6502 may have derived its own
+        // copy (e.g. for opts.tube), and the two must not disagree.
+        this.model = this.processor.model;
         this._capturedChars = [];
         this._captureHookInstalled = false;
     }

--- a/tests/unit/test-models.js
+++ b/tests/unit/test-models.js
@@ -1,0 +1,60 @@
+import { describe, it, expect } from "vitest";
+import { findModel } from "../../src/models.js";
+import { fake6502 } from "../../src/fake6502.js";
+
+describe("Model", () => {
+    describe("withTube", () => {
+        it("returns a copy, leaving the original untouched", () => {
+            const master = findModel("Master");
+            const withTube = master.withTube();
+
+            expect(withTube).not.toBe(master);
+            expect(withTube.tube.name).toBe("Tube65C02");
+            expect(master.tube).toBeUndefined();
+        });
+
+        it("preserves the derived getters", () => {
+            const master = findModel("Master");
+            const withTube = master.withTube();
+
+            expect(withTube.nmos).toBe(master.nmos);
+            expect(withTube.opcodesFactory).toBe(master.opcodesFactory);
+        });
+
+        it("preserves the rest of the model", () => {
+            const master = findModel("Master");
+            const withTube = master.withTube();
+
+            expect(withTube.name).toBe(master.name);
+            expect(withTube.isMaster).toBe(master.isMaster);
+            expect(withTube.isAtom).toBe(master.isAtom);
+            expect(withTube.Fdc).toBe(master.Fdc);
+            expect(withTube.os).toBe(master.os);
+        });
+
+        it("does not disturb a model that already has a tube", () => {
+            const withTube = findModel("Master").withTube();
+
+            expect(withTube.withTube().tube).toBe(withTube.tube);
+        });
+    });
+});
+
+describe("fake6502 tube handling", () => {
+    it("attaches a tube when asked", () => {
+        expect(fake6502(findModel("Master"), { tube: true }).model.tube.name).toBe("Tube65C02");
+    });
+
+    it("does not leak the tube into later machines using the same model", () => {
+        fake6502(findModel("Master"), { tube: true });
+
+        expect(findModel("Master").tube).toBeUndefined();
+        expect(fake6502(findModel("Master"), {}).model.tube).toBeUndefined();
+    });
+
+    it("leaves the model's own tube setting alone when no tube is specified", () => {
+        const model = findModel("Master").withTube();
+
+        expect(fake6502(model, {}).model.tube.name).toBe("Tube65C02");
+    });
+});


### PR DESCRIPTION
`MachineSession` now forwards a `tube` option through `TestMachine` to `fake6502`, so headless/embedding users (jsbeeb-mcp in particular) can boot a machine with the 65C02 second processor attached:

```js
const session = new MachineSession("Master", { tube: true });
```

This also fixes a latent state-leak in `fake6502`: it mutated the **shared** `Model` instance from `allModels` when `opts.tube` was set, so a later `fake6502()` call for the same model name silently inherited the previous caller's tube (a real problem for a long-lived process creating many sessions, like the MCP server). When `opts.tube` is specified, the model is now shallow-cloned (prototype preserved, so the `nmos`/`opcodesFactory` getters survive) before setting `model.tube`. Behaviour is unchanged when `opts.tube` is not passed.

Tested headless on Windows/node 24: `Master` + `tube: true` boots to "Acorn TUBE 6502 64K" with `Tube6502` at the default `cpuMultiplier` of 2; a subsequent session in the same process without `tube` correctly gets `FakeTube`. Lint/prettier clean; the lint-staged related-test run passed on commit.

Context: I'm using this to develop/verify Master Turbo (4MHz internal 6502 co-pro) software with the jsbeeb-mcp server — companion PR there exposes this as a `tube` flag on `create_machine`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)