### PR TITLE
fix: clock the second processor at its own 3MHz

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,8 +171,7 @@ sudo rpm -i out/dist/jsbeeb-1.0.1.x86_64.rpm
   running at their real-world rates. May be fractional or below one to slow the CPU down. NB disc loads become
   unreliable with a too-slow CPU, and running too fast might cause the browser to hang.
 - `tubeCpuMultiplier=X` speeds up the 65c02 second processor by a factor of `X`, a whole number. `1`, the default, is
-  the real 3MHz part. The MOS transfers the language across the Tube on a timing promise rather than a handshake, so a
-  second processor slower than about 2.2MHz drops bytes and never reaches its prompt.
+  the real 3MHz part.
 - `sbLeft` / `sbRight` / `sbBottom` - a URL to place left of, right of, or below the cub monitor. The left and right
   should be around 648 high and the bottom image should be around 896 wide. Left and right wider than 300 will run into
   problems on smaller screens; bottom taller than 100 or so similarly.

--- a/README.md
+++ b/README.md
@@ -170,6 +170,9 @@ sudo rpm -i out/dist/jsbeeb-1.0.1.x86_64.rpm
 - `cpuMultiplier=X` speeds up the CPU by a factor of `X` relative to the peripherals: video, sound and the VIAs keep
   running at their real-world rates. May be fractional or below one to slow the CPU down. NB disc loads become
   unreliable with a too-slow CPU, and running too fast might cause the browser to hang.
+- `tubeCpuMultiplier=X` speeds up the 65c02 second processor by a factor of `X`, a whole number. `1`, the default, is
+  the real 3MHz part. The MOS transfers the language across the Tube on a timing promise rather than a handshake, so a
+  second processor slower than about 2.2MHz drops bytes and never reaches its prompt.
 - `sbLeft` / `sbRight` / `sbBottom` - a URL to place left of, right of, or below the cub monitor. The left and right
   should be around 648 high and the bottom image should be around 896 wide. Left and right wider than 300 will run into
   problems on smaller screens; bottom taller than 100 or so similarly.

--- a/docs/snapshot-format.md
+++ b/docs/snapshot-format.md
@@ -365,22 +365,22 @@ Track keys are strings like `"false:0"` (lower side, track 0) or `"true:5"` (upp
 
 Present only when a co-processor was fitted.
 
-| Field      | Type       | Description                                                     |
-| ---------- | ---------- | --------------------------------------------------------------- |
-| `a`        | number     | Parasite accumulator                                            |
-| `x`        | number     | Parasite X register                                             |
-| `y`        | number     | Parasite Y register                                             |
-| `s`        | number     | Parasite stack pointer                                          |
-| `pc`       | number     | Parasite program counter                                        |
-| `p`        | number     | Parasite status flags as a byte                                 |
-| `nmiLevel` | boolean    | Parasite NMI line level                                         |
-| `nmiEdge`  | boolean    | Whether a parasite NMI edge is pending                          |
-| `takeInt`  | boolean    | Whether an interrupt is to be taken before the next instruction |
-| `cycles`   | number     | Cycles owed to the parasite; it has no scheduler of its own     |
-| `romPaged` | boolean    | Whether the boot ROM is paged in at `0xF000`                    |
-| `memory`   | Uint8Array | 64KB of parasite RAM                                            |
-| `rom`      | Uint8Array | _(Optional)_ 4KB parasite ROM, only when `includeRoms` is set   |
-| `ula`      | object     | Tube ULA state (see below)                                      |
+| Field      | Type       | Description                                                            |
+| ---------- | ---------- | ---------------------------------------------------------------------- |
+| `a`        | number     | Parasite accumulator                                                   |
+| `x`        | number     | Parasite X register                                                    |
+| `y`        | number     | Parasite Y register                                                    |
+| `s`        | number     | Parasite stack pointer                                                 |
+| `pc`       | number     | Parasite program counter                                               |
+| `p`        | number     | Parasite status flags as a byte                                        |
+| `nmiLevel` | boolean    | Parasite NMI line level                                                |
+| `nmiEdge`  | boolean    | Whether a parasite NMI edge is pending                                 |
+| `takeInt`  | boolean    | Whether an interrupt is to be taken before the next instruction        |
+| `cycles`   | number     | Cycles owed to the parasite, in halves; it has no scheduler of its own |
+| `romPaged` | boolean    | Whether the boot ROM is paged in at `0xF000`                           |
+| `memory`   | Uint8Array | 64KB of parasite RAM                                                   |
+| `rom`      | Uint8Array | _(Optional)_ 4KB parasite ROM, only when `includeRoms` is set          |
+| `ula`      | object     | Tube ULA state (see below)                                             |
 
 #### Tube ULA (`state.tube.ula`)
 

--- a/index.html
+++ b/index.html
@@ -897,7 +897,7 @@
                   </div>
                   <div class="form-check" id="tubeCpuMultiplierGroup">
                     <label class="form-check-label" for="tubeCpuMultiplier">
-                      Tube CPU multiplier: <span id="tubeCpuMultiplierValue">2</span>x
+                      Tube CPU: <span id="tubeCpuMultiplierValue">1x (3MHz)</span>
                     </label>
                     <input
                       type="range"
@@ -905,7 +905,7 @@
                       id="tubeCpuMultiplier"
                       min="1"
                       max="8"
-                      value="2"
+                      value="1"
                       step="1"
                       disabled
                     />

--- a/src/6502.js
+++ b/src/6502.js
@@ -18,7 +18,7 @@ const signExtend = utils.signExtend;
 export const TubeCpuClockMhz = 3;
 const HostClockMhz = 2;
 const TubeCyclesPerHostCycle = TubeCpuClockMhz / HostClockMhz;
-// 1x is real hardware. Slower than about 1.1x loses bytes in the MOS's unhandshaken 10us/byte R3 transfers.
+// Below about 2.2MHz the MOS's unhandshaken 10us/byte R3 transfers lose data.
 export const DefaultTubeCpuMultiplier = 1;
 
 function _set(byte, mask, set) {

--- a/src/6502.js
+++ b/src/6502.js
@@ -15,8 +15,11 @@ import { AtomMMC2 } from "./mmc.js";
 
 const signExtend = utils.signExtend;
 
-// Speed of the second processor relative to the host, as fitted to a Master Turbo.
-export const DefaultTubeCpuMultiplier = 2;
+export const TubeCpuClockMhz = 3;
+const HostClockMhz = 2;
+const TubeCyclesPerHostCycle = TubeCpuClockMhz / HostClockMhz;
+// 1x is real hardware. Slower than about 1.1x loses bytes in the MOS's unhandshaken 10us/byte R3 transfers.
+export const DefaultTubeCpuMultiplier = 1;
 
 function _set(byte, mask, set) {
     return (byte & ~mask) | (set ? mask : 0);
@@ -479,7 +482,7 @@ class Tube6502 extends Base6502 {
     }
 
     execute(cycles) {
-        this.cycles += (cycles * this.cpuMultiplier) | 0;
+        this.cycles += cycles * TubeCyclesPerHostCycle * this.cpuMultiplier;
         if (this.cycles < 3) return;
         while (this.cycles > 0) {
             const opcode = this.readmem(this.pc);

--- a/src/config.js
+++ b/src/config.js
@@ -1,6 +1,11 @@
 "use strict";
 import { allModels, findModel } from "./models.js";
 import { getFilterForMode } from "./canvas.js";
+import { TubeCpuClockMhz } from "./6502.js";
+
+function showTubeCpuMultiplier(value) {
+    document.getElementById("tubeCpuMultiplierValue").textContent = `${value}x (${value * TubeCpuClockMhz}MHz)`;
+}
 
 /**
  * The sideways ROMs the optional fittings need, in the order they claim banks.
@@ -114,7 +119,7 @@ export class Config extends EventTarget {
 
         document.getElementById("tubeCpuMultiplier").addEventListener("input", () => {
             const val = parseInt(document.getElementById("tubeCpuMultiplier").value, 10);
-            document.getElementById("tubeCpuMultiplierValue").textContent = val;
+            showTubeCpuMultiplier(val);
             this.changed.tubeCpuMultiplier = val;
         });
 
@@ -193,7 +198,7 @@ export class Config extends EventTarget {
     setTubeCpuMultiplier(value) {
         this.tubeCpuMultiplier = value;
         document.getElementById("tubeCpuMultiplier").value = value;
-        document.getElementById("tubeCpuMultiplierValue").textContent = value;
+        showTubeCpuMultiplier(value);
     }
 
     setDropdownText(modelName) {

--- a/tests/integration/tube.js
+++ b/tests/integration/tube.js
@@ -104,7 +104,19 @@ describe("Tube co-processor", () => {
         expect(cpu.tube.pc).toBe(cpu.tube.readmem(0xfffc) | (cpu.tube.readmem(0xfffd) << 8));
     });
 
-    it("runs the parasite at the requested multiple of the host clock", async () => {
+    it("boots the language across the tube at the default speed", async () => {
+        const machine = new TestMachine("Master", { tube: true });
+        await machine.initialise();
+        machine.startCapture();
+
+        await machine.runFor(20 * 1000 * 1000);
+
+        // The prompt only arrives if the parasite kept up with the MOS's unhandshaken R3
+        // transfer: the ULA drops bytes the host never re-checks, and a part-copied BASIC hangs.
+        expect(machine.drainText({ raw: true })).toContain("BASIC\n\n>");
+    });
+
+    it("passes the requested multiplier on to the parasite", async () => {
         const machine = new TestMachine("Master", { tube: true, tubeCpuMultiplier: 4 });
         await machine.initialise();
 

--- a/tests/integration/tube.js
+++ b/tests/integration/tube.js
@@ -109,7 +109,7 @@ describe("Tube co-processor", () => {
         await machine.initialise();
         machine.startCapture();
 
-        await machine.runFor(20 * 1000 * 1000);
+        await machine.runFor(4 * 1000 * 1000);
 
         // The prompt only arrives if the parasite kept up with the MOS's unhandshaken R3
         // transfer: the ULA drops bytes the host never re-checks, and a part-copied BASIC hangs.

--- a/tests/unit/test-models.js
+++ b/tests/unit/test-models.js
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import { allModels, basicOnly, findModel, TEST_6502, TEST_65C02, TEST_65C12 } from "../../src/models.js";
 import { fake6502 } from "../../src/fake6502.js";
+import { DefaultTubeCpuMultiplier } from "../../src/6502.js";
 
 describe("Model", () => {
     it("is frozen so per-session settings cannot be stored on it", () => {
@@ -32,7 +33,7 @@ describe("fake6502 tube handling", () => {
         const cpu = fake6502(findModel("Master"), { tube: true });
 
         expect(cpu.hasTube).toBe(true);
-        expect(cpu.tube.cpuMultiplier).toBe(2);
+        expect(cpu.tube.cpuMultiplier).toBe(DefaultTubeCpuMultiplier);
     });
 
     it("attaches no tube by default", () => {


### PR DESCRIPTION
`tubeCpuMultiplier` was a multiple of the host's 2MHz, so 1x ran the parasite at 2MHz and the machine hung after printing BASIC. It is now a multiple of the co-processor's own 3MHz clock, so 1x is real hardware.

Fixes #703

🤖 Generated with [Claude Code](https://claude.com/claude-code)