### PR TITLE
fix: model serial transmit timing

### DIFF
--- a/docs/snapshot-format.md
+++ b/docs/snapshot-format.md
@@ -224,22 +224,21 @@ Contains ~20 scalar fields for SAA5050 rendering state. Glyph table references a
 
 ### ACIA (`state.acia`)
 
-| Field                        | Type         | Description                             |
-| ---------------------------- | ------------ | --------------------------------------- |
-| `sr`                         | number       | Status Register                         |
-| `cr`                         | number       | Control Register                        |
-| `dr`                         | number       | Data Register                           |
-| `rs423Selected`              | boolean      | RS-423 mode selected                    |
-| `motorOn`                    | boolean      | Tape motor state                        |
-| `tapeCarrierCount`           | number       | Carrier detect counter                  |
-| `tapeDcdLineLevel`           | boolean      | DCD line level                          |
-| `hadDcdHigh`                 | boolean      | DCD high seen flag                      |
-| `serialReceiveRate`          | number       | Receive baud rate                       |
-| `serialReceiveCyclesPerByte` | number       | Cycles per byte at current receive rate |
-| `serialTransmitRate`         | number       | Transmit baud rate                      |
-| `txCompleteTaskOffset`       | number\|null | TX complete task offset                 |
-| `runTapeTaskOffset`          | number\|null | Tape poll task offset                   |
-| `runRs423TaskOffset`         | number\|null | RS-423 poll task offset                 |
+| Field                  | Type         | Description             |
+| ---------------------- | ------------ | ----------------------- |
+| `sr`                   | number       | Status Register         |
+| `cr`                   | number       | Control Register        |
+| `dr`                   | number       | Data Register           |
+| `rs423Selected`        | boolean      | RS-423 mode selected    |
+| `motorOn`              | boolean      | Tape motor state        |
+| `tapeCarrierCount`     | number       | Carrier detect counter  |
+| `tapeDcdLineLevel`     | boolean      | DCD line level          |
+| `hadDcdHigh`           | boolean      | DCD high seen flag      |
+| `serialReceiveRate`    | number       | Receive baud rate       |
+| `serialTransmitRate`   | number       | Transmit baud rate      |
+| `txCompleteTaskOffset` | number\|null | TX complete task offset |
+| `runTapeTaskOffset`    | number\|null | Tape poll task offset   |
+| `runRs423TaskOffset`   | number\|null | RS-423 poll task offset |
 
 ### ADC (`state.adc`)
 

--- a/docs/snapshot-format.md
+++ b/docs/snapshot-format.md
@@ -224,21 +224,22 @@ Contains ~20 scalar fields for SAA5050 rendering state. Glyph table references a
 
 ### ACIA (`state.acia`)
 
-| Field                        | Type         | Description                     |
-| ---------------------------- | ------------ | ------------------------------- |
-| `sr`                         | number       | Status Register                 |
-| `cr`                         | number       | Control Register                |
-| `dr`                         | number       | Data Register                   |
-| `rs423Selected`              | boolean      | RS-423 mode selected            |
-| `motorOn`                    | boolean      | Tape motor state                |
-| `tapeCarrierCount`           | number       | Carrier detect counter          |
-| `tapeDcdLineLevel`           | boolean      | DCD line level                  |
-| `hadDcdHigh`                 | boolean      | DCD high seen flag              |
-| `serialReceiveRate`          | number       | Baud rate                       |
-| `serialReceiveCyclesPerByte` | number       | Cycles per byte at current rate |
-| `txCompleteTaskOffset`       | number\|null | TX complete task offset         |
-| `runTapeTaskOffset`          | number\|null | Tape poll task offset           |
-| `runRs423TaskOffset`         | number\|null | RS-423 poll task offset         |
+| Field                        | Type         | Description                             |
+| ---------------------------- | ------------ | --------------------------------------- |
+| `sr`                         | number       | Status Register                         |
+| `cr`                         | number       | Control Register                        |
+| `dr`                         | number       | Data Register                           |
+| `rs423Selected`              | boolean      | RS-423 mode selected                    |
+| `motorOn`                    | boolean      | Tape motor state                        |
+| `tapeCarrierCount`           | number       | Carrier detect counter                  |
+| `tapeDcdLineLevel`           | boolean      | DCD line level                          |
+| `hadDcdHigh`                 | boolean      | DCD high seen flag                      |
+| `serialReceiveRate`          | number       | Receive baud rate                       |
+| `serialReceiveCyclesPerByte` | number       | Cycles per byte at current receive rate |
+| `serialTransmitRate`         | number       | Transmit baud rate                      |
+| `txCompleteTaskOffset`       | number\|null | TX complete task offset                 |
+| `runTapeTaskOffset`          | number\|null | Tape poll task offset                   |
+| `runRs423TaskOffset`         | number\|null | RS-423 poll task offset                 |
 
 ### ADC (`state.adc`)
 

--- a/src/6502.js
+++ b/src/6502.js
@@ -697,7 +697,8 @@ export class Cpu6502 extends Base6502 {
             getGamepads: this.config.getGamepads,
         });
         this.uservia = new via.UserVia(this, this.scheduler, this.model.isMaster, this.config.userPort);
-        this.acia = new Acia(this, this.soundChip.toneGenerator, this.scheduler, this.touchScreen, this.relayNoise);
+        // The touchscreen does not exist until resetPeripherals runs, so an RS-423 device is attached later.
+        this.acia = new Acia(this, this.soundChip.toneGenerator, this.scheduler, null, this.relayNoise);
         this.serial = new Serial(this.acia);
         this.adconverter = new Adc(this.sysvia, this.scheduler);
         this.soundChip.setScheduler(this.scheduler);

--- a/src/6502.js
+++ b/src/6502.js
@@ -697,8 +697,7 @@ export class Cpu6502 extends Base6502 {
             getGamepads: this.config.getGamepads,
         });
         this.uservia = new via.UserVia(this, this.scheduler, this.model.isMaster, this.config.userPort);
-        // The touchscreen does not exist until resetPeripherals runs, so an RS-423 device is attached later.
-        this.acia = new Acia(this, this.soundChip.toneGenerator, this.scheduler, null, this.relayNoise);
+        this.acia = new Acia(this, this.soundChip.toneGenerator, this.scheduler, this.relayNoise);
         this.serial = new Serial(this.acia);
         this.adconverter = new Adc(this.sysvia, this.scheduler);
         this.soundChip.setScheduler(this.scheduler);

--- a/src/acia.js
+++ b/src/acia.js
@@ -22,17 +22,27 @@ export class Acia {
         this.hadDcdHigh = false;
         this.serialReceiveRate = 0;
         this.serialReceiveCyclesPerByte = 0;
+        this.serialTransmitRate = 0;
+        this.serialTransmitCyclesPerByte = 0;
 
         this.setSerialReceive(19200);
+        this.setSerialTransmit(19200);
         this.txCompleteTask = scheduler.newTask(() => {
             this.sr |= 0x02; // set the TDRE
+            this.updateIrq();
         });
         this.runTapeTask = scheduler.newTask(() => this.runTape());
         this.runRs423Task = scheduler.newTask(() => this.runRs423());
     }
 
+    // MC6850: the transmit interrupt is selected by CR6:CR5 = 01 and follows
+    // TDRE, which a high CTS inhibits.
+    txIrq() {
+        return (this.cr & 0x60) === 0x20 && (this.sr & 0x0a) === 0x02;
+    }
+
     updateIrq() {
-        if (this.sr & this.cr & 0x80) {
+        if (this.sr & this.cr & 0x80 || this.txIrq()) {
             this.cpu.interrupt |= 0x04;
         } else {
             this.cpu.interrupt &= ~0x04;
@@ -77,6 +87,7 @@ export class Acia {
             return this.dr;
         } else {
             let result = (this.sr & 0x7f) | (this.sr & this.cr & 0x80);
+            if (this.txIrq()) result |= 0x80;
             // MC6850: "A low CTS indicates that there is a Clear-to-Send
             // from the modem. In the high state, the Transmit Data Register
             // Empty bit is inhibited".
@@ -100,10 +111,7 @@ export class Acia {
     write(addr, val) {
         if (addr & 1) {
             this.sr &= ~0x02;
-            // It's not clear how long this can take; it's when the shift register is loaded.
-            // That could be straight away if not already tx-ing, but as we don't really tx,
-            // be conservative here.
-            this.txCompleteTask.reschedule(2000);
+            this.txCompleteTask.reschedule(this.serialTransmitCyclesPerByte);
             this.updateIrq();
             if (this.rs423Selected && this.rs423Handler) this.rs423Handler.onTransmit(val);
         } else {
@@ -113,7 +121,10 @@ export class Acia {
                 this.reset();
             } else {
                 this.cr = val;
+                // The word format in CR changes how long a byte takes on the wire.
                 this.setSerialReceive(this.serialReceiveRate);
+                this.setSerialTransmit(this.serialTransmitRate);
+                this.updateIrq();
             }
         }
     }
@@ -213,6 +224,7 @@ export class Acia {
             hadDcdHigh: this.hadDcdHigh,
             serialReceiveRate: this.serialReceiveRate,
             serialReceiveCyclesPerByte: this.serialReceiveCyclesPerByte,
+            serialTransmitRate: this.serialTransmitRate,
             txCompleteTaskOffset: this.txCompleteTask.scheduled()
                 ? this.txCompleteTask.expireEpoch - scheduler.epoch
                 : null,
@@ -232,6 +244,8 @@ export class Acia {
         this.hadDcdHigh = state.hadDcdHigh;
         this.serialReceiveRate = state.serialReceiveRate;
         this.serialReceiveCyclesPerByte = state.serialReceiveCyclesPerByte;
+        // Snapshots taken before transmit timing was modelled have no rate.
+        this.setSerialTransmit(state.serialTransmitRate ?? 19200);
         this.updateIrq();
 
         this.txCompleteTask.cancel();
@@ -294,7 +308,8 @@ export class Acia {
                 parityBits = 1;
                 break;
         }
-        return wordLength + stopBits + parityBits;
+        const startBits = 1;
+        return startBits + wordLength + stopBits + parityBits;
     }
 
     rts() {
@@ -305,6 +320,11 @@ export class Acia {
     setSerialReceive(rate) {
         this.serialReceiveRate = rate;
         this.serialReceiveCyclesPerByte = this.secondsToCycles(this.numBitsPerByte() / rate);
+    }
+
+    setSerialTransmit(rate) {
+        this.serialTransmitRate = rate;
+        this.serialTransmitCyclesPerByte = this.secondsToCycles(this.numBitsPerByte() / rate);
     }
 
     runTape() {

--- a/src/acia.js
+++ b/src/acia.js
@@ -121,7 +121,7 @@ export class Acia {
                 this.reset();
             } else {
                 this.cr = val;
-                // The word format in CR changes how long a byte takes on the wire.
+                // The word format in CR changes the byte time.
                 this.setSerialReceive(this.serialReceiveRate);
                 this.setSerialTransmit(this.serialTransmitRate);
                 this.updateIrq();
@@ -244,7 +244,7 @@ export class Acia {
         this.hadDcdHigh = state.hadDcdHigh;
         this.serialReceiveRate = state.serialReceiveRate;
         this.serialReceiveCyclesPerByte = state.serialReceiveCyclesPerByte;
-        // Snapshots taken before transmit timing was modelled have no rate.
+        // Snapshots predating transmit timing have no saved rate.
         this.setSerialTransmit(state.serialTransmitRate ?? 19200);
         this.updateIrq();
 

--- a/src/acia.js
+++ b/src/acia.js
@@ -223,7 +223,6 @@ export class Acia {
             tapeDcdLineLevel: this.tapeDcdLineLevel,
             hadDcdHigh: this.hadDcdHigh,
             serialReceiveRate: this.serialReceiveRate,
-            serialReceiveCyclesPerByte: this.serialReceiveCyclesPerByte,
             serialTransmitRate: this.serialTransmitRate,
             txCompleteTaskOffset: this.txCompleteTask.scheduled()
                 ? this.txCompleteTask.expireEpoch - scheduler.epoch
@@ -242,8 +241,8 @@ export class Acia {
         this.tapeCarrierCount = state.tapeCarrierCount;
         this.tapeDcdLineLevel = state.tapeDcdLineLevel;
         this.hadDcdHigh = state.hadDcdHigh;
-        this.serialReceiveRate = state.serialReceiveRate;
-        this.serialReceiveCyclesPerByte = state.serialReceiveCyclesPerByte;
+        // The byte times are derived from the rates and the restored word format, not saved.
+        this.setSerialReceive(state.serialReceiveRate);
         // Snapshots predating transmit timing have no saved rate.
         this.setSerialTransmit(state.serialTransmitRate ?? 19200);
         this.updateIrq();

--- a/src/acia.js
+++ b/src/acia.js
@@ -5,10 +5,10 @@
 // http://www.classiccmp.org/dunfield/r/6850.pdf
 
 export class Acia {
-    constructor(cpu, toneGen, scheduler, rs423Handler, relayNoise) {
+    constructor(cpu, toneGen, scheduler, relayNoise) {
         this.cpu = cpu;
         this.toneGen = toneGen;
-        this.rs423Handler = rs423Handler;
+        this.rs423Handler = null;
         this.relayNoise = relayNoise;
 
         this.sr = 0x00;
@@ -121,7 +121,6 @@ export class Acia {
                 this.reset();
             } else {
                 this.cr = val;
-                // The word format in CR changes the byte time.
                 this.setSerialReceive(this.serialReceiveRate);
                 this.setSerialTransmit(this.serialTransmitRate);
                 this.updateIrq();

--- a/src/main.js
+++ b/src/main.js
@@ -681,8 +681,7 @@ const mouseJoystickSource = new MouseJoystickSource(screenCanvas);
 /**
  * Attach an RS-423 composite handler to the ACIA that combines the touchscreen
  * (which sends position data to the BBC) with the speech output (which speaks
- * text the BBC sends out).  Both are resolved as each byte arrives, so the one
- * call after processor.initialise() survives hard resets and speech being toggled.
+ * text the BBC sends out).
  */
 function setupRs423Handler() {
     processor.acia.setRs423Handler({

--- a/src/main.js
+++ b/src/main.js
@@ -685,14 +685,14 @@ const mouseJoystickSource = new MouseJoystickSource(screenCanvas);
  * again whenever speechOutput.enabled changes.
  */
 function setupRs423Handler() {
-    const touchScreen = processor.touchScreen;
+    // A hard reset builds a new touchscreen, so it is looked up per call rather than captured.
     processor.acia.setRs423Handler({
         onTransmit(val) {
-            touchScreen.onTransmit(val);
+            processor.touchScreen.onTransmit(val);
             speechOutput.onTransmit(val);
         },
         tryReceive(rts) {
-            return touchScreen.tryReceive(rts);
+            return processor.touchScreen.tryReceive(rts);
         },
     });
 }

--- a/src/main.js
+++ b/src/main.js
@@ -681,8 +681,8 @@ const mouseJoystickSource = new MouseJoystickSource(screenCanvas);
 /**
  * Attach an RS-423 composite handler to the ACIA that combines the touchscreen
  * (which sends position data to the BBC) with the speech output (which speaks
- * text the BBC sends out).  Call this once after processor.initialise() and
- * again whenever speechOutput.enabled changes.
+ * text the BBC sends out).  Both are resolved as each byte arrives, so the one
+ * call after processor.initialise() survives hard resets and speech being toggled.
  */
 function setupRs423Handler() {
     processor.acia.setRs423Handler({

--- a/src/main.js
+++ b/src/main.js
@@ -685,7 +685,6 @@ const mouseJoystickSource = new MouseJoystickSource(screenCanvas);
  * again whenever speechOutput.enabled changes.
  */
 function setupRs423Handler() {
-    // A hard reset builds a new touchscreen, so it is looked up per call rather than captured.
     processor.acia.setRs423Handler({
         onTransmit(val) {
             processor.touchScreen.onTransmit(val);

--- a/src/serial.js
+++ b/src/serial.js
@@ -20,6 +20,7 @@ export class Serial {
         this.transmitRate = val & 0x07;
         this.receiveRate = (val >>> 3) & 0x07;
         this.acia.setSerialReceive(table[this.receiveRate]);
+        this.acia.setSerialTransmit(table[this.transmitRate]);
         this.acia.setMotor(!!(val & 0x80));
         this.acia.selectRs423(!!(val & 0x40));
     }

--- a/src/snapshot-helpers.js
+++ b/src/snapshot-helpers.js
@@ -26,6 +26,7 @@ export const DefaultAcia = {
     hadDcdHigh: false,
     serialReceiveRate: 19200,
     serialReceiveCyclesPerByte: 0,
+    serialTransmitRate: 19200,
     txCompleteTaskOffset: null,
     runTapeTaskOffset: null,
     runRs423TaskOffset: null,

--- a/src/snapshot-helpers.js
+++ b/src/snapshot-helpers.js
@@ -25,7 +25,6 @@ export const DefaultAcia = {
     tapeDcdLineLevel: false,
     hadDcdHigh: false,
     serialReceiveRate: 19200,
-    serialReceiveCyclesPerByte: 0,
     serialTransmitRate: 19200,
     txCompleteTaskOffset: null,
     runTapeTaskOffset: null,

--- a/tests/unit/test-acia-adc-state.js
+++ b/tests/unit/test-acia-adc-state.js
@@ -10,7 +10,7 @@ describe("Acia snapshotState / restoreState", () => {
         scheduler = new Scheduler();
         cpu = { interrupt: 0 };
         const toneGen = { mute: () => {}, tone: () => {} };
-        acia = new Acia(cpu, toneGen, scheduler, null);
+        acia = new Acia(cpu, toneGen, scheduler);
     });
 
     it("should snapshot and restore register state", () => {
@@ -25,7 +25,7 @@ describe("Acia snapshotState / restoreState", () => {
 
         const snapshot = acia.snapshotState();
 
-        const acia2 = new Acia(cpu, { mute: () => {}, tone: () => {} }, scheduler, null);
+        const acia2 = new Acia(cpu, { mute: () => {}, tone: () => {} }, scheduler);
         acia2.restoreState(snapshot);
 
         expect(acia2.sr).toBe(0x82);
@@ -43,7 +43,7 @@ describe("Acia snapshotState / restoreState", () => {
         acia.setSerialTransmit(1200);
 
         const snapshot = acia.snapshotState();
-        const acia2 = new Acia(cpu, { mute: () => {}, tone: () => {} }, scheduler, null);
+        const acia2 = new Acia(cpu, { mute: () => {}, tone: () => {} }, scheduler);
         acia2.restoreState(snapshot);
 
         expect(acia2.serialReceiveRate).toBe(9600);
@@ -66,7 +66,7 @@ describe("Acia snapshotState / restoreState", () => {
         acia.txCompleteTask.schedule(500);
         const snapshot = acia.snapshotState();
 
-        const acia2 = new Acia(cpu, { mute: () => {}, tone: () => {} }, scheduler, null);
+        const acia2 = new Acia(cpu, { mute: () => {}, tone: () => {} }, scheduler);
         acia2.restoreState(snapshot);
 
         expect(acia2.txCompleteTask.scheduled()).toBe(true);
@@ -83,7 +83,7 @@ describe("Acia snapshotState / restoreState", () => {
         const snapshot = acia.snapshotState();
         cpu.interrupt = 0;
 
-        const acia2 = new Acia(cpu, { mute: () => {}, tone: () => {} }, scheduler, null);
+        const acia2 = new Acia(cpu, { mute: () => {}, tone: () => {} }, scheduler);
         acia2.restoreState(snapshot);
         expect(cpu.interrupt & 0x04).toBe(0x04);
     });

--- a/tests/unit/test-acia-adc-state.js
+++ b/tests/unit/test-acia-adc-state.js
@@ -40,6 +40,7 @@ describe("Acia snapshotState / restoreState", () => {
 
     it("should snapshot and restore serial rate", () => {
         acia.setSerialReceive(9600);
+        acia.setSerialTransmit(1200);
 
         const snapshot = acia.snapshotState();
         const acia2 = new Acia(cpu, { mute: () => {}, tone: () => {} }, scheduler, null);
@@ -47,6 +48,8 @@ describe("Acia snapshotState / restoreState", () => {
 
         expect(acia2.serialReceiveRate).toBe(9600);
         expect(acia2.serialReceiveCyclesPerByte).toBe(acia.serialReceiveCyclesPerByte);
+        expect(acia2.serialTransmitRate).toBe(1200);
+        expect(acia2.serialTransmitCyclesPerByte).toBe(acia.serialTransmitCyclesPerByte);
     });
 
     it("should snapshot scheduled task offsets", () => {

--- a/tests/unit/test-acia.js
+++ b/tests/unit/test-acia.js
@@ -11,7 +11,7 @@ const Tdre = 0x02;
 
 function createScheduledAcia(scheduler, cr, transmitRate) {
     const cpu = { interrupt: 0 };
-    const acia = new Acia(cpu, { mute: vi.fn(), tone: vi.fn() }, scheduler, null);
+    const acia = new Acia(cpu, { mute: vi.fn(), tone: vi.fn() }, scheduler);
     acia.write(0, cr);
     acia.setSerialTransmit(transmitRate);
     return { cpu, acia };
@@ -25,7 +25,9 @@ function createMockAcia(relayNoise) {
             reschedule: vi.fn(),
         })),
     };
-    return new Acia({ interrupt: 0 }, { mute: vi.fn(), tone: vi.fn() }, scheduler, {}, relayNoise);
+    const acia = new Acia({ interrupt: 0 }, { mute: vi.fn(), tone: vi.fn() }, scheduler, relayNoise);
+    acia.setRs423Handler({});
+    return acia;
 }
 
 describe("Acia", () => {

--- a/tests/unit/test-acia.js
+++ b/tests/unit/test-acia.js
@@ -1,5 +1,24 @@
 import { describe, it, expect, vi, afterEach } from "vitest";
 import { Acia } from "../../src/acia.js";
+import { Scheduler } from "../../src/scheduler.js";
+
+// Control register word select 101: 8 data bits, 1 stop bit, no parity.
+const EightBitsOneStopNoParity = 0x14;
+// Control register word select 000: 7 data bits, 2 stop bits, even parity.
+const SevenBitsTwoStopEvenParity = 0x00;
+const TransmitInterruptEnable = 0x20;
+const Tdre = 0x02;
+
+function createScheduledAcia(scheduler, cr, transmitRate) {
+    const cpu = { interrupt: 0 };
+    const acia = new Acia(cpu, { mute: vi.fn(), tone: vi.fn() }, scheduler, null, {
+        motorOn: vi.fn(),
+        motorOff: vi.fn(),
+    });
+    acia.write(0, cr);
+    acia.setSerialTransmit(transmitRate);
+    return { cpu, acia };
+}
 
 function createMockAcia(relayNoise) {
     const scheduler = {
@@ -44,6 +63,60 @@ describe("Acia", () => {
             relayNoise.motorOn.mockClear();
             acia.setMotor(true); // already on
             expect(relayNoise.motorOn).not.toHaveBeenCalled();
+        });
+    });
+
+    describe("transmit timing", () => {
+        const timeToEmpty = (cr, rate) => {
+            const scheduler = new Scheduler();
+            const { acia } = createScheduledAcia(scheduler, cr, rate);
+            acia.write(1, 0x55);
+            expect(acia.read(0) & Tdre).toBe(0);
+            let cycles = 0;
+            while (!(acia.read(0) & Tdre)) {
+                scheduler.polltime(1);
+                cycles++;
+            }
+            return cycles;
+        };
+
+        it("should empty the transmit register after one byte time", () => {
+            // 10 bits at 75 baud is 0.1333s, or 266666 cycles of the 2MHz clock.
+            expect(timeToEmpty(EightBitsOneStopNoParity, 75)).toBe(266666);
+        });
+
+        it("should scale with the transmit rate", () => {
+            expect(timeToEmpty(EightBitsOneStopNoParity, 19200)).toBe(1041);
+        });
+
+        it("should account for the word format", () => {
+            // 11 bits at 75 baud.
+            expect(timeToEmpty(SevenBitsTwoStopEvenParity, 75)).toBe(293333);
+        });
+
+        it("should interrupt when the transmit register empties", () => {
+            const scheduler = new Scheduler();
+            const { cpu, acia } = createScheduledAcia(
+                scheduler,
+                EightBitsOneStopNoParity | TransmitInterruptEnable,
+                19200,
+            );
+            acia.write(1, 0x55);
+            expect(cpu.interrupt).toBe(0);
+            scheduler.polltime(1041);
+            expect(cpu.interrupt).toBe(0x04);
+            expect(acia.read(0) & 0x80).toBe(0x80);
+
+            acia.write(1, 0x55);
+            expect(cpu.interrupt).toBe(0);
+        });
+
+        it("should not interrupt when the transmit interrupt is disabled", () => {
+            const scheduler = new Scheduler();
+            const { cpu, acia } = createScheduledAcia(scheduler, EightBitsOneStopNoParity, 19200);
+            acia.write(1, 0x55);
+            scheduler.polltime(1041);
+            expect(cpu.interrupt).toBe(0);
         });
     });
 });

--- a/tests/unit/test-acia.js
+++ b/tests/unit/test-acia.js
@@ -11,10 +11,7 @@ const Tdre = 0x02;
 
 function createScheduledAcia(scheduler, cr, transmitRate) {
     const cpu = { interrupt: 0 };
-    const acia = new Acia(cpu, { mute: vi.fn(), tone: vi.fn() }, scheduler, null, {
-        motorOn: vi.fn(),
-        motorOff: vi.fn(),
-    });
+    const acia = new Acia(cpu, { mute: vi.fn(), tone: vi.fn() }, scheduler, null);
     acia.write(0, cr);
     acia.setSerialTransmit(transmitRate);
     return { cpu, acia };
@@ -67,11 +64,13 @@ describe("Acia", () => {
     });
 
     describe("transmit timing", () => {
+        // A 10 bit byte at 75 baud takes 0.1333s: 266666 cycles of the 2MHz clock.
+        const ByteCyclesAt75Baud = 266666;
+
         const timeToEmpty = (cr, rate) => {
             const scheduler = new Scheduler();
             const { acia } = createScheduledAcia(scheduler, cr, rate);
             acia.write(1, 0x55);
-            expect(acia.read(0) & Tdre).toBe(0);
             let cycles = 0;
             while (!(acia.read(0) & Tdre)) {
                 scheduler.polltime(1);
@@ -81,16 +80,11 @@ describe("Acia", () => {
         };
 
         it("should empty the transmit register after one byte time", () => {
-            // 10 bits at 75 baud is 0.1333s, or 266666 cycles of the 2MHz clock.
-            expect(timeToEmpty(EightBitsOneStopNoParity, 75)).toBe(266666);
-        });
-
-        it("should scale with the transmit rate", () => {
-            expect(timeToEmpty(EightBitsOneStopNoParity, 19200)).toBe(1041);
+            expect(timeToEmpty(EightBitsOneStopNoParity, 75)).toBe(ByteCyclesAt75Baud);
         });
 
         it("should account for the word format", () => {
-            // 11 bits at 75 baud.
+            // Eleven bits: start, seven data, parity, two stop.
             expect(timeToEmpty(SevenBitsTwoStopEvenParity, 75)).toBe(293333);
         });
 
@@ -99,11 +93,11 @@ describe("Acia", () => {
             const { cpu, acia } = createScheduledAcia(
                 scheduler,
                 EightBitsOneStopNoParity | TransmitInterruptEnable,
-                19200,
+                75,
             );
             acia.write(1, 0x55);
             expect(cpu.interrupt).toBe(0);
-            scheduler.polltime(1041);
+            scheduler.polltime(ByteCyclesAt75Baud);
             expect(cpu.interrupt).toBe(0x04);
             expect(acia.read(0) & 0x80).toBe(0x80);
 
@@ -113,9 +107,9 @@ describe("Acia", () => {
 
         it("should not interrupt when the transmit interrupt is disabled", () => {
             const scheduler = new Scheduler();
-            const { cpu, acia } = createScheduledAcia(scheduler, EightBitsOneStopNoParity, 19200);
+            const { cpu, acia } = createScheduledAcia(scheduler, EightBitsOneStopNoParity, 75);
             acia.write(1, 0x55);
-            scheduler.polltime(1041);
+            scheduler.polltime(ByteCyclesAt75Baud);
             expect(cpu.interrupt).toBe(0);
         });
     });

--- a/tests/unit/test-serial.js
+++ b/tests/unit/test-serial.js
@@ -5,6 +5,7 @@ describe("Serial", () => {
     // Create mock for the ACIA dependency
     const mockAcia = {
         setSerialReceive: vi.fn(),
+        setSerialTransmit: vi.fn(),
         setMotor: vi.fn(),
         selectRs423: vi.fn(),
     };
@@ -78,6 +79,15 @@ describe("Serial", () => {
             }
         });
 
+        it("should set correct transmit baud rate", () => {
+            for (let i = 0; i < 8; i++) {
+                serial.write(0, i);
+
+                expect(serial.transmitRate).toBe(i);
+                expect(mockAcia.setSerialTransmit).toHaveBeenLastCalledWith(baudRateTable[i]);
+            }
+        });
+
         it("should set motor state based on bit 7", () => {
             // Test with bit 7 = 0
             serial.write(0, 0x00);
@@ -110,6 +120,7 @@ describe("Serial", () => {
             expect(serial.transmitRate).toBe(2);
             expect(serial.receiveRate).toBe(5);
             expect(mockAcia.setSerialReceive).toHaveBeenCalledWith(baudRateTable[5]);
+            expect(mockAcia.setSerialTransmit).toHaveBeenCalledWith(baudRateTable[2]);
             expect(mockAcia.setMotor).toHaveBeenCalledWith(true);
             expect(mockAcia.selectRs423).toHaveBeenCalledWith(true);
         });
@@ -133,6 +144,7 @@ describe("Serial", () => {
             expect(serial.receiveRate).toBe(7); // (0xFE >>> 3) & 0x07 = 7
             // Check ACIA was updated
             expect(mockAcia.setSerialReceive).toHaveBeenLastCalledWith(baudRateTable[7]);
+            expect(mockAcia.setSerialTransmit).toHaveBeenLastCalledWith(baudRateTable[6]);
             expect(mockAcia.setMotor).toHaveBeenLastCalledWith(true);
             expect(mockAcia.selectRs423).toHaveBeenLastCalledWith(true);
         });


### PR DESCRIPTION
`Serial.write` decoded the transmit rate and discarded it, and the ACIA used a fixed 2000 cycle guess for the byte time. The transmit interrupt was not modelled at all, so the OS fell back to draining its output buffer on the 100Hz tick: a 100 bytes/sec ceiling at every baud rate. `numBitsPerByte` also omitted the start bit.

All three are needed to match real hardware. BigEd's test program on a real Master takes 134 ticks at `*FX8,1`; measured here:

| build | ticks |
| --- | --- |
| transmit rate only | 131 |
| rate and transmit IRQ | 121 |
| rate and start bit, no IRQ | 141 |
| all three | 134 |

The start bit applies to the receive path too, so tape byte times grow by 10% and are now right.

Also fixes two touchscreen bugs found while tracing the RS-423 path: the handler captured the touchscreen object, so a hard reset left the ACIA talking to the orphaned one while mouse input went to the new one; and the ACIA constructor was passed `this.touchScreen` before it existed, so the argument was always undefined.

Fixes #66

🤖 Generated with [Claude Code](https://claude.com/claude-code)