### PR TITLE
ci: pin Claude workflows to claude-opus-5

### DIFF
--- a/.github/workflows/claude-issue-triage.yml
+++ b/.github/workflows/claude-issue-triage.yml
@@ -96,6 +96,9 @@ jobs:
       - name: Run Claude Code for Issue Triage
         uses: anthropics/claude-code-base-action@beta
         with:
+          # Pin the model explicitly: the action's own default has pointed at a
+          # retired model in the past, which 404s every run.
+          model: "claude-opus-5"
           prompt_file: /tmp/claude-prompts/triage-prompt.txt
           allowed_tools: "Bash(gh label list),mcp__github__get_issue,mcp__github__get_issue_comments,mcp__github__update_issue,mcp__github__search_issues,mcp__github__list_issues"
           timeout_minutes: "5"

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -40,8 +40,9 @@ jobs:
           additional_permissions: |
             actions: read
 
-          # Optional: Specify model (defaults to Claude Sonnet 4, uncomment for Claude Opus 4.1)
-          # model: "claude-opus-4-1-20250805"
+          # Pin the model explicitly: the action's own default has pointed at a
+          # retired model in the past, which 404s every run.
+          model: "claude-opus-5"
 
           # Optional: Customize the trigger phrase (default: @claude)
           # trigger_phrase: "/claude"


### PR DESCRIPTION
## What's broken

The **Claude Issue Triage** workflow has been failing on every run since ~2026-07-21. Each run dies on its very first API call:

```
API Error: 404 {"type":"error","error":{"type":"not_found_error","message":"model: claude-sonnet-4-20250514"}}
```

`claude-sonnet-4-20250514` is a retired model ID. Neither workflow ever set a `model` input, so both inherited a default baked into the `anthropics/*@beta` actions — and that default now points at a model the API no longer serves. Nothing in this repo caused the breakage; the moving `@beta` tag did.

## Changes

- **`.github/workflows/claude-issue-triage.yml`** — added an explicit `model: "claude-opus-5"` to the `with:` block of the "Run Claude Code for Issue Triage" step (`anthropics/claude-code-base-action@beta`). This is the workflow that is actually failing.
- **`.github/workflows/claude.yml`** — this one uses `anthropics/claude-code-action@beta` and is exposed to the same stale default, so it gets the same explicit `model: "claude-opus-5"`. It also carried a commented-out model hint referencing `claude-opus-4-1-20250805` (deprecated) alongside a claim that the default was "Claude Sonnet 4" — both misleading, so the comment is replaced with one explaining why the model is pinned.

`claude-opus-5` is the complete, current model ID — **no date suffix**. Appending one is exactly what produces the 404 seen above.

The other two workflows (`release-please.yml`, `test-and-deploy.yml`) were checked and reference no Claude/Anthropic model or action, so they need no change.

Both files were validated as well-formed YAML, and `model` parses as a sibling of the other `with:` inputs in each.

## Follow-up suggestion (not done here)

Both workflows track `@beta` on the `anthropics/*` actions, which is a moving target — that's precisely how a changed upstream default broke CI with no commit on our side. Pinning each action to a release tag or commit SHA, and bumping deliberately, would stop this class of failure from recurring. Left out of this PR to keep it to the minimal fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
