### PR TITLE
perf: decode flux marks with 32 bit words instead of BigInts

### DIFF
--- a/src/disc.js
+++ b/src/disc.js
@@ -355,24 +355,62 @@ class Sector {
     }
 }
 
-// What the 64 bit mark detector holds at an address mark, split into high and low 32 bit halves.
-// The FM case only pins down the high half, the last eight zero bits of sync (0x88888888 being
-// FM data 0x00 with all clocks set); the low half is the marker byte itself, decoded separately.
-// The MFM case matches the whole of 0xaaaa448944894489.
+/** Nibbles in each 32 bit half of a {@link BitWindow64}. */
+const NibblesPerHalf = 8;
+
+/**
+ * A 64 bit shift register, held as a pair of unsigned 32 bit halves. BigInt would say this more
+ * directly but costs an order of magnitude more per bit shifted.
+ */
+export class BitWindow64 {
+    constructor() {
+        this.hi = 0;
+        this.lo = 0;
+    }
+
+    /**
+     * @param {Number} bit 0 or 1, shifted into bit 0
+     * @returns {Number} the bit shifted out of bit 63
+     */
+    shiftIn(bit) {
+        const shiftedOut = this.hi >>> 31;
+        this.hi = ((this.hi << 1) | (this.lo >>> 31)) >>> 0;
+        this.lo = ((this.lo << 1) | bit) >>> 0;
+        return shiftedOut;
+    }
+
+    /**
+     * @returns {boolean} whether all 64 bits match the halves given
+     */
+    equals(hi, lo) {
+        return this.hi === hi && this.lo === lo;
+    }
+
+    /**
+     * @param {Number} nibble
+     * @returns {Number} the length of the run of `nibble` ending at bit 0
+     */
+    countTrailingNibbles(nibble) {
+        let count = 0;
+        for (let bits = this.lo; (bits & 0xf) === nibble; bits >>>= 4) count++;
+        // Only a low half that matched all the way up can have a run continuing into the high half.
+        if (count === NibblesPerHalf) for (let bits = this.hi; (bits & 0xf) === nibble; bits >>>= 4) count++;
+        return count;
+    }
+}
+
+// What the mark detector holds at an address mark. The FM case only pins down the high half,
+// the tail of the zero sync run; the low half is the marker byte itself, decoded separately.
 const FmSyncHi = 0x88888888;
 const MfmMarkerHi = 0xaaaa4489;
 const MfmMarkerLo = 0x44894489;
-const NibblesPerWord = 8;
-// Sync ahead of an address mark is counted in zero data bits, so this is two bytes' worth.
-// A run no longer than this is unusual enough to be worth logging.
+// One data bit of zero, FM encoded with its clock, is the pulse nibble 0x8.
+const FmZeroBitPulses = 0x8;
+// FmSyncHi is eight of those, so a match has already seen this much of the sync run.
+const FmSyncHiZeroBits = 8;
+// Sync is counted in zero data bits, so a run no longer than two bytes' worth is short enough
+// to be worth logging.
 const ShortSyncZeros = 16;
-
-/** @returns {Number} how many low nibbles of `word` are the FM pulses for a zero data bit */
-function countSyncNibbles(word) {
-    let count = 0;
-    for (let bits = word; (bits & 0xf) === 0x8; bits >>>= 4) count++;
-    return count;
-}
 
 class Track {
     constructor(upper, trackNum, initialByte) {
@@ -413,40 +451,30 @@ class Track {
         let doMfmMarkerByte = false;
         let isMfm = false;
         let pulses = 0;
-        // The mark detector is a 64 bit sliding window over the pulse stream, and its previous
-        // 64 bits. Both are pairs of unsigned 32 bit Numbers rather than BigInts, which cost an
-        // order of magnitude more in a loop that runs once per bit of every track.
-        let markDetectorHi = 0;
-        let markDetectorLo = 0;
-        let markDetectorPrevHi = 0;
-        let markDetectorPrevLo = 0;
+        // The mark detector is a 64 bit sliding window over the pulse stream; the bits leaving it
+        // spill into a second window, which the sync run length is counted from.
+        const markDetector = new BitWindow64();
+        const markDetectorPrev = new BitWindow64();
         let dataByte;
         let sector = null;
         for (let pulseIndex = 0; pulseIndex < bitLength; ++pulseIndex) {
             if ((pulseIndex & 31) === 0) pulses = this.pulses2Us[pulseIndex >>> 5];
-            markDetectorPrevHi = ((markDetectorPrevHi << 1) | (markDetectorPrevLo >>> 31)) >>> 0;
-            markDetectorPrevLo = ((markDetectorPrevLo << 1) | (markDetectorHi >>> 31)) >>> 0;
-            markDetectorHi = ((markDetectorHi << 1) | (markDetectorLo >>> 31)) >>> 0;
             const pulseBit = pulses >>> 31;
-            markDetectorLo = ((markDetectorLo << 1) | pulseBit) >>> 0;
+            markDetectorPrev.shiftIn(markDetector.shiftIn(pulseBit));
             shiftRegister = ((shiftRegister << 1) | pulseBit) & 0xffffffff;
             numShifts++;
             pulses = (pulses << 1) & 0xffffffff;
-            if (markDetectorHi === FmSyncHi) {
-                const { clocks, data, iffyPulses } = IbmDiscFormat._2usPulsesToFm(markDetectorLo);
+            if (markDetector.hi === FmSyncHi) {
+                const { clocks, data, iffyPulses } = IbmDiscFormat._2usPulsesToFm(markDetector.lo);
                 if (iffyPulses || clocks !== IbmDiscFormat.markClockPattern) continue;
                 isMfm = false;
                 doMfmMarkerByte = false;
-                const lowNibbles = countSyncNibbles(markDetectorPrevLo);
-                // A run reaching the top of the low word may continue into the high word.
-                const highNibbles = lowNibbles === NibblesPerWord ? countSyncNibbles(markDetectorPrevHi) : 0;
-                // Matching FmSyncHi already accounted for a whole word of sync.
-                const num0s = NibblesPerWord + lowNibbles + highNibbles;
+                const num0s = FmSyncHiZeroBits + markDetectorPrev.countTrailingNibbles(FmZeroBitPulses);
                 if (num0s <= ShortSyncZeros) {
                     console.log(`Short zeros sync ${this.description}`);
                 }
                 dataByte = data;
-            } else if (markDetectorHi === MfmMarkerHi && markDetectorLo === MfmMarkerLo) {
+            } else if (markDetector.equals(MfmMarkerHi, MfmMarkerLo)) {
                 // Next byte is MFM marker.
                 isMfm = true;
                 doMfmMarkerByte = true;

--- a/src/disc.js
+++ b/src/disc.js
@@ -355,6 +355,25 @@ class Sector {
     }
 }
 
+// What the 64 bit mark detector holds at an address mark, split into high and low 32 bit halves.
+// The FM case only pins down the high half, the last eight zero bits of sync (0x88888888 being
+// FM data 0x00 with all clocks set); the low half is the marker byte itself, decoded separately.
+// The MFM case matches the whole of 0xaaaa448944894489.
+const FmSyncHi = 0x88888888;
+const MfmMarkerHi = 0xaaaa4489;
+const MfmMarkerLo = 0x44894489;
+const NibblesPerWord = 8;
+// Sync ahead of an address mark is counted in zero data bits, so this is two bytes' worth.
+// A run no longer than this is unusual enough to be worth logging.
+const ShortSyncZeros = 16;
+
+/** @returns {Number} how many low nibbles of `word` are the FM pulses for a zero data bit */
+function countSyncNibbles(word) {
+    let count = 0;
+    for (let bits = word; (bits & 0xf) === 0x8; bits >>>= 4) count++;
+    return count;
+}
+
 class Track {
     constructor(upper, trackNum, initialByte) {
         this.length = IbmDiscFormat.bytesPerTrack; // Default size, will be updated when track is populated
@@ -394,40 +413,40 @@ class Track {
         let doMfmMarkerByte = false;
         let isMfm = false;
         let pulses = 0;
-        let markDetector = 0n;
-        let markDetectorPrev = 0n;
-        const all64b = 0xffffffffffffffffn;
-        const top32of64b = 0xffffffff00000000n;
-        const fmMarker = 0x8888888800000000n;
-        const mfmMarker = 0xaaaa448944894489n;
+        // The mark detector is a 64 bit sliding window over the pulse stream, and its previous
+        // 64 bits. Both are pairs of unsigned 32 bit Numbers rather than BigInts, which cost an
+        // order of magnitude more in a loop that runs once per bit of every track.
+        let markDetectorHi = 0;
+        let markDetectorLo = 0;
+        let markDetectorPrevHi = 0;
+        let markDetectorPrevLo = 0;
         let dataByte;
         let sector = null;
         for (let pulseIndex = 0; pulseIndex < bitLength; ++pulseIndex) {
             if ((pulseIndex & 31) === 0) pulses = this.pulses2Us[pulseIndex >>> 5];
-            markDetectorPrev = (markDetectorPrev << 1n) & all64b;
-            markDetectorPrev |= markDetector >> 63n;
-            markDetector = (markDetector << 1n) & all64b;
-            shiftRegister = (shiftRegister << 1) & 0xffffffff;
+            markDetectorPrevHi = ((markDetectorPrevHi << 1) | (markDetectorPrevLo >>> 31)) >>> 0;
+            markDetectorPrevLo = ((markDetectorPrevLo << 1) | (markDetectorHi >>> 31)) >>> 0;
+            markDetectorHi = ((markDetectorHi << 1) | (markDetectorLo >>> 31)) >>> 0;
+            const pulseBit = pulses >>> 31;
+            markDetectorLo = ((markDetectorLo << 1) | pulseBit) >>> 0;
+            shiftRegister = ((shiftRegister << 1) | pulseBit) & 0xffffffff;
             numShifts++;
-            if (pulses & 0x80000000) {
-                markDetector |= 1n;
-                shiftRegister |= 1;
-            }
             pulses = (pulses << 1) & 0xffffffff;
-            if ((markDetector & top32of64b) === fmMarker) {
-                const { clocks, data, iffyPulses } = IbmDiscFormat._2usPulsesToFm(Number(markDetector & 0xffffffffn));
+            if (markDetectorHi === FmSyncHi) {
+                const { clocks, data, iffyPulses } = IbmDiscFormat._2usPulsesToFm(markDetectorLo);
                 if (iffyPulses || clocks !== IbmDiscFormat.markClockPattern) continue;
                 isMfm = false;
                 doMfmMarkerByte = false;
-                let num0s = 8;
-                for (let bits = markDetectorPrev; (bits & 0xfn) === 0x8n; bits >>= 4n) {
-                    num0s++;
-                }
-                if (num0s <= 16) {
+                const lowNibbles = countSyncNibbles(markDetectorPrevLo);
+                // A run reaching the top of the low word may continue into the high word.
+                const highNibbles = lowNibbles === NibblesPerWord ? countSyncNibbles(markDetectorPrevHi) : 0;
+                // Matching FmSyncHi already accounted for a whole word of sync.
+                const num0s = NibblesPerWord + lowNibbles + highNibbles;
+                if (num0s <= ShortSyncZeros) {
                     console.log(`Short zeros sync ${this.description}`);
                 }
                 dataByte = data;
-            } else if (markDetector === mfmMarker) {
+            } else if (markDetectorHi === MfmMarkerHi && markDetectorLo === MfmMarkerLo) {
                 // Next byte is MFM marker.
                 isMfm = true;
                 doMfmMarkerByte = true;

--- a/src/disc.js
+++ b/src/disc.js
@@ -355,9 +355,6 @@ class Sector {
     }
 }
 
-/** Nibbles in each 32 bit half of a {@link BitWindow64}. */
-const NibblesPerHalf = 8;
-
 /**
  * A 64 bit shift register, held as a pair of unsigned 32 bit halves. BigInt would say this more
  * directly but costs an order of magnitude more per bit shifted.
@@ -391,10 +388,11 @@ export class BitWindow64 {
      * @returns {Number} the length of the run of `nibble` ending at bit 0
      */
     countTrailingNibbles(nibble) {
+        const nibblesPerHalf = 8;
         let count = 0;
         for (let bits = this.lo; (bits & 0xf) === nibble; bits >>>= 4) count++;
         // Only a low half that matched all the way up can have a run continuing into the high half.
-        if (count === NibblesPerHalf) for (let bits = this.hi; (bits & 0xf) === nibble; bits >>>= 4) count++;
+        if (count === nibblesPerHalf) for (let bits = this.hi; (bits & 0xf) === nibble; bits >>>= 4) count++;
         return count;
     }
 }

--- a/tests/unit/test-disc.js
+++ b/tests/unit/test-disc.js
@@ -1,7 +1,54 @@
 import { describe, it, expect } from "vitest";
 
-import { Disc, DiscConfig, IbmDiscFormat, loadSsd, loadAdf, toSsdOrDsd } from "../../src/disc.js";
+import { BitWindow64, Disc, DiscConfig, IbmDiscFormat, loadSsd, loadAdf, toSsdOrDsd } from "../../src/disc.js";
 import * as fs from "node:fs";
+
+describe("BitWindow64", function () {
+    /** Shift the low `count` bits of a BigInt in, most significant first. */
+    function shiftIn(window, value, count = 64) {
+        for (let bit = count - 1; bit >= 0; --bit) window.shiftIn(Number((value >> BigInt(bit)) & 1n));
+        return window;
+    }
+
+    it("holds the last 64 bits shifted in", () => {
+        const window = shiftIn(new BitWindow64(), 0xaaaa448944894489n);
+        expect(window.hi).toBe(0xaaaa4489);
+        expect(window.lo).toBe(0x44894489);
+    });
+
+    it("keeps both halves unsigned as bits cross bit 31 and bit 63", () => {
+        const window = shiftIn(new BitWindow64(), 0xffffffffffffffffn);
+        expect(window.hi).toBe(0xffffffff);
+        expect(window.lo).toBe(0xffffffff);
+    });
+
+    it("returns the bit leaving bit 63", () => {
+        const window = shiftIn(new BitWindow64(), 0x8000000000000000n);
+        expect(window.shiftIn(0)).toBe(1);
+        expect(window.shiftIn(0)).toBe(0);
+    });
+
+    it("matches a 64 bit value only in full", () => {
+        const window = shiftIn(new BitWindow64(), 0xaaaa448944894489n);
+        expect(window.equals(0xaaaa4489, 0x44894489)).toBe(true);
+        expect(window.equals(0xaaaa4489, 0x44894488)).toBe(false);
+        expect(window.equals(0xaaaa4488, 0x44894489)).toBe(false);
+    });
+
+    it("counts a run of nibbles ending at bit 0", () => {
+        expect(shiftIn(new BitWindow64(), 0x1234567988888888n).countTrailingNibbles(0x8)).toBe(8);
+    });
+
+    it("counts a run continuing into the high half", () => {
+        expect(shiftIn(new BitWindow64(), 0x1234567888888888n).countTrailingNibbles(0x8)).toBe(9);
+        expect(shiftIn(new BitWindow64(), 0x1238888888888888n).countTrailingNibbles(0x8)).toBe(13);
+        expect(shiftIn(new BitWindow64(), 0x8888888888888888n).countTrailingNibbles(0x8)).toBe(16);
+    });
+
+    it("counts nothing when the lowest nibble differs", () => {
+        expect(shiftIn(new BitWindow64(), 0x8888888888888880n).countTrailingNibbles(0x8)).toBe(0);
+    });
+});
 
 describe("IBM disc format tests", function () {
     it("calculates FM crcs", () => {


### PR DESCRIPTION
The 64 bit mark detector in `Track.findSectorIds` and the 64 bits behind it were `BigInt`s, shifted and masked once per bit: 100,096 times per side, 16.2M for a double-sided 81 track disc. Both are now `BitWindow64`, a 64 bit shift register held as a pair of unsigned 32 bit halves.

The comparisons are the same ones. FM matches the high half only (`0x88888888`, the tail of the zero sync run); MFM matches both halves of `0xaaaa448944894489`. The sync run count used to walk one BigInt a nibble at a time and now walks the low half, then the high half only if the low half matched all the way up, which is exactly when the old loop would have carried into bits 32-63.

## Measurements

Node 24, this machine. Elite is the bundled `public/discs/elite.hfe` (81 tracks, double sided); Stairway to Hell is the #740 capture (81 tracks, single sided).

`findSectorIds` alone, over all 162 sides of elite, best of seven, before and after interleaved to keep machine drift out of it:

| | |
| --- | --- |
| before | 1695ms |
| after | ~115ms |

Full disc scan via `ssdOrDsdShortfalls`, which also reads every sector's data:

| | before | after |
| --- | --- | --- |
| elite | 1960ms | ~150ms |
| Stairway to Hell | 1214ms | ~85ms |

Holding the halves in a class rather than four flat locals costs about 25% of the bit loop, ~115ms against ~90ms over 162 sides. That is the deliberate price of having the shifting and the run count behind an API with unit tests, in a decoder whose failure mode is silently misreading a protected disc.

## Correctness

The output is byte-identical on all five real captures from #740. For each disc I hashed every decoded sector (MFM flag, id and data bit offsets, deleted flag, both CRC error flags, byte length, header bytes, sector data) and compared before and after:

| disc | digest before == after |
| --- | --- |
| Elite (bundled) | yes |
| Carousel | yes |
| Stairway to Hell | yes |
| Perplexity | yes |
| Disc Drive Utilities | yes |

Also differential-fuzzed the old and new implementations against each other over 400 randomly generated tracks, with the pulse stream biased towards the marker and sync patterns so the branches actually fire: identical sector output and identical console diagnostics, including the "Short zeros sync" warning that exercises the split nibble count.

`BitWindow64` has unit tests of its own in `test-disc.js`, driven from BigInt values: bits crossing bit 31 and bit 63, the bit leaving the top, full-width equality, and nibble runs that stop mid-half, carry across the half boundary, fill all 16 nibbles, or are empty.

Unit tests pass, as does `tests/integration/protection.js`. The three integration files that fail here fail on `main` too, for a missing `dp111_6502Timing` submodule.

## What this does not do

The issue lists three cheaper wins alongside this one. None are here:

- **Per-track caching with invalidation on write.** `toSsdOrDsd` scans every track twice and the catalogue reader scans again, so it would buy roughly another 2x. But `pulses2Us` is written directly by `TrackBuilder`, `Disc.writePulses`, `Disc.restoreState` and `disc-hfe.js`, and a missed invalidation means silently serving a stale sector layout. That is a worse failure than a slow scan, and 150ms is no longer a scan anyone waits on.
- **Skipping tracks with no pulses.** Worth about 1ms per blank side now.
- **Deferring `Sector.read()` until a caller wants data.** `sectorShortfall` needs `sectorData` for two of its four checks, so `ssdOrDsdShortfalls` would still read most sectors.

## Risk that remains

This is a transliteration of 64 bit C arithmetic into 32 bit pairs, and the failure mode is a misread protected disc rather than a crash. The evidence above is five real captures and a fuzz run, not a proof. The `elite.hfe` timeout overrides added in #744 are left in place; they are now generous rather than necessary.

Fixes #749

🤖 Generated with [Claude Code](https://claude.com/claude-code)
