### PR TITLE
feat: offer second processor speeds that are not multiples of 3MHz

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,8 +170,9 @@ sudo rpm -i out/dist/jsbeeb-1.0.1.x86_64.rpm
 - `cpuMultiplier=X` speeds up the CPU by a factor of `X` relative to the peripherals: video, sound and the VIAs keep
   running at their real-world rates. May be fractional or below one to slow the CPU down. NB disc loads become
   unreliable with a too-slow CPU, and running too fast might cause the browser to hang.
-- `tubeCpuMultiplier=X` speeds up the 65c02 second processor by a factor of `X`, a whole number. `1`, the default, is
-  the real 3MHz part.
+- `tubeCpuMultiplier=X` speeds up the 65c02 second processor by a factor of `X`, which may be fractional. `1`, the
+  default, is the real 3MHz part; `1.3333` is the Master Turbo's 4MHz 65C102. Below about `0.73` (2.2MHz) the MOS's
+  unhandshaken tube transfers lose data.
 - `sbLeft` / `sbRight` / `sbBottom` - a URL to place left of, right of, or below the cub monitor. The left and right
   should be around 648 high and the bottom image should be around 896 wide. Left and right wider than 300 will run into
   problems on smaller screens; bottom taller than 100 or so similarly.

--- a/docs/snapshot-format.md
+++ b/docs/snapshot-format.md
@@ -365,22 +365,22 @@ Track keys are strings like `"false:0"` (lower side, track 0) or `"true:5"` (upp
 
 Present only when a co-processor was fitted.
 
-| Field      | Type       | Description                                                            |
-| ---------- | ---------- | ---------------------------------------------------------------------- |
-| `a`        | number     | Parasite accumulator                                                   |
-| `x`        | number     | Parasite X register                                                    |
-| `y`        | number     | Parasite Y register                                                    |
-| `s`        | number     | Parasite stack pointer                                                 |
-| `pc`       | number     | Parasite program counter                                               |
-| `p`        | number     | Parasite status flags as a byte                                        |
-| `nmiLevel` | boolean    | Parasite NMI line level                                                |
-| `nmiEdge`  | boolean    | Whether a parasite NMI edge is pending                                 |
-| `takeInt`  | boolean    | Whether an interrupt is to be taken before the next instruction        |
-| `cycles`   | number     | Cycles owed to the parasite, in halves; it has no scheduler of its own |
-| `romPaged` | boolean    | Whether the boot ROM is paged in at `0xF000`                           |
-| `memory`   | Uint8Array | 64KB of parasite RAM                                                   |
-| `rom`      | Uint8Array | _(Optional)_ 4KB parasite ROM, only when `includeRoms` is set          |
-| `ula`      | object     | Tube ULA state (see below)                                             |
+| Field      | Type       | Description                                                             |
+| ---------- | ---------- | ----------------------------------------------------------------------- |
+| `a`        | number     | Parasite accumulator                                                    |
+| `x`        | number     | Parasite X register                                                     |
+| `y`        | number     | Parasite Y register                                                     |
+| `s`        | number     | Parasite stack pointer                                                  |
+| `pc`       | number     | Parasite program counter                                                |
+| `p`        | number     | Parasite status flags as a byte                                         |
+| `nmiLevel` | boolean    | Parasite NMI line level                                                 |
+| `nmiEdge`  | boolean    | Whether a parasite NMI edge is pending                                  |
+| `takeInt`  | boolean    | Whether an interrupt is to be taken before the next instruction         |
+| `cycles`   | number     | Cycles owed to the parasite, fractional; it has no scheduler of its own |
+| `romPaged` | boolean    | Whether the boot ROM is paged in at `0xF000`                            |
+| `memory`   | Uint8Array | 64KB of parasite RAM                                                    |
+| `rom`      | Uint8Array | _(Optional)_ 4KB parasite ROM, only when `includeRoms` is set           |
+| `ula`      | object     | Tube ULA state (see below)                                              |
 
 #### Tube ULA (`state.tube.ula`)
 

--- a/index.html
+++ b/index.html
@@ -897,18 +897,10 @@
                   </div>
                   <div class="form-check" id="tubeCpuMultiplierGroup">
                     <label class="form-check-label" for="tubeCpuMultiplier">
-                      Tube CPU: <span id="tubeCpuMultiplierValue">1x (3MHz)</span>
+                      Tube CPU: <span id="tubeCpuMultiplierValue">3MHz (1x)</span>
                     </label>
-                    <input
-                      type="range"
-                      class="form-range"
-                      id="tubeCpuMultiplier"
-                      min="1"
-                      max="8"
-                      value="1"
-                      step="1"
-                      disabled
-                    />
+                    <!-- The slider indexes the speed list in config.js, which sets its max. -->
+                    <input type="range" class="form-range" id="tubeCpuMultiplier" min="0" value="0" step="1" disabled />
                   </div>
                   <div class="form-check">
                     <input class="form-check-input" type="checkbox" id="hasMusic5000" name="hasMusic5000" />

--- a/src/config.js
+++ b/src/config.js
@@ -3,8 +3,30 @@ import { allModels, findModel } from "./models.js";
 import { getFilterForMode } from "./canvas.js";
 import { TubeCpuClockMhz } from "./6502.js";
 
+/** The parasite speeds the slider offers, in MHz: the external 6502, the Master Turbo's 65C102, then overclocks. */
+const TubeCpuSpeedsMhz = [3, 4, 6, 8, 12, 24];
+
+const round = (value, places) => Number(value.toFixed(places));
+
+/** The same speeds as multiples of the parasite's own clock, rounded so a shared URL stays readable. */
+export const TubeCpuMultipliers = TubeCpuSpeedsMhz.map((mhz) => round(mhz / TubeCpuClockMhz, 4));
+
+/** @returns {string} the speed a multiplier gives, e.g. "4MHz (1.33x)". */
+export function tubeCpuSpeedLabel(multiplier) {
+    return `${round(multiplier * TubeCpuClockMhz, 2)}MHz (${round(multiplier, 2)}x)`;
+}
+
+/** @returns {number} the slider position offering the speed closest to `multiplier`. */
+export function nearestTubeCpuSpeedIndex(multiplier) {
+    const distanceAt = (index) => Math.abs(TubeCpuMultipliers[index] - multiplier);
+    return TubeCpuMultipliers.reduce((best, _, index) => (distanceAt(index) < distanceAt(best) ? index : best), 0);
+}
+
 function showTubeCpuMultiplier(value) {
-    document.getElementById("tubeCpuMultiplierValue").textContent = `${value}x (${value * TubeCpuClockMhz}MHz)`;
+    const label = tubeCpuSpeedLabel(value);
+    document.getElementById("tubeCpuMultiplierValue").textContent = label;
+    // The slider itself carries a position, so it needs telling what that position means.
+    document.getElementById("tubeCpuMultiplier").setAttribute("aria-valuetext", label);
 }
 
 /**
@@ -117,8 +139,10 @@ export class Config extends EventTarget {
             });
         }
 
-        document.getElementById("tubeCpuMultiplier").addEventListener("input", () => {
-            const val = parseInt(document.getElementById("tubeCpuMultiplier").value, 10);
+        const tubeCpuSlider = document.getElementById("tubeCpuMultiplier");
+        tubeCpuSlider.max = TubeCpuMultipliers.length - 1;
+        tubeCpuSlider.addEventListener("input", () => {
+            const val = TubeCpuMultipliers[parseInt(tubeCpuSlider.value, 10)];
             showTubeCpuMultiplier(val);
             this.changed.tubeCpuMultiplier = val;
         });
@@ -195,9 +219,10 @@ export class Config extends EventTarget {
         for (const el of document.querySelectorAll(".keyboard-layout")) el.textContent = text;
     }
 
+    /** Snaps the slider to the nearest speed offered, but labels the exact `value`, which a URL may put in between. */
     setTubeCpuMultiplier(value) {
         this.tubeCpuMultiplier = value;
-        document.getElementById("tubeCpuMultiplier").value = value;
+        document.getElementById("tubeCpuMultiplier").value = nearestTubeCpuSpeedIndex(value);
         showTubeCpuMultiplier(value);
     }
 

--- a/src/main.js
+++ b/src/main.js
@@ -138,7 +138,7 @@ const paramTypes = {
     audiofilterfreq: ParamTypes.FLOAT,
     audiofilterq: ParamTypes.FLOAT,
     cpuMultiplier: ParamTypes.FLOAT,
-    tubeCpuMultiplier: ParamTypes.INT,
+    tubeCpuMultiplier: ParamTypes.FLOAT,
     microphoneChannel: ParamTypes.INT,
 
     // String parameters (these are the default but listed for clarity)

--- a/tests/unit/test-config.js
+++ b/tests/unit/test-config.js
@@ -1,5 +1,12 @@
 import { describe, it, expect } from "vitest";
-import { fittedRoms, needsRestart, restartPending } from "../../src/config.js";
+import {
+    fittedRoms,
+    nearestTubeCpuSpeedIndex,
+    needsRestart,
+    restartPending,
+    TubeCpuMultipliers,
+    tubeCpuSpeedLabel,
+} from "../../src/config.js";
 import { findModel } from "../../src/models.js";
 
 describe("fittedRoms", () => {
@@ -85,5 +92,37 @@ describe("restartPending", () => {
 
     it("ignores settings the running machine can follow", () => {
         expect(restartPending({ ...running, keyLayout: "natural" }, running)).toBe(false);
+    });
+});
+
+describe("tube cpu speeds", () => {
+    it("offers the real parts and the overclocks", () => {
+        expect(TubeCpuMultipliers.map(tubeCpuSpeedLabel)).toEqual([
+            "3MHz (1x)",
+            "4MHz (1.33x)",
+            "6MHz (2x)",
+            "8MHz (2.67x)",
+            "12MHz (4x)",
+            "24MHz (8x)",
+        ]);
+    });
+
+    it("keeps the multipliers short enough to share in a URL", () => {
+        expect(TubeCpuMultipliers.map(String)).toEqual(["1", "1.3333", "2", "2.6667", "4", "8"]);
+    });
+
+    it("labels a multiplier from a URL as it stands", () => {
+        expect(tubeCpuSpeedLabel(0.75)).toBe("2.25MHz (0.75x)");
+        expect(tubeCpuSpeedLabel(1.3333)).toBe("4MHz (1.33x)");
+    });
+
+    it("puts the slider on the speed asked for", () => {
+        expect(TubeCpuMultipliers.map(nearestTubeCpuSpeedIndex)).toEqual([0, 1, 2, 3, 4, 5]);
+    });
+
+    it("puts the slider nearest a speed it does not offer", () => {
+        expect(nearestTubeCpuSpeedIndex(1.3)).toBe(1);
+        expect(nearestTubeCpuSpeedIndex(0.5)).toBe(0);
+        expect(nearestTubeCpuSpeedIndex(100)).toBe(5);
     });
 });

--- a/tests/unit/test-models.js
+++ b/tests/unit/test-models.js
@@ -52,3 +52,29 @@ describe("fake6502 tube handling", () => {
         expect(cpu.tube.cpuMultiplier).toBe(4);
     });
 });
+
+describe("tube cpu speed", () => {
+    /** @returns {number} how many two-cycle NOPs the parasite gets through in `hostCycles`, run one at a time. */
+    function nopsRun(multiplier, hostCycles) {
+        const tube = fake6502(findModel("Master"), { tube: true, tubeCpuMultiplier: multiplier }).tube;
+        tube.romPaged = false;
+        tube.memory.fill(0xea);
+        tube.pc = 0x1000;
+        for (let i = 0; i < hostCycles; ++i) tube.execute(1);
+        return tube.pc - 0x1000;
+    }
+
+    it("carries the half cycles the 3MHz parasite is owed each host cycle", () => {
+        expect(nopsRun(1, 2000)).toBe(1500);
+    });
+
+    it("carries the part cycles a fractional multiplier leaves over", () => {
+        // 5MHz is two and a half parasite cycles per host cycle: 1200 of them is exactly 1500 NOPs.
+        expect(nopsRun(5 / 3, 1200)).toBe(1500);
+    });
+
+    it("gets a third more done at the Master Turbo's 4MHz", () => {
+        expect(nopsRun(4 / 3, 3000)).toBe(3000);
+        expect(nopsRun(1, 3000)).toBe(2250);
+    });
+});


### PR DESCRIPTION
Fixes #733.

The Tube CPU slider now indexes a list of real speeds (3, 4, 6, 8, 12, 24MHz) rather than whole multiples of the parasite's 3MHz clock, so the Master Turbo's 4MHz 65C102 is reachable again. `tubeCpuMultiplier` is parsed as a float, so existing integer links mean exactly what they did.

The engine needed no change: `Tube6502.execute` accumulates in float and `polltime` only subtracts integers, so the part cycles carry over rather than being lost. There are now tests for that.

Decisions worth a look:

- The multipliers are rounded to four places, so 4MHz shares as `tubeCpuMultiplier=1.3333` rather than seventeen digits of 4/3. That runs the parasite at 3.9999MHz.
- The label leads with the speed and puts the multiplier after: `4MHz (1.33x)`, `24MHz (8x)`. Every offered speed is shorter than the `8x (24MHz)` it replaces, so it stays on one line.
- A multiplier from a URL that is not on the list is labelled as it stands (`0.75` shows `2.25MHz (0.75x)`) and the slider snaps to the nearest speed it does offer.
- The slider's `max` comes from the speed list in `config.js` so the two cannot drift apart; `aria-valuetext` carries the label now that the value itself is just a position.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DPt4XEKzMWCccMQx5rq7uV
