### PR TITLE
fix: give the external second processor its real CMOS instruction set

### DIFF
--- a/src/models.js
+++ b/src/models.js
@@ -234,7 +234,8 @@ export const allModels = [
         name: "Tube65C102",
         synonyms: [],
         os: ["tube/65C102Tube.rom"],
-        // Boards are reported with both Rockwell and GTE parts, so keep the superset of the two.
+        // Boards are reported with both Rockwell and GTE parts, so keep the superset of the two
+        // until #756 lets the fitted co-processor be chosen.
         cpuModel: CpuModel.CMOS65C02,
         isMaster: false,
         clockMhz: 4,

--- a/src/models.js
+++ b/src/models.js
@@ -225,8 +225,7 @@ export const allModels = [
         name: "Tube65C02",
         synonyms: [],
         os: ["tube/6502Tube.rom"],
-        // The production ANC01 wedge carries a GTE 65SC02, whose x7 and xF columns are blank:
-        // the base CMOS set, which for us is CMOS65C12. Only pre-production boards were NMOS.
+        // The production wedge's GTE 65SC02 has no Rockwell bit instructions.
         cpuModel: CpuModel.CMOS65C12,
         isMaster: false,
         clockMhz: 3,
@@ -235,9 +234,7 @@ export const allModels = [
         name: "Tube65C102",
         synonyms: [],
         os: ["tube/65C102Tube.rom"],
-        // ADC06 boards are reported with both Rockwell R65C102s and GTE G65SC102s, and only the
-        // Rockwell part has the bit instructions. Staying with the superset until someone runs
-        // Dormann's Rockwell tests on real hardware: a superset only ever runs more, never less.
+        // Boards are reported with both Rockwell and GTE parts, so keep the superset of the two.
         cpuModel: CpuModel.CMOS65C02,
         isMaster: false,
         clockMhz: 4,

--- a/src/models.js
+++ b/src/models.js
@@ -225,8 +225,9 @@ export const allModels = [
         name: "Tube65C02",
         synonyms: [],
         os: ["tube/6502Tube.rom"],
-        // TODO(#746): the external second processor was an NMOS 6502A.
-        cpuModel: CpuModel.CMOS65C02,
+        // The production ANC01 wedge carries a GTE 65SC02, whose x7 and xF columns are blank:
+        // the base CMOS set, which for us is CMOS65C12. Only pre-production boards were NMOS.
+        cpuModel: CpuModel.CMOS65C12,
         isMaster: false,
         clockMhz: 3,
     }),
@@ -234,7 +235,9 @@ export const allModels = [
         name: "Tube65C102",
         synonyms: [],
         os: ["tube/65C102Tube.rom"],
-        // TODO(#746): Acorn's 65C102 has no Rockwell bit instructions.
+        // ADC06 boards are reported with both Rockwell R65C102s and GTE G65SC102s, and only the
+        // Rockwell part has the bit instructions. Staying with the superset until someone runs
+        // Dormann's Rockwell tests on real hardware: a superset only ever runs more, never less.
         cpuModel: CpuModel.CMOS65C02,
         isMaster: false,
         clockMhz: 4,

--- a/tests/integration/tube.js
+++ b/tests/integration/tube.js
@@ -116,6 +116,20 @@ describe("Tube co-processor", () => {
         expect(machine.drainText({ raw: true })).toContain("BASIC\n\n>");
     });
 
+    it("boots the language across the external second processor", async () => {
+        const machine = new TestMachine("B-DFS1.2", { tube: true });
+        await machine.initialise();
+        machine.startCapture();
+
+        await machine.runFor(4 * 1000 * 1000);
+
+        // The client ROM's boot uses none of the opcodes the CPU variants disagree about, so
+        // this only guards against the wedge breaking outright, not against the wrong variant.
+        const text = machine.drainText({ raw: true });
+        expect(text).toContain("Acorn TUBE 6502 64K");
+        expect(text).toContain("BASIC\n\n>");
+    });
+
     it("passes the requested multiplier on to the parasite", async () => {
         const machine = new TestMachine("Master", { tube: true, tubeCpuMultiplier: 4 });
         await machine.initialise();

--- a/tests/integration/tube.js
+++ b/tests/integration/tube.js
@@ -116,15 +116,13 @@ describe("Tube co-processor", () => {
         expect(machine.drainText({ raw: true })).toContain("BASIC\n\n>");
     });
 
-    it("boots the language across the external second processor", async () => {
+    it("still brings the external second processor's client ROM up on the base CMOS core", async () => {
         const machine = new TestMachine("B-DFS1.2", { tube: true });
         await machine.initialise();
         machine.startCapture();
 
         await machine.runFor(4 * 1000 * 1000);
 
-        // The client ROM's boot uses none of the opcodes the CPU variants disagree about, so
-        // this only guards against the wedge breaking outright, not against the wrong variant.
         const text = machine.drainText({ raw: true });
         expect(text).toContain("Acorn TUBE 6502 64K");
         expect(text).toContain("BASIC\n\n>");

--- a/tests/unit/test-models.js
+++ b/tests/unit/test-models.js
@@ -27,6 +27,29 @@ describe("Model", () => {
     });
 });
 
+const IncA = 0x1a; // Absent from the NMOS 6502, present on every CMOS part.
+const Smb0Zp = 0x87; // Present only on Rockwell parts; a one-byte undefined NOP on the rest.
+// Doubles as SMB0's operand and, on the parts where SMB0 is a one-byte NOP, as the NOP that
+// then runs in its place, so the two cases differ only in the byte SMB0 would have touched.
+const ScratchZp = 0xea;
+
+/** Assemble `program` into the parasite's RAM and run it from a known register state. */
+function runOnParasite(model, program, { a = 0, x = 0 } = {}) {
+    const ProgramStart = 0x1000;
+    const parasite = fake6502(findModel(model), { tube: true }).tube;
+    parasite.romPaged = false;
+    parasite.memory.fill(0xea); // NOP, so whatever follows the program is harmless
+    parasite.memory[ScratchZp] = 0;
+    parasite.memory.set(program, ProgramStart);
+    parasite.pc = ProgramStart;
+    parasite.a = a;
+    parasite.x = x;
+    // Tube6502.execute does nothing at all with fewer than three parasite cycles banked, so
+    // ask for enough host cycles to clear that on the slower of the two parasite clocks.
+    parasite.execute(4);
+    return parasite;
+}
+
 describe("fake6502 tube handling", () => {
     it("attaches a tube when asked", () => {
         const cpu = fake6502(findModel("Master"), { tube: true });
@@ -61,6 +84,18 @@ describe("fake6502 tube handling", () => {
         const cpu = fake6502(findModel("B-DFS1.2"), { tube: true });
 
         expect(cpu.tube.cyclesPerHostCycle).toBe(1.5);
+    });
+
+    it("gives both co-processors the CMOS additions", () => {
+        expect(runOnParasite("B-DFS1.2", [IncA], { a: 0x41 }).a).toBe(0x42);
+        expect(runOnParasite("Master", [IncA], { a: 0x41 }).a).toBe(0x42);
+    });
+
+    it("gives the Rockwell bit instructions to the Turbo alone", () => {
+        // Same program either side, so the difference can only be the CPU. The Turbo keeps the
+        // superset deliberately: real ADC06 boards are reported with both Rockwell and GTE parts.
+        expect(runOnParasite("B-DFS1.2", [Smb0Zp, ScratchZp]).memory[ScratchZp]).toBe(0);
+        expect(runOnParasite("Master", [Smb0Zp, ScratchZp]).memory[ScratchZp]).toBe(1);
     });
 
     it("runs the parasite the given multiple of its clock", () => {

--- a/tests/unit/test-models.js
+++ b/tests/unit/test-models.js
@@ -27,10 +27,9 @@ describe("Model", () => {
     });
 });
 
-const IncA = 0x1a; // Absent from the NMOS 6502, present on every CMOS part.
-const Smb0Zp = 0x87; // Present only on Rockwell parts; a one-byte undefined NOP on the rest.
-// Doubles as SMB0's operand and, on the parts where SMB0 is a one-byte NOP, as the NOP that
-// then runs in its place, so the two cases differ only in the byte SMB0 would have touched.
+const IncA = 0x1a;
+const Smb0Zp = 0x87; // A Rockwell instruction; a one-byte NOP on the base CMOS parts.
+// Chosen to be NOP, so it is harmless when read as an opcode rather than as SMB0's operand.
 const ScratchZp = 0xea;
 
 /** Assemble `program` into the parasite's RAM and run it from a known register state. */
@@ -44,9 +43,7 @@ function runOnParasite(model, program, { a = 0, x = 0 } = {}) {
     parasite.pc = ProgramStart;
     parasite.a = a;
     parasite.x = x;
-    // Tube6502.execute does nothing at all with fewer than three parasite cycles banked, so
-    // ask for enough host cycles to clear that on the slower of the two parasite clocks.
-    parasite.execute(4);
+    parasite.execute(4); // Below three parasite cycles, execute does nothing at all.
     return parasite;
 }
 
@@ -92,8 +89,7 @@ describe("fake6502 tube handling", () => {
     });
 
     it("gives the Rockwell bit instructions to the Turbo alone", () => {
-        // Same program either side, so the difference can only be the CPU. The Turbo keeps the
-        // superset deliberately: real ADC06 boards are reported with both Rockwell and GTE parts.
+        // Same program either side, so the difference can only be the CPU.
         expect(runOnParasite("B-DFS1.2", [Smb0Zp, ScratchZp]).memory[ScratchZp]).toBe(0);
         expect(runOnParasite("Master", [Smb0Zp, ScratchZp]).memory[ScratchZp]).toBe(1);
     });


### PR DESCRIPTION
Fixes #746, though the research contradicted the issue on both counts, so only one of the two models moves.

## External 6502 Second Processor: `CMOS65C02` -> `CMOS65C12`

The issue assumed an NMOS 6502A. The production ANC01 wedge, the one with `6502 TUBE 1.10`, is CMOS:

- [Chris's Acorns ANC01](https://chrisacorns.computinghistory.org.uk/8bit_Upgrades/Acorn_ANC01_65022ndproc.html) lists a **GTE 65SC02P-1** on the board.
- MAME's [`tube_6502.cpp`](https://github.com/mamedev/mame/blob/master/src/devices/bus/bbc/tube/tube_6502.cpp) gives the production device a `G65SC02`, and reserves the NMOS `M6502` for the pre-production board with the Tube 0.0x ROMs.
- Nigel Barnes on [stardot](https://stardot.org.uk/forums/viewtopic.php?t=18326): "The released board has a 12MHz crystal to run the G65SC02 at 3MHz". The NMOS SY6502C is pre-production, and Acorn's service manual saying "6502C" is the likely source of the NMOS belief.

A G65SC02 has the base CMOS set with columns x7 and xF blank ([CMD datasheet](http://archive.6502.org/datasheets/cmd_65c02_family.pdf)), which is exactly the existing `opcodes65c12` table. The fix is real but smaller than the issue expected: the wedge loses RMB/SMB/BBR/BBS and keeps the rest of the CMOS set. The model name `Tube65C02` was accurate all along.

## 65C102 Turbo: unchanged

The Turbo stays on `CMOS65C02`. The issue's claim that it lacks the Rockwell instructions could not be confirmed:

- Chris's Acorns and BeebMaster describe the ADC06 as a **65SC102** (GTE, would lack them), [Domesday86](https://www.domesday86.com/?page_id=1962) as an **R65C102** (Rockwell, would have them), and [stardot](https://www.stardot.org.uk/forums/viewtopic.php?t=28205) reports both markings.
- MAME models it as `R65C102`, i.e. with the bit instructions. b-em, BeebEm and PiTubeDirect all implement them for 6502 tubes without distinguishing models.
- The one solid measurement, [hoglet running Dormann's tests](https://stardot.org.uk/forums/viewtopic.php?t=16681), covers the Master's own G65SC12, not the co-processor.

Nobody appears to have run the Rockwell tests on real ADC06 hardware, and narrowing the core on that evidence would risk rejecting code a real board runs. The superset stays, with a comment recording why.

## Tests

`tests/unit/test-models.js` assembles short programs into parasite RAM and runs them: `INC A` to show both co-processors have the CMOS additions, and `SMB0` to show only the Turbo has the Rockwell ones. Both assertions were checked to fail if the model constant is wrong.

`tests/integration/tube.js` gains a BBC B boot alongside the existing Master one. It guards against the wedge breaking outright rather than against the wrong variant, since the client ROM's boot touches none of the disputed opcodes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)




Which board a given Turbo carried, and the fact that a Master could equally have an external second processor, are both cases the current model cannot express. Follow-up in #756.

