### PR TITLE
fix: report teletext channel load failures to the user

### DIFF
--- a/src/6502.js
+++ b/src/6502.js
@@ -1425,8 +1425,7 @@ export class Cpu6502 extends Base6502 {
     buildPolltime() {
         const nop = (_cycles) => {};
         const tubeStuff = this.hasTube ? (cycles) => this.tube.execute(cycles) : nop;
-        // The adaptor itself does not exist until reset() runs, so branch on the fitting, not the object.
-        const teletextStuff = this.hasTeletextAdaptor ? (cycles) => this.teletextAdaptor.polltime(cycles) : nop;
+        const teletextStuff = this.teletextAdaptor ? (cycles) => this.teletextAdaptor.polltime(cycles) : nop;
         const musicStuff = this.music5000 ? (cycles) => this.music5000.polltime(cycles) : nop;
         const econetStuff = this.econet
             ? (cycles) => {

--- a/src/6502.js
+++ b/src/6502.js
@@ -673,6 +673,7 @@ export class Cpu6502 extends Base6502 {
         this.hasTube = !!this.config.tube;
         this.hasMusic5000 = !!this.config.hasMusic5000;
         this.hasTeletextAdaptor = !!this.config.hasTeletextAdaptor;
+        this.teletextAdaptor = this.hasTeletextAdaptor ? new TeletextAdaptor(this) : null;
         this.tube = this.hasTube
             ? new Tube6502(this.config.tube, this, { cpuMultiplier: this.config.tubeCpuMultiplier })
             : new FakeTube();
@@ -1364,7 +1365,6 @@ export class Cpu6502 extends Base6502 {
         this.adconverter.reset();
 
         this.touchScreen = new TouchScreen(this.scheduler);
-        if (this.hasTeletextAdaptor) this.teletextAdaptor = new TeletextAdaptor(this);
         if (this.econet) this.filestore = new Filestore(this, this.econet);
     }
 

--- a/src/main.js
+++ b/src/main.js
@@ -667,6 +667,8 @@ processor = new CpuClass(model, {
     econet,
 });
 
+processor.teletextAdaptor?.addEventListener("showError", (e) => showError(e.detail.context, e.detail.error));
+
 // Create input sources
 const gamepadSource = new GamepadSource(emulationConfig.getGamepads);
 // Create MicrophoneInput but don't enable by default

--- a/src/teletext_adaptor.js
+++ b/src/teletext_adaptor.js
@@ -42,7 +42,6 @@ export class TeletextAdaptor extends EventTarget {
     constructor(cpu) {
         super();
         this.cpu = cpu;
-        this.frameBuffer = new Array(16).fill(0).map(() => new Array(64).fill(0));
         // Not cleared by a reset, so a fetch still in flight across one is recognised as stale.
         this.streamRequest = 0;
         this.clearState();
@@ -59,7 +58,7 @@ export class TeletextAdaptor extends EventTarget {
         this.colPtr = 0x00;
         this.streamData = null;
         this.pollCount = 0;
-        for (const row of this.frameBuffer) row.fill(0);
+        this.frameBuffer = new Array(16).fill(0).map(() => new Array(64).fill(0));
     }
 
     reset(hard) {

--- a/src/teletext_adaptor.js
+++ b/src/teletext_adaptor.js
@@ -34,9 +34,21 @@ Status register:
 
 */
 
-export class TeletextAdaptor {
+/**
+ * Emulates the Acorn teletext adaptor. Dispatches a `showError` CustomEvent, carrying
+ * `context` and `error` in its detail, when a channel's stream cannot be loaded.
+ */
+export class TeletextAdaptor extends EventTarget {
     constructor(cpu) {
+        super();
         this.cpu = cpu;
+        this.frameBuffer = new Array(16).fill(0).map(() => new Array(64).fill(0));
+        // Not cleared by a reset, so a fetch still in flight across one is recognised as stale.
+        this.streamRequest = 0;
+        this.clearState();
+    }
+
+    clearState() {
         this.teletextStatus = 0x0f; /* low nibble comes from LK4-7 and mystery links which are left floating */
         this.teletextInts = false;
         this.teletextEnable = false;
@@ -45,23 +57,33 @@ export class TeletextAdaptor {
         this.totalFrames = 0;
         this.rowPtr = 0x00;
         this.colPtr = 0x00;
-        this.frameBuffer = new Array(16).fill(0).map(() => new Array(64).fill(0));
         this.streamData = null;
-        this.streamRequest = 0;
         this.pollCount = 0;
+        for (const row of this.frameBuffer) row.fill(0);
     }
 
     reset(hard) {
-        if (hard) {
-            console.log("Teletext adaptor: initialisation");
-            this.loadChannelStream(this.channel);
-        }
+        if (!hard) return;
+        this.clearState();
+        this.loadChannelStream(this.channel);
     }
 
     async loadChannelStream(channel) {
         console.log("Teletext adaptor: switching to channel " + channel);
         const request = ++this.streamRequest;
-        const data = await utils.loadData(`teletext/txt${channel}.dat`);
+        let data;
+        try {
+            data = await utils.loadData(`teletext/txt${channel}.dat`);
+        } catch (error) {
+            if (request !== this.streamRequest) return;
+            console.error(`Teletext adaptor: failed to load channel ${channel}`, error);
+            this.dispatchEvent(
+                new CustomEvent("showError", {
+                    detail: { context: `loading teletext channel ${channel}`, error },
+                }),
+            );
+            return;
+        }
         // Fetches can resolve out of order; only the newest request may apply its data.
         if (request !== this.streamRequest) return;
         this.streamData = data;

--- a/src/teletext_adaptor.js
+++ b/src/teletext_adaptor.js
@@ -59,6 +59,8 @@ export class TeletextAdaptor extends EventTarget {
         this.streamData = null;
         this.pollCount = 0;
         this.frameBuffer = new Array(16).fill(0).map(() => new Array(64).fill(0));
+        // Only a register access clears our IRQ, so an interrupt latched before the reset would hang the machine.
+        this.cpu.interrupt &= ~(1 << TELETEXT_IRQ);
     }
 
     reset(hard) {

--- a/tests/unit/test-teletext-adaptor.js
+++ b/tests/unit/test-teletext-adaptor.js
@@ -25,6 +25,7 @@ describe("TeletextAdaptor", () => {
 
         // Silence console logs during tests
         vi.spyOn(console, "log").mockImplementation(() => {});
+        vi.spyOn(console, "error").mockImplementation(() => {});
 
         // Override loadChannelStream to avoid actual network calls
         teletext.loadChannelStream = vi.fn();
@@ -223,23 +224,31 @@ describe("TeletextAdaptor", () => {
     describe("Channel stream loading", () => {
         const TELETEXT_FRAME_SIZE = 860;
 
-        // Resolvers for the fetches the adaptor has started, keyed by the URL it asked for.
+        // Settlers for the fetches the adaptor has started, keyed by the URL it asked for.
         const pending = new Map();
         let adaptor;
 
         beforeEach(() => {
             pending.clear();
             vi.spyOn(utils, "loadData").mockImplementation(
-                (url) => new Promise((resolve) => pending.set(url, resolve)),
+                (url) => new Promise((resolve, reject) => pending.set(url, { resolve, reject })),
             );
             adaptor = new TeletextAdaptor(mockCpu);
         });
 
         // Each byte holds the channel number, so the frame buffer shows which stream was applied.
         const resolveChannel = (channel, length = TELETEXT_FRAME_SIZE) =>
-            pending.get(`teletext/txt${channel}.dat`)(new Uint8Array(length).fill(channel));
+            pending.get(`teletext/txt${channel}.dat`).resolve(new Uint8Array(length).fill(channel));
+
+        const failChannel = (channel, error) => pending.get(`teletext/txt${channel}.dat`).reject(error);
 
         const settle = () => new Promise((resolve) => setTimeout(resolve));
+
+        const listenForErrors = () => {
+            const errors = [];
+            adaptor.addEventListener("showError", (e) => errors.push(e.detail));
+            return errors;
+        };
 
         it("should ignore a response that arrives after a newer channel's", async () => {
             adaptor.write(0, 0x04 | 1); // Teletext enable, channel 1
@@ -260,6 +269,59 @@ describe("TeletextAdaptor", () => {
             await settle();
 
             expect(adaptor.totalFrames).toBe(2);
+        });
+
+        it("should report a failed load", async () => {
+            const errors = listenForErrors();
+            const failure = new Error("404");
+
+            adaptor.write(0, 0x04 | 1); // Teletext enable, channel 1
+            failChannel(1, failure);
+            await settle();
+
+            expect(errors).toEqual([{ context: "loading teletext channel 1", error: failure }]);
+        });
+
+        it("should not report a failure from a superseded request", async () => {
+            const errors = listenForErrors();
+
+            adaptor.write(0, 0x04 | 1); // Teletext enable, channel 1
+            adaptor.write(0, 0x04 | 2); // Teletext enable, channel 2
+            failChannel(1, new Error("404"));
+            resolveChannel(2);
+            await settle();
+
+            expect(errors).toEqual([]);
+            expect(adaptor.totalFrames).toBe(1);
+        });
+
+        it("should discard a fetch still in flight over a hard reset", async () => {
+            adaptor.write(0, 0x04 | 1); // Teletext enable, channel 1
+            adaptor.reset(true);
+
+            resolveChannel(0, 3 * TELETEXT_FRAME_SIZE);
+            resolveChannel(1, 5 * TELETEXT_FRAME_SIZE);
+            await settle();
+
+            expect(adaptor.totalFrames).toBe(3);
+        });
+
+        it("should clear state on a hard reset", async () => {
+            adaptor.write(0, 0x0c | 1); // Teletext enable, interrupts, channel 1
+            resolveChannel(1);
+            await settle();
+            adaptor.update();
+            expect(adaptor.frameBuffer[0][1]).toBe(1);
+
+            adaptor.reset(true);
+
+            expect(adaptor.teletextStatus).toBe(0x0f);
+            expect(adaptor.teletextEnable).toBe(false);
+            expect(adaptor.teletextInts).toBe(false);
+            expect(adaptor.channel).toBe(0);
+            expect(adaptor.streamData).toBe(null);
+            expect(adaptor.totalFrames).toBe(0);
+            expect(adaptor.frameBuffer[0][1]).toBe(0);
         });
     });
 

--- a/tests/unit/test-teletext-adaptor.js
+++ b/tests/unit/test-teletext-adaptor.js
@@ -312,6 +312,7 @@ describe("TeletextAdaptor", () => {
             await settle();
             adaptor.update();
             expect(adaptor.frameBuffer[0][1]).toBe(1);
+            expect(mockCpu.interrupt & (1 << TELETEXT_IRQ)).toBe(1 << TELETEXT_IRQ);
 
             adaptor.reset(true);
 
@@ -322,6 +323,7 @@ describe("TeletextAdaptor", () => {
             expect(adaptor.streamData).toBe(null);
             expect(adaptor.totalFrames).toBe(0);
             expect(adaptor.frameBuffer[0][1]).toBe(0);
+            expect(mockCpu.interrupt & (1 << TELETEXT_IRQ)).toBe(0);
         });
     });
 


### PR DESCRIPTION
A failed fetch of `teletext/txtN.dat` left the adaptor showing whatever it last had, with nothing but an unhandled rejection to say so. It now dispatches a `showError` event that `main.js` bridges to the error modal, the same route `Keyboard` already uses.

The obstacle #737 describes is the adaptor's lifetime: `resetPeripherals()` rebuilt it on every hard reset, so there was nowhere stable for `main.js` to attach a listener. It is now constructed once in the `Cpu6502` constructor and `reset(true)` clears its state via a new `clearState()`, which is field-for-field what constructing a fresh one used to do. `streamRequest` is deliberately excluded so the out-of-order guard from #734 still rejects a fetch that was in flight across the reset; there is a test pinning that.

The last commit is a separate, pre-existing bug found while reviewing this one, and is easy to drop if you'd rather it went elsewhere: only a register access clears the adaptor's IRQ, so a hard reset taken while INT was latched left bit 5 of `cpu.interrupt` asserted with `teletextInts` false, and nothing would ever claim it. `clearState()` now clears it.

Fixes #737

🤖 Generated with [Claude Code](https://claude.com/claude-code)