### PR TITLE
refactor: move per-session settings off the shared Model singletons

### DIFF
--- a/src/6502.js
+++ b/src/6502.js
@@ -16,7 +16,7 @@ import { AtomMMC2 } from "./mmc.js";
 const signExtend = utils.signExtend;
 
 // Speed of the second processor relative to the host, as fitted to a Master Turbo.
-const DefaultTubeCpuMultiplier = 2;
+export const DefaultTubeCpuMultiplier = 2;
 
 function _set(byte, mask, set) {
     return (byte & ~mask) | (set ? mask : 0);
@@ -623,13 +623,11 @@ export class Cpu6502 extends Base6502 {
         this.cpuMultiplier = this.config.cpuMultiplier;
         this.videoCyclesBatch = this.config.videoCyclesBatch | 0;
         this.peripheralCyclesPerSecond = 2 * 1000 * 1000;
-        this.hasTube = !!this.config.coProcessor;
+        this.hasTube = !!this.config.tube;
         this.hasMusic5000 = !!this.config.hasMusic5000;
         this.hasTeletextAdaptor = !!this.config.hasTeletextAdaptor;
         this.tube = this.hasTube
-            ? new Tube6502(this.config.coProcessor, this, {
-                  cpuMultiplier: this.config.tubeCpuMultiplier || DefaultTubeCpuMultiplier,
-              })
+            ? new Tube6502(this.config.tube, this, { cpuMultiplier: this.config.tubeCpuMultiplier })
             : new FakeTube();
         this.music5000PageSel = 0;
         this.econet = econet;

--- a/src/6502.js
+++ b/src/6502.js
@@ -623,7 +623,6 @@ export class Cpu6502 extends Base6502 {
         this.cpuMultiplier = this.config.cpuMultiplier;
         this.videoCyclesBatch = this.config.videoCyclesBatch | 0;
         this.peripheralCyclesPerSecond = 2 * 1000 * 1000;
-        // Resolved once rather than read per access; hasTube is checked every batch.
         this.hasTube = !!this.config.coProcessor;
         this.hasMusic5000 = !!this.config.hasMusic5000;
         this.hasTeletextAdaptor = !!this.config.hasTeletextAdaptor;
@@ -1372,7 +1371,7 @@ export class Cpu6502 extends Base6502 {
     // Builds common code between polltimeSlow and polltimeFast
     buildPolltime() {
         const nop = (_cycles) => {};
-        const tubeStuff = (cycles) => (this.hasTube ? this.tube.execute(cycles) : nop);
+        const tubeStuff = this.hasTube ? (cycles) => this.tube.execute(cycles) : nop;
         const teletextStuff = this.teletextAdaptor ? (cycles) => this.teletextAdaptor.polltime(cycles) : nop;
         const musicStuff = this.music5000 ? (cycles) => this.music5000.polltime(cycles) : nop;
         const econetStuff = this.econet

--- a/src/6502.js
+++ b/src/6502.js
@@ -15,6 +15,9 @@ import { AtomMMC2 } from "./mmc.js";
 
 const signExtend = utils.signExtend;
 
+// Speed of the second processor relative to the host, as fitted to a Master Turbo.
+const DefaultTubeCpuMultiplier = 2;
+
 function _set(byte, mask, set) {
     return (byte & ~mask) | (set ? mask : 0);
 }
@@ -407,11 +410,11 @@ class Base6502 {
 }
 
 class Tube6502 extends Base6502 {
-    constructor(model, cpu) {
+    constructor(model, cpu, { cpuMultiplier = DefaultTubeCpuMultiplier } = {}) {
         super(model, { cycleAccurate: false });
 
         this.cycles = 0;
-        this.cpuMultiplier = 2;
+        this.cpuMultiplier = cpuMultiplier;
         this.romPaged = true;
         this.memory = new Uint8Array(65536);
         this.rom = new Uint8Array(4096);
@@ -620,10 +623,15 @@ export class Cpu6502 extends Base6502 {
         this.cpuMultiplier = this.config.cpuMultiplier;
         this.videoCyclesBatch = this.config.videoCyclesBatch | 0;
         this.peripheralCyclesPerSecond = 2 * 1000 * 1000;
-        this.tube = model.tube ? new Tube6502(model.tube, this) : new FakeTube();
-        if (model.tube && this.config.tubeCpuMultiplier) {
-            this.tube.cpuMultiplier = this.config.tubeCpuMultiplier;
-        }
+        // Resolved once rather than read per access; hasTube is checked every batch.
+        this.hasTube = !!this.config.coProcessor;
+        this.hasMusic5000 = !!this.config.hasMusic5000;
+        this.hasTeletextAdaptor = !!this.config.hasTeletextAdaptor;
+        this.tube = this.hasTube
+            ? new Tube6502(this.config.coProcessor, this, {
+                  cpuMultiplier: this.config.tubeCpuMultiplier || DefaultTubeCpuMultiplier,
+              })
+            : new FakeTube();
         this.music5000PageSel = 0;
         this.econet = econet;
 
@@ -799,7 +807,7 @@ export class Cpu6502 extends Base6502 {
 
         switch (addr & ~0x0003) {
             case 0xfc10:
-                if (this.model.hasTeletextAdaptor) return this.teletextAdaptor.read(addr - 0xfc10);
+                if (this.hasTeletextAdaptor) return this.teletextAdaptor.read(addr - 0xfc10);
                 break;
             case 0xfc20:
             case 0xfc24:
@@ -822,7 +830,7 @@ export class Cpu6502 extends Base6502 {
                 // IDE
                 break;
             case 0xfcfc:
-                if (addr === 0xfcff && this.model.hasMusic5000) return this.music5000PageSel;
+                if (addr === 0xfcff && this.hasMusic5000) return this.music5000PageSel;
                 break;
             case 0xfe00:
             case 0xfe04:
@@ -909,7 +917,7 @@ export class Cpu6502 extends Base6502 {
                 return this.tube.read(addr);
         }
 
-        if (this.model.hasMusic5000) {
+        if (this.hasMusic5000) {
             if ((this.music5000PageSel & 0xf0) === 0x30 && (addr & 0xff00) === 0xfd00) {
                 return this.music5000.read(this.music5000PageSel, addr);
             }
@@ -966,14 +974,14 @@ export class Cpu6502 extends Base6502 {
         addr &= 0xffff;
         b |= 0;
 
-        if (this.model.hasMusic5000 && (addr & 0xff00) === 0xfd00 && (this.music5000PageSel & 0xf0) === 0x30) {
+        if (this.hasMusic5000 && (addr & 0xff00) === 0xfd00 && (this.music5000PageSel & 0xf0) === 0x30) {
             this.music5000.write(this.music5000PageSel, addr, b);
             return;
         }
 
         switch (addr & ~0x0003) {
             case 0xfc10:
-                if (this.model.hasTeletextAdaptor) return this.teletextAdaptor.write(addr - 0xfc10, b);
+                if (this.hasTeletextAdaptor) return this.teletextAdaptor.write(addr - 0xfc10, b);
                 break;
             case 0xfc20:
             case 0xfc24:
@@ -996,7 +1004,7 @@ export class Cpu6502 extends Base6502 {
                 // IDE
                 break;
             case 0xfcfc:
-                if (addr === 0xfcff && this.model.hasMusic5000) {
+                if (addr === 0xfcff && this.hasMusic5000) {
                     this.music5000PageSel = b;
                 }
                 break;
@@ -1304,7 +1312,7 @@ export class Cpu6502 extends Base6502 {
         this.adconverter.reset();
 
         this.touchScreen = new TouchScreen(this.scheduler);
-        if (this.model.hasTeletextAdaptor) this.teletextAdaptor = new TeletextAdaptor(this);
+        if (this.hasTeletextAdaptor) this.teletextAdaptor = new TeletextAdaptor(this);
         if (this.econet) this.filestore = new Filestore(this, this.econet);
     }
 
@@ -1364,7 +1372,7 @@ export class Cpu6502 extends Base6502 {
     // Builds common code between polltimeSlow and polltimeFast
     buildPolltime() {
         const nop = (_cycles) => {};
-        const tubeStuff = (cycles) => (this.model.tube ? this.tube.execute(cycles) : nop);
+        const tubeStuff = (cycles) => (this.hasTube ? this.tube.execute(cycles) : nop);
         const teletextStuff = this.teletextAdaptor ? (cycles) => this.teletextAdaptor.polltime(cycles) : nop;
         const musicStuff = this.music5000 ? (cycles) => this.music5000.polltime(cycles) : nop;
         const econetStuff = this.econet
@@ -1506,7 +1514,7 @@ export class Cpu6502 extends Base6502 {
         if (this.model.os.length) {
             await this.loadOs.apply(this, this.model.os);
         }
-        if (this.model.tube) {
+        if (this.hasTube) {
             await this.tube.loadOs();
         }
         this.reset(true);

--- a/src/config.js
+++ b/src/config.js
@@ -9,16 +9,20 @@ export class Config extends EventTarget {
         this.onClose = onClose;
         this.changed = {};
         this.model = null;
-        this.coProcessor = null;
+        this.coProcessor = false;
+        this.hasEconet = false;
+        this.hasMusic5000 = false;
+        this.hasTeletextAdaptor = false;
+        this.extraRoms = [];
         const configuration = document.getElementById("configuration");
         configuration.addEventListener("show.bs.modal", () => {
             this.changed = {};
             this.setDropdownText(this.model.name);
-            this.set65c02(this.model.tube);
+            this.set65c02(this.coProcessor);
             this.setTubeCpuMultiplier(this.tubeCpuMultiplier);
-            this.setTeletext(this.model.hasTeletextAdaptor);
-            this.setMusic5000(this.model.hasMusic5000);
-            this.setEconet(this.model.hasEconet);
+            this.setTeletext(this.hasTeletextAdaptor);
+            this.setMusic5000(this.hasMusic5000);
+            this.setEconet(this.hasEconet);
         });
 
         configuration.addEventListener("hide.bs.modal", () => {
@@ -136,7 +140,7 @@ export class Config extends EventTarget {
     set65c02(enabled) {
         enabled = !!enabled;
         document.getElementById("65c02").checked = enabled;
-        this.model.tube = enabled ? findModel("Tube65c02") : null;
+        this.coProcessor = enabled;
         document.getElementById("tubeCpuMultiplier").disabled = !enabled;
     }
 
@@ -149,7 +153,7 @@ export class Config extends EventTarget {
     setEconet(enabled) {
         enabled = !!enabled;
         document.getElementById("hasEconet").checked = enabled;
-        this.model.hasEconet = enabled;
+        this.hasEconet = enabled;
 
         if (enabled && this.model.isMaster) {
             this.addRemoveROM("master/anfs-4.25.rom", true);
@@ -159,14 +163,14 @@ export class Config extends EventTarget {
     setMusic5000(enabled) {
         enabled = !!enabled;
         document.getElementById("hasMusic5000").checked = enabled;
-        this.model.hasMusic5000 = enabled;
+        this.hasMusic5000 = enabled;
         this.addRemoveROM("ample.rom", enabled);
     }
 
     setTeletext(enabled) {
         enabled = !!enabled;
         document.getElementById("hasTeletextAdaptor").checked = enabled;
-        this.model.hasTeletextAdaptor = enabled;
+        this.hasTeletextAdaptor = enabled;
         this.addRemoveROM("ats-3.0.rom", enabled);
     }
 
@@ -176,13 +180,11 @@ export class Config extends EventTarget {
     }
 
     addRemoveROM(romName, required) {
-        if (required && !this.model.os.includes(romName)) {
-            this.model.os.push(romName);
-        } else {
-            let pos = this.model.os.indexOf(romName);
-            if (pos !== -1) {
-                this.model.os.splice(pos, 1);
-            }
+        const pos = this.extraRoms.indexOf(romName);
+        if (required) {
+            if (pos === -1) this.extraRoms.push(romName);
+        } else if (pos !== -1) {
+            this.extraRoms.splice(pos, 1);
         }
     }
 

--- a/src/config.js
+++ b/src/config.js
@@ -2,6 +2,20 @@
 import { allModels, findModel } from "./models.js";
 import { getFilterForMode } from "./canvas.js";
 
+/**
+ * The sideways ROMs the optional fittings need, in the order they claim banks.
+ *
+ * @param {{model: object, hasEconet: boolean, hasMusic5000: boolean, hasTeletextAdaptor: boolean}} settings
+ * @returns {string[]}
+ */
+export function fittedRoms({ model, hasEconet, hasMusic5000, hasTeletextAdaptor }) {
+    return [
+        ...(hasEconet && model.isMaster ? ["master/anfs-4.25.rom"] : []),
+        ...(hasMusic5000 ? ["ample.rom"] : []),
+        ...(hasTeletextAdaptor ? ["ats-3.0.rom"] : []),
+    ];
+}
+
 export class Config extends EventTarget {
     constructor(onChange, onClose) {
         super();
@@ -13,7 +27,6 @@ export class Config extends EventTarget {
         this.hasEconet = false;
         this.hasMusic5000 = false;
         this.hasTeletextAdaptor = false;
-        this.extraRoms = [];
         const configuration = document.getElementById("configuration");
         configuration.addEventListener("show.bs.modal", () => {
             this.changed = {};
@@ -154,24 +167,18 @@ export class Config extends EventTarget {
         enabled = !!enabled;
         document.getElementById("hasEconet").checked = enabled;
         this.hasEconet = enabled;
-
-        if (enabled && this.model.isMaster) {
-            this.addRemoveROM("master/anfs-4.25.rom", true);
-        }
     }
 
     setMusic5000(enabled) {
         enabled = !!enabled;
         document.getElementById("hasMusic5000").checked = enabled;
         this.hasMusic5000 = enabled;
-        this.addRemoveROM("ample.rom", enabled);
     }
 
     setTeletext(enabled) {
         enabled = !!enabled;
         document.getElementById("hasTeletextAdaptor").checked = enabled;
         this.hasTeletextAdaptor = enabled;
-        this.addRemoveROM("ats-3.0.rom", enabled);
     }
 
     setDropdownText(modelName) {
@@ -179,13 +186,8 @@ export class Config extends EventTarget {
         if (el) el.textContent = modelName;
     }
 
-    addRemoveROM(romName, required) {
-        const pos = this.extraRoms.indexOf(romName);
-        if (required) {
-            if (pos === -1) this.extraRoms.push(romName);
-        } else if (pos !== -1) {
-            this.extraRoms.splice(pos, 1);
-        }
+    get extraRoms() {
+        return fittedRoms(this);
     }
 
     mapLegacyModels(parsedQuery) {

--- a/src/fake6502.js
+++ b/src/fake6502.js
@@ -3,7 +3,7 @@
 
 import { FakeVideo } from "./video.js";
 import { FakeSoundChip } from "./soundchip.js";
-import { TEST_6502, TEST_65C02, TEST_65C12 } from "./models.js";
+import { TEST_6502, TEST_65C02, TEST_65C12, TubeModel } from "./models.js";
 import { FakeDdNoise } from "./ddnoise.js";
 import { FakeRelayNoise } from "./relaynoise.js";
 import { Cpu6502, AtomCpu6502 } from "./6502.js";
@@ -19,7 +19,6 @@ const dbgr = {
 export function fake6502(model, opts) {
     opts = opts || {};
     model = model || TEST_6502;
-    if (opts.tube) model = model.withTube();
     const CpuClass = model.isAtom ? AtomCpu6502 : Cpu6502;
     return new CpuClass(model, {
         dbgr,
@@ -30,6 +29,10 @@ export function fake6502(model, opts) {
         music5000: new FakeMusic5000(),
         cmos: new Cmos(),
         cycleAccurate: opts.cycleAccurate,
+        config: {
+            coProcessor: opts.tube ? TubeModel : null,
+            tubeCpuMultiplier: opts.tubeCpuMultiplier,
+        },
     });
 }
 

--- a/src/fake6502.js
+++ b/src/fake6502.js
@@ -30,7 +30,7 @@ export function fake6502(model, opts) {
         cmos: new Cmos(),
         cycleAccurate: opts.cycleAccurate,
         config: {
-            coProcessor: opts.tube ? TubeModel : null,
+            tube: opts.tube ? TubeModel : null,
             tubeCpuMultiplier: opts.tubeCpuMultiplier,
         },
     });

--- a/src/main.js
+++ b/src/main.js
@@ -219,24 +219,6 @@ const userPort = {
     },
 };
 
-const emulationConfig = {
-    keyLayout: keyLayout,
-    cpuMultiplier: cpuMultiplier,
-    tubeCpuMultiplier: parsedQuery.tubeCpuMultiplier || 2,
-    videoCyclesBatch: parsedQuery.videoCyclesBatch,
-    extraRoms: extraRoms,
-    userPort: userPort,
-    printerPort: printerPort,
-    getGamepads: function () {
-        // Gamepads are only available in secure contexts. If e.g. loading from http:// urls they aren't there.
-        return navigator.getGamepads ? navigator.getGamepads() : [];
-    },
-    debugFlags: {
-        logFdcCommands: parsedQuery.logFdcCommands !== undefined,
-        logFdcStateChanges: parsedQuery.logFdcStateChanges !== undefined,
-    },
-};
-
 // Speech output: initialised from URL param; can be toggled at runtime via the Settings panel.
 // Must be created before Config so the onClose callback and setSpeechOutput() call can reference it.
 const speechOutput = new SpeechOutput();
@@ -315,13 +297,29 @@ config.setDisplayMode(displayMode);
 
 model = config.model;
 
-// Resolved after the config.setX calls above have applied the URL parameters. ROM order
-// determines sideways bank allocation, and the fittings' ROMs claim banks before any
-// the user asked for with ?rom=.
-emulationConfig.coProcessor = config.coProcessor ? TubeModel : null;
-emulationConfig.hasMusic5000 = config.hasMusic5000;
-emulationConfig.hasTeletextAdaptor = config.hasTeletextAdaptor;
-emulationConfig.extraRoms = [...config.extraRoms, ...extraRoms];
+// Built here, once the config.setX calls above have applied the URL parameters.
+const emulationConfig = {
+    keyLayout: keyLayout,
+    cpuMultiplier: cpuMultiplier,
+    tubeCpuMultiplier: config.tubeCpuMultiplier,
+    videoCyclesBatch: parsedQuery.videoCyclesBatch,
+    coProcessor: config.coProcessor ? TubeModel : null,
+    hasMusic5000: config.hasMusic5000,
+    hasTeletextAdaptor: config.hasTeletextAdaptor,
+    // ROM order determines sideways bank allocation, and the fittings' ROMs claim banks
+    // before any the user asked for with ?rom=.
+    extraRoms: [...config.extraRoms, ...extraRoms],
+    userPort: userPort,
+    printerPort: printerPort,
+    getGamepads: function () {
+        // Gamepads are only available in secure contexts. If e.g. loading from http:// urls they aren't there.
+        return navigator.getGamepads ? navigator.getGamepads() : [];
+    },
+    debugFlags: {
+        logFdcCommands: parsedQuery.logFdcCommands !== undefined,
+        logFdcStateChanges: parsedQuery.logFdcStateChanges !== undefined,
+    },
+};
 
 function sbBind(div, url, onload) {
     const img = div.querySelector("img");

--- a/src/main.js
+++ b/src/main.js
@@ -19,6 +19,7 @@ import { GoogleDriveLoader } from "./google-drive.js";
 import * as tokeniser from "./basic-tokenise.js";
 import * as canvasLib from "./canvas.js";
 import { Config } from "./config.js";
+import { TubeModel } from "./models.js";
 import { initialise as electron } from "./app/electron.js";
 import { AudioHandler } from "./web/audio-handler.js";
 import { Econet } from "./econet.js";
@@ -220,7 +221,6 @@ const userPort = {
 
 const emulationConfig = {
     keyLayout: keyLayout,
-    coProcessor: parsedQuery.coProcessor,
     cpuMultiplier: cpuMultiplier,
     tubeCpuMultiplier: parsedQuery.tubeCpuMultiplier || 2,
     videoCyclesBatch: parsedQuery.videoCyclesBatch,
@@ -314,6 +314,14 @@ let displayMode = parsedQuery.displayMode || "rgb";
 config.setDisplayMode(displayMode);
 
 model = config.model;
+
+// Resolved after the config.setX calls above have applied the URL parameters. ROM order
+// determines sideways bank allocation, and the fittings' ROMs claim banks before any
+// the user asked for with ?rom=.
+emulationConfig.coProcessor = config.coProcessor ? TubeModel : null;
+emulationConfig.hasMusic5000 = config.hasMusic5000;
+emulationConfig.hasTeletextAdaptor = config.hasTeletextAdaptor;
+emulationConfig.extraRoms = [...config.extraRoms, ...extraRoms];
 
 function sbBind(div, url, onload) {
     const img = div.querySelector("img");
@@ -612,7 +620,7 @@ window.addEventListener("beforeunload", function (event) {
     }
 });
 
-if (model.hasEconet) {
+if (config.hasEconet) {
     econet = new Econet(stationId);
 } else {
     document.getElementById("fsmenuitem").style.display = "none";
@@ -656,7 +664,7 @@ processor = new CpuClass(model, {
     soundChip: audioHandler.soundChip,
     ddNoise: audioHandler.ddNoise,
     relayNoise: audioHandler.relayNoise,
-    music5000: model.hasMusic5000 ? audioHandler.music5000 : null,
+    music5000: config.hasMusic5000 ? audioHandler.music5000 : null,
     cmos,
     config: emulationConfig,
     econet,
@@ -1690,7 +1698,7 @@ syncLights = function () {
         drive0.update(processor.fdc.motorOn[0]);
         drive1.update(processor.fdc.motorOn[1]);
         cassette.update(processor.acia.motorOn);
-        if (model.hasEconet) {
+        if (config.hasEconet) {
             network.update(processor.econet.activityLight());
         }
     }

--- a/src/main.js
+++ b/src/main.js
@@ -7,7 +7,7 @@ import "./jsbeeb.css";
 import * as utils from "./utils.js";
 import { FakeVideo, Video } from "./video.js";
 import { Debugger } from "./web/debug.js";
-import { Cpu6502, AtomCpu6502 } from "./6502.js";
+import { Cpu6502, AtomCpu6502, DefaultTubeCpuMultiplier } from "./6502.js";
 import * as utils_atom from "./utils_atom.js";
 import { LoadSD } from "./mmc.js";
 import { Cmos } from "./cmos.js";
@@ -271,7 +271,7 @@ const config = new Config(
         if (changed.tubeCpuMultiplier !== undefined) {
             emulationConfig.tubeCpuMultiplier = changed.tubeCpuMultiplier;
             config.setTubeCpuMultiplier(changed.tubeCpuMultiplier);
-            if (processor.tube && processor.tube.cpuMultiplier !== undefined) {
+            if (processor.hasTube) {
                 processor.tube.cpuMultiplier = changed.tubeCpuMultiplier;
             }
         }
@@ -285,7 +285,7 @@ config.mapLegacyModels(parsedQuery);
 config.setModel(parsedQuery.model || guessModelFromHostname(window.location.hostname));
 config.setKeyLayout(keyLayout);
 config.set65c02(parsedQuery.coProcessor);
-config.setTubeCpuMultiplier(parsedQuery.tubeCpuMultiplier || 2);
+config.setTubeCpuMultiplier(parsedQuery.tubeCpuMultiplier || DefaultTubeCpuMultiplier);
 config.setEconet(parsedQuery.hasEconet);
 config.setMusic5000(parsedQuery.hasMusic5000);
 config.setTeletext(parsedQuery.hasTeletextAdaptor);
@@ -297,20 +297,22 @@ config.setDisplayMode(displayMode);
 
 model = config.model;
 
-// Built here, once the config.setX calls above have applied the URL parameters.
+// Depends on the config.setX calls above having applied the URL parameters. Note
+// cpuMultiplier is not one of them: it is read from the query string further down, and
+// this deliberately captures the value it has here.
 const emulationConfig = {
-    keyLayout: keyLayout,
-    cpuMultiplier: cpuMultiplier,
+    keyLayout,
+    cpuMultiplier,
     tubeCpuMultiplier: config.tubeCpuMultiplier,
     videoCyclesBatch: parsedQuery.videoCyclesBatch,
-    coProcessor: config.coProcessor ? TubeModel : null,
+    tube: config.coProcessor ? TubeModel : null,
     hasMusic5000: config.hasMusic5000,
     hasTeletextAdaptor: config.hasTeletextAdaptor,
     // ROM order determines sideways bank allocation, and the fittings' ROMs claim banks
     // before any the user asked for with ?rom=.
     extraRoms: [...config.extraRoms, ...extraRoms],
-    userPort: userPort,
-    printerPort: printerPort,
+    userPort,
+    printerPort,
     getGamepads: function () {
         // Gamepads are only available in secure contexts. If e.g. loading from http:// urls they aren't there.
         return navigator.getGamepads ? navigator.getGamepads() : [];

--- a/src/models.js
+++ b/src/models.js
@@ -274,9 +274,9 @@ export const basicOnly = new Model({
 });
 
 /**
- * The only second processor jsbeeb emulates. Machine-building code passes this (or
- * null) as the emulation config's `coProcessor`, so that 6502.js needn't import this
- * module and close an import cycle via the FDC modules.
+ * The only second processor jsbeeb emulates. Machine-building code passes this as the
+ * emulation config's `tube`, so that 6502.js needn't import this module and close an
+ * import cycle via the FDC modules.
  */
 export const TubeModel = findModel("Tube65C02");
 

--- a/src/models.js
+++ b/src/models.js
@@ -10,12 +10,16 @@ const CpuModel = Object.freeze({
     CMOS65C12: 2,
 });
 
-// The only second processor jsbeeb emulates. Named here so the one place that
-// knows a "tube" means this particular model is the Model class itself.
-const TubeModelName = "Tube65C02";
-
+/**
+ * Describes what a machine *is*: which CPU, which ROMs, which disc controller.
+ * Anything a user can turn on and off for a session (second processor, Econet,
+ * Music 5000, teletext adaptor) belongs in the emulation config passed to Cpu6502.
+ *
+ * Instances are shared process-wide via `allModels` and frozen, so they can be handed
+ * to any number of machines without one session's settings leaking into the next.
+ */
 class Model {
-    constructor({ name, synonyms, os, cpuModel, isMaster, isAtom, swram, fdc, tube, cmosOverride, banks } = {}) {
+    constructor({ name, synonyms, os, cpuModel, isMaster, isAtom, swram, fdc, cmosOverride, banks } = {}) {
         this.name = name;
         this.synonyms = synonyms;
         this.os = os;
@@ -26,25 +30,7 @@ class Model {
         this.Fdc = fdc;
         this.swram = swram;
         this.isTest = false;
-        this.tube = tube;
         this.cmosOverride = cmosOverride;
-        this.hasEconet = false;
-        this.hasMusic5000 = false;
-    }
-
-    /**
-     * Returns a copy of this model with the 65C02 second processor attached,
-     * leaving this model untouched.
-     *
-     * The models in `allModels` are shared singletons, so a machine must never set
-     * `tube` on one in place: a machine created later in the same process would
-     * inherit it. Copying with `Object.create` rather than the constructor keeps
-     * both the prototype getters below and any flags set after construction.
-     *
-     * @returns {Model}
-     */
-    withTube() {
-        return Object.assign(Object.create(Model.prototype), this, { tube: findModel(TubeModelName) });
     }
 
     get nmos() {
@@ -286,3 +272,18 @@ export const basicOnly = new Model({
     swram: masterSwram,
     fdc: NoiseAwareWdFdc,
 });
+
+/**
+ * The only second processor jsbeeb emulates. Machine-building code passes this (or
+ * null) as the emulation config's `coProcessor`, so that 6502.js needn't import this
+ * module and close an import cycle via the FDC modules.
+ */
+export const TubeModel = findModel("Tube65C02");
+
+// After the isTest assignments above, so those still apply.
+for (const model of [...allModels, TEST_6502, TEST_65C02, TEST_65C12, basicOnly]) {
+    Object.freeze(model.os);
+    Object.freeze(model.synonyms);
+    Object.freeze(model);
+}
+Object.freeze(allModels);

--- a/tests/integration/tube.js
+++ b/tests/integration/tube.js
@@ -1,0 +1,33 @@
+import { describe, it, expect } from "vitest";
+import { TestMachine } from "../test-machine.js";
+
+describe("Tube co-processor", () => {
+    it("runs the parasite processor alongside the host", async () => {
+        const machine = new TestMachine("Master", { tube: true });
+        await machine.initialise();
+        const parasite = machine.processor.tube;
+        const startPc = parasite.pc;
+
+        machine.processor.execute(200 * 1000);
+
+        expect(machine.processor.hasTube).toBe(true);
+        expect(parasite.pc).not.toBe(startPc);
+    });
+
+    it("leaves the parasite absent when no co-processor is fitted", async () => {
+        const machine = new TestMachine("Master");
+        await machine.initialise();
+
+        machine.processor.execute(200 * 1000);
+
+        expect(machine.processor.hasTube).toBe(false);
+        expect(machine.processor.tube.pc).toBeUndefined();
+    });
+
+    it("runs the parasite at the requested multiple of the host clock", async () => {
+        const machine = new TestMachine("Master", { tube: true, tubeCpuMultiplier: 4 });
+        await machine.initialise();
+
+        expect(machine.processor.tube.cpuMultiplier).toBe(4);
+    });
+});

--- a/tests/test-machine.js
+++ b/tests/test-machine.js
@@ -11,10 +11,8 @@ const MaxCyclesPerIter = 100 * 1000;
 export class TestMachine {
     constructor(model, opts) {
         model = model || "B-DFS1.2";
-        this.processor = fake6502(findModel(model), opts || {});
-        // Read the model back from the processor: fake6502 may have derived its own
-        // copy (e.g. for opts.tube), and the two must not disagree.
-        this.model = this.processor.model;
+        this.model = findModel(model);
+        this.processor = fake6502(this.model, opts || {});
         this._capturedChars = [];
         this._captureHookInstalled = false;
     }

--- a/tests/test-machine.js
+++ b/tests/test-machine.js
@@ -12,6 +12,7 @@ export class TestMachine {
     constructor(model, opts) {
         model = model || "B-DFS1.2";
         this.model = findModel(model);
+        if (!this.model) throw new Error(`Unknown model "${model}"`);
         this.processor = fake6502(this.model, opts || {});
         this._capturedChars = [];
         this._captureHookInstalled = false;

--- a/tests/unit/test-config.js
+++ b/tests/unit/test-config.js
@@ -1,0 +1,35 @@
+import { describe, it, expect } from "vitest";
+import { fittedRoms } from "../../src/config.js";
+import { findModel } from "../../src/models.js";
+
+describe("fittedRoms", () => {
+    const master = findModel("Master");
+    const beeb = findModel("B-DFS1.2");
+    const none = { model: beeb, hasEconet: false, hasMusic5000: false, hasTeletextAdaptor: false };
+
+    it("fits nothing when nothing is enabled", () => {
+        expect(fittedRoms(none)).toEqual([]);
+    });
+
+    it("fits the Music 5000 and teletext ROMs", () => {
+        expect(fittedRoms({ ...none, hasMusic5000: true })).toEqual(["ample.rom"]);
+        expect(fittedRoms({ ...none, hasTeletextAdaptor: true })).toEqual(["ats-3.0.rom"]);
+    });
+
+    it("fits ANFS only on a Master", () => {
+        expect(fittedRoms({ ...none, model: master, hasEconet: true })).toEqual(["master/anfs-4.25.rom"]);
+        expect(fittedRoms({ ...none, hasEconet: true })).toEqual([]);
+    });
+
+    it("orders the ROMs so bank allocation is predictable", () => {
+        const all = { model: master, hasEconet: true, hasMusic5000: true, hasTeletextAdaptor: true };
+
+        expect(fittedRoms(all)).toEqual(["master/anfs-4.25.rom", "ample.rom", "ats-3.0.rom"]);
+    });
+
+    it("gives the same answer however many times it is asked", () => {
+        const all = { model: master, hasEconet: true, hasMusic5000: true, hasTeletextAdaptor: true };
+
+        expect(fittedRoms(all)).toEqual(fittedRoms(all));
+    });
+});

--- a/tests/unit/test-models.js
+++ b/tests/unit/test-models.js
@@ -1,60 +1,53 @@
 import { describe, it, expect } from "vitest";
-import { findModel } from "../../src/models.js";
+import { allModels, findModel } from "../../src/models.js";
 import { fake6502 } from "../../src/fake6502.js";
 
 describe("Model", () => {
-    describe("withTube", () => {
-        it("returns a copy, leaving the original untouched", () => {
-            const master = findModel("Master");
-            const withTube = master.withTube();
+    it("is frozen so per-session settings cannot be stored on it", () => {
+        const master = findModel("Master");
 
-            expect(withTube).not.toBe(master);
-            expect(withTube.tube.name).toBe("Tube65C02");
-            expect(master.tube).toBeUndefined();
-        });
+        expect(Object.isFrozen(master)).toBe(true);
+        expect(() => {
+            "use strict";
+            master.hasEconet = true;
+        }).toThrow(TypeError);
+    });
 
-        it("preserves the derived getters", () => {
-            const master = findModel("Master");
-            const withTube = master.withTube();
+    it("freezes every model, not just the selectable ones", () => {
+        expect(allModels.every((model) => Object.isFrozen(model))).toBe(true);
+    });
 
-            expect(withTube.nmos).toBe(master.nmos);
-            expect(withTube.opcodesFactory).toBe(master.opcodesFactory);
-        });
+    it("carries no per-session settings", () => {
+        const master = findModel("Master");
 
-        it("preserves the rest of the model", () => {
-            const master = findModel("Master");
-            const withTube = master.withTube();
-
-            expect(withTube.name).toBe(master.name);
-            expect(withTube.isMaster).toBe(master.isMaster);
-            expect(withTube.isAtom).toBe(master.isAtom);
-            expect(withTube.Fdc).toBe(master.Fdc);
-            expect(withTube.os).toBe(master.os);
-        });
-
-        it("does not disturb a model that already has a tube", () => {
-            const withTube = findModel("Master").withTube();
-
-            expect(withTube.withTube().tube).toBe(withTube.tube);
-        });
+        expect(master.tube).toBeUndefined();
+        expect(master.hasEconet).toBeUndefined();
+        expect(master.hasMusic5000).toBeUndefined();
+        expect(master.hasTeletextAdaptor).toBeUndefined();
     });
 });
 
 describe("fake6502 tube handling", () => {
     it("attaches a tube when asked", () => {
-        expect(fake6502(findModel("Master"), { tube: true }).model.tube.name).toBe("Tube65C02");
+        const cpu = fake6502(findModel("Master"), { tube: true });
+
+        expect(cpu.hasTube).toBe(true);
+        expect(cpu.tube.cpuMultiplier).toBe(2);
+    });
+
+    it("attaches no tube by default", () => {
+        expect(fake6502(findModel("Master"), {}).hasTube).toBe(false);
     });
 
     it("does not leak the tube into later machines using the same model", () => {
         fake6502(findModel("Master"), { tube: true });
 
-        expect(findModel("Master").tube).toBeUndefined();
-        expect(fake6502(findModel("Master"), {}).model.tube).toBeUndefined();
+        expect(fake6502(findModel("Master"), {}).hasTube).toBe(false);
     });
 
-    it("leaves the model's own tube setting alone when no tube is specified", () => {
-        const model = findModel("Master").withTube();
+    it("honours a tube cpu multiplier", () => {
+        const cpu = fake6502(findModel("Master"), { tube: true, tubeCpuMultiplier: 4 });
 
-        expect(fake6502(model, {}).model.tube.name).toBe("Tube65C02");
+        expect(cpu.tube.cpuMultiplier).toBe(4);
     });
 });

--- a/tests/unit/test-models.js
+++ b/tests/unit/test-models.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { allModels, findModel } from "../../src/models.js";
+import { allModels, basicOnly, findModel, TEST_6502, TEST_65C02, TEST_65C12 } from "../../src/models.js";
 import { fake6502 } from "../../src/fake6502.js";
 
 describe("Model", () => {
@@ -7,14 +7,14 @@ describe("Model", () => {
         const master = findModel("Master");
 
         expect(Object.isFrozen(master)).toBe(true);
-        expect(() => {
-            "use strict";
-            master.hasEconet = true;
-        }).toThrow(TypeError);
+        expect(() => (master.hasEconet = true)).toThrow(TypeError);
     });
 
-    it("freezes every model, not just the selectable ones", () => {
-        expect(allModels.every((model) => Object.isFrozen(model))).toBe(true);
+    it("freezes every model and its rom list", () => {
+        for (const model of [...allModels, TEST_6502, TEST_65C02, TEST_65C12, basicOnly]) {
+            expect(Object.isFrozen(model), `${model.name} should be frozen`).toBe(true);
+            expect(Object.isFrozen(model.os), `${model.name} os should be frozen`).toBe(true);
+        }
     });
 
     it("carries no per-session settings", () => {


### PR DESCRIPTION
Fixes #711.

`Model` was holding two unrelated kinds of thing: what a machine *is* (CPU, ROMs, disc controller) and how a particular session has it fitted out (second processor, Econet, Music 5000, teletext adaptor). The second group was being mutated in place on singletons shared process-wide.

This is harmless in the browser, which has one machine and reloads the page whenever any of these change. It fails in a long-lived process that builds many machines, which is how it surfaced: in #706 the tube leaked from one headless `MachineSession` into the next.

## What changed

**The four fittings moved into the emulation config** that `Cpu6502` already receives, alongside `tubeCpuMultiplier`, `extraRoms` and friends. `main.js` already had a `coProcessor` field in that config; nothing read it, so this mostly finishes a job that was started and left half-wired.

**Models are frozen**, along with their `os` and `synonyms` arrays, so any future in-place edit fails at the mutation rather than as inexplicable behaviour two sessions later.

**`Cpu6502` resolves the fittings once** in its constructor rather than reading through the model on every access. `hasTube` is checked every execution batch, so this is marginally cheaper than the property chain it replaces.

**`Tube6502` takes its cpu multiplier as a constructor argument** instead of having it assigned immediately after construction. The runtime poke in `main.js` stays, since that one is a genuine live update when the slider moves.

## A second leak, found on the way

`Config.addRemoveROM` was pushing onto `this.model.os`, the shared model's ROM array. Enabling Music 5000 therefore appended `ample.rom` to that model permanently, for every machine built from it afterwards in the same process. Same class of bug as the tube and less visible, and shallow-freezing the model would not have caught it.

`Config` now owns that list. Its ROMs are ordered ahead of any `?rom=` ones, because ROM order determines sideways bank allocation and this keeps that allocation unchanged.

## Compatibility

URL parameters are untouched: `coProcessor` remains the config-layer and query-parameter name, with "tube" kept as the internal word in `6502.js`. Snapshots record only `model.name`, so they are unaffected.

## Testing

Lint, prettier, 605 unit tests, 60 integration tests, the full CPU suite and a production build all pass. Verified headless that a `Master` with `tube: true` boots with a `Tube6502` and loads the tube ROM, and that a second session in the same process gets a `FakeTube`.

Not covered by automated tests, and worth a click-through before merge: the browser settings modal, specifically the co-processor, Music 5000, teletext and Econet toggles.

## Later commits on this branch

**The tube polltime branch is now decided at build time.** `tubeStuff` tested `this.hasTube` on every `polltime`, unlike its teletext, music and econet siblings, which pick between the real function and `nop` once in `buildPolltime()`. It also returned `nop` rather than calling it when no tube was fitted, harmless only because the result is discarded.

**Added integration coverage for the parasite actually executing**, which nothing tested. Confirmed the test fails if `tubeStuff` is stubbed out, so it genuinely guards the wiring.

**The emulation config is built in one place.** It had been an early object literal with four fields bolted on later, because those four depend on the `config.setX` calls having run. The literal now sits below those calls and is built once. The position is deliberate: `cpuMultiplier` is reassigned from the URL further down the file, so the literal still captures exactly the value it captured before the move.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

