### PR TITLE
fix: let the configuration dialog scroll on short screens

### DIFF
--- a/index.html
+++ b/index.html
@@ -787,8 +787,6 @@
       aria-labelledby="configurationModalLabel"
       aria-hidden="true"
     >
-      <!-- Scrollable: this dialog has far more settings than the others and would otherwise
-           run off the bottom of a short screen. -->
       <div class="modal-dialog modal-dialog-scrollable">
         <div class="modal-content">
           <div class="modal-header">

--- a/index.html
+++ b/index.html
@@ -787,7 +787,9 @@
       aria-labelledby="configurationModalLabel"
       aria-hidden="true"
     >
-      <div class="modal-dialog">
+      <!-- Scrollable: this dialog has far more settings than the others and would otherwise
+           run off the bottom of a short screen. -->
+      <div class="modal-dialog modal-dialog-scrollable">
         <div class="modal-content">
           <div class="modal-header">
             <h5 class="modal-title" id="configurationModalLabel">Emulation Configuration</h5>


### PR DESCRIPTION
The Emulation Configuration dialog is around three times the size of any
other dialog in the app (215 lines of markup against 78 for the next
largest, `help`). On a short viewport it ran off the bottom of the screen
rather than scrolling, so the settings below the fold were unreachable.

Adds Bootstrap's `modal-dialog-scrollable`, which caps the dialog at the
viewport height and scrolls the modal body internally. The header and the
Close button in the footer stay pinned.

Scoped to this one dialog deliberately: all twelve modals were measured
and this is the only outlier. If `help` proves tight on a short screen it
wants the same one-line change.

## Testing

Lint clean, 633 unit tests pass, `npm run build` succeeds. The visual
behaviour was checked by hand rather than automated: the scrollbar belongs
inside the dialog rather than on the page, and the Close button should stay
visible while scrolling the settings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)