### PR TITLE
feat: save and restore second processor state

### DIFF
--- a/docs/snapshot-format.md
+++ b/docs/snapshot-format.md
@@ -1,4 +1,4 @@
-# jsbeeb Snapshot Format (Version 2)
+# jsbeeb Snapshot Format (Version 3)
 
 jsbeeb saves emulator state as gzip-compressed JSON files with the extension `.json.gz`. TypedArrays (RAM, palette data, etc.) are encoded as base64 within the JSON. Uncompressed `.json` files are also accepted on load for backward compatibility.
 
@@ -7,22 +7,24 @@ jsbeeb saves emulator state as gzip-compressed JSON files with the extension `.j
 ```json
 {
   "format": "jsbeeb-snapshot",
-  "version": 2,
+  "version": 3,
   "model": "BBC B with DFS 1.2",
+  "coProcessor": false,
   "timestamp": "2026-03-15T12:00:00.000Z",
   "media": { "disc1": "sth:Acornsoft/Drogna", "disc1Crc32": -1234567890 },
   "state": { ... }
 }
 ```
 
-| Field       | Type   | Description                                                                     |
-| ----------- | ------ | ------------------------------------------------------------------------------- |
-| `format`    | string | Always `"jsbeeb-snapshot"`                                                      |
-| `version`   | number | Format version (currently `2`)                                                  |
-| `model`     | string | jsbeeb model name or synonym (e.g. `"B"`, `"Master"`, `"BBC Master 128 (DFS)"`) |
-| `timestamp` | string | ISO 8601 timestamp of when the snapshot was created                             |
-| `media`     | object | _(Optional)_ Disc source references for reload on restore (see below)           |
-| `state`     | object | The full emulator state (see below)                                             |
+| Field         | Type    | Description                                                                     |
+| ------------- | ------- | ------------------------------------------------------------------------------- |
+| `format`      | string  | Always `"jsbeeb-snapshot"`                                                      |
+| `version`     | number  | Format version (currently `3`)                                                  |
+| `model`       | string  | jsbeeb model name or synonym (e.g. `"B"`, `"Master"`, `"BBC Master 128 (DFS)"`) |
+| `coProcessor` | boolean | _(v3+)_ Whether a second processor was fitted. Absent means no                  |
+| `timestamp`   | string  | ISO 8601 timestamp of when the snapshot was created                             |
+| `media`       | object  | _(Optional)_ Disc source references for reload on restore (see below)           |
+| `state`       | object  | The full emulator state (see below)                                             |
 
 ### Media references (`media`)
 
@@ -47,6 +49,7 @@ When `discNCrc32` is present, it is compared against the CRC32 of the reloaded d
 
 - **v1** — Initial release. CPU, memory, VIA, video, sound, ACIA, ADC.
 - **v2** — Added FDC, disc drive, and disc track data. Dirty track persistence, embedded disc image data for local files, and CRC32 verification. v1 snapshots load with FDC state unchanged.
+- **v3** — Added second processor state (`state.tube`) and the top-level `coProcessor` flag. Nothing before v3 captured tube state, so earlier snapshots are always host-only and load into a machine without a co-processor unchanged.
 
 ### Imported snapshots
 
@@ -57,7 +60,7 @@ Snapshots can be imported from other emulators. The `importedFrom` field in the 
 | `"b-em"`       | B-em snapshot (`.snp` file, v1 or v3)            |
 | `"beebem-uef"` | BeebEm UEF save state (`.uef` with 0x046C chunk) |
 
-Imported snapshots use the same `jsbeeb-snapshot` format (version 2) and do not include FDC or disc state (`state.fdc` will be absent).
+Imported snapshots use the same `jsbeeb-snapshot` format (version 3) and do not include FDC or disc state (`state.fdc` will be absent).
 
 B-em snapshots include the full ROM contents in the `roms` field (256KB, all 16 banks). BeebEm UEF snapshots only include sideways RAM banks via the `swRamBanks` field (an object keyed by bank number, each value a `Uint8Array` of 16KB). On restore, `swRamBanks` selectively overwrites individual ROM banks without touching the ROMs jsbeeb has already loaded.
 
@@ -65,7 +68,9 @@ B-em snapshots include the full ROM contents in the `roms` field (256KB, all 16 
 
 When loading, the snapshot model is compared to the current model using `isSameModel()`. Names are resolved through `findModel()`, so synonyms and old names match (e.g. `"B"` matches `"BBC B with DFS 1.2"`), but the result must be the same model: filesystem variants are separate models and so are _not_ interchangeable (e.g. `"BBC Master 128 (DFS)"` does not match `"BBC Master 128 (ADFS)"`).
 
-If the models differ, the snapshot is stashed in `sessionStorage` under `jsbeeb-pending-state` and the page reloads with the snapshot's model in the query string, picking the state back up on the way in. `restoreSnapshot()` itself does not reload; given a mismatch it throws.
+The co-processor is emulation config rather than part of the model, so the model name cannot tell a Master Turbo from a plain Master. The `coProcessor` flag is compared separately, and `restoreSnapshot()` throws if it does not match the running machine.
+
+If the models or co-processor settings differ, the snapshot is stashed in `sessionStorage` under `jsbeeb-pending-state` and the page reloads with the snapshot's model and co-processor setting in the query string, picking the state back up on the way in. `restoreSnapshot()` itself does not reload; given a mismatch it throws.
 
 ## TypedArray encoding
 
@@ -354,7 +359,44 @@ Track keys are strings like `"false:0"` (lower side, track 0) or `"true:5"` (upp
 
 **Save-to-file vs rewind:** When saving to a file, `tracks` is empty (`{}`) and `dirtyTracks` contains only tracks that have been written since the disc was loaded. On restore, the base disc is first reloaded from the media source (URL or embedded image data), then dirty track overlays are applied on top. This preserves disc writes (e.g. game saves) across save/restore cycles. For in-memory rewind snapshots, `tracks` contains full pulse data with structural sharing: clean tracks share `pulses2Us` references across snapshots, and only tracks written since the previous snapshot are freshly copied. This keeps rewind memory proportional to disc write activity rather than total disc size.
 
-## Known limitations (v2)
+### Second processor (`state.tube`) — _v3+_
+
+Present only when a co-processor was fitted; the top-level `coProcessor` flag says whether to expect it.
+
+| Field      | Type       | Description                                                     |
+| ---------- | ---------- | --------------------------------------------------------------- |
+| `a`        | number     | Parasite accumulator                                            |
+| `x`        | number     | Parasite X register                                             |
+| `y`        | number     | Parasite Y register                                             |
+| `s`        | number     | Parasite stack pointer                                          |
+| `pc`       | number     | Parasite program counter                                        |
+| `p`        | number     | Parasite status flags as a byte                                 |
+| `nmiLevel` | boolean    | Parasite NMI line level                                         |
+| `nmiEdge`  | boolean    | Whether a parasite NMI edge is pending                          |
+| `takeInt`  | boolean    | Whether an interrupt is to be taken before the next instruction |
+| `cycles`   | number     | Cycles owed to the parasite; it has no scheduler of its own     |
+| `romPaged` | boolean    | Whether the boot ROM is paged in at `0xF000`                    |
+| `memory`   | Uint8Array | 64KB of parasite RAM                                            |
+| `rom`      | Uint8Array | _(Optional)_ 4KB parasite ROM, only when `includeRoms` is set   |
+| `ula`      | object     | Tube ULA state (see below)                                      |
+
+#### Tube ULA (`state.tube.ula`)
+
+| Field                          | Type         | Description                                         |
+| ------------------------------ | ------------ | --------------------------------------------------- |
+| `internalStatusRegister`       | number       | Control flags (IRQ/NMI enables, R3 two-byte mode)   |
+| `hostStatus`                   | Uint8Array   | Status of registers 1-4 as the host sees them       |
+| `parasiteStatus`               | Uint8Array   | Status of registers 1-4 as the parasite sees them   |
+| `parasiteToHostData`           | Uint8Array[] | The four parasite-to-host FIFOs (R1 holds 24 bytes) |
+| `hostToParasiteData`           | Uint8Array[] | The four host-to-parasite FIFOs                     |
+| `parasiteToHostFifoByteCount1` | number       | Bytes waiting in the parasite-to-host R1 FIFO       |
+| `parasiteToHostFifoByteCount3` | number       | Bytes waiting in the parasite-to-host R3 FIFO       |
+| `hostToParasiteFifoByteCount3` | number       | Bytes waiting in the host-to-parasite R3 FIFO       |
+
+The interrupt and reset lines are not saved. `Tube.restoreState()` derives them from the status registers and FIFO counts, in the same way the host's `interrupt` is rebuilt by the VIA and ACIA restores. Because the parasite's NMI is edge triggered, this can leave a spurious edge behind, so the parasite's registers are restored afterwards to put the true edge state back.
+
+## Known limitations (v3)
 
 - **No tape position** — tape playback position is not saved.
+- **BeebEm UEF co-processor state is not imported** — BeebEm records a tube type in its `EmuState` chunk, but jsbeeb does not read it, so a UEF save state taken with a second processor imports as host-only.
 - **ROMs not saved** (in jsbeeb-native snapshots) — ROMs are loaded from files and don't change at runtime. Imported b-em snapshots include ROMs in the optional `roms` field.

--- a/docs/snapshot-format.md
+++ b/docs/snapshot-format.md
@@ -72,6 +72,8 @@ The co-processor is emulation config rather than part of the model, so the model
 
 If the models or co-processor settings differ, the snapshot is stashed in `sessionStorage` under `jsbeeb-pending-state` and the page reloads with the snapshot's model and co-processor setting in the query string, picking the state back up on the way in. `restoreSnapshot()` itself does not reload; given a mismatch it throws.
 
+Loading a pre-v3 snapshot while a co-processor is fitted therefore restarts the machine without one, since such a snapshot describes a host-only machine.
+
 ## TypedArray encoding
 
 Any TypedArray in the state tree is serialized as:
@@ -393,7 +395,7 @@ Present only when a co-processor was fitted; the top-level `coProcessor` flag sa
 | `parasiteToHostFifoByteCount3` | number       | Bytes waiting in the parasite-to-host R3 FIFO       |
 | `hostToParasiteFifoByteCount3` | number       | Bytes waiting in the host-to-parasite R3 FIFO       |
 
-The interrupt and reset lines are not saved. `Tube.restoreState()` derives them from the status registers and FIFO counts, in the same way the host's `interrupt` is rebuilt by the VIA and ACIA restores. Because the parasite's NMI is edge triggered, this can leave a spurious edge behind, so the parasite's registers are restored afterwards to put the true edge state back.
+The interrupt and reset lines are not saved. `Tube.restoreState()` derives them from the status registers and FIFO counts, in the same way the host's `interrupt` is rebuilt by the VIA and ACIA restores. It runs after the parasite's registers have been restored, so the edge-triggered NMI moves from its saved level to the one the ULA implies: a snapshot that agrees produces no edge, while an imported one whose idea of the line is out of date gets the rising edge it is owed.
 
 ## Known limitations (v3)
 

--- a/docs/snapshot-format.md
+++ b/docs/snapshot-format.md
@@ -66,11 +66,11 @@ B-em snapshots include the full ROM contents in the `roms` field (256KB, all 16 
 
 ### Model compatibility
 
-When loading, the snapshot model is compared to the current model using `isSameModel()`. Names are resolved through `findModel()`, so synonyms and old names match (e.g. `"B"` matches `"BBC B with DFS 1.2"`), but the result must be the same model: filesystem variants are separate models and so are _not_ interchangeable (e.g. `"BBC Master 128 (DFS)"` does not match `"BBC Master 128 (ADFS)"`).
+When loading, the snapshot's model must match the current one. Names are resolved through the model list, so synonyms and old names match (e.g. `"B"` matches `"BBC B with DFS 1.2"`), but the result must be the same model: filesystem variants are separate models and so are _not_ interchangeable (e.g. `"BBC Master 128 (DFS)"` does not match `"BBC Master 128 (ADFS)"`).
 
-The co-processor is emulation config rather than part of the model, so the model name cannot tell a Master Turbo from a plain Master. The `coProcessor` flag is compared separately, and `restoreSnapshot()` throws if it does not match the running machine.
+The co-processor is emulation config rather than part of the model, so the model name cannot tell a Master Turbo from a plain Master. The `coProcessor` flag is therefore compared separately, and a mismatch is an error.
 
-If the models or co-processor settings differ, the snapshot is stashed in `sessionStorage` under `jsbeeb-pending-state` and the page reloads with the snapshot's model and co-processor setting in the query string, picking the state back up on the way in. `restoreSnapshot()` itself does not reload; given a mismatch it throws.
+If the models or co-processor settings differ, the snapshot is stashed in `sessionStorage` under `jsbeeb-pending-state` and the page reloads with the snapshot's model and co-processor setting in the query string, picking the state back up on the way in.
 
 Loading a pre-v3 snapshot while a co-processor is fitted therefore restarts the machine without one, since such a snapshot describes a host-only machine.
 
@@ -116,7 +116,7 @@ The `type` field is the constructor name: `Uint8Array`, `Uint16Array`, `Uint32Ar
 | `ram`              | Uint8Array | RAM contents (128KB, excludes ROMs)                                                               |
 | `roms`             | Uint8Array | _(Optional)_ ROM contents (256KB, 16 x 16KB banks). Only present in snapshots imported from b-em. |
 
-**Note:** `interrupt` is not saved — it is reconstructed by the VIA and ACIA `restoreState()` calls which reassert their interrupt lines.
+**Note:** `interrupt` is not saved — it is reconstructed from the VIA and ACIA state, which reasserts their interrupt lines.
 
 ### Scheduler (`state.scheduler`)
 
@@ -363,7 +363,7 @@ Track keys are strings like `"false:0"` (lower side, track 0) or `"true:5"` (upp
 
 ### Second processor (`state.tube`) — _v3+_
 
-Present only when a co-processor was fitted; the top-level `coProcessor` flag says whether to expect it.
+Present only when a co-processor was fitted.
 
 | Field      | Type       | Description                                                     |
 | ---------- | ---------- | --------------------------------------------------------------- |
@@ -395,7 +395,7 @@ Present only when a co-processor was fitted; the top-level `coProcessor` flag sa
 | `parasiteToHostFifoByteCount3` | number       | Bytes waiting in the parasite-to-host R3 FIFO       |
 | `hostToParasiteFifoByteCount3` | number       | Bytes waiting in the host-to-parasite R3 FIFO       |
 
-The interrupt and reset lines are not saved. `Tube.restoreState()` derives them from the status registers and FIFO counts, in the same way the host's `interrupt` is rebuilt by the VIA and ACIA restores. It runs after the parasite's registers have been restored, so the edge-triggered NMI moves from its saved level to the one the ULA implies: a snapshot that agrees produces no edge, while an imported one whose idea of the line is out of date gets the rising edge it is owed.
+The interrupt and reset lines are not saved: they follow from the status registers and FIFO counts above, in the same way the host's `interrupt` follows from the VIA and ACIA state. The parasite's NMI is edge triggered, so `nmiLevel` and `nmiEdge` are saved, being the one part of it that cannot be recovered that way.
 
 ## Known limitations (v3)
 

--- a/src/6502.js
+++ b/src/6502.js
@@ -496,23 +496,16 @@ class Tube6502 extends Base6502 {
             nmiLevel: this._nmiLevel,
             nmiEdge: this._nmiEdge,
             takeInt: this.takeInt,
-            // Cycles owed to the parasite; it has no scheduler of its own, so nothing here is
-            // relative to the host's epoch.
+            // The parasite has no scheduler of its own, so this is not relative to any epoch.
             cycles: this.cycles,
             romPaged: this.romPaged,
             memory: this.memory.slice(),
-            // The ROM is loaded from file at boot and never written, so it is only worth
-            // carrying for a self-contained snapshot.
             rom: includeRoms ? this.rom.slice() : undefined,
             ula: this.tube.snapshotState(),
         };
     }
 
     restoreState(state) {
-        // Before the registers: restoring the ULA re-derives the interrupt lines, which can
-        // leave a spurious NMI edge that the saved register state below then corrects.
-        this.tube.restoreState(state.ula);
-
         this.a = state.a;
         this.x = state.x;
         this.y = state.y;
@@ -526,6 +519,11 @@ class Tube6502 extends Base6502 {
         this.romPaged = state.romPaged;
         this.memory.set(state.memory);
         if (state.rom) this.rom.set(state.rom);
+
+        // After the registers, so that the NMI line moves from its saved level to the one the
+        // ULA implies. A restore that agrees produces no edge; an imported snapshot whose idea
+        // of the line is out of date gets the rising edge it is owed.
+        this.tube.restoreState(state.ula);
     }
 
     async loadOs() {
@@ -1293,7 +1291,8 @@ export class Cpu6502 extends Base6502 {
             this.fdc.restoreState(state.fdc);
         }
 
-        // Tube state (v3+). A snapshot from a machine without a co-processor carries none, so
+        // Tube state (v3+). restoreSnapshot() refuses a snapshot whose co-processor setting does
+        // not match, so state without a tube only reaches here from a direct restoreState call;
         // reset the parasite rather than leave it running on state the host knows nothing about.
         if (this.hasTube) {
             if (state.tube) this.tube.restoreState(state.tube);

--- a/src/6502.js
+++ b/src/6502.js
@@ -485,6 +485,49 @@ class Tube6502 extends Base6502 {
         }
     }
 
+    snapshotState({ includeRoms = false } = {}) {
+        return {
+            a: this.a,
+            x: this.x,
+            y: this.y,
+            s: this.s,
+            pc: this.pc,
+            p: this.p.asByte(),
+            nmiLevel: this._nmiLevel,
+            nmiEdge: this._nmiEdge,
+            takeInt: this.takeInt,
+            // Cycles owed to the parasite; it has no scheduler of its own, so nothing here is
+            // relative to the host's epoch.
+            cycles: this.cycles,
+            romPaged: this.romPaged,
+            memory: this.memory.slice(),
+            // The ROM is loaded from file at boot and never written, so it is only worth
+            // carrying for a self-contained snapshot.
+            rom: includeRoms ? this.rom.slice() : undefined,
+            ula: this.tube.snapshotState(),
+        };
+    }
+
+    restoreState(state) {
+        // Before the registers: restoring the ULA re-derives the interrupt lines, which can
+        // leave a spurious NMI edge that the saved register state below then corrects.
+        this.tube.restoreState(state.ula);
+
+        this.a = state.a;
+        this.x = state.x;
+        this.y = state.y;
+        this.s = state.s;
+        this.pc = state.pc;
+        this.p.setFromByte(state.p);
+        this._nmiLevel = state.nmiLevel;
+        this._nmiEdge = state.nmiEdge;
+        this.takeInt = state.takeInt;
+        this.cycles = state.cycles;
+        this.romPaged = state.romPaged;
+        this.memory.set(state.memory);
+        if (state.rom) this.rom.set(state.rom);
+    }
+
     async loadOs() {
         console.log("Loading tube rom from roms/" + this.model.os);
         const tubeRom = this.rom;
@@ -1188,6 +1231,7 @@ export class Cpu6502 extends Base6502 {
             acia: this.acia.snapshotState(),
             adc: this.adconverter.snapshotState(),
             fdc: this.fdc.snapshotState(),
+            tube: this.hasTube ? this.tube.snapshotState({ includeRoms }) : undefined,
         };
     }
 
@@ -1247,6 +1291,13 @@ export class Cpu6502 extends Base6502 {
         // FDC state (v2+). If absent (v1 snapshot), FDC keeps its current state.
         if (state.fdc) {
             this.fdc.restoreState(state.fdc);
+        }
+
+        // Tube state (v3+). A snapshot from a machine without a co-processor carries none, so
+        // reset the parasite rather than leave it running on state the host knows nothing about.
+        if (this.hasTube) {
+            if (state.tube) this.tube.restoreState(state.tube);
+            else this.tube.reset(true);
         }
     }
 

--- a/src/6502.js
+++ b/src/6502.js
@@ -427,6 +427,10 @@ class Tube6502 extends Base6502 {
         this.pc = this.readmem(0xfffc) | (this.readmem(0xfffd) << 8);
         this.p.i = true;
         this.s = (this.s - 3) & 0xff; // Simulate 3 dummy pushes during reset
+        // A latched NMI would otherwise survive the reset and be taken on the first instruction
+        // after it, defeating the empty R3 FIFO the ULA seeds for exactly that reason.
+        this._nmiLevel = this._nmiEdge = false;
+        this.takeInt = false;
         this.tube.reset(hard);
     }
 
@@ -520,9 +524,8 @@ class Tube6502 extends Base6502 {
         this.memory.set(state.memory);
         if (state.rom) this.rom.set(state.rom);
 
-        // After the registers, so that the NMI line moves from its saved level to the one the
-        // ULA implies. A restore that agrees produces no edge; an imported snapshot whose idea
-        // of the line is out of date gets the rising edge it is owed.
+        // After the registers, so the edge-triggered NMI moves from its saved level to the one
+        // the ULA implies: no edge if they agree, and the edge it is owed if they do not.
         this.tube.restoreState(state.ula);
     }
 
@@ -1291,9 +1294,8 @@ export class Cpu6502 extends Base6502 {
             this.fdc.restoreState(state.fdc);
         }
 
-        // Tube state (v3+). restoreSnapshot() refuses a snapshot whose co-processor setting does
-        // not match, so state without a tube only reaches here from a direct restoreState call;
-        // reset the parasite rather than leave it running on state the host knows nothing about.
+        // Tube state (v3+). Rather than leave the parasite running on state the host knows
+        // nothing about, reset it; restoreSnapshot() rejects such a pairing before reaching here.
         if (this.hasTube) {
             if (state.tube) this.tube.restoreState(state.tube);
             else this.tube.reset(true);

--- a/src/bem-snapshot.js
+++ b/src/bem-snapshot.js
@@ -296,7 +296,11 @@ async function parseBemTube(sections, tubeName) {
     if (!sections["T"] || !sections["P"]) {
         throw new Error("Truncated b-em snapshot: it holds only one of the two co-processor sections");
     }
-    if (tubeName && !BemSupportedTubes.includes(tubeName)) {
+    // b-em only writes these sections for a co-processor it started, which it always names.
+    if (!tubeName) {
+        throw new Error("Corrupt b-em snapshot: it holds co-processor state but names no co-processor");
+    }
+    if (!BemSupportedTubes.includes(tubeName)) {
         throw new Error(
             `Unsupported b-em co-processor "${tubeName}": jsbeeb only emulates the 64K 65C02 second processor`,
         );
@@ -306,6 +310,11 @@ async function parseBemTube(sections, tubeName) {
     if (ulaSection[0] !== BemTubeUlaVersion) {
         throw new Error(`Unsupported b-em tube ULA state version ${ulaSection[0]}`);
     }
+    if (ulaSection.length < 2 + BemTubeUlaSize) {
+        throw new Error(
+            `Truncated b-em tube ULA state: expected ${2 + BemTubeUlaSize} bytes, got ${ulaSection.length}`,
+        );
+    }
     const romPaged = !!ulaSection[1];
     const ula = ulaSection.slice(2, 2 + BemTubeUlaSize);
     const at = (field) => ula[BemTubeUlaOffsets[field]];
@@ -314,6 +323,10 @@ async function parseBemTube(sections, tubeName) {
     // the bytes have to be linearised into the order jsbeeb expects to read them.
     const ph1Count = at("ph1count");
     const ph1Head = at("ph1head");
+    // Out-of-range counts would restore a FIFO jsbeeb's own reads could never have produced.
+    if (ph1Count > BemPh1Size || ph1Head >= BemPh1Size || at("ph3pos") > 2 || at("hp3pos") > 2) {
+        throw new Error("Corrupt b-em tube ULA state: FIFO counts out of range");
+    }
     const ph1 = new Uint8Array(BemPh1Size);
     for (let i = 0; i < ph1Count; i++) {
         ph1[i] = ula[BemTubeUlaOffsets.ph1 + ((ph1Head + i) % BemPh1Size)];

--- a/src/bem-snapshot.js
+++ b/src/bem-snapshot.js
@@ -255,7 +255,125 @@ function readString(data, pos) {
     return str;
 }
 
-function parseBemV3(buffer) {
+// b-em writes the tube ULA as a raw struct dump. Version 2 is all single-byte fields, so it has
+// no padding and can be read directly; version 1 used native ints and is not supported here.
+const BemTubeUlaVersion = 2;
+const BemTubeUlaOffsets = {
+    ph1: 0, // 24-byte parasite-to-host R1 FIFO, held as a circular buffer
+    ph2: 24,
+    ph3: 25, // 2 bytes
+    ph4: 27,
+    hp1: 29, // phl (byte 28) is a latch jsbeeb does not model
+    hp2: 30,
+    hp3: 31, // 2 bytes
+    hp4: 33,
+    hstat: 35, // 4 bytes; hpl (byte 34) likewise unmodelled
+    pstat: 39, // 4 bytes
+    r1stat: 43,
+    ph1tail: 44,
+    ph1head: 45,
+    ph1count: 46,
+    ph3pos: 47,
+    hp3pos: 48,
+};
+const BemTubeUlaSize = 49;
+const BemPh1Size = 24;
+// 9 bytes of registers, then RAM, then ROM. Only the 64K 6502 parasites map onto jsbeeb's:
+// b-em's "6502 Turbo" has 16MB of RAM, and its other co-processors are different CPUs entirely.
+const BemTubeRegisterBytes = 9;
+const BemTubeRamSize = 65536;
+const BemSupportedTubes = ["6502 Internal", "6502 External"];
+
+/**
+ * Convert b-em's tube sections into jsbeeb tube state.
+ * @param {object} sections - parsed v3 sections
+ * @param {string|null} tubeName - co-processor name from the model section
+ * @returns {Promise<object|null>} jsbeeb tube state, or null if no usable co-processor
+ */
+async function parseBemTube(sections, tubeName) {
+    if (!sections["T"] || !sections["P"]) return null;
+    if (tubeName && !BemSupportedTubes.includes(tubeName)) {
+        throw new Error(
+            `Unsupported b-em co-processor "${tubeName}": jsbeeb only emulates the 64K 65C02 second processor`,
+        );
+    }
+
+    const ulaSection = sections["T"].data;
+    if (ulaSection[0] !== BemTubeUlaVersion) {
+        throw new Error(`Unsupported b-em tube ULA state version ${ulaSection[0]}`);
+    }
+    const romPaged = !!ulaSection[1];
+    const ula = ulaSection.slice(2, 2 + BemTubeUlaSize);
+    const at = (field) => ula[BemTubeUlaOffsets[field]];
+
+    // b-em keeps the R1 FIFO as a circular buffer; jsbeeb shifts its contents down on read, so
+    // the bytes have to be linearised into the order jsbeeb expects to read them.
+    const ph1Count = at("ph1count");
+    const ph1 = new Uint8Array(BemPh1Size);
+    for (let i = 0; i < ph1Count; i++) {
+        ph1[i] = ula[BemTubeUlaOffsets.ph1 + ((at("ph1head") + i) % BemPh1Size)];
+    }
+
+    const parasite = await decompress(sections["P"].data, "deflate");
+    const romSize = parasite.length - BemTubeRegisterBytes - BemTubeRamSize;
+    if (romSize < 0) {
+        throw new Error(
+            `Unsupported b-em co-processor: expected ${BemTubeRamSize} bytes of parasite RAM, ` +
+                `but the state section holds ${parasite.length - BemTubeRegisterBytes}`,
+        );
+    }
+
+    return {
+        a: parasite[2],
+        x: parasite[3],
+        y: parasite[4],
+        p: parasite[5] | 0x30,
+        s: parasite[6],
+        pc: parasite[7] | (parasite[8] << 8),
+        // b-em's oldnmi is the previous NMI level, used for the same edge detection jsbeeb does.
+        nmiLevel: !!parasite[1],
+        nmiEdge: false,
+        takeInt: false,
+        cycles: 0,
+        romPaged,
+        memory: parasite.slice(BemTubeRegisterBytes, BemTubeRegisterBytes + BemTubeRamSize),
+        // The parasite ROM is loaded from file at boot, so b-em's copy is not needed.
+        ula: {
+            internalStatusRegister: at("r1stat"),
+            hostStatus: ula.slice(BemTubeUlaOffsets.hstat, BemTubeUlaOffsets.hstat + 4),
+            parasiteStatus: ula.slice(BemTubeUlaOffsets.pstat, BemTubeUlaOffsets.pstat + 4),
+            parasiteToHostData: [
+                ph1,
+                Uint8Array.of(at("ph2")),
+                ula.slice(BemTubeUlaOffsets.ph3, BemTubeUlaOffsets.ph3 + 2),
+                Uint8Array.of(at("ph4")),
+            ],
+            hostToParasiteData: [
+                Uint8Array.of(at("hp1")),
+                Uint8Array.of(at("hp2")),
+                ula.slice(BemTubeUlaOffsets.hp3, BemTubeUlaOffsets.hp3 + 2),
+                Uint8Array.of(at("hp4")),
+            ],
+            parasiteToHostFifoByteCount1: ph1Count,
+            parasiteToHostFifoByteCount3: at("ph3pos"),
+            hostToParasiteFifoByteCount3: at("hp3pos"),
+        },
+    };
+}
+
+/**
+ * Read the co-processor name from b-em's model section, if one was fitted.
+ * The name follows the model strings and flag bytes, so those have to be stepped over first.
+ * @returns {string|null}
+ */
+function readBemTubeName(data, pos) {
+    for (let i = 0; i < 4; i++) readString(data, pos); // os, cmos, rom setup, fdc names
+    pos.offset += 6; // model flag bytes
+    const fitted = data[pos.offset++];
+    return fitted ? readString(data, pos) : null;
+}
+
+async function parseBemV3(buffer) {
     const bytes = new Uint8Array(buffer);
     let offset = 8; // Skip "BEMSNAP3" signature
 
@@ -281,11 +399,13 @@ function parseBemV3(buffer) {
     // Parse model section to determine jsbeeb model name.
     // Use jsbeeb synonyms (from models.js) so findModel() resolves them.
     let modelName = "B";
+    let tubeName = null;
     if (sections["m"]) {
         const pos = { offset: 0 };
         const data = sections["m"].data;
         readVar(data, pos); // curmodel index (skip)
         const name = readString(data, pos);
+        tubeName = readBemTubeName(data, pos);
         if (name.includes("Master")) {
             if (name.includes("ADFS")) modelName = "MasterADFS";
             else if (name.includes("ANFS")) modelName = "MasterANFS";
@@ -311,23 +431,21 @@ function parseBemV3(buffer) {
     if (memSection) {
         // Memory is zlib-compressed; decompression is async.
         // Decompressed layout: 2 bytes (fe30, fe34) + 64KB RAM + 256KB ROM
-        return decompress(memSection.data, "deflate").then((memData) => {
-            cpuState.fe30 = memData[0];
-            cpuState.fe34 = memData[1];
-            const ramStart = 2;
-            const ramSize = 64 * 1024;
-            ram.set(memData.slice(ramStart, ramStart + ramSize));
-            const romStart = ramStart + ramSize;
-            if (memData.length > romStart) {
-                roms = memData.slice(romStart, romStart + 262144);
-            }
-            return finishV3Parse(modelName, cpuState, ram, roms, sections);
-        });
+        const memData = await decompress(memSection.data, "deflate");
+        cpuState.fe30 = memData[0];
+        cpuState.fe34 = memData[1];
+        const ramStart = 2;
+        const ramSize = 64 * 1024;
+        ram.set(memData.slice(ramStart, ramStart + ramSize));
+        const romStart = ramStart + ramSize;
+        if (memData.length > romStart) {
+            roms = memData.slice(romStart, romStart + 262144);
+        }
     }
-    return finishV3Parse(modelName, cpuState, ram, roms, sections);
+    return finishV3Parse(modelName, cpuState, ram, roms, sections, await parseBemTube(sections, tubeName));
 }
 
-function finishV3Parse(modelName, cpuState, ram, roms, sections) {
+function finishV3Parse(modelName, cpuState, ram, roms, sections, tube) {
     // Parse system VIA
     let sysvia = convertViaState(
         {
@@ -466,5 +584,6 @@ function finishV3Parse(modelName, cpuState, ram, roms, sections) {
         uservia,
         buildVideoState(ulaControl, ulaPalette, crtcRegs, nulaCollook, crtcCounters),
         soundChip,
+        tube,
     );
 }

--- a/src/bem-snapshot.js
+++ b/src/bem-snapshot.js
@@ -259,16 +259,16 @@ function readString(data, pos) {
 // no padding and can be read directly; version 1 used native ints and is not supported here.
 const BemTubeUlaVersion = 2;
 const BemTubeUlaOffsets = {
-    ph1: 0, // 24 bytes
+    ph1: 0,
     ph2: 24,
-    ph3: 25, // 2 bytes
+    ph3: 25,
     ph4: 27,
     hp1: 29, // phl (byte 28) is a latch jsbeeb does not model
     hp2: 30,
-    hp3: 31, // 2 bytes
+    hp3: 31,
     hp4: 33,
-    hstat: 35, // 4 bytes; hpl (byte 34) likewise unmodelled
-    pstat: 39, // 4 bytes
+    hstat: 35, // hpl (byte 34) likewise unmodelled
+    pstat: 39,
     r1stat: 43,
     ph1head: 45, // ph1tail (byte 44) matters only to b-em, which appends there
     ph1count: 46,
@@ -277,11 +277,10 @@ const BemTubeUlaOffsets = {
 };
 const BemTubeUlaSize = 49;
 const BemPh1Size = 24;
-// 9 bytes of registers, then RAM, then ROM. Only the 64K 6502 parasites map onto jsbeeb's:
-// b-em's "6502 Turbo" has 16MB of RAM, and its other co-processors are different CPUs entirely.
+// 9 bytes of registers, then RAM, then ROM.
 const BemTubeRegisterBytes = 9;
 const BemTubeRamSize = 65536;
-const BemTubeRomSize = 2048;
+// b-em's other co-processors are different CPUs, and its "6502 Turbo" has 16MB of RAM.
 const BemSupportedTubes = ["6502 Internal", "6502 External"];
 
 /**
@@ -291,7 +290,12 @@ const BemSupportedTubes = ["6502 Internal", "6502 External"];
  * @returns {Promise<object|null>} jsbeeb tube state, or null if no usable co-processor
  */
 async function parseBemTube(sections, tubeName) {
-    if (!sections["T"] || !sections["P"]) return null;
+    // b-em names the model's co-processor even when it failed to start one, so naming a tube but
+    // carrying no state for it is valid. Carrying only one of the two sections is not.
+    if (!sections["T"] && !sections["P"]) return null;
+    if (!sections["T"] || !sections["P"]) {
+        throw new Error("Truncated b-em snapshot: it holds only one of the two co-processor sections");
+    }
     if (tubeName && !BemSupportedTubes.includes(tubeName)) {
         throw new Error(
             `Unsupported b-em co-processor "${tubeName}": jsbeeb only emulates the 64K 65C02 second processor`,
@@ -315,14 +319,14 @@ async function parseBemTube(sections, tubeName) {
         ph1[i] = ula[BemTubeUlaOffsets.ph1 + ((ph1Head + i) % BemPh1Size)];
     }
 
-    // b-em builds its co-processor list from a config file, so the name alone cannot be trusted
-    // to mean the 64K parasite: check the section is exactly the size that implies.
+    // Those names come from a config file, so size is the real check. It cannot be exact: the
+    // trailing ROM's size comes from that same config, and b-em records it as zero if unset.
     const parasite = await decompress(sections["P"].data, "deflate");
-    const expectedSize = BemTubeRegisterBytes + BemTubeRamSize + BemTubeRomSize;
-    if (parasite.length !== expectedSize) {
+    const romBytes = parasite.length - BemTubeRegisterBytes - BemTubeRamSize;
+    if (romBytes < 0 || romBytes > BemTubeRamSize) {
         throw new Error(
-            `Unsupported b-em co-processor: expected ${expectedSize} bytes of parasite state ` +
-                `(64K RAM and a 2K ROM), but the snapshot holds ${parasite.length}`,
+            `Unsupported b-em co-processor: expected ${BemTubeRamSize} bytes of parasite RAM, ` +
+                `but the state section holds ${parasite.length - BemTubeRegisterBytes}`,
         );
     }
 
@@ -333,9 +337,8 @@ async function parseBemTube(sections, tubeName) {
         p: parasite[5] | 0x30,
         s: parasite[6],
         pc: parasite[7] | (parasite[8] << 8),
-        // b-em's oldnmi is the NMI level as of the parasite's last instruction, which may lag the
-        // line the ULA state implies. Restoring the ULA afterwards settles the line and raises an
-        // edge if one is owed. b-em's skipint has no jsbeeb equivalent and is dropped.
+        // b-em's oldnmi is the NMI level as of the parasite's last instruction, so it may lag the
+        // line its ULA state implies. b-em's skipint has no jsbeeb equivalent and is dropped.
         nmiLevel: !!parasite[1],
         nmiEdge: false,
         takeInt: false,

--- a/src/bem-snapshot.js
+++ b/src/bem-snapshot.js
@@ -259,7 +259,7 @@ function readString(data, pos) {
 // no padding and can be read directly; version 1 used native ints and is not supported here.
 const BemTubeUlaVersion = 2;
 const BemTubeUlaOffsets = {
-    ph1: 0, // 24-byte parasite-to-host R1 FIFO, held as a circular buffer
+    ph1: 0, // 24 bytes
     ph2: 24,
     ph3: 25, // 2 bytes
     ph4: 27,
@@ -270,8 +270,7 @@ const BemTubeUlaOffsets = {
     hstat: 35, // 4 bytes; hpl (byte 34) likewise unmodelled
     pstat: 39, // 4 bytes
     r1stat: 43,
-    ph1tail: 44,
-    ph1head: 45,
+    ph1head: 45, // ph1tail (byte 44) matters only to b-em, which appends there
     ph1count: 46,
     ph3pos: 47,
     hp3pos: 48,
@@ -282,6 +281,7 @@ const BemPh1Size = 24;
 // b-em's "6502 Turbo" has 16MB of RAM, and its other co-processors are different CPUs entirely.
 const BemTubeRegisterBytes = 9;
 const BemTubeRamSize = 65536;
+const BemTubeRomSize = 2048;
 const BemSupportedTubes = ["6502 Internal", "6502 External"];
 
 /**
@@ -309,17 +309,20 @@ async function parseBemTube(sections, tubeName) {
     // b-em keeps the R1 FIFO as a circular buffer; jsbeeb shifts its contents down on read, so
     // the bytes have to be linearised into the order jsbeeb expects to read them.
     const ph1Count = at("ph1count");
+    const ph1Head = at("ph1head");
     const ph1 = new Uint8Array(BemPh1Size);
     for (let i = 0; i < ph1Count; i++) {
-        ph1[i] = ula[BemTubeUlaOffsets.ph1 + ((at("ph1head") + i) % BemPh1Size)];
+        ph1[i] = ula[BemTubeUlaOffsets.ph1 + ((ph1Head + i) % BemPh1Size)];
     }
 
+    // b-em builds its co-processor list from a config file, so the name alone cannot be trusted
+    // to mean the 64K parasite: check the section is exactly the size that implies.
     const parasite = await decompress(sections["P"].data, "deflate");
-    const romSize = parasite.length - BemTubeRegisterBytes - BemTubeRamSize;
-    if (romSize < 0) {
+    const expectedSize = BemTubeRegisterBytes + BemTubeRamSize + BemTubeRomSize;
+    if (parasite.length !== expectedSize) {
         throw new Error(
-            `Unsupported b-em co-processor: expected ${BemTubeRamSize} bytes of parasite RAM, ` +
-                `but the state section holds ${parasite.length - BemTubeRegisterBytes}`,
+            `Unsupported b-em co-processor: expected ${expectedSize} bytes of parasite state ` +
+                `(64K RAM and a 2K ROM), but the snapshot holds ${parasite.length}`,
         );
     }
 
@@ -330,7 +333,9 @@ async function parseBemTube(sections, tubeName) {
         p: parasite[5] | 0x30,
         s: parasite[6],
         pc: parasite[7] | (parasite[8] << 8),
-        // b-em's oldnmi is the previous NMI level, used for the same edge detection jsbeeb does.
+        // b-em's oldnmi is the NMI level as of the parasite's last instruction, which may lag the
+        // line the ULA state implies. Restoring the ULA afterwards settles the line and raises an
+        // edge if one is owed. b-em's skipint has no jsbeeb equivalent and is dropped.
         nmiLevel: !!parasite[1],
         nmiEdge: false,
         takeInt: false,
@@ -363,7 +368,6 @@ async function parseBemTube(sections, tubeName) {
 
 /**
  * Read the co-processor name from b-em's model section, if one was fitted.
- * The name follows the model strings and flag bytes, so those have to be stepped over first.
  * @returns {string|null}
  */
 function readBemTubeName(data, pos) {

--- a/src/main.js
+++ b/src/main.js
@@ -32,7 +32,14 @@ import { SpeechOutput } from "./speech-output.js";
 import { MouseJoystickSource } from "./mouse-joystick-source.js";
 import { calculateMouseCoordinates } from "./mouse-coordinates.js";
 import { getFilterForMode } from "./canvas.js";
-import { createSnapshot, restoreSnapshot, snapshotToJSON, snapshotFromJSON, isSameModel } from "./snapshot.js";
+import {
+    createSnapshot,
+    restoreSnapshot,
+    snapshotToJSON,
+    snapshotFromJSON,
+    isSameModel,
+    hasCoProcessor,
+} from "./snapshot.js";
 import { isBemSnapshot, parseBemSnapshot } from "./bem-snapshot.js";
 import { isUefSnapshot, parseUefSnapshot } from "./uef-snapshot.js";
 import { RewindBuffer } from "./rewind.js";
@@ -1577,10 +1584,10 @@ async function loadStateFromFile(file, preReadBuffer) {
             }
             snapshot = snapshotFromJSON(text);
         }
-        if (!isSameModel(snapshot.model, model.name)) {
-            // Model mismatch: stash state and reload with correct model
+        if (!isSameModel(snapshot.model, model.name) || hasCoProcessor(snapshot) !== processor.hasTube) {
+            // Model or co-processor mismatch: stash state and reload with a matching machine
             sessionStorage.setItem("jsbeeb-pending-state", snapshotToJSON(snapshot));
-            const newQuery = { ...parsedQuery, model: snapshot.model };
+            const newQuery = { ...parsedQuery, model: snapshot.model, coProcessor: hasCoProcessor(snapshot) };
             const baseUrl = window.location.origin + window.location.pathname;
             window.location.href = buildUrlFromParams(baseUrl, newQuery, paramTypes);
             return;

--- a/src/snapshot-helpers.js
+++ b/src/snapshot-helpers.js
@@ -166,12 +166,25 @@ export function buildVideoState(ulaControl, ulaPalette, crtcRegs, nulaCollook, c
  * @param {object} uservia - jsbeeb user VIA state
  * @param {object} video - jsbeeb video state (from buildVideoState)
  * @param {object} soundChip - jsbeeb sound chip state
+ * @param {object|null} [tube] - jsbeeb tube state, or null if no co-processor was fitted
  */
-export function buildSnapshot(importedFrom, modelName, cpuState, ram, roms, sysvia, uservia, video, soundChip) {
+export function buildSnapshot(
+    importedFrom,
+    modelName,
+    cpuState,
+    ram,
+    roms,
+    sysvia,
+    uservia,
+    video,
+    soundChip,
+    tube = null,
+) {
     return {
         format: "jsbeeb-snapshot",
-        version: 2,
+        version: 3,
         model: modelName,
+        coProcessor: !!tube,
         timestamp: new Date().toISOString(),
         importedFrom,
         state: {
@@ -203,6 +216,7 @@ export function buildSnapshot(importedFrom, modelName, cpuState, ram, roms, sysv
             soundChip,
             acia: { ...DefaultAcia },
             adc: { ...DefaultAdc },
+            ...(tube ? { tube } : {}),
         },
     };
 }

--- a/src/snapshot.js
+++ b/src/snapshot.js
@@ -4,7 +4,15 @@ import { typedArrayToBase64, base64ToTypedArray } from "./state-utils.js";
 import { findModel } from "./models.js";
 
 const SnapshotFormat = "jsbeeb-snapshot";
-const SnapshotVersion = 2;
+const SnapshotVersion = 3;
+
+/**
+ * Whether a snapshot was taken on a machine with a second processor fitted.
+ * Nothing before version 3 captured tube state, so those snapshots are always host-only.
+ */
+export function hasCoProcessor(snapshot) {
+    return !!snapshot.coProcessor;
+}
 
 /**
  * Check if two model names resolve to the same model (accounting for
@@ -70,6 +78,9 @@ export function createSnapshot(cpu, model, media) {
         format: SnapshotFormat,
         version: SnapshotVersion,
         model: model.name,
+        // The co-processor is emulation config rather than part of the model, so the model name
+        // cannot distinguish a Turbo from a plain Master. Recorded separately for that reason.
+        coProcessor: cpu.hasTube,
         timestamp: new Date().toISOString(),
         state,
     };
@@ -93,6 +104,13 @@ export function restoreSnapshot(cpu, model, snapshot) {
     }
     if (!isSameModel(snapshot.model, model.name)) {
         throw new Error(`Model mismatch: snapshot is for "${snapshot.model}" but current model is "${model.name}"`);
+    }
+    if (hasCoProcessor(snapshot) !== cpu.hasTube) {
+        const fitted = (yes) => (yes ? "with a second processor" : "without a second processor");
+        throw new Error(
+            `Co-processor mismatch: snapshot was taken ${fitted(hasCoProcessor(snapshot))} ` +
+                `but this machine is ${fitted(cpu.hasTube)}`,
+        );
     }
     cpu.restoreState(snapshot.state);
 }

--- a/src/snapshot.js
+++ b/src/snapshot.js
@@ -78,8 +78,8 @@ export function createSnapshot(cpu, model, media) {
         format: SnapshotFormat,
         version: SnapshotVersion,
         model: model.name,
-        // The co-processor is emulation config rather than part of the model, so the model name
-        // cannot distinguish a Turbo from a plain Master. Recorded separately for that reason.
+        // The model name cannot distinguish a Turbo from a plain Master: the co-processor is
+        // emulation config rather than part of the model.
         coProcessor: cpu.hasTube,
         timestamp: new Date().toISOString(),
         state,

--- a/src/tube.js
+++ b/src/tube.js
@@ -308,11 +308,9 @@ export class Tube {
     }
 
     /**
-     * The interrupt and reset lines are not saved: updateInterrupts() derives them from the
-     * status registers and FIFO counts, in the same way the host's `interrupt` is rebuilt by
-     * the VIA and ACIA restores. Because the parasite's NMI is edge triggered, this can leave
-     * a spurious edge behind; Tube6502.restoreState() restores the parasite's registers
-     * afterwards, which puts the true edge state back.
+     * The interrupt and reset lines are not saved: they are derived from the status registers
+     * and FIFO counts, in the same way the host's `interrupt` is rebuilt by the VIA and ACIA
+     * restores.
      */
     restoreState(state) {
         this.internalStatusRegister = state.internalStatusRegister;

--- a/src/tube.js
+++ b/src/tube.js
@@ -219,7 +219,7 @@ export class Tube {
                 if (this.hostStatus[TUBE_ULA_R3] & TUBE_ULA_FLAG_DATA_REGISTER_NOT_FULL) {
                     if (this.internalStatusRegister & TUBE_ULA_FLAG_STATUS_ENABLE_2_BYTE_R3_DATA) {
                         if (this.hostToParasiteFifoByteCount3 < 2) {
-                            this.hostToParasiteData[this.hostToParasiteFifoByteCount3++] = value;
+                            this.hostToParasiteData[TUBE_ULA_R3][this.hostToParasiteFifoByteCount3++] = value;
                         }
                         if (this.hostToParasiteFifoByteCount3 === 2) {
                             this.parasiteStatus[TUBE_ULA_R3] |= TUBE_ULA_FLAG_DATA_AVAILABLE;
@@ -294,6 +294,40 @@ export class Tube {
         }
         return result;
     }
+    snapshotState() {
+        return {
+            internalStatusRegister: this.internalStatusRegister,
+            hostStatus: this.hostStatus.slice(),
+            parasiteStatus: this.parasiteStatus.slice(),
+            parasiteToHostData: this.parasiteToHostData.map((fifo) => fifo.slice()),
+            hostToParasiteData: this.hostToParasiteData.map((fifo) => fifo.slice()),
+            parasiteToHostFifoByteCount1: this.parasiteToHostFifoByteCount1,
+            parasiteToHostFifoByteCount3: this.parasiteToHostFifoByteCount3,
+            hostToParasiteFifoByteCount3: this.hostToParasiteFifoByteCount3,
+        };
+    }
+
+    /**
+     * The interrupt and reset lines are not saved: updateInterrupts() derives them from the
+     * status registers and FIFO counts, in the same way the host's `interrupt` is rebuilt by
+     * the VIA and ACIA restores. Because the parasite's NMI is edge triggered, this can leave
+     * a spurious edge behind; Tube6502.restoreState() restores the parasite's registers
+     * afterwards, which puts the true edge state back.
+     */
+    restoreState(state) {
+        this.internalStatusRegister = state.internalStatusRegister;
+        this.hostStatus.set(state.hostStatus);
+        this.parasiteStatus.set(state.parasiteStatus);
+        for (let i = 0; i < 4; i++) {
+            this.parasiteToHostData[i].set(state.parasiteToHostData[i]);
+            this.hostToParasiteData[i].set(state.hostToParasiteData[i]);
+        }
+        this.parasiteToHostFifoByteCount1 = state.parasiteToHostFifoByteCount1;
+        this.parasiteToHostFifoByteCount3 = state.parasiteToHostFifoByteCount3;
+        this.hostToParasiteFifoByteCount3 = state.hostToParasiteFifoByteCount3;
+        this.updateInterrupts();
+    }
+
     parasiteWrite(address, value) {
         //  Not implemented - needs to be integrated with the parasite CPU code:
         //  Boot mode is terminated by the software when it selects any one of the Tube addresses.

--- a/tests/integration/tube.js
+++ b/tests/integration/tube.js
@@ -54,6 +54,26 @@ describe("Tube co-processor", () => {
         expect(cpu.tube.memory).toEqual(expected.memory);
     });
 
+    it("raises a parasite NMI the restored state was owed but had not seen", async () => {
+        const machine = new TestMachine("Master", { tube: true });
+        await machine.initialise();
+        const cpu = machine.processor;
+        cpu.execute(200 * 1000);
+        const state = cpu.snapshotState();
+
+        // As an imported snapshot can be: the ULA has R3 data pending with NMI enabled, but the
+        // parasite's own idea of the line predates it.
+        state.tube.nmiLevel = false;
+        state.tube.nmiEdge = false;
+        state.tube.ula.internalStatusRegister |= 0x08; // M: enable parasite NMI from R3
+        state.tube.ula.parasiteToHostFifoByteCount3 = 0;
+
+        cpu.restoreState(state);
+
+        expect(cpu.tube._nmiLevel).toBe(true);
+        expect(cpu.tube._nmiEdge).toBe(true);
+    });
+
     it("resets the parasite when restoring state that has none", async () => {
         const machine = new TestMachine("Master", { tube: true });
         await machine.initialise();

--- a/tests/integration/tube.js
+++ b/tests/integration/tube.js
@@ -1,6 +1,9 @@
 import { describe, it, expect } from "vitest";
 import { TestMachine } from "../test-machine.js";
 
+// The ULA's M flag, which lets pending R3 data raise the parasite's NMI.
+const TubeStatusEnableParasiteNmiFromR3 = 0x08;
+
 describe("Tube co-processor", () => {
     it("runs the parasite processor alongside the host", async () => {
         const machine = new TestMachine("Master", { tube: true });
@@ -65,13 +68,26 @@ describe("Tube co-processor", () => {
         // parasite's own idea of the line predates it.
         state.tube.nmiLevel = false;
         state.tube.nmiEdge = false;
-        state.tube.ula.internalStatusRegister |= 0x08; // M: enable parasite NMI from R3
+        state.tube.ula.internalStatusRegister |= TubeStatusEnableParasiteNmiFromR3;
         state.tube.ula.parasiteToHostFifoByteCount3 = 0;
 
         cpu.restoreState(state);
 
         expect(cpu.tube._nmiLevel).toBe(true);
         expect(cpu.tube._nmiEdge).toBe(true);
+    });
+
+    it("does not take a latched NMI across a parasite reset", async () => {
+        const machine = new TestMachine("Master", { tube: true });
+        await machine.initialise();
+        const parasite = machine.processor.tube;
+        parasite.NMI(true);
+        expect(parasite._nmiEdge).toBe(true);
+
+        parasite.reset(true);
+
+        expect(parasite._nmiEdge).toBe(false);
+        expect(parasite.takeInt).toBe(false);
     });
 
     it("resets the parasite when restoring state that has none", async () => {

--- a/tests/integration/tube.js
+++ b/tests/integration/tube.js
@@ -24,6 +24,50 @@ describe("Tube co-processor", () => {
         expect(machine.processor.tube.pc).toBeUndefined();
     });
 
+    it("restores the parasite to exactly where it was", async () => {
+        const machine = new TestMachine("Master", { tube: true });
+        await machine.initialise();
+        const cpu = machine.processor;
+        cpu.execute(200 * 1000);
+
+        const state = cpu.snapshotState();
+        cpu.execute(200 * 1000);
+        cpu.restoreState(state);
+
+        expect(cpu.snapshotState().tube).toEqual(state.tube);
+    });
+
+    it("keeps the parasite running identically after a restore", async () => {
+        const machine = new TestMachine("Master", { tube: true });
+        await machine.initialise();
+        const cpu = machine.processor;
+        cpu.execute(200 * 1000);
+
+        const state = cpu.snapshotState();
+        cpu.execute(100 * 1000);
+        const expected = { pc: cpu.tube.pc, memory: cpu.tube.memory.slice() };
+
+        cpu.restoreState(state);
+        cpu.execute(100 * 1000);
+
+        expect(cpu.tube.pc).toBe(expected.pc);
+        expect(cpu.tube.memory).toEqual(expected.memory);
+    });
+
+    it("resets the parasite when restoring state that has none", async () => {
+        const machine = new TestMachine("Master", { tube: true });
+        await machine.initialise();
+        const cpu = machine.processor;
+        cpu.execute(200 * 1000);
+        const state = cpu.snapshotState();
+        delete state.tube; // as a pre-v3 snapshot would be
+
+        cpu.restoreState(state);
+
+        expect(cpu.tube.romPaged).toBe(true);
+        expect(cpu.tube.pc).toBe(cpu.tube.readmem(0xfffc) | (cpu.tube.readmem(0xfffd) << 8));
+    });
+
     it("runs the parasite at the requested multiple of the host clock", async () => {
         const machine = new TestMachine("Master", { tube: true, tubeCpuMultiplier: 4 });
         await machine.initialise();

--- a/tests/unit/test-bem-snapshot.js
+++ b/tests/unit/test-bem-snapshot.js
@@ -290,8 +290,10 @@ describe("b-em tube import", () => {
     });
 
     it("rejects a parasite whose RAM is not the 64K jsbeeb emulates", async () => {
-        const buffer = await makeBemV3WithTube({ ramSize: 16384 });
-
-        await expect(parseBemSnapshot(buffer)).rejects.toThrow(/parasite RAM/);
+        await expect(parseBemSnapshot(await makeBemV3WithTube({ ramSize: 16384 }))).rejects.toThrow(/parasite state/);
+        // A renamed Turbo in b-em's config would get past the name check on size alone.
+        await expect(parseBemSnapshot(await makeBemV3WithTube({ ramSize: 0x1000000 }))).rejects.toThrow(
+            /parasite state/,
+        );
     });
 });

--- a/tests/unit/test-bem-snapshot.js
+++ b/tests/unit/test-bem-snapshot.js
@@ -180,7 +180,13 @@ function section(key, data, compressed = false) {
  * Build a BEMSNAP3 carrying only the model and tube sections, which is all the tube import
  * needs. `ula` and `parasite` are sparse overrides applied to otherwise-zeroed state.
  */
-async function makeBemV3WithTube({ tubeName = "6502 External", ula = {}, parasite = {}, ramSize = 65536 } = {}) {
+async function makeBemV3WithTube({
+    tubeName = "6502 External",
+    ula = {},
+    parasite = {},
+    ramSize = 65536,
+    romSize = 2048,
+} = {}) {
     const model = [
         ...encodeVar(3),
         ...encodeString("BBC B"),
@@ -202,7 +208,7 @@ async function makeBemV3WithTube({ tubeName = "6502 External", ula = {}, parasit
     ulaBytes[1] = ula.romPaged ?? 1;
     for (const [offset, value] of Object.entries(ula.fields ?? {})) ulaBytes[2 + Number(offset)] = value;
 
-    const parasiteBytes = new Uint8Array(9 + ramSize + 2048);
+    const parasiteBytes = new Uint8Array(9 + ramSize + romSize);
     parasiteBytes[1] = parasite.oldnmi ?? 0;
     parasiteBytes[2] = parasite.a ?? 0;
     parasiteBytes[3] = parasite.x ?? 0;
@@ -290,10 +296,14 @@ describe("b-em tube import", () => {
     });
 
     it("rejects a parasite whose RAM is not the 64K jsbeeb emulates", async () => {
-        await expect(parseBemSnapshot(await makeBemV3WithTube({ ramSize: 16384 }))).rejects.toThrow(/parasite state/);
+        await expect(parseBemSnapshot(await makeBemV3WithTube({ ramSize: 16384 }))).rejects.toThrow(/parasite RAM/);
         // A renamed Turbo in b-em's config would get past the name check on size alone.
-        await expect(parseBemSnapshot(await makeBemV3WithTube({ ramSize: 0x1000000 }))).rejects.toThrow(
-            /parasite state/,
-        );
+        await expect(parseBemSnapshot(await makeBemV3WithTube({ ramSize: 0x1000000 }))).rejects.toThrow(/parasite RAM/);
+    });
+
+    it("accepts a parasite whose ROM size b-em's config left unset", async () => {
+        const snapshot = await parseBemSnapshot(await makeBemV3WithTube({ romSize: 0 }));
+
+        expect(snapshot.coProcessor).toBe(true);
     });
 });

--- a/tests/unit/test-bem-snapshot.js
+++ b/tests/unit/test-bem-snapshot.js
@@ -162,18 +162,11 @@ function encodeString(str) {
 }
 
 function section(key, data, compressed = false) {
-    const code = key.charCodeAt(0);
-    if (compressed) {
-        return [
-            code | 0x80,
-            data.length & 0xff,
-            (data.length >> 8) & 0xff,
-            (data.length >> 16) & 0xff,
-            data.length >>> 24,
-            ...data,
-        ];
-    }
-    return [code, data.length & 0xff, (data.length >> 8) & 0xff, ...data];
+    // Compressed sections flag the key and carry a 4-byte length rather than 2.
+    const lengthBytes = compressed ? 4 : 2;
+    const header = [key.charCodeAt(0) | (compressed ? 0x80 : 0)];
+    for (let i = 0; i < lengthBytes; i++) header.push((data.length >>> (i * 8)) & 0xff);
+    return [...header, ...data];
 }
 
 /**
@@ -182,6 +175,7 @@ function section(key, data, compressed = false) {
  */
 async function makeBemV3WithTube({
     tubeName = "6502 External",
+    tubeState = true,
     ula = {},
     parasite = {},
     ramSize = 65536,
@@ -190,17 +184,8 @@ async function makeBemV3WithTube({
 } = {}) {
     const model = [
         ...encodeVar(3),
-        ...encodeString("BBC B"),
-        ...encodeString("os12"),
-        ...encodeString(""),
-        ...encodeString("std"),
-        ...encodeString("none"),
-        0,
-        0,
-        0,
-        0,
-        0,
-        0,
+        ...["BBC B", "os12", "", "std", "none"].flatMap(encodeString),
+        ...new Array(6).fill(0), // model flag bytes
         ...(tubeName ? [1, ...encodeString(tubeName)] : [0]),
     ];
 
@@ -209,22 +194,16 @@ async function makeBemV3WithTube({
     ulaSection[1] = ula.romPaged ?? 1;
     for (const [offset, value] of Object.entries(ula.fields ?? {})) ulaSection[2 + Number(offset)] = value;
 
+    const { a = 0, x = 0, y = 0, s = 0, pc = 0, flags = 0, oldnmi = 0 } = parasite;
     const parasiteBytes = new Uint8Array(9 + ramSize + romSize);
-    parasiteBytes[1] = parasite.oldnmi ?? 0;
-    parasiteBytes[2] = parasite.a ?? 0;
-    parasiteBytes[3] = parasite.x ?? 0;
-    parasiteBytes[4] = parasite.y ?? 0;
-    parasiteBytes[5] = parasite.flags ?? 0;
-    parasiteBytes[6] = parasite.s ?? 0;
-    parasiteBytes[7] = (parasite.pc ?? 0) & 0xff;
-    parasiteBytes[8] = (parasite.pc ?? 0) >> 8;
+    parasiteBytes.set([0, oldnmi, a, x, y, flags, s, pc & 0xff, pc >> 8]);
     for (const [addr, value] of Object.entries(parasite.memory ?? {})) parasiteBytes[9 + Number(addr)] = value;
 
     return new Uint8Array([
         ...new TextEncoder().encode("BEMSNAP3"),
         ...section("m", model),
-        ...section("T", ulaSection),
-        ...section("P", await deflate(parasiteBytes), true),
+        ...(tubeState ? section("T", ulaSection) : []),
+        ...(tubeState ? section("P", await deflate(parasiteBytes), true) : []),
     ]).buffer;
 }
 
@@ -259,26 +238,7 @@ describe("b-em tube import", () => {
     });
 
     it("reports no co-processor when none was fitted", async () => {
-        const buffer = new Uint8Array([
-            ...new TextEncoder().encode("BEMSNAP3"),
-            ...section("m", [
-                ...encodeVar(3),
-                ...encodeString("BBC B"),
-                ...encodeString("os12"),
-                ...encodeString(""),
-                ...encodeString("std"),
-                ...encodeString("none"),
-                0,
-                0,
-                0,
-                0,
-                0,
-                0,
-                0,
-            ]),
-        ]).buffer;
-
-        const snapshot = await parseBemSnapshot(buffer);
+        const snapshot = await parseBemSnapshot(await makeBemV3WithTube({ tubeName: null, tubeState: false }));
 
         expect(snapshot.coProcessor).toBe(false);
         expect(snapshot.state.tube).toBeUndefined();

--- a/tests/unit/test-bem-snapshot.js
+++ b/tests/unit/test-bem-snapshot.js
@@ -186,6 +186,7 @@ async function makeBemV3WithTube({
     parasite = {},
     ramSize = 65536,
     romSize = 2048,
+    ulaBytes = 51,
 } = {}) {
     const model = [
         ...encodeVar(3),
@@ -203,10 +204,10 @@ async function makeBemV3WithTube({
         ...(tubeName ? [1, ...encodeString(tubeName)] : [0]),
     ];
 
-    const ulaBytes = new Uint8Array(51);
-    ulaBytes[0] = 2; // struct version
-    ulaBytes[1] = ula.romPaged ?? 1;
-    for (const [offset, value] of Object.entries(ula.fields ?? {})) ulaBytes[2 + Number(offset)] = value;
+    const ulaSection = new Uint8Array(ulaBytes);
+    ulaSection[0] = 2; // struct version
+    ulaSection[1] = ula.romPaged ?? 1;
+    for (const [offset, value] of Object.entries(ula.fields ?? {})) ulaSection[2 + Number(offset)] = value;
 
     const parasiteBytes = new Uint8Array(9 + ramSize + romSize);
     parasiteBytes[1] = parasite.oldnmi ?? 0;
@@ -222,7 +223,7 @@ async function makeBemV3WithTube({
     return new Uint8Array([
         ...new TextEncoder().encode("BEMSNAP3"),
         ...section("m", model),
-        ...section("T", ulaBytes),
+        ...section("T", ulaSection),
         ...section("P", await deflate(parasiteBytes), true),
     ]).buffer;
 }
@@ -299,6 +300,28 @@ describe("b-em tube import", () => {
         await expect(parseBemSnapshot(await makeBemV3WithTube({ ramSize: 16384 }))).rejects.toThrow(/parasite RAM/);
         // A renamed Turbo in b-em's config would get past the name check on size alone.
         await expect(parseBemSnapshot(await makeBemV3WithTube({ ramSize: 0x1000000 }))).rejects.toThrow(/parasite RAM/);
+    });
+
+    it("rejects a truncated ULA section", async () => {
+        const buffer = await makeBemV3WithTube({ ulaBytes: 20 });
+
+        await expect(parseBemSnapshot(buffer)).rejects.toThrow(/Truncated b-em tube ULA/);
+    });
+
+    it("rejects FIFO counts a real machine could not have produced", async () => {
+        const tooManyBytesQueued = await makeBemV3WithTube({ ula: { fields: { 46: 30 } } }); // ph1count
+        const headPastTheEnd = await makeBemV3WithTube({ ula: { fields: { 45: 24 } } }); // ph1head
+        const overfullR3 = await makeBemV3WithTube({ ula: { fields: { 48: 3 } } }); // hp3pos
+
+        for (const buffer of [tooManyBytesQueued, headPastTheEnd, overfullR3]) {
+            await expect(parseBemSnapshot(buffer)).rejects.toThrow(/FIFO counts out of range/);
+        }
+    });
+
+    it("rejects co-processor state that names no co-processor", async () => {
+        const buffer = await makeBemV3WithTube({ tubeName: null });
+
+        await expect(parseBemSnapshot(buffer)).rejects.toThrow(/names no co-processor/);
     });
 
     it("accepts a parasite whose ROM size b-em's config left unset", async () => {

--- a/tests/unit/test-bem-snapshot.js
+++ b/tests/unit/test-bem-snapshot.js
@@ -69,7 +69,7 @@ describe("parseBemSnapshot", () => {
         const snapshot = await parseBemSnapshot(buffer);
 
         expect(snapshot.format).toBe("jsbeeb-snapshot");
-        expect(snapshot.version).toBe(2);
+        expect(snapshot.version).toBe(3);
         expect(snapshot.model).toBe("B");
         expect(snapshot.state.a).toBe(0x42);
         expect(snapshot.state.x).toBe(0x10);
@@ -138,5 +138,160 @@ describe("parseBemSnapshot", () => {
         const buffer = makeMinimalBemSnapshot({ model: 4 });
         const snapshot = await parseBemSnapshot(buffer);
         expect(snapshot.model).toBe("B");
+    });
+});
+
+async function deflate(bytes) {
+    const stream = new Blob([bytes]).stream().pipeThrough(new CompressionStream("deflate"));
+    return new Uint8Array(await new Response(stream).arrayBuffer());
+}
+
+function encodeVar(value) {
+    // b-em's variable-length integer: 7 bits per byte, top bit marks the last one.
+    const out = [];
+    while (value >= 0x80) {
+        out.push(value & 0x7f);
+        value >>= 7;
+    }
+    out.push(value | 0x80);
+    return out;
+}
+
+function encodeString(str) {
+    return [...encodeVar(str.length), ...new TextEncoder().encode(str)];
+}
+
+function section(key, data, compressed = false) {
+    const code = key.charCodeAt(0);
+    if (compressed) {
+        return [
+            code | 0x80,
+            data.length & 0xff,
+            (data.length >> 8) & 0xff,
+            (data.length >> 16) & 0xff,
+            data.length >>> 24,
+            ...data,
+        ];
+    }
+    return [code, data.length & 0xff, (data.length >> 8) & 0xff, ...data];
+}
+
+/**
+ * Build a BEMSNAP3 carrying only the model and tube sections, which is all the tube import
+ * needs. `ula` and `parasite` are sparse overrides applied to otherwise-zeroed state.
+ */
+async function makeBemV3WithTube({ tubeName = "6502 External", ula = {}, parasite = {}, ramSize = 65536 } = {}) {
+    const model = [
+        ...encodeVar(3),
+        ...encodeString("BBC B"),
+        ...encodeString("os12"),
+        ...encodeString(""),
+        ...encodeString("std"),
+        ...encodeString("none"),
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        ...(tubeName ? [1, ...encodeString(tubeName)] : [0]),
+    ];
+
+    const ulaBytes = new Uint8Array(51);
+    ulaBytes[0] = 2; // struct version
+    ulaBytes[1] = ula.romPaged ?? 1;
+    for (const [offset, value] of Object.entries(ula.fields ?? {})) ulaBytes[2 + Number(offset)] = value;
+
+    const parasiteBytes = new Uint8Array(9 + ramSize + 2048);
+    parasiteBytes[1] = parasite.oldnmi ?? 0;
+    parasiteBytes[2] = parasite.a ?? 0;
+    parasiteBytes[3] = parasite.x ?? 0;
+    parasiteBytes[4] = parasite.y ?? 0;
+    parasiteBytes[5] = parasite.flags ?? 0;
+    parasiteBytes[6] = parasite.s ?? 0;
+    parasiteBytes[7] = (parasite.pc ?? 0) & 0xff;
+    parasiteBytes[8] = (parasite.pc ?? 0) >> 8;
+    for (const [addr, value] of Object.entries(parasite.memory ?? {})) parasiteBytes[9 + Number(addr)] = value;
+
+    return new Uint8Array([
+        ...new TextEncoder().encode("BEMSNAP3"),
+        ...section("m", model),
+        ...section("T", ulaBytes),
+        ...section("P", await deflate(parasiteBytes), true),
+    ]).buffer;
+}
+
+describe("b-em tube import", () => {
+    it("imports the parasite processor state", async () => {
+        const buffer = await makeBemV3WithTube({
+            parasite: { a: 0x11, x: 0x22, y: 0x33, s: 0x44, pc: 0xf800, oldnmi: 1, memory: { 0x1234: 0x99 } },
+        });
+
+        const snapshot = await parseBemSnapshot(buffer);
+
+        expect(snapshot.coProcessor).toBe(true);
+        expect(snapshot.state.tube.a).toBe(0x11);
+        expect(snapshot.state.tube.x).toBe(0x22);
+        expect(snapshot.state.tube.y).toBe(0x33);
+        expect(snapshot.state.tube.s).toBe(0x44);
+        expect(snapshot.state.tube.pc).toBe(0xf800);
+        expect(snapshot.state.tube.nmiLevel).toBe(true);
+        expect(snapshot.state.tube.romPaged).toBe(true);
+        expect(snapshot.state.tube.memory[0x1234]).toBe(0x99);
+    });
+
+    it("linearises the circular R1 FIFO into the order jsbeeb reads it", async () => {
+        // Three bytes sitting at the end of the 24-byte ring, wrapping to the start.
+        const fields = { 22: 0xaa, 23: 0xbb, 0: 0xcc, 45: 22, 46: 3 }; // ph1[22], ph1[23], ph1[0], head, count
+        const buffer = await makeBemV3WithTube({ ula: { fields } });
+
+        const snapshot = await parseBemSnapshot(buffer);
+
+        expect([...snapshot.state.tube.ula.parasiteToHostData[0].slice(0, 3)]).toEqual([0xaa, 0xbb, 0xcc]);
+        expect(snapshot.state.tube.ula.parasiteToHostFifoByteCount1).toBe(3);
+    });
+
+    it("reports no co-processor when none was fitted", async () => {
+        const buffer = new Uint8Array([
+            ...new TextEncoder().encode("BEMSNAP3"),
+            ...section("m", [
+                ...encodeVar(3),
+                ...encodeString("BBC B"),
+                ...encodeString("os12"),
+                ...encodeString(""),
+                ...encodeString("std"),
+                ...encodeString("none"),
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+            ]),
+        ]).buffer;
+
+        const snapshot = await parseBemSnapshot(buffer);
+
+        expect(snapshot.coProcessor).toBe(false);
+        expect(snapshot.state.tube).toBeUndefined();
+    });
+
+    it("rejects co-processors that are a different CPU entirely", async () => {
+        const buffer = await makeBemV3WithTube({ tubeName: "Z80 ROM 1.21" });
+
+        await expect(parseBemSnapshot(buffer)).rejects.toThrow(/only emulates the 64K 65C02/);
+    });
+
+    it("rejects the 6502 Turbo, whose 16MB of RAM jsbeeb cannot hold", async () => {
+        const buffer = await makeBemV3WithTube({ tubeName: "6502 Turbo", ramSize: 0x1000000 });
+
+        await expect(parseBemSnapshot(buffer)).rejects.toThrow(/only emulates the 64K 65C02/);
+    });
+
+    it("rejects a parasite whose RAM is not the 64K jsbeeb emulates", async () => {
+        const buffer = await makeBemV3WithTube({ ramSize: 16384 });
+
+        await expect(parseBemSnapshot(buffer)).rejects.toThrow(/parasite RAM/);
     });
 });

--- a/tests/unit/test-snapshot.js
+++ b/tests/unit/test-snapshot.js
@@ -6,7 +6,7 @@ import { SoundChip } from "../../src/soundchip.js";
 import { FakeDdNoise } from "../../src/ddnoise.js";
 import { Cmos } from "../../src/cmos.js";
 import { FakeMusic5000 } from "../../src/music5000.js";
-import { TEST_6502 } from "../../src/models.js";
+import { TEST_6502, TubeModel } from "../../src/models.js";
 import { Disc, DiscConfig, loadSsd } from "../../src/disc.js";
 import { crc32 } from "../../src/utils.js";
 import { discFor } from "../../src/fdc.js";
@@ -14,7 +14,7 @@ import { DiscDrive } from "../../src/disc-drive.js";
 import { Scheduler } from "../../src/scheduler.js";
 import { WdFdc } from "../../src/wd-fdc.js";
 
-function makeCpu() {
+function makeCpu(config = {}) {
     const fb32 = new Uint32Array(1024 * 768);
     const video = new Video(false, fb32, () => {});
     const soundChip = new SoundChip(() => {});
@@ -26,6 +26,7 @@ function makeCpu() {
         ddNoise: new FakeDdNoise(),
         music5000: new FakeMusic5000(),
         cmos: new Cmos(),
+        config,
     });
 }
 
@@ -43,7 +44,7 @@ describe("Snapshot coordinator", () => {
             const snapshot = createSnapshot(cpu, model);
 
             expect(snapshot.format).toBe("jsbeeb-snapshot");
-            expect(snapshot.version).toBe(2);
+            expect(snapshot.version).toBe(3);
             expect(snapshot.model).toBe(model.name);
             expect(snapshot.timestamp).toBeDefined();
             expect(snapshot.state).toBeDefined();
@@ -105,7 +106,7 @@ describe("Snapshot coordinator", () => {
 
             // Verify metadata survived
             expect(restored.format).toBe("jsbeeb-snapshot");
-            expect(restored.version).toBe(2);
+            expect(restored.version).toBe(3);
             expect(restored.model).toBe(model.name);
 
             // Verify TypedArrays were properly reconstructed
@@ -172,6 +173,42 @@ describe("Snapshot coordinator", () => {
             const cpu2 = makeCpu();
             // Should not throw — FDC keeps its current state
             expect(() => restoreSnapshot(cpu2, model, snapshot)).not.toThrow();
+        });
+    });
+
+    describe("co-processor", () => {
+        it("records that no co-processor was fitted", () => {
+            expect(createSnapshot(cpu, model).coProcessor).toBe(false);
+        });
+
+        it("records a fitted co-processor and its state", () => {
+            const tubeCpu = makeCpu({ tube: TubeModel });
+            const snapshot = createSnapshot(tubeCpu, model);
+
+            expect(snapshot.coProcessor).toBe(true);
+            expect(snapshot.state.tube.ula).toBeDefined();
+        });
+
+        it("refuses to restore a host-only snapshot into a machine with a co-processor", () => {
+            const snapshot = createSnapshot(cpu, model);
+
+            expect(() => restoreSnapshot(makeCpu({ tube: TubeModel }), model, snapshot)).toThrow(
+                /Co-processor mismatch/,
+            );
+        });
+
+        it("refuses to restore a co-processor snapshot into a machine without one", () => {
+            const snapshot = createSnapshot(makeCpu({ tube: TubeModel }), model);
+
+            expect(() => restoreSnapshot(cpu, model, snapshot)).toThrow(/Co-processor mismatch/);
+        });
+
+        it("still loads pre-v3 snapshots, which never recorded a co-processor", () => {
+            const snapshot = createSnapshot(cpu, model);
+            snapshot.version = 2;
+            delete snapshot.coProcessor;
+
+            expect(() => restoreSnapshot(makeCpu(), model, snapshot)).not.toThrow();
         });
     });
 

--- a/tests/unit/test-uef-snapshot.js
+++ b/tests/unit/test-uef-snapshot.js
@@ -181,7 +181,7 @@ describe("parseUefSnapshot", () => {
         const buffer = makeUefSnapshot();
         const snap = parseUefSnapshot(buffer);
         expect(snap.format).toBe("jsbeeb-snapshot");
-        expect(snap.version).toBe(2);
+        expect(snap.version).toBe(3);
         expect(snap.importedFrom).toBe("beebem-uef");
     });
 
@@ -472,7 +472,7 @@ describe("parseUefSnapshot", () => {
         // Find and truncate the sys VIA chunk in the buffer
         const bytes = new Uint8Array(buffer);
         // Overwrite the VIA chunk length to make it too short
-        for (let i = 12; i < bytes.length - 6; ) {
+        for (let i = 12; i < bytes.length - 6;) {
             const chunkId = bytes[i] | (bytes[i + 1] << 8);
             const chunkLen = bytes[i + 2] | (bytes[i + 3] << 8) | (bytes[i + 4] << 16) | (bytes[i + 5] << 24);
             if (chunkId === 0x0467 && bytes[i + 6] === 0) {


### PR DESCRIPTION
Fixes #712.

Snapshots captured no Tube state at all, so save/restore and rewind silently produced a corrupt machine on a co-processor: the host was rewound while the parasite carried on from wherever it happened to be, communicating over FIFOs that no longer related to either side.

## What's saved

`Tube6502` and the `Tube` ULA gain `snapshotState`/`restoreState`, and the format goes to **version 3**. The parasite's 64K of RAM is included whenever a co-processor is fitted; its ROM is loaded from file at boot, so it only rides along under `includeRoms`. Host-only snapshots are unchanged apart from the new `coProcessor` flag, so nothing about the non-tube path gets bigger or slower.

The parasite needs no scheduler handling: `Tube6502.execute` keeps a plain cycle residual, with nothing relative to the host's epoch.

## Interrupt lines

Not saved. `updateInterrupts()` re-derives them from the status registers and FIFO counts, exactly as the host's `interrupt` is rebuilt by the VIA and ACIA restores.

The subtlety is that the parasite's NMI is edge triggered. The ULA is restored **after** the parasite's registers, so the line moves from its saved level to the one the ULA implies: a jsbeeb snapshot, where the two agree, produces no edge, while an imported snapshot whose idea of the line is out of date gets the rising edge it is owed. Getting this backwards loses an NMI, and there's a regression test that fails if the order is flipped.

## A reset bug found on the way

`Tube6502.reset()` never cleared `_nmiEdge` or `takeInt`, so a latched NMI survived a reset and was taken on the first instruction after it. That defeats the empty R3 FIFO the ULA deliberately seeds on reset for exactly that reason, and the host CPU's own reset has always cleared both. It is reachable today whenever the host asserts PRST through the ULA, independently of snapshots, and this branch newly routes the reset-on-restore path through it.

## Co-processor mismatches

The co-processor is emulation config rather than part of the model, so the model name cannot tell a Master Turbo from a plain Master, and `isSameModel` reports both as `"Master"`. A top-level `coProcessor` flag records it. `restoreSnapshot()` now throws on a mismatch, and the load path reloads with a matching machine exactly as it already does for a model mismatch.

## Backward compatibility

Nothing before v3 wrote tube state, so "absent" unambiguously means host-only. Old snapshots load unchanged onto host-only machines. Loading one while a co-processor is fitted restarts the machine without one, since that is the machine the snapshot describes.

## b-em import

b-em v3 snapshots carry tube state in their `'T'` (ULA) and `'P'` (parasite) sections. We were skipping both and silently dropping the co-processor, which is the same class of bug as #712 through a different door. They're now imported, including converting b-em's circular R1 FIFO into the linear form jsbeeb's shift-down reads expect. Every struct offset was verified against b-em's `src/tube.h`; the v2 layout is all single-byte fields, so the raw `fwrite` dump has no padding. v1 ULA layouts used native ints and are rejected.

Co-processors jsbeeb cannot emulate are rejected rather than half-loaded. b-em builds its co-processor list from a config file, so the name alone isn't trusted and the parasite section size is checked too — as a range, not an exact match, because b-em takes the parasite ROM size from that same config and records zero when the key is absent.

A snapshot may legitimately name a tube and carry no state for it: `tube_init` sets `curtube = -1` when the boot ROM cannot be loaded, while leaving the model's tube set. That machine really did run host-only, so it imports as host-only. Carrying only one of the two sections is corrupt, and does throw.

**Not covered:** BeebEm UEF save states. Their `EmuState` chunk records a tube type that we don't read, so those still import as host-only. Noted as a known limitation in the docs rather than guessed at, since the BeebEm source isn't to hand.

## Testing

`docs/snapshot-format.md` is updated with the new state tables and the compatibility rules. 624 unit tests and 8 tube integration tests pass, lint clean. The NMI-ordering and reset fixes each have a regression test verified to fail without the fix.

Reviewed twice by subagents against the b-em C source. The first pass caught the NMI ordering; the second caught the reset bug and a size check that had been tightened so far it rejected valid b-em snapshots.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
