### PR TITLE
feat: document key remapping, and report mappings that can't be applied

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Some things to know:
 - Remapping replaces what that host key normally does; in the Space Invaders example above, `Enter` no longer presses
   `RETURN`.
 - The remapping is applied on top of whichever keyboard layout is selected, and survives changing layout or model.
-- If a name isn't recognised the mapping is skipped, with a note in the browser's developer console saying which name
+- If a name isn't recognised the mapping is skipped, and the emulator says so on startup, naming the parameter that
   was at fault.
 - On the Atom, use the Atom's own key names (`LOCK`, `UP_DOWN`, `LEFT_RIGHT` and so on) rather than the BBC's.
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ different peripherals.
 ## Table of Contents
 
 - [Keyboard Mappings](#keyboard-mappings)
+- [Remapping Keys](#remapping-keys)
 - [Emulator Shortcuts](#emulator-shortcuts)
 - [Save State and Rewind](#save-state-and-rewind)
 - [Getting Set Up to Run Locally](#getting-set-up-to-run-locally)
@@ -35,6 +36,65 @@ The BBC had a somewhat different-looking keyboard to a modern PC, and so it's us
 
 To play right now, visit [https://bbc.xania.org/](https://bbc.xania.org/). To load the default disc image (Elite in this
 case), press shift-F12 (which is shift-Break on the BBC).
+
+### Remapping Keys
+
+Plenty of games use keys that are awkward on a modern keyboard: `COPY` (which is `End`, or `fn`+`→` on a Mac), or
+`CAPS LOCK` (which on a Mac toggles rather than acting as a key you hold down). Any host key can be made to press any
+BBC key by adding a `KEY.` parameter to the URL:
+
+```
+KEY.<host key>=<BBC key>
+```
+
+Add one for each key you want to change. For example, Superior Software's Space Invaders fires with `COPY`; this makes
+`Enter` fire instead:
+
+[`https://bbc.xania.org/?disc1=sth:Superior/SpaceInvaders-Superior.zip&autoboot&KEY.ENTER=COPY`](https://bbc.xania.org/?disc1=sth%3ASuperior%2FSpaceInvaders-Superior.zip&autoboot&KEY.ENTER=COPY)
+
+Superior's Frogger uses `A`/`Z`/`DELETE`/`COPY` to move; this puts it on the arrow keys:
+
+[`https://bbc.xania.org/?disc1=sth:Superior/Frogger-Superior.zip&autoboot&KEY.UP=A&KEY.DOWN=Z&KEY.LEFT=DELETE&KEY.RIGHT=COPY`](https://bbc.xania.org/?disc1=sth%3ASuperior%2FFrogger-Superior.zip&autoboot&KEY.UP=A&KEY.DOWN=Z&KEY.LEFT=DELETE&KEY.RIGHT=COPY)
+
+And Superior's Hunchback steers with `CAPS LOCK` and `CTRL`, which the arrow keys can stand in for:
+
+[`https://bbc.xania.org/?disc1=sth:Superior/Hunchback-Superior.zip&autoboot&KEY.LEFT=CAPSLOCK&KEY.RIGHT=CTRL`](https://bbc.xania.org/?disc1=sth%3ASuperior%2FHunchback-Superior.zip&autoboot&KEY.LEFT=CAPSLOCK&KEY.RIGHT=CTRL)
+
+The **host key** names are jsbeeb's names for the keys on your own keyboard. Most are what you'd expect, but note:
+
+- `ENTER` (the BBC's `RETURN` key is called `ENTER` on the host side)
+- `K0` to `K9` for the number keys, `NUMPAD0` to `NUMPAD9` for the keypad
+- `SHIFT_LEFT` / `SHIFT_RIGHT`, `CTRL_LEFT` / `CTRL_RIGHT`, `ALT_LEFT` / `ALT_RIGHT` to distinguish the two of each
+- `BACK_QUOTE`, `APOSTROPHE`, `SEMICOLON`, `MINUS`, `EQUALS`, `HASH`, `BACKSLASH`, `LEFT_SQUARE_BRACKET`,
+  `RIGHT_SQUARE_BRACKET` for punctuation
+
+The **BBC key** names are:
+
+```
+RETURN COPY DELETE ESCAPE TAB SPACE SHIFT SHIFTLOCK CAPSLOCK CTRL
+LEFT RIGHT UP DOWN
+A-Z, K0-K9 (the number keys), F0-F9 (the red function keys)
+SEMICOLON_PLUS MINUS COMMA PERIOD SLASH AT COLON_STAR HAT_TILDE
+UNDERSCORE_POUND PIPE_BACKSLASH LEFT_SQUARE_BRACKET RIGHT_SQUARE_BRACKET
+
+(and, on the Master's numeric keypad only)
+NUMPAD0-NUMPAD9 NUMPADPLUS NUMPADMINUS NUMPADSLASH NUMPADASTERISK NUMPADCOMMA
+NUMPADHASH NUMPADENTER NUMPAD_DELETE NUMPAD_DECIMAL_POINT
+```
+
+Some things to know:
+
+- Names are case-insensitive, and a remapped key ignores the `SHIFT` state, so `KEY.ENTER=COPY` presses `COPY` whether
+  or not shift is held.
+- Remapping replaces what that host key normally does; in the Space Invaders example above, `Enter` no longer presses
+  `RETURN`.
+- The remapping is applied on top of whichever keyboard layout is selected, and survives changing layout or model.
+- If a name isn't recognised the mapping is skipped, with a note in the browser's developer console saying which name
+  was at fault.
+- On the Atom, use the Atom's own key names (`LOCK`, `UP_DOWN`, `LEFT_RIGHT` and so on) rather than the BBC's.
+
+The definitive lists are `keyCodes` (host) and `BBC` (BBC micro) in [`src/utils.js`](src/utils.js), and `ATOM` in
+[`src/utils_atom.js`](src/utils_atom.js).
 
 ### Emulator Shortcuts
 
@@ -62,6 +122,35 @@ jsbeeb supports both USB/Bluetooth gamepads and mouse-based analogue joystick em
 
 - X-axis: Left = 65535, Right = 0
 - Y-axis: Up = 65535, Down = 0
+
+A gamepad presses BBC keys, and which key each control presses can be changed from the URL in the same way as
+[remapping the keyboard](#remapping-keys):
+
+```
+GP.<gamepad control>=<BBC key>
+```
+
+By default the D-pad presses the "Snapper" keys (`Z`, `X`, `:`, `/`), the `A` button presses `RETURN` and `Start`
+presses `SPACE`. To play Superior's Space Invaders on a pad, where `COPY` fires:
+
+[`https://bbc.xania.org/?disc1=sth:Superior/SpaceInvaders-Superior.zip&autoboot&GP.FIRE=COPY`](https://bbc.xania.org/?disc1=sth%3ASuperior%2FSpaceInvaders-Superior.zip&autoboot&GP.FIRE=COPY)
+
+The gamepad control names are:
+
+- `FIRE` — every button at once, which is usually what you want for a one-button game
+- `UP` `DOWN` `LEFT` `RIGHT` — both analogue sticks at once, plus one face button each (`UP` is also `A`, `DOWN` is
+  `X`, `LEFT` is `Y`, `RIGHT` is `B`)
+- `UP1` `DOWN1` `LEFT1` `RIGHT1` — the left stick only; `UP2` `DOWN2` … — the right stick only; `UP3` `DOWN3` … — the
+  face buttons only
+- `A` `B` `X` `Y` `START` `BACK` `LB` `RB` `LT` `RT` — individual buttons, by their Xbox 360 names
+- `FIRE1` `FIRE2` — clicking the left and right sticks
+
+The BBC key names are the same as for the keyboard, and digits may be written either way round: `GP.A=1` and `GP.A=K1`
+both press `1`. Unlike `KEY.`, gamepad mappings are BBC-only: there's no Atom equivalent. The D-pad's default mapping
+can't currently be changed.
+
+The older `LEFT=`, `RIGHT=`, `UP=`, `DOWN=` and `FIRE=` parameters (no `GP.` prefix) still work and mean the same
+thing.
 
 ## Getting Set Up to Run Locally
 
@@ -157,6 +246,8 @@ sudo rpm -i out/dist/jsbeeb-1.0.1.x86_64.rpm
 - `disc1=sth:ZZZ` - loads disc ZZZ from the Stairway to Hell archive
 - `tape=XXX` - loads tape XXX (from the `tapes/` directory)
 - `tape=sth:ZZZ` - loads tape ZZZ from the Stairway to Hell archive
+- `KEY.X=Y` - makes host key `X` press BBC key `Y`, e.g. `KEY.ENTER=COPY`. See
+  [Remapping Keys](#remapping-keys).
 - `patch=P` - applies a memory patch `P`. See below.
 - `loadBasic=X` - loads 'X' (a resource on the webserver) as text, tokenises it and puts it in `PAGE` as if you'd typed
   it in to the emulator

--- a/src/gamepads.js
+++ b/src/gamepads.js
@@ -39,16 +39,21 @@ export class GamePad {
          this.gamepadAxisMapping[3][-1] = BBC.COLON_STAR; // up
          this.gamepadAxisMapping[3][1] = BBC.SLASH;      // down
          */
+    /**
+     * Maps a gamepad button or stick direction to a BBC key.
+     * @param {string} gamepadKey - the gamepad control, eg `FIRE2`
+     * @param {string} bbcKey - the BBC key to press, eg `RETURN`
+     * @returns {?string} a description of the problem, or null if the mapping was applied
+     */
     remap(gamepadKey, bbcKey) {
         // convert "1" into "K1"
-        if ("0123456789".indexOf(bbcKey) > 0) {
+        if (bbcKey.length === 1 && bbcKey >= "0" && bbcKey <= "9") {
             bbcKey = "K" + bbcKey;
         }
 
         const mappedBbcKey = BBC[bbcKey];
         if (!mappedBbcKey) {
-            console.log("unknown BBC key: " + bbcKey);
-            return;
+            return `unknown BBC key "${bbcKey}".`;
         }
 
         switch (gamepadKey) {
@@ -152,8 +157,10 @@ export class GamePad {
                 this.gamepadMapping[6] = mappedBbcKey;
                 break;
             default:
-                console.log("unknown gamepad key: " + gamepadKey);
+                return `unknown gamepad control "${gamepadKey}".`;
         }
+
+        return null;
     }
 
     update(sysvia) {

--- a/src/main.js
+++ b/src/main.js
@@ -52,7 +52,7 @@ import {
     parseMediaParams,
     parseQueryString,
     processAutobootParams,
-    processKeyboardParams,
+    processInputParams,
 } from "./url-params.js";
 
 let processor;
@@ -297,10 +297,8 @@ config.setDisplayMode(displayMode);
 
 model = config.model;
 
-// Process keyboard and gamepad mappings. Must come after the model is known: `KEY.`
-// parameters are validated against the emulated machine's key names, which differ on the
-// Atom. Anything we couldn't apply is shown below, once the error dialog is available.
-const keyMappingWarnings = processKeyboardParams(
+// Must come after we know the model, to validate names against those of the hardware.
+const keyMappingWarnings = processInputParams(
     parsedQuery,
     model.isAtom ? utils_atom.ATOM : BBC,
     keyCodes,
@@ -383,8 +381,6 @@ function showError(context, error) {
     errorDialogModal.show();
 }
 
-// A mistyped `KEY.`/`GP.` parameter is easy to miss otherwise: the emulator starts up
-// looking perfectly normal, but with the keys still where the game put them.
 if (keyMappingWarnings.length) {
     showError("applying the key mappings in the URL", keyMappingWarnings.join(" "));
 }

--- a/src/main.js
+++ b/src/main.js
@@ -177,9 +177,6 @@ const { discImage: queryDiscImage, secondDiscImage: querySecondDisc, mmcImage } 
 if (queryDiscImage) discImage = queryDiscImage;
 if (querySecondDisc) secondDiscImage = querySecondDisc;
 
-// Process keyboard mappings
-parsedQuery = processKeyboardParams(parsedQuery, BBC, keyCodes, utils.userKeymap, gamepad);
-
 // Handle specific query parameters
 if (Array.isArray(parsedQuery.rom)) {
     parsedQuery.rom.forEach((romPath) => {
@@ -300,6 +297,17 @@ config.setDisplayMode(displayMode);
 
 model = config.model;
 
+// Process keyboard and gamepad mappings. Must come after the model is known: `KEY.`
+// parameters are validated against the emulated machine's key names, which differ on the
+// Atom. Anything we couldn't apply is shown below, once the error dialog is available.
+const keyMappingWarnings = processKeyboardParams(
+    parsedQuery,
+    model.isAtom ? utils_atom.ATOM : BBC,
+    keyCodes,
+    utils.userKeymap,
+    gamepad,
+);
+
 // Depends on the config.setX calls above having applied the URL parameters.
 const emulationConfig = {
     keyLayout,
@@ -373,6 +381,12 @@ function showError(context, error) {
     errorDialog.querySelector(".context").textContent = context;
     errorDialog.querySelector(".error").textContent = error;
     errorDialogModal.show();
+}
+
+// A mistyped `KEY.`/`GP.` parameter is easy to miss otherwise: the emulator starts up
+// looking perfectly normal, but with the keys still where the game put them.
+if (keyMappingWarnings.length) {
+    showError("applying the key mappings in the URL", keyMappingWarnings.join(" "));
 }
 
 function createCanvasForFilter(filterClass) {

--- a/src/url-params.js
+++ b/src/url-params.js
@@ -161,52 +161,58 @@ export function buildUrlFromParams(baseUrl, parsedQuery, paramTypes = {}) {
 }
 
 /**
- * Process keyboard mapping parameters from query string
+ * Process keyboard and gamepad mapping parameters from query string
  * @param {Object} parsedQuery - The parsed query parameters
- * @param {Object} BBC - BBC key constants
+ * @param {Object} machineKeys - Emulated machine's key constants (`BBC`, or `ATOM` for the Atom)
  * @param {Object} keyCodes - Key code constants
  * @param {Array} userKeymap - Array to store user key mappings
  * @param {Object} gamepad - Gamepad object for handling mapping
- * @returns {Object} Updated query parameters
+ * @returns {string[]} descriptions of any mappings that were skipped, for showing to the user
  */
-export function processKeyboardParams(parsedQuery, BBC, keyCodes, userKeymap, gamepad) {
+export function processKeyboardParams(parsedQuery, machineKeys, keyCodes, userKeymap, gamepad) {
+    const warnings = [];
+
     Object.entries(parsedQuery).forEach(([key, val]) => {
         if (!val) return;
 
-        // eg KEY.CAPSLOCK=CTRL
+        // Keyboard remapping: `KEY.<host key>=<machine key>`, eg `KEY.CAPSLOCK=CTRL` makes the
+        // host's Caps Lock press the BBC's Ctrl. Host names come from `keyCodes` (so it's
+        // `ENTER`, not `RETURN`), machine names from `BBC` (or `ATOM`); both are listed in the
+        // README's "Remapping Keys" section. Unrecognised names are skipped and reported.
         if (key.toUpperCase().indexOf("KEY.") === 0) {
-            const bbcKey = val.toUpperCase();
+            const machineKey = val.toUpperCase();
+            const nativeKey = key.substring(4).toUpperCase(); // remove KEY.
 
-            if (BBC[bbcKey]) {
-                const nativeKey = key.substring(4).toUpperCase(); // remove KEY.
-                if (keyCodes[nativeKey]) {
-                    console.log("mapping " + nativeKey + " to " + bbcKey);
-                    userKeymap.push({ native: nativeKey, bbc: bbcKey });
-                } else {
-                    console.log("unknown key: " + nativeKey);
-                }
+            if (!machineKeys[machineKey]) {
+                warnings.push(`${key}=${val}: "${machineKey}" is not a key on the emulated machine.`);
+            } else if (!keyCodes[nativeKey]) {
+                warnings.push(`${key}=${val}: "${nativeKey}" is not a key on your keyboard.`);
             } else {
-                console.log("unknown BBC key: " + val);
+                console.log("mapping " + nativeKey + " to " + machineKey);
+                userKeymap.push({ native: nativeKey, key: machineKey });
             }
         } else if (key.indexOf("GP.") === 0) {
             // gamepad mapping
             // eg ?GP.FIRE2=RETURN
             const gamepadKey = key.substring(3).toUpperCase(); // remove GP. prefix
-            gamepad.remap(gamepadKey, val.toUpperCase());
+            const problem = gamepad.remap(gamepadKey, val.toUpperCase());
+            if (problem) warnings.push(`${key}=${val}: ${problem}`);
         } else {
             switch (key) {
                 case "LEFT":
                 case "RIGHT":
                 case "UP":
                 case "DOWN":
-                case "FIRE":
-                    gamepad.remap(key, val.toUpperCase());
+                case "FIRE": {
+                    const problem = gamepad.remap(key, val.toUpperCase());
+                    if (problem) warnings.push(`${key}=${val}: ${problem}`);
                     break;
+                }
             }
         }
     });
 
-    return parsedQuery;
+    return warnings;
 }
 
 /**

--- a/src/url-params.js
+++ b/src/url-params.js
@@ -169,16 +169,14 @@ export function buildUrlFromParams(baseUrl, parsedQuery, paramTypes = {}) {
  * @param {Object} gamepad - Gamepad object for handling mapping
  * @returns {string[]} descriptions of any mappings that were skipped, for showing to the user
  */
-export function processKeyboardParams(parsedQuery, machineKeys, keyCodes, userKeymap, gamepad) {
+export function processInputParams(parsedQuery, machineKeys, keyCodes, userKeymap, gamepad) {
     const warnings = [];
 
     Object.entries(parsedQuery).forEach(([key, val]) => {
         if (!val) return;
 
-        // Keyboard remapping: `KEY.<host key>=<machine key>`, eg `KEY.CAPSLOCK=CTRL` makes the
-        // host's Caps Lock press the BBC's Ctrl. Host names come from `keyCodes` (so it's
-        // `ENTER`, not `RETURN`), machine names from `BBC` (or `ATOM`); both are listed in the
-        // README's "Remapping Keys" section. Unrecognised names are skipped and reported.
+        // `KEY.<host key>=<machine key>`, eg `KEY.CAPSLOCK=CTRL`. Host names come from
+        // `keyCodes`, so the BBC's RETURN is ENTER here; both lists are in the README.
         if (key.toUpperCase().indexOf("KEY.") === 0) {
             const machineKey = val.toUpperCase();
             const nativeKey = key.substring(4).toUpperCase(); // remove KEY.

--- a/src/utils.js
+++ b/src/utils.js
@@ -657,6 +657,13 @@ export function getKeyMap(keyLayout) {
         keys2[shiftDown][s] = colRow;
     }
 
+    // Deliberately replace any existing binding for a key, in both shift states.
+    // Unlike `map` this doesn't warn about the clash: overriding a default is the point.
+    function remap(s, colRow) {
+        keys2[true][s] = colRow;
+        keys2[false][s] = colRow;
+    }
+
     // shiftDown undefined -> map both
     function map(s, colRow, shiftDown) {
         if ((!s && s !== 0) || !colRow) {
@@ -935,11 +942,11 @@ export function getKeyMap(keyLayout) {
     // eg Master Dunjunz needs # Del 3 , * Enter
     // https://web.archive.org/web/20080305042238/http://bbc.nvg.org/doc/games/Dunjunz-docs.txt
 
-    // user keymapping
-    // do last (to override defaults)
-    while (userKeymap.length > 0) {
-        const mapping = userKeymap.pop();
-        map(keyCodes[mapping.native], BBC[mapping.bbc]);
+    // User key mapping from `KEY.<host>=<bbc>` URL parameters; see the "Remapping Keys"
+    // section of the README. Done last so it overrides the defaults above, and read
+    // without consuming so the mapping survives rebuilding the map (layout or model change).
+    for (const mapping of userKeymap) {
+        remap(keyCodes[mapping.native], BBC[mapping.key]);
     }
 
     return keys2;

--- a/src/utils.js
+++ b/src/utils.js
@@ -657,8 +657,7 @@ export function getKeyMap(keyLayout) {
         keys2[shiftDown][s] = colRow;
     }
 
-    // Deliberately replace any existing binding for a key, in both shift states.
-    // Unlike `map` this doesn't warn about the clash: overriding a default is the point.
+    // Overriding a default is the point here, so unlike `map` this doesn't warn about the clash.
     function remap(s, colRow) {
         keys2[true][s] = colRow;
         keys2[false][s] = colRow;
@@ -942,9 +941,8 @@ export function getKeyMap(keyLayout) {
     // eg Master Dunjunz needs # Del 3 , * Enter
     // https://web.archive.org/web/20080305042238/http://bbc.nvg.org/doc/games/Dunjunz-docs.txt
 
-    // User key mapping from `KEY.<host>=<bbc>` URL parameters; see the "Remapping Keys"
-    // section of the README. Done last so it overrides the defaults above, and read
-    // without consuming so the mapping survives rebuilding the map (layout or model change).
+    // `KEY.` URL parameters, applied last so they win. Not consumed: this map is rebuilt on
+    // layout and model changes, and the user's mapping has to survive that.
     for (const mapping of userKeymap) {
         remap(keyCodes[mapping.native], BBC[mapping.key]);
     }

--- a/src/utils_atom.js
+++ b/src/utils_atom.js
@@ -249,8 +249,7 @@ export function getKeyMapAtom(keyLayout) {
         keys2[shiftDown][s] = colRow;
     }
 
-    // Deliberately replace any existing binding for a key, in both shift states.
-    // Unlike `map` this doesn't warn about the clash: overriding a default is the point.
+    // Overriding a default is the point here, so unlike `map` this doesn't warn about the clash.
     function remap(s, colRow) {
         keys2[true][s] = colRow;
         keys2[false][s] = colRow;
@@ -484,9 +483,7 @@ export function getKeyMapAtom(keyLayout) {
         // Z - M normal
     }
 
-    // User key mapping from `KEY.<host>=<atom>` URL parameters; see the "Remapping Keys"
-    // section of the README. Done last so it overrides the defaults above, and read
-    // without consuming so the mapping survives rebuilding the map (layout change).
+    // `KEY.` URL parameters, applied last so they win. See the equivalent in `getKeyMap`.
     for (const mapping of userKeymap) {
         remap(keyCodes[mapping.native], ATOM[mapping.key]);
     }

--- a/src/utils_atom.js
+++ b/src/utils_atom.js
@@ -249,6 +249,13 @@ export function getKeyMapAtom(keyLayout) {
         keys2[shiftDown][s] = colRow;
     }
 
+    // Deliberately replace any existing binding for a key, in both shift states.
+    // Unlike `map` this doesn't warn about the clash: overriding a default is the point.
+    function remap(s, colRow) {
+        keys2[true][s] = colRow;
+        keys2[false][s] = colRow;
+    }
+
     // shiftDown undefined -> map both
     function map(s, colRow, shiftDown) {
         if ((!s && s !== 0) || !colRow) {
@@ -477,11 +484,11 @@ export function getKeyMapAtom(keyLayout) {
         // Z - M normal
     }
 
-    // user keymapping
-    // do last (to override defaults)
-    while (userKeymap.length > 0) {
-        const mapping = userKeymap.pop();
-        map(keyCodes[mapping.native], ATOM[mapping.atom]);
+    // User key mapping from `KEY.<host>=<atom>` URL parameters; see the "Remapping Keys"
+    // section of the README. Done last so it overrides the defaults above, and read
+    // without consuming so the mapping survives rebuilding the map (layout change).
+    for (const mapping of userKeymap) {
+        remap(keyCodes[mapping.native], ATOM[mapping.key]);
     }
 
     return keys2;

--- a/tests/unit/test-gamepads.js
+++ b/tests/unit/test-gamepads.js
@@ -1,0 +1,47 @@
+import { describe, it, expect } from "vitest";
+
+import { GamePad } from "../../src/gamepads.js";
+import { BBC } from "../../src/utils.js";
+
+describe("GamePad", function () {
+    describe("remap", function () {
+        it("maps a button to a BBC key", function () {
+            const gamepad = new GamePad();
+
+            expect(gamepad.remap("A", "COPY")).toBeNull();
+            expect(gamepad.gamepadMapping[0]).toEqual(BBC.COPY);
+        });
+
+        it("maps the sticks and a face button together for the direction names", function () {
+            const gamepad = new GamePad();
+
+            expect(gamepad.remap("LEFT", "DELETE")).toBeNull();
+            expect(gamepad.gamepadAxisMapping[0][-1]).toEqual(BBC.DELETE); // left stick
+            expect(gamepad.gamepadAxisMapping[2][-1]).toEqual(BBC.DELETE); // right stick
+        });
+
+        it("accepts digits with or without the K prefix", function () {
+            const gamepad = new GamePad();
+
+            expect(gamepad.remap("A", "0")).toBeNull();
+            expect(gamepad.gamepadMapping[0]).toEqual(BBC.K0);
+
+            expect(gamepad.remap("B", "K9")).toBeNull();
+            expect(gamepad.gamepadMapping[1]).toEqual(BBC.K9);
+        });
+
+        it("reports an unknown BBC key without changing anything", function () {
+            const gamepad = new GamePad();
+            const before = gamepad.gamepadMapping[0];
+
+            expect(gamepad.remap("A", "NOTAKEY")).toMatch(/unknown BBC key/);
+            expect(gamepad.gamepadMapping[0]).toEqual(before);
+        });
+
+        it("reports an unknown gamepad control", function () {
+            const gamepad = new GamePad();
+
+            expect(gamepad.remap("WIBBLE", "COPY")).toMatch(/unknown gamepad control/);
+        });
+    });
+});

--- a/tests/unit/test-url-params.js
+++ b/tests/unit/test-url-params.js
@@ -3,7 +3,7 @@ import { describe, it, expect, vi } from "vitest";
 import {
     parseQueryString,
     buildUrlFromParams,
-    processKeyboardParams,
+    processInputParams,
     processAutobootParams,
     parseMediaParams,
     guessModelFromHostname,
@@ -221,7 +221,7 @@ describe("URL Parameters", () => {
         });
     });
 
-    describe("processKeyboardParams", () => {
+    describe("processInputParams", () => {
         it("should process keyboard mappings", () => {
             const machineKeys = { CTRL: "CTRL", SHIFT: "SHIFT" };
             const keyCodes = { A: 65, B: 66 };
@@ -236,7 +236,7 @@ describe("URL Parameters", () => {
                 other: "value",
             };
 
-            const warnings = processKeyboardParams(parsedQuery, machineKeys, keyCodes, userKeymap, gamepad);
+            const warnings = processInputParams(parsedQuery, machineKeys, keyCodes, userKeymap, gamepad);
 
             expect(userKeymap).toEqual([
                 { native: "A", key: "CTRL" },
@@ -255,7 +255,7 @@ describe("URL Parameters", () => {
             const userKeymap = [];
             const gamepad = { remap: vi.fn().mockReturnValue('unknown gamepad control "WIBBLE".') };
 
-            const warnings = processKeyboardParams(
+            const warnings = processInputParams(
                 { "KEY.A": "NOTAKEY", "KEY.NOTAKEY": "CTRL", "GP.WIBBLE": "CTRL" },
                 machineKeys,
                 keyCodes,

--- a/tests/unit/test-url-params.js
+++ b/tests/unit/test-url-params.js
@@ -223,7 +223,7 @@ describe("URL Parameters", () => {
 
     describe("processKeyboardParams", () => {
         it("should process keyboard mappings", () => {
-            const BBC = { CTRL: "CTRL", SHIFT: "SHIFT" };
+            const machineKeys = { CTRL: "CTRL", SHIFT: "SHIFT" };
             const keyCodes = { A: 65, B: 66 };
             const userKeymap = [];
             const gamepad = { remap: vi.fn() };
@@ -236,16 +236,39 @@ describe("URL Parameters", () => {
                 other: "value",
             };
 
-            processKeyboardParams(parsedQuery, BBC, keyCodes, userKeymap, gamepad);
+            const warnings = processKeyboardParams(parsedQuery, machineKeys, keyCodes, userKeymap, gamepad);
 
             expect(userKeymap).toEqual([
-                { native: "A", bbc: "CTRL" },
-                { native: "B", bbc: "SHIFT" },
+                { native: "A", key: "CTRL" },
+                { native: "B", key: "SHIFT" },
             ]);
+            expect(warnings).toEqual([]);
 
             expect(gamepad.remap).toHaveBeenCalledTimes(2);
             expect(gamepad.remap).toHaveBeenCalledWith("FIRE2", "RETURN");
             expect(gamepad.remap).toHaveBeenCalledWith("UP", "Q");
+        });
+
+        it("should report mappings it can't apply", () => {
+            const machineKeys = { CTRL: "CTRL" };
+            const keyCodes = { A: 65 };
+            const userKeymap = [];
+            const gamepad = { remap: vi.fn().mockReturnValue('unknown gamepad control "WIBBLE".') };
+
+            const warnings = processKeyboardParams(
+                { "KEY.A": "NOTAKEY", "KEY.NOTAKEY": "CTRL", "GP.WIBBLE": "CTRL" },
+                machineKeys,
+                keyCodes,
+                userKeymap,
+                gamepad,
+            );
+
+            expect(warnings).toEqual([
+                'KEY.A=NOTAKEY: "NOTAKEY" is not a key on the emulated machine.',
+                'KEY.NOTAKEY=CTRL: "NOTAKEY" is not a key on your keyboard.',
+                'GP.WIBBLE=CTRL: unknown gamepad control "WIBBLE".',
+            ]);
+            expect(userKeymap).toEqual([]);
         });
     });
 

--- a/tests/unit/test-utils.js
+++ b/tests/unit/test-utils.js
@@ -13,7 +13,13 @@ import {
     crc32,
     createZipBlob,
     unzip,
+    BBC,
+    keyCodes,
+    getKeyMap,
+    userKeymap,
 } from "../../src/utils.js";
+import { ATOM, getKeyMapAtom } from "../../src/utils_atom.js";
+import { processKeyboardParams } from "../../src/url-params.js";
 
 describe("Utils tests", function () {
     "use strict";
@@ -344,6 +350,47 @@ describe("Utils tests", function () {
             expect(stringToBBCKeys("a").length).toBe(3); // With CAPSLOCK toggles
             expect(stringToBBCKeys("!").length).toBe(3); // With SHIFT
         });
+    });
+});
+
+describe("User key mapping from KEY. URL parameters", function () {
+    afterEach(function () {
+        userKeymap.length = 0;
+    });
+
+    const applyParams = (params, machineKeys) =>
+        processKeyboardParams(params, machineKeys, keyCodes, userKeymap, { remap: () => null });
+
+    it("overrides the default binding for the host key", function () {
+        expect(getKeyMap("physical")[false][keyCodes.ENTER]).toEqual(BBC.RETURN);
+
+        applyParams({ "KEY.ENTER": "COPY" }, BBC);
+
+        const keyMap = getKeyMap("physical");
+        expect(keyMap[false][keyCodes.ENTER]).toEqual(BBC.COPY);
+        expect(keyMap[true][keyCodes.ENTER]).toEqual(BBC.COPY);
+    });
+
+    it("survives the key map being rebuilt, as on a layout or model change", function () {
+        applyParams({ "KEY.ENTER": "COPY" }, BBC);
+
+        getKeyMap("physical");
+        expect(getKeyMap("physical")[false][keyCodes.ENTER]).toEqual(BBC.COPY);
+    });
+
+    it("applies to the Atom, whose key names differ from the BBC's", function () {
+        applyParams({ "KEY.ENTER": "LOCK" }, ATOM);
+
+        expect(getKeyMapAtom("physical")[false][keyCodes.ENTER]).toEqual(ATOM.LOCK);
+    });
+
+    it("ignores unknown host and machine key names", function () {
+        // RETURN is the BBC's name for the key the host calls ENTER: not a host key name.
+        const warnings = applyParams({ "KEY.RETURN": "COPY", "KEY.ENTER": "NOTAKEY" }, BBC);
+
+        expect(warnings).toHaveLength(2);
+        expect(userKeymap).toEqual([]);
+        expect(getKeyMap("physical")[false][keyCodes.ENTER]).toEqual(BBC.RETURN);
     });
 });
 

--- a/tests/unit/test-utils.js
+++ b/tests/unit/test-utils.js
@@ -19,7 +19,7 @@ import {
     userKeymap,
 } from "../../src/utils.js";
 import { ATOM, getKeyMapAtom } from "../../src/utils_atom.js";
-import { processKeyboardParams } from "../../src/url-params.js";
+import { processInputParams } from "../../src/url-params.js";
 
 describe("Utils tests", function () {
     "use strict";
@@ -359,7 +359,7 @@ describe("User key mapping from KEY. URL parameters", function () {
     });
 
     const applyParams = (params, machineKeys) =>
-        processKeyboardParams(params, machineKeys, keyCodes, userKeymap, { remap: () => null });
+        processInputParams(params, machineKeys, keyCodes, userKeymap, { remap: () => null });
 
     it("overrides the default binding for the host key", function () {
         expect(getKeyMap("physical")[false][keyCodes.ENTER]).toEqual(BBC.RETURN);


### PR DESCRIPTION
Prompted by a note from one of the original Superior Software authors, who can't comfortably play his own games any
more: Invaders fires with `COPY`, Hunchback steers with `CAPS LOCK` and `CTRL`. The `KEY.` URL parameters have always
been able to fix that, but they were undocumented and failed silently.

Documents them, and fixes what didn't work.

### Documentation

A "Remapping Keys" section in the README with the syntax, the host-side and BBC-side name lists, and three worked
examples, all of which load and autoboot today:

- [`?disc1=sth:Superior/SpaceInvaders-Superior.zip&autoboot&KEY.ENTER=COPY`](https://bbc.xania.org/?disc1=sth%3ASuperior%2FSpaceInvaders-Superior.zip&autoboot&KEY.ENTER=COPY)
- [`?disc1=sth:Superior/Frogger-Superior.zip&autoboot&KEY.UP=A&KEY.DOWN=Z&KEY.LEFT=DELETE&KEY.RIGHT=COPY`](https://bbc.xania.org/?disc1=sth%3ASuperior%2FFrogger-Superior.zip&autoboot&KEY.UP=A&KEY.DOWN=Z&KEY.LEFT=DELETE&KEY.RIGHT=COPY)
- [`?disc1=sth:Superior/Hunchback-Superior.zip&autoboot&KEY.LEFT=CAPSLOCK&KEY.RIGHT=CTRL`](https://bbc.xania.org/?disc1=sth%3ASuperior%2FHunchback-Superior.zip&autoboot&KEY.LEFT=CAPSLOCK&KEY.RIGHT=CTRL)

The `GP.` gamepad parameters are documented too, in the Joystick Support section.

### Behaviour

Mappings that can't be applied now appear in the error dialog rather than only in the console, and say which half was
wrong. `KEY.RETURN=COPY` is the obvious trap — the key the BBC calls `RETURN` is `ENTER` on the host side — and
previously gave no feedback at all.

### Fixes

- **The mapping was applied once, then lost.** `userKeymap` was drained with `pop()` while building the key map, so
  changing keyboard layout or model silently reverted it.
- **`KEY.` did nothing on the Atom.** `getKeyMapAtom` read `mapping.atom`; `processKeyboardParams` only ever wrote
  `mapping.bbc`. Entries are now `{native, key}`, validated against `ATOM` or `BBC` depending on the model — which
  means processing them after the model is resolved.
- **`GP.x=0` was rejected**, as `"0123456789".indexOf(key) > 0` excludes `"0"` itself.

Also adds a `remap()` helper so a deliberate override no longer logs `Warning: duplicate binding for key 13`.

Tests cover the override applying in both shift states, surviving a rebuild, working on the Atom, unknown names being
reported, and `GamePad.remap`'s new return contract.

Not addressed here, and now filed as #748: doing any of this from the UI instead of the URL. The D-pad's default
gamepad mapping also has no name, so it can't be remapped at all; noted in the README.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
