### PR TITLE
fix: discard stale teletext channel fetches

### DIFF
--- a/src/teletext_adaptor.js
+++ b/src/teletext_adaptor.js
@@ -61,11 +61,9 @@ export class TeletextAdaptor {
     async loadChannelStream(channel) {
         console.log("Teletext adaptor: switching to channel " + channel);
         const request = ++this.streamRequest;
-        const data = await utils
-            .loadData(`teletext/txt${channel}.dat`)
-            .catch((e) => console.log(`Teletext adaptor: cannot load channel ${channel}: ${e}`));
+        const data = await utils.loadData(`teletext/txt${channel}.dat`);
         // Fetches can resolve out of order; only the newest request may apply its data.
-        if (!data || request !== this.streamRequest) return;
+        if (request !== this.streamRequest) return;
         this.streamData = data;
         this.totalFrames = Math.floor(data.length / TELETEXT_FRAME_SIZE);
         this.currentFrame = 0;

--- a/src/teletext_adaptor.js
+++ b/src/teletext_adaptor.js
@@ -35,9 +35,8 @@ Status register:
 */
 
 export class TeletextAdaptor {
-    constructor(cpu, loadData = utils.loadData) {
+    constructor(cpu) {
         this.cpu = cpu;
-        this.loadData = loadData;
         this.teletextStatus = 0x0f; /* low nibble comes from LK4-7 and mystery links which are left floating */
         this.teletextInts = false;
         this.teletextEnable = false;
@@ -62,8 +61,8 @@ export class TeletextAdaptor {
     async loadChannelStream(channel) {
         console.log("Teletext adaptor: switching to channel " + channel);
         const request = ++this.streamRequest;
-        const data = await this.loadData(`teletext/txt${channel}.dat`);
-        // Fetches can resolve out of order; only the most recently requested channel counts.
+        const data = await utils.loadData(`teletext/txt${channel}.dat`);
+        // Fetches can resolve out of order; only the newest request may apply its data.
         if (request !== this.streamRequest) return;
         this.streamData = data;
         this.totalFrames = Math.floor(data.length / TELETEXT_FRAME_SIZE);

--- a/src/teletext_adaptor.js
+++ b/src/teletext_adaptor.js
@@ -61,9 +61,11 @@ export class TeletextAdaptor {
     async loadChannelStream(channel) {
         console.log("Teletext adaptor: switching to channel " + channel);
         const request = ++this.streamRequest;
-        const data = await utils.loadData(`teletext/txt${channel}.dat`);
+        const data = await utils
+            .loadData(`teletext/txt${channel}.dat`)
+            .catch((e) => console.log(`Teletext adaptor: cannot load channel ${channel}: ${e}`));
         // Fetches can resolve out of order; only the newest request may apply its data.
-        if (request !== this.streamRequest) return;
+        if (!data || request !== this.streamRequest) return;
         this.streamData = data;
         this.totalFrames = Math.floor(data.length / TELETEXT_FRAME_SIZE);
         this.currentFrame = 0;

--- a/src/teletext_adaptor.js
+++ b/src/teletext_adaptor.js
@@ -35,8 +35,9 @@ Status register:
 */
 
 export class TeletextAdaptor {
-    constructor(cpu) {
+    constructor(cpu, loadData = utils.loadData) {
         this.cpu = cpu;
+        this.loadData = loadData;
         this.teletextStatus = 0x0f; /* low nibble comes from LK4-7 and mystery links which are left floating */
         this.teletextInts = false;
         this.teletextEnable = false;
@@ -47,6 +48,7 @@ export class TeletextAdaptor {
         this.colPtr = 0x00;
         this.frameBuffer = new Array(16).fill(0).map(() => new Array(64).fill(0));
         this.streamData = null;
+        this.streamRequest = 0;
         this.pollCount = 0;
     }
 
@@ -57,14 +59,15 @@ export class TeletextAdaptor {
         }
     }
 
-    loadChannelStream(channel) {
+    async loadChannelStream(channel) {
         console.log("Teletext adaptor: switching to channel " + channel);
-        const teletextRef = this;
-        utils.loadData("teletext/txt" + channel + ".dat").then(function (data) {
-            teletextRef.streamData = data;
-            teletextRef.totalFrames = data.length / TELETEXT_FRAME_SIZE;
-            teletextRef.currentFrame = 0;
-        });
+        const request = ++this.streamRequest;
+        const data = await this.loadData(`teletext/txt${channel}.dat`);
+        // Fetches can resolve out of order; only the most recently requested channel counts.
+        if (request !== this.streamRequest) return;
+        this.streamData = data;
+        this.totalFrames = Math.floor(data.length / TELETEXT_FRAME_SIZE);
+        this.currentFrame = 0;
     }
 
     read(addr) {

--- a/tests/unit/test-teletext-adaptor.js
+++ b/tests/unit/test-teletext-adaptor.js
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach, vi, afterEach } from "vitest";
 import { TeletextAdaptor } from "../../src/teletext_adaptor.js";
+import * as utils from "../../src/utils.js";
 
 describe("TeletextAdaptor", () => {
     // Constants
@@ -223,44 +224,30 @@ describe("TeletextAdaptor", () => {
         const TELETEXT_FRAME_SIZE = 860;
 
         // Resolvers for the fetches the adaptor has started, keyed by the URL it asked for.
-        let pending;
+        const pending = new Map();
         let adaptor;
 
-        const flushPromises = () => new Promise((resolve) => setTimeout(resolve, 0));
-
-        const resolveChannel = (channel, frames) => {
-            // Each byte identifies the channel, so any frame buffer content shows which stream won.
-            const data = new Uint8Array(frames * TELETEXT_FRAME_SIZE).fill(channel);
-            pending.get(`teletext/txt${channel}.dat`)(data);
-        };
-
         beforeEach(() => {
-            pending = new Map();
-            adaptor = new TeletextAdaptor(mockCpu, (url) => new Promise((resolve) => pending.set(url, resolve)));
+            pending.clear();
+            vi.spyOn(utils, "loadData").mockImplementation(
+                (url) => new Promise((resolve) => pending.set(url, resolve)),
+            );
+            adaptor = new TeletextAdaptor(mockCpu);
         });
 
-        it("should ignore a stale response that arrives after a newer channel's", async () => {
+        // Each byte holds the channel number, so the frame buffer shows which stream was applied.
+        const resolveChannel = (channel, length = TELETEXT_FRAME_SIZE) =>
+            pending.get(`teletext/txt${channel}.dat`)(new Uint8Array(length).fill(channel));
+
+        const settle = () => new Promise((resolve) => setTimeout(resolve));
+
+        it("should ignore a response that arrives after a newer channel's", async () => {
             adaptor.write(0, 0x04 | 1); // Teletext enable, channel 1
             adaptor.write(0, 0x04 | 2); // Teletext enable, channel 2
 
-            resolveChannel(2, 1);
-            resolveChannel(1, 1);
-            await flushPromises();
-
-            adaptor.update();
-
-            expect(adaptor.channel).toBe(2);
-            expect(adaptor.frameBuffer[0][1]).toBe(2);
-        });
-
-        it("should use the newest response even when an older one arrives last", async () => {
-            adaptor.write(0, 0x04 | 1); // Teletext enable, channel 1
-            adaptor.write(0, 0x04 | 2); // Teletext enable, channel 2
-
-            resolveChannel(1, 1);
-            resolveChannel(2, 1);
-            await flushPromises();
-
+            resolveChannel(2);
+            resolveChannel(1);
+            await settle();
             adaptor.update();
 
             expect(adaptor.frameBuffer[0][1]).toBe(2);
@@ -269,9 +256,8 @@ describe("TeletextAdaptor", () => {
         it("should round a truncated stream down to whole frames", async () => {
             adaptor.write(0, 0x04 | 1); // Teletext enable, channel 1
 
-            const truncated = new Uint8Array(2 * TELETEXT_FRAME_SIZE + 100).fill(1);
-            pending.get("teletext/txt1.dat")(truncated);
-            await flushPromises();
+            resolveChannel(1, 2 * TELETEXT_FRAME_SIZE + 100);
+            await settle();
 
             expect(adaptor.totalFrames).toBe(2);
         });

--- a/tests/unit/test-teletext-adaptor.js
+++ b/tests/unit/test-teletext-adaptor.js
@@ -219,6 +219,64 @@ describe("TeletextAdaptor", () => {
         });
     });
 
+    describe("Channel stream loading", () => {
+        const TELETEXT_FRAME_SIZE = 860;
+
+        // Resolvers for the fetches the adaptor has started, keyed by the URL it asked for.
+        let pending;
+        let adaptor;
+
+        const flushPromises = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+        const resolveChannel = (channel, frames) => {
+            // Each byte identifies the channel, so any frame buffer content shows which stream won.
+            const data = new Uint8Array(frames * TELETEXT_FRAME_SIZE).fill(channel);
+            pending.get(`teletext/txt${channel}.dat`)(data);
+        };
+
+        beforeEach(() => {
+            pending = new Map();
+            adaptor = new TeletextAdaptor(mockCpu, (url) => new Promise((resolve) => pending.set(url, resolve)));
+        });
+
+        it("should ignore a stale response that arrives after a newer channel's", async () => {
+            adaptor.write(0, 0x04 | 1); // Teletext enable, channel 1
+            adaptor.write(0, 0x04 | 2); // Teletext enable, channel 2
+
+            resolveChannel(2, 1);
+            resolveChannel(1, 1);
+            await flushPromises();
+
+            adaptor.update();
+
+            expect(adaptor.channel).toBe(2);
+            expect(adaptor.frameBuffer[0][1]).toBe(2);
+        });
+
+        it("should use the newest response even when an older one arrives last", async () => {
+            adaptor.write(0, 0x04 | 1); // Teletext enable, channel 1
+            adaptor.write(0, 0x04 | 2); // Teletext enable, channel 2
+
+            resolveChannel(1, 1);
+            resolveChannel(2, 1);
+            await flushPromises();
+
+            adaptor.update();
+
+            expect(adaptor.frameBuffer[0][1]).toBe(2);
+        });
+
+        it("should round a truncated stream down to whole frames", async () => {
+            adaptor.write(0, 0x04 | 1); // Teletext enable, channel 1
+
+            const truncated = new Uint8Array(2 * TELETEXT_FRAME_SIZE + 100).fill(1);
+            pending.get("teletext/txt1.dat")(truncated);
+            await flushPromises();
+
+            expect(adaptor.totalFrames).toBe(2);
+        });
+    });
+
     describe("Update and polling", () => {
         it("should update status and frame counter on update()", () => {
             // Set initial state


### PR DESCRIPTION
Switching channels twice left two fetches in flight with nothing tying a response to the channel that asked for it, so the slower one won and the adaptor showed a stream it was no longer tuned to. Each request now carries a token and a superseded response is dropped. Also floors `totalFrames`, so a truncated stream no longer yields a fraction of a frame.

Fixes #727

🤖 Generated with [Claude Code](https://claude.com/claude-code)