### PR TITLE
fix: write two-byte Tube R3 transfers into the right FIFO

### DIFF
--- a/src/tube.js
+++ b/src/tube.js
@@ -219,7 +219,7 @@ export class Tube {
                 if (this.hostStatus[TUBE_ULA_R3] & TUBE_ULA_FLAG_DATA_REGISTER_NOT_FULL) {
                     if (this.internalStatusRegister & TUBE_ULA_FLAG_STATUS_ENABLE_2_BYTE_R3_DATA) {
                         if (this.hostToParasiteFifoByteCount3 < 2) {
-                            this.hostToParasiteData[this.hostToParasiteFifoByteCount3++] = value;
+                            this.hostToParasiteData[TUBE_ULA_R3][this.hostToParasiteFifoByteCount3++] = value;
                         }
                         if (this.hostToParasiteFifoByteCount3 === 2) {
                             this.parasiteStatus[TUBE_ULA_R3] |= TUBE_ULA_FLAG_DATA_AVAILABLE;

--- a/tests/unit/test-tube.js
+++ b/tests/unit/test-tube.js
@@ -1,0 +1,46 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { Tube } from "../../src/tube.js";
+
+// Tube ULA register addresses, as seen at 0xFEE0 on the host and 0xFEF8 on the parasite.
+const R1Status = 0;
+const R1Data = 1;
+const R3Data = 5;
+// Written to R1 status: S sets the flags named in the rest of the byte, V selects two-byte R3.
+const SetControlFlags = 0x80;
+const TwoByteR3 = 0x10;
+
+function fakeCpu() {
+    return { interrupt: 0, resetHeldLow: false, NMI() {} };
+}
+
+describe("Tube ULA", () => {
+    let tube;
+
+    beforeEach(() => {
+        tube = new Tube(fakeCpu(), fakeCpu());
+        tube.reset(true);
+    });
+
+    describe("two-byte register 3 transfers", () => {
+        beforeEach(() => {
+            tube.hostWrite(R1Status, SetControlFlags | TwoByteR3);
+        });
+
+        it("delivers both bytes to the parasite in order", () => {
+            tube.hostWrite(R3Data, 0x11);
+            tube.hostWrite(R3Data, 0x22);
+
+            expect(tube.parasiteRead(R3Data)).toBe(0x11);
+            expect(tube.parasiteRead(R3Data)).toBe(0x22);
+        });
+
+        it("leaves the register 1 FIFO alone", () => {
+            tube.hostWrite(R3Data, 0x11);
+            tube.hostWrite(R3Data, 0x22);
+
+            tube.hostWrite(R1Data, 0x77);
+
+            expect(tube.parasiteRead(R1Data)).toBe(0x77);
+        });
+    });
+});


### PR DESCRIPTION
## The bug

In `Tube.hostWrite`, the two-byte register 3 path indexed `hostToParasiteData` with the FIFO *byte count* rather than the *register number*:

```js
this.hostToParasiteData[this.hostToParasiteFifoByteCount3++] = value;
```

`hostToParasiteData` is an array of four `Uint8Array` FIFOs, one per Tube register. So instead of writing a byte into the R3 FIFO, this replaced `hostToParasiteData[0]` and `[1]` — the R1 and R2 FIFOs themselves — with plain numbers.

The parasite side of the same transfer has always been indexed correctly:

```js
this.parasiteToHostData[TUBE_ULA_R3][this.parasiteToHostFifoByteCount3++] = value;
```

## Consequences

Two-byte R3 transfers from host to parasite delivered nothing: the parasite read R3 and got whatever was in the untouched FIFO, not the bytes the host wrote. Worse, the R1 FIFO was left as a number, so the next `parasiteRead` of R1 data indexed `[0]` on a number and returned `undefined` — a value that then flowed on into the parasite's registers.

## Tests

`tests/unit/test-tube.js` is new, and both tests fail on `main`:

- *delivers both bytes to the parasite in order* — got `0` instead of `0x11`
- *leaves the register 1 FIFO alone* — got `undefined` instead of `0x77`

Found while adding Tube state to snapshots (#712). Pulled out as its own PR because it is an emulation bug in its own right and stands independently of that work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)