### PR TITLE
fix: let Safari finish blob downloads before the URL is revoked

### DIFF
--- a/src/dom-utils.js
+++ b/src/dom-utils.js
@@ -30,3 +30,19 @@ export function fadeOut(el, duration = 400) {
         if (el.style.opacity === "0") el.style.display = "none";
     }, duration);
 }
+
+// Safari fetches the blob a task or more after the click, so the URL must outlive it.
+// 40s matches FileSaver.js.
+const BlobUrlLifetimeMs = 40000;
+
+/** Save a blob to the user's downloads under the given file name. */
+export function downloadBlob(blob, fileName) {
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = fileName;
+    document.body.appendChild(a);
+    a.click();
+    a.remove();
+    setTimeout(() => URL.revokeObjectURL(url), BlobUrlLifetimeMs);
+}

--- a/src/main.js
+++ b/src/main.js
@@ -44,6 +44,7 @@ import { isBemSnapshot, parseBemSnapshot } from "./bem-snapshot.js";
 import { isUefSnapshot, parseUefSnapshot } from "./uef-snapshot.js";
 import { RewindBuffer } from "./rewind.js";
 import { RewindUI } from "./rewind-ui.js";
+import { downloadBlob } from "./dom-utils.js";
 import {
     buildUrlFromParams,
     guessModelFromHostname,
@@ -471,18 +472,8 @@ function replaceOrAddExtension(name, newExt) {
  * @param {string} extension - The file extension to use
  */
 function downloadDriveData(data, name, extension) {
-    const a = document.createElement("a");
-    document.body.appendChild(a);
-    a.style = "display: none";
-
-    const fileName = replaceOrAddExtension(name, extension);
     const blob = new Blob([data], { type: "application/octet-stream" });
-    const url = window.URL.createObjectURL(blob);
-
-    a.href = url;
-    a.download = fileName;
-    a.click();
-    window.URL.revokeObjectURL(url);
+    downloadBlob(blob, replaceOrAddExtension(name, extension));
 }
 
 async function loadHTMLFile(file) {
@@ -1546,13 +1537,8 @@ document.getElementById("save-state").addEventListener("click", async function (
         const snapshot = createSnapshot(processor, model, Object.keys(media).length > 0 ? media : undefined);
         const json = snapshotToJSON(snapshot);
         const blob = await compressBlob(new Blob([json]));
-        const url = URL.createObjectURL(blob);
         const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
-        const a = document.createElement("a");
-        a.href = url;
-        a.download = `jsbeeb-${model.name}-${timestamp}.json.gz`;
-        a.click();
-        URL.revokeObjectURL(url);
+        downloadBlob(blob, `jsbeeb-${model.name}-${timestamp}.json.gz`);
     } catch (e) {
         showError("saving state", e);
     }

--- a/tests/unit/test-dom-utils.js
+++ b/tests/unit/test-dom-utils.js
@@ -1,0 +1,42 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { downloadBlob } from "../../src/dom-utils.js";
+
+describe("dom-utils", () => {
+    describe("downloadBlob", () => {
+        let clicked;
+
+        beforeEach(() => {
+            vi.useFakeTimers();
+            clicked = [];
+            vi.spyOn(HTMLAnchorElement.prototype, "click").mockImplementation(function () {
+                clicked.push({ href: this.href, download: this.download, inDocument: this.isConnected });
+            });
+            vi.spyOn(URL, "createObjectURL").mockReturnValue("blob:test-url");
+            vi.spyOn(URL, "revokeObjectURL").mockImplementation(() => {});
+        });
+
+        afterEach(() => {
+            vi.restoreAllMocks();
+            vi.useRealTimers();
+        });
+
+        it("clicks an anchor in the document with the given file name", () => {
+            downloadBlob(new Blob(["data"]), "disc.ssd");
+            expect(clicked).toEqual([{ href: "blob:test-url", download: "disc.ssd", inDocument: true }]);
+        });
+
+        it("keeps the object URL alive past the click so Safari can fetch it", () => {
+            downloadBlob(new Blob(["data"]), "disc.ssd");
+            expect(URL.revokeObjectURL).not.toHaveBeenCalled();
+            vi.runAllTimers();
+            expect(URL.revokeObjectURL).toHaveBeenCalledWith("blob:test-url");
+        });
+
+        it("leaves no anchor behind", () => {
+            downloadBlob(new Blob(["data"]), "disc.ssd");
+            expect(document.querySelector("a")).toBeNull();
+        });
+    });
+});


### PR DESCRIPTION
Both download paths revoked the blob object URL synchronously right after clicking the anchor. Safari fetches the blob on a later task, so by then there was nothing to fetch and the download silently did nothing.

Shared `downloadBlob` helper in `dom-utils.js` now defers the revoke (40s, as FileSaver.js does) and tidies up the anchor it creates.

Not verified on real Safari; the unit test covers the ordering only.

Fixes #494

🤖 Generated with [Claude Code](https://claude.com/claude-code)