### PR TITLE
perf: skip the shortfall scan when forcing an SSD or DSD save

### DIFF
--- a/src/disc.js
+++ b/src/disc.js
@@ -713,12 +713,14 @@ export function ssdOrDsdShortfalls(disc) {
  * @throws if the disc holds anything an SSD or DSD cannot, and `force` is not set
  */
 export function toSsdOrDsd(disc, { force = false } = {}) {
-    const shortfalls = ssdOrDsdShortfalls(disc);
-    if (shortfalls.length && !force)
-        throw new Error(
-            `This disc cannot be saved as SSD or DSD: it has ${shortfalls.join(", ")}. ` +
-                `Save it as HFE to keep everything.`,
-        );
+    if (!force) {
+        const shortfalls = ssdOrDsdShortfalls(disc);
+        if (shortfalls.length)
+            throw new Error(
+                `This disc cannot be saved as SSD or DSD: it has ${shortfalls.join(", ")}. ` +
+                    `Save it as HFE to keep everything.`,
+            );
+    }
     const numSides = disc.isDoubleSided ? 2 : 1;
     const result = new Uint8Array(
         numSides * SsdFormat.tracksPerDisc * SsdFormat.sectorsPerTrack * SsdFormat.sectorSize,

--- a/src/disc.js
+++ b/src/disc.js
@@ -709,7 +709,8 @@ export function ssdOrDsdShortfalls(disc) {
 /**
  * @returns {Uint8Array}
  * @param {Disc} disc
- * @param {boolean} [force] save what fits instead of refusing a disc that will not fit
+ * @param {object} [options]
+ * @param {boolean} [options.force] save what fits instead of refusing a disc that will not fit
  * @throws if the disc holds anything an SSD or DSD cannot, and `force` is not set
  */
 export function toSsdOrDsd(disc, { force = false } = {}) {

--- a/tests/unit/test-disc-hfe.js
+++ b/tests/unit/test-disc-hfe.js
@@ -18,7 +18,7 @@ describe("HFE loader tests", function () {
         }
     });
 
-    it("should refuse to save a protected disc as SSD or DSD", () => {
+    it("should refuse to save a protected disc as SSD or DSD", { timeout: 30000 }, () => {
         const disc = new Disc(true, new DiscConfig(), "test.hfe");
         loadHfe(disc, data);
 
@@ -31,7 +31,7 @@ describe("HFE loader tests", function () {
         expect(() => toSsdOrDsd(disc)).toThrow(/cannot be saved as SSD or DSD/);
     });
 
-    it("should save what fits when forced", () => {
+    it("should save what fits when forced", { timeout: 30000 }, () => {
         const disc = new Disc(true, new DiscConfig(), "test.hfe");
         loadHfe(disc, data);
 


### PR DESCRIPTION
The two elite.hfe tests added in #740 blew the 5s default timeout locally. Each scans all 162 track sides for sectors, and the forced save did that scan twice: `toSsdOrDsd` computed the shortfall list even with `force` set, where it is only used to build the error message. Skipping it there halves the forced save and leaves output byte-identical, since the write loop already re-checks each sector with `sectorShortfall`.

Timeout overrides on both tests, matching the rest of the file.

`tests/unit/test-disc-hfe.js` goes from failing at ~19s to passing in ~9s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DPt4XEKzMWCccMQx5rq7uV
