### PR TITLE
refactor: ask the model how fast the machine runs

### DIFF
--- a/src/6502.js
+++ b/src/6502.js
@@ -666,7 +666,7 @@ export class Cpu6502 extends Base6502 {
         this.resetLine = true;
         this.cpuMultiplier = this.config.cpuMultiplier;
         this.videoCyclesBatch = this.config.videoCyclesBatch | 0;
-        this.peripheralCyclesPerSecond = 2 * 1000 * 1000;
+        this.peripheralCyclesPerSecond = model.cyclesPerSecond;
         this.hasTube = !!this.config.tube;
         this.hasMusic5000 = !!this.config.hasMusic5000;
         this.hasTeletextAdaptor = !!this.config.hasTeletextAdaptor;
@@ -1361,7 +1361,7 @@ export class Cpu6502 extends Base6502 {
         this.fdc.powerOnReset();
         this.adconverter.reset();
 
-        this.touchScreen = new TouchScreen(this.scheduler);
+        this.touchScreen = new TouchScreen(this.scheduler, this.model.cyclesPerSecond);
         if (this.econet) this.filestore = new Filestore(this, this.econet);
     }
 
@@ -1614,8 +1614,6 @@ export class AtomCpu6502 extends Cpu6502 {
             this.ramRomOs = expanded;
         }
 
-        // Atom runs at 1 MHz
-        this.peripheralCyclesPerSecond = 1 * 1000 * 1000;
         // reset() and debugger.setCpu() are called by initialise() after loadOs().
     }
 

--- a/src/6502.js
+++ b/src/6502.js
@@ -1478,9 +1478,10 @@ export class Cpu6502 extends Base6502 {
         // that from both, to keep the domain low (while accumulating seconds). Take care to preserve the bottom
         // bit though; as that encodes whether we're on an even or odd bus cycle.
         const smaller = Math.min(this.targetCycles, this.currentCycles) & 0xfffffffe;
-        if (smaller >= 2 * 1000 * 1000) {
-            this.targetCycles -= 2 * 1000 * 1000;
-            this.currentCycles -= 2 * 1000 * 1000;
+        const cyclesPerSecond = this.model.cyclesPerSecond;
+        if (smaller >= cyclesPerSecond) {
+            this.targetCycles -= cyclesPerSecond;
+            this.currentCycles -= cyclesPerSecond;
             this.cycleSeconds++;
         }
         // Any tracing or debugging means we need to run the potentially slower version: the debug read or

--- a/src/6847.js
+++ b/src/6847.js
@@ -111,6 +111,11 @@ only 1 bit is used of SG6 - to get yellow/red, cyan/orange
 // constant for the graphics mode
 const MODE_AG = 0x10; // graphics mode
 
+// The MC6847 datasheet specifies 3.579545 MHz, but 3.638004 is used here as an
+// empirical correction to align VSync/interrupt timing with the CPU clock.
+// TODO: revisit once full integration is testable.
+const VdgClockMhz = 3.638004;
+
 export class Video6847 {
     constructor(video) {
         this.video = video;
@@ -225,6 +230,9 @@ export class Video6847 {
     reset(cpu, ppia) {
         this.cpu = cpu;
         this.ppia = ppia;
+        // polltime() is handed CPU cycles, so how far the VDG advances per
+        // cycle depends on how fast the CPU it's attached to runs.
+        this.vdgCyclesPerCpuCycle = cpu ? VdgClockMhz / cpu.model.clockMhz : 0;
     }
 
     // USE PAINT from VIDEO
@@ -344,11 +352,7 @@ export class Video6847 {
         // it doesn't draw the whole frame.  It regularly gives control back to the CPU.
 
         const vdgcharclock = this.pixelsPerChar / 2; // 4 or 8
-        // The MC6847 datasheet specifies 3.579545 MHz, but 3.638004 is used here
-        // as an empirical correction to align VSync/interrupt timing with the Atom's
-        // 1 MHz CPU clock. TODO: revisit once full integration is testable.
-        const vdgclock = 3.638004;
-        this.vdg_cycles += clocks * vdgclock;
+        this.vdg_cycles += clocks * this.vdgCyclesPerCpuCycle;
 
         const vdgframelines = 262; //  312 PAL (but no pal on standard atom)  262; // NTSC
         const vdglinetime = 228; // vdg cycles to do a line; not 227.5

--- a/src/acia.js
+++ b/src/acia.js
@@ -265,8 +265,9 @@ export class Acia {
         }
     }
 
+    // Byte times are held in CPU cycles because that's what the scheduler counts.
     secondsToCycles(sec) {
-        return Math.floor(2 * 1000 * 1000 * sec) | 0;
+        return Math.floor(this.cpu.model.cyclesPerSecond * sec) | 0;
     }
 
     numBitsPerByte() {

--- a/src/econet.js
+++ b/src/econet.js
@@ -1,6 +1,9 @@
 // Code ported from Beebem (C to .js) by Jason Robson
 // The majority of the commentary here is also from Beebem
 
+// How long a four-way handshake may stall before we resend.
+const RetryTimeoutSecs = 0.5;
+
 // Econet support classes
 class ADLC {
     constructor() {
@@ -57,10 +60,11 @@ export class ReceiveBlock {
 
 // Econet class definition
 export class Econet {
-    constructor(stationId_) {
+    constructor(stationId_, cyclesPerSecond) {
         // Config parameters
         this.TIME_BETWEEN_BYTES = 128;
         this.SERVER_STATION_ID = 254;
+        this.retryCycles = (cyclesPerSecond * RetryTimeoutSecs) | 0;
 
         // 4-way handshake states
         this.FWH_Idle = 0;
@@ -156,7 +160,7 @@ export class Econet {
             }
 
             // Re-tries
-            if (this.pollTotalCycles > this.wireStateEntryTimer + 1000000) {
+            if (this.pollTotalCycles > this.wireStateEntryTimer + this.retryCycles) {
                 if (this.wireState !== this.FWH_Idle) {
                     switch (this.wireState) {
                         case this.FWH_RX_Scout_Received:

--- a/src/main.js
+++ b/src/main.js
@@ -352,7 +352,7 @@ sbBind(document.querySelector(".sidebar.bottom"), parsedQuery.sbBottom, function
 });
 
 if (cpuMultiplier !== 1) console.log(`CPU multiplier set to ${cpuMultiplier}`);
-const cpuSpeed = model.clockMhz * 1000 * 1000;
+const cpuSpeed = model.cyclesPerSecond;
 const clocksPerSecond = (cpuMultiplier * cpuSpeed) | 0;
 const MaxCyclesPerFrame = clocksPerSecond / 10;
 
@@ -533,7 +533,7 @@ pastetext.addEventListener("drop", async function (event) {
         await loadStateFromFile(file, arrayBuffer);
     } else if (file.name.toLowerCase().endsWith(".uef")) {
         // Regular UEF tape image (not a BeebEm save state)
-        setProcessorTape(await loadTapeFromData(file.name, new Uint8Array(arrayBuffer), model.isAtom));
+        setProcessorTape(await loadTapeFromData(file.name, new Uint8Array(arrayBuffer), model));
     } else {
         await loadHTMLFile(file);
     }
@@ -619,7 +619,7 @@ window.addEventListener("beforeunload", function (event) {
 });
 
 if (config.hasEconet) {
-    econet = new Econet(stationId);
+    econet = new Econet(stationId, model.cyclesPerSecond);
 } else {
     document.getElementById("fsmenuitem").style.display = "none";
 }
@@ -1207,17 +1207,16 @@ async function loadTapeImage(tapeImage) {
     const split = splitImage(tapeImage);
     tapeImage = split.image;
     const schema = split.schema;
-    const isAtom = model.isAtom;
 
     switch (schema) {
         case "|":
         case "sth":
-            return await loadTapeFromData(tapeImage, await tapeSth.fetch(tapeImage), isAtom);
+            return await loadTapeFromData(tapeImage, await tapeSth.fetch(tapeImage), model);
 
         case "data": {
             const arr = Array.prototype.map.call(atob(tapeImage), (x) => x.charCodeAt(0));
             const { name, data } = await utils.unzipDiscImage(arr);
-            return await loadTapeFromData(name, data, isAtom);
+            return await loadTapeFromData(name, data, model);
         }
 
         case "http":
@@ -1232,7 +1231,7 @@ async function loadTapeImage(tapeImage) {
                 tapeData = unzipped.data;
                 tapeImage = unzipped.name;
             }
-            return await loadTapeFromData(tapeImage, tapeData, isAtom);
+            return await loadTapeFromData(tapeImage, tapeData, model);
         }
 
         default: {
@@ -1244,7 +1243,7 @@ async function loadTapeImage(tapeImage) {
                 tapeData = unzipped.data;
                 tapeName = unzipped.name;
             }
-            return await loadTapeFromData(tapeName, tapeData, isAtom);
+            return await loadTapeFromData(tapeName, tapeData, model);
         }
     }
 }
@@ -1277,7 +1276,7 @@ document.getElementById("tape_load").addEventListener("change", async function (
         tapeData = unzipped.data;
         tapeName = unzipped.name;
     }
-    setProcessorTape(await loadTapeFromData(tapeName, tapeData, model.isAtom));
+    setProcessorTape(await loadTapeFromData(tapeName, tapeData, model));
     delete parsedQuery.tape;
     updateUrl();
     bootstrap.Modal.getInstance(document.getElementById("tapes"))?.hide();
@@ -1940,7 +1939,7 @@ function VirtualSpeedUpdater() {
         if (this.cycles) {
             const thisMHz = this.cycles / this.time / 1000;
             this.v.textContent = thisMHz.toFixed(1);
-            if (this.cycles >= 10 * 2 * 1000 * 1000) {
+            if (this.cycles >= 10 * cpuSpeed) {
                 this.cycles = this.time = 0;
             }
             this.header.style.color = this.speedy ? "red" : "white";

--- a/src/models.js
+++ b/src/models.js
@@ -35,6 +35,15 @@ class Model {
         this.cmosOverride = cmosOverride;
     }
 
+    /**
+     * How many CPU cycles this machine runs in a second. Everything that
+     * converts between real time and emulated cycles should ask here rather
+     * than assuming a clock speed.
+     */
+    get cyclesPerSecond() {
+        return this.clockMhz * 1000 * 1000;
+    }
+
     get nmos() {
         return this._cpuModel === CpuModel.MOS6502;
     }

--- a/src/tapes.js
+++ b/src/tapes.js
@@ -1,9 +1,6 @@
 "use strict";
 import * as utils from "./utils.js";
 
-const BbcCpuSpeed = 2 * 1000 * 1000;
-const AtomCpuSpeed = 1 * 1000 * 1000;
-
 function secsToClocks(secs, cpuSpeed) {
     return (cpuSpeed * secs) | 0;
 }
@@ -25,11 +22,11 @@ function parityOf(curByte) {
 const ParityN = "N".charCodeAt(0);
 
 class UefTape {
-    constructor(stream, isAtom = false) {
+    constructor(stream, model) {
         this.stream = stream;
         this.baseFrequency = 1200;
-        this.isAtom = isAtom;
-        this.cpuSpeed = isAtom ? AtomCpuSpeed : BbcCpuSpeed;
+        this.isAtom = model.isAtom;
+        this.cpuSpeed = model.cyclesPerSecond;
         this.rewind();
 
         this.curChunk = this.readChunk();
@@ -265,9 +262,10 @@ class UefTape {
 const dividerTable = [1, 16, 64, -1];
 
 class TapefileTape {
-    constructor(stream) {
+    constructor(stream, model) {
         this.count = 0;
         this.stream = stream;
+        this.cpuSpeed = model.cyclesPerSecond;
     }
 
     rate(acia) {
@@ -278,7 +276,7 @@ class TapefileTape {
         const divider = dividerTable[acia.cr & 0x03];
         // http://beebwiki.mdfs.net/index.php/Serial_ULA says the serial rate is ignored
         // for cassette mode.
-        const cpp = (2 * 1000 * 1000) / (19200 / divider);
+        const cpp = this.cpuSpeed / (19200 / divider);
         return Math.floor(bitsPerByte * cpp);
     }
 
@@ -297,7 +295,7 @@ class TapefileTape {
             } else if (byte === 0x04) {
                 acia.setTapeCarrier(true);
                 // Simulate 5 seconds of carrier.
-                return 5 * 2 * 1000 * 1000;
+                return secsToClocks(5, this.cpuSpeed);
             } else if (byte !== 0xff) {
                 throw "Got a weird byte in the tape";
             }
@@ -307,15 +305,15 @@ class TapefileTape {
     }
 }
 
-export async function loadTapeFromData(name, data, isAtom = false) {
+export async function loadTapeFromData(name, data, model) {
     const stream = await utils.DataStream.create(name, data);
     if (stream.readByte(0) === 0xff && stream.readByte(1) === 0x04) {
         console.log("Detected a 'tapefile' tape");
-        return new TapefileTape(stream);
+        return new TapefileTape(stream, model);
     }
     if (stream.readNulString(0) === "UEF File!") {
         console.log("Detected a UEF tape");
-        return new UefTape(stream, isAtom);
+        return new UefTape(stream, model);
     }
     console.log("Unknown tape format");
     return null;

--- a/src/touchscreen.js
+++ b/src/touchscreen.js
@@ -3,7 +3,6 @@
 import * as utils from "./utils.js";
 
 const PollHz = 8; // Made up
-const PollCycles = (2 * 1000 * 1000) / PollHz;
 
 function doScale(val, scale, margin) {
     val = (val - margin) / (1 - 2 * margin);
@@ -11,8 +10,9 @@ function doScale(val, scale, margin) {
 }
 
 export class TouchScreen {
-    constructor(scheduler) {
+    constructor(scheduler, cyclesPerSecond) {
         this.scheduler = scheduler;
+        this.pollCycles = cyclesPerSecond / PollHz;
         this.mouse = [];
         this.outBuffer = new utils.Fifo(16);
         this.delay = 0;
@@ -47,7 +47,7 @@ export class TouchScreen {
 
     poll() {
         this.doRead();
-        this.pollTask.reschedule(PollCycles);
+        this.pollTask.reschedule(this.pollCycles);
     }
 
     store(byte) {
@@ -81,6 +81,6 @@ export class TouchScreen {
                 if (this.mode === 1) this.doRead();
                 break;
         }
-        this.pollTask.ensureScheduled(this.mode === 129 || this.mode === 130, PollCycles);
+        this.pollTask.ensureScheduled(this.mode === 129 || this.mode === 130, this.pollCycles);
     }
 }

--- a/tests/test-machine.js
+++ b/tests/test-machine.js
@@ -178,7 +178,7 @@ export class TestMachine {
                     return true;
                 }
             });
-            await this.runFor(secs * 1 * 1000 * 1000); // Atom is 1 MHz
+            await this.runFor(secs * this.model.cyclesPerSecond);
             hook.remove();
             assert(hit, "Atom did not reach keyboard input in time");
             return this.runFor(10 * 1000);
@@ -191,7 +191,7 @@ export class TestMachine {
                 return true;
             }
         });
-        await this.runFor(secs * 2 * 1000 * 1000);
+        await this.runFor(secs * this.model.cyclesPerSecond);
         hook.remove();
         assert(hit, "did not hit appropriate breakpoint in time");
         return this.runFor(10 * 1000);
@@ -206,7 +206,7 @@ export class TestMachine {
                 return true;
             }
         });
-        await this.runFor(secs * 2 * 1000 * 1000);
+        await this.runFor(secs * this.model.cyclesPerSecond);
         hook.remove();
         assert(hit, "did not hit appropriate breakpoint in time");
     }
@@ -370,7 +370,8 @@ export class TestMachine {
         let nextEventCycle = 0;
         let done = false;
 
-        const currentCycle = () => this.processor.cycleSeconds * 2000000 + this.processor.currentCycles;
+        const currentCycle = () =>
+            this.processor.cycleSeconds * this.model.cyclesPerSecond + this.processor.currentCycles;
 
         const hook = this.processor.debugInstruction.add(() => {
             if (currentCycle() < nextEventCycle) return;
@@ -425,7 +426,8 @@ export class TestMachine {
         let done = false;
         let shiftHeld = false;
 
-        const currentCycle = () => this.processor.cycleSeconds * 1000000 + this.processor.currentCycles;
+        const currentCycle = () =>
+            this.processor.cycleSeconds * this.model.cyclesPerSecond + this.processor.currentCycles;
 
         const isShift = (entry) => entry[0] === SHIFT[0] && entry[1] === SHIFT[1];
 

--- a/tests/unit/test-6847.js
+++ b/tests/unit/test-6847.js
@@ -78,4 +78,20 @@ describe("Video6847", () => {
             expect(vdg.scanlineCounter).toBe(0);
         });
     });
+
+    describe("VDG clock", () => {
+        const fakeCpu = (clockMhz) => ({ model: { clockMhz } });
+
+        it("advances 3.638004 VDG cycles per cycle of the Atom's 1MHz CPU", () => {
+            const vdg = new Video6847(makeStubVideo());
+            vdg.reset(fakeCpu(1), {});
+            expect(vdg.vdgCyclesPerCpuCycle).toBeCloseTo(3.638004, 6);
+        });
+
+        it("advances half as far per cycle if the CPU runs twice as fast", () => {
+            const vdg = new Video6847(makeStubVideo());
+            vdg.reset(fakeCpu(2), {});
+            expect(vdg.vdgCyclesPerCpuCycle).toBeCloseTo(3.638004 / 2, 6);
+        });
+    });
 });

--- a/tests/unit/test-acia-adc-state.js
+++ b/tests/unit/test-acia-adc-state.js
@@ -2,13 +2,14 @@ import { describe, it, expect, beforeEach } from "vitest";
 import { Acia } from "../../src/acia.js";
 import { Adc } from "../../src/adc.js";
 import { Scheduler } from "../../src/scheduler.js";
+import { findModel } from "../../src/models.js";
 
 describe("Acia snapshotState / restoreState", () => {
     let scheduler, cpu, acia;
 
     beforeEach(() => {
         scheduler = new Scheduler();
-        cpu = { interrupt: 0 };
+        cpu = { interrupt: 0, model: findModel("B-DFS1.2") };
         const toneGen = { mute: () => {}, tone: () => {} };
         acia = new Acia(cpu, toneGen, scheduler);
     });

--- a/tests/unit/test-acia.js
+++ b/tests/unit/test-acia.js
@@ -1,6 +1,9 @@
 import { describe, it, expect, vi, afterEach } from "vitest";
 import { Acia } from "../../src/acia.js";
 import { Scheduler } from "../../src/scheduler.js";
+import { findModel } from "../../src/models.js";
+
+const BbcModel = findModel("B-DFS1.2");
 
 // Control register word select 101: 8 data bits, 1 stop bit, no parity.
 const EightBitsOneStopNoParity = 0x14;
@@ -9,8 +12,8 @@ const SevenBitsTwoStopEvenParity = 0x00;
 const TransmitInterruptEnable = 0x20;
 const Tdre = 0x02;
 
-function createScheduledAcia(scheduler, cr, transmitRate) {
-    const cpu = { interrupt: 0 };
+function createScheduledAcia(scheduler, cr, transmitRate, model = BbcModel) {
+    const cpu = { interrupt: 0, model };
     const acia = new Acia(cpu, { mute: vi.fn(), tone: vi.fn() }, scheduler);
     acia.write(0, cr);
     acia.setSerialTransmit(transmitRate);
@@ -25,7 +28,7 @@ function createMockAcia(relayNoise) {
             reschedule: vi.fn(),
         })),
     };
-    const acia = new Acia({ interrupt: 0 }, { mute: vi.fn(), tone: vi.fn() }, scheduler, relayNoise);
+    const acia = new Acia({ interrupt: 0, model: BbcModel }, { mute: vi.fn(), tone: vi.fn() }, scheduler, relayNoise);
     acia.setRs423Handler({});
     return acia;
 }
@@ -69,9 +72,9 @@ describe("Acia", () => {
         // A 10 bit byte at 75 baud takes 0.1333s: 266666 cycles of the 2MHz clock.
         const ByteCyclesAt75Baud = 266666;
 
-        const timeToEmpty = (cr, rate) => {
+        const timeToEmpty = (cr, rate, model) => {
             const scheduler = new Scheduler();
-            const { acia } = createScheduledAcia(scheduler, cr, rate);
+            const { acia } = createScheduledAcia(scheduler, cr, rate, model);
             acia.write(1, 0x55);
             let cycles = 0;
             while (!(acia.read(0) & Tdre)) {
@@ -83,6 +86,13 @@ describe("Acia", () => {
 
         it("should empty the transmit register after one byte time", () => {
             expect(timeToEmpty(EightBitsOneStopNoParity, 75)).toBe(ByteCyclesAt75Baud);
+        });
+
+        it("should count the byte time in the machine's own cycles", () => {
+            // The scheduler counts CPU cycles, so the same 0.1333s takes half
+            // as many of them on a 1MHz machine. (The Atom has no ACIA; it is
+            // only standing in here as a machine with a different clock.)
+            expect(timeToEmpty(EightBitsOneStopNoParity, 75, findModel("Atom"))).toBe(ByteCyclesAt75Baud / 2);
         });
 
         it("should account for the word format", () => {

--- a/tests/unit/test-cpu-state.js
+++ b/tests/unit/test-cpu-state.js
@@ -6,7 +6,7 @@ import { SoundChip } from "../../src/soundchip.js";
 import { FakeDdNoise } from "../../src/ddnoise.js";
 import { Cmos } from "../../src/cmos.js";
 import { FakeMusic5000 } from "../../src/music5000.js";
-import { TEST_6502 } from "../../src/models.js";
+import { findModel, TEST_6502 } from "../../src/models.js";
 
 function makeCpu() {
     const fb32 = new Uint32Array(1024 * 768);
@@ -249,5 +249,43 @@ describe("Cpu6502 cpuMultiplier", () => {
 
         cpu.polltime(1);
         expect(cpu.scheduler.epoch).toBe(1);
+    });
+});
+
+describe("cycle counter rollover", () => {
+    // The CPU keeps its cycle counters small by subtracting a second's worth
+    // and bumping cycleSeconds. Consumers (the Atom speaker, test helpers)
+    // reconstruct absolute time as cycleSeconds * clock + currentCycles, so
+    // rolling over by the wrong amount makes emulated time jump backwards.
+    const runAcrossASecond = async (model) => {
+        const cpu = fake6502(model);
+        await cpu.initialise();
+        const absolute = () => cpu.cycleSeconds * model.cyclesPerSecond + cpu.currentCycles;
+        let previous = absolute();
+        let wentBackwards = false;
+        // Bounded so a rollover that never happens fails rather than hangs.
+        for (let chunk = 0; chunk < 50 && cpu.cycleSeconds < 1; ++chunk) {
+            cpu.execute(100000);
+            const now = absolute();
+            if (now < previous) wentBackwards = true;
+            previous = now;
+        }
+        return { cpu, wentBackwards, absolute: absolute() };
+    };
+
+    it("rolls a 2MHz machine over after two million cycles", async () => {
+        const { cpu, wentBackwards, absolute } = await runAcrossASecond(TEST_6502);
+
+        expect(cpu.cycleSeconds).toBe(1);
+        expect(wentBackwards).toBe(false);
+        expect(absolute).toBeGreaterThanOrEqual(2 * 1000 * 1000);
+    });
+
+    it("rolls a 1MHz machine over after one million cycles", async () => {
+        const { cpu, wentBackwards, absolute } = await runAcrossASecond(findModel("Atom"));
+
+        expect(cpu.cycleSeconds).toBe(1);
+        expect(wentBackwards).toBe(false);
+        expect(absolute).toBeLessThan(2 * 1000 * 1000);
     });
 });

--- a/tests/unit/test-models.js
+++ b/tests/unit/test-models.js
@@ -17,6 +17,11 @@ describe("Model", () => {
         }
     });
 
+    it("reports its clock in cycles per second", () => {
+        expect(findModel("Master").cyclesPerSecond).toBe(2 * 1000 * 1000);
+        expect(findModel("Atom").cyclesPerSecond).toBe(1 * 1000 * 1000);
+    });
+
     it("carries no per-session settings", () => {
         const master = findModel("Master");
 

--- a/tests/unit/test-tapes.js
+++ b/tests/unit/test-tapes.js
@@ -1,5 +1,9 @@
 import { describe, it, expect } from "vitest";
 import { loadTapeFromData } from "../../src/tapes.js";
+import { findModel } from "../../src/models.js";
+
+const BbcModel = findModel("B-DFS1.2");
+const AtomModel = findModel("Atom");
 
 // Build a minimal UEF file: "UEF File!\0" + version (minor, major) + chunks.
 // UefTape constructor reads the first chunk, so at least one must be present.
@@ -75,7 +79,7 @@ describe("tapes", () => {
     describe("loadTapeFromData", () => {
         it("should detect UEF format", async () => {
             const uef = makeUef([{ id: 0x0100, data: [0x41] }]);
-            const tape = await loadTapeFromData("test.uef", uef);
+            const tape = await loadTapeFromData("test.uef", uef, BbcModel);
             expect(tape).not.toBeNull();
             // Verify it behaves as a UEF tape: poll should not throw
             expect(() => tape.poll(mockAcia())).not.toThrow();
@@ -83,7 +87,7 @@ describe("tapes", () => {
 
         it("should detect tapefile format", async () => {
             const tapefile = makeTapefile();
-            const tape = await loadTapeFromData("test.tape", tapefile);
+            const tape = await loadTapeFromData("test.tape", tapefile, BbcModel);
             expect(tape).not.toBeNull();
             // First poll reads the 0xFF 0x04 carrier header and returns 5s delay
             expect(tape.poll(mockAcia())).toBe(5 * 2 * 1000 * 1000);
@@ -91,14 +95,37 @@ describe("tapes", () => {
 
         it("should return null for unknown format", async () => {
             const unknown = new Uint8Array([0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b]);
-            const tape = await loadTapeFromData("test.bin", unknown);
+            const tape = await loadTapeFromData("test.bin", unknown, BbcModel);
             expect(tape).toBeNull();
         });
 
         it("should reject UEF with unsupported major version", async () => {
             const uef = makeUef([{ id: 0x0100, data: [0x41] }]);
             uef[11] = 0x01; // major version 1
-            await expect(loadTapeFromData("test.uef", uef)).rejects.toThrow(/Unsupported UEF version/);
+            await expect(loadTapeFromData("test.uef", uef, BbcModel)).rejects.toThrow(/Unsupported UEF version/);
+        });
+    });
+
+    describe("tape timing follows the machine's clock", () => {
+        // Chunk 0x0116 is a gap given in seconds as a 32-bit float; the tape
+        // must turn it into however many cycles that is on this machine.
+        const oneSecondGap = () =>
+            makeUef([
+                { id: 0x0000, data: [0x00] },
+                { id: 0x0116, data: [0x00, 0x00, 0x80, 0x3f] },
+            ]);
+
+        it("turns a one second gap into one second of CPU cycles", async () => {
+            const bbc = await loadTapeFromData("test.uef", oneSecondGap(), BbcModel);
+            expect(bbc.poll(mockAcia())).toBe(2 * 1000 * 1000);
+
+            const atom = await loadTapeFromData("test.uef", oneSecondGap(), AtomModel);
+            expect(atom.poll(mockAcia())).toBe(1 * 1000 * 1000);
+        });
+
+        it("simulates five seconds of tapefile carrier at the machine's clock", async () => {
+            const atom = await loadTapeFromData("test.tape", makeTapefile(), AtomModel);
+            expect(atom.poll(mockAcia())).toBe(5 * 1000 * 1000);
         });
     });
 
@@ -110,7 +137,7 @@ describe("tapes", () => {
                 { id: 0x0110, data: [0x01, 0x00] }, // carrier tone, count=1
                 { id: 0x0100, data: [0x41] },
             ]);
-            const tape = await loadTapeFromData("test.uef", uef);
+            const tape = await loadTapeFromData("test.uef", uef, BbcModel);
             expect(pollUntilReceived(tape)).toBe(0x41);
         });
 
@@ -119,7 +146,7 @@ describe("tapes", () => {
                 { id: 0x0000, data: [0x74, 0x65, 0x73, 0x74, 0x00] }, // "test\0"
                 { id: 0x0100, data: [0x41] },
             ]);
-            const tape = await loadTapeFromData("test.uef", uef);
+            const tape = await loadTapeFromData("test.uef", uef, BbcModel);
             // Poll past the origin chunk and receive data from the next chunk
             expect(pollUntilReceived(tape)).toBe(0x41);
         });
@@ -129,7 +156,7 @@ describe("tapes", () => {
                 { id: 0x0110, data: [0x01, 0x00] },
                 { id: 0x0100, data: [0x41] },
             ]);
-            const tape = await loadTapeFromData("test.uef", uef);
+            const tape = await loadTapeFromData("test.uef", uef, BbcModel);
             expect(pollUntilReceived(tape)).toBe(0x41);
 
             tape.rewind();
@@ -172,7 +199,7 @@ describe("tapes", () => {
             // With phase-continuous generation, the last wavebit of a '1' bit
             // must equal the first wavebit of the following '0' bit.
             const uef = makeAtomUef(0x00);
-            const tape = await loadTapeFromData("test.uef", uef, true);
+            const tape = await loadTapeFromData("test.uef", uef, AtomModel);
             const bits = collectWavebits(tape);
 
             // Carrier is 16 wavebits. The 16th is the last carrier wavebit,
@@ -184,8 +211,8 @@ describe("tapes", () => {
         it("should produce the same waveform from two identical tapes", async () => {
             const uef1 = makeAtomUef(0x55);
             const uef2 = makeAtomUef(0x55);
-            const tape1 = await loadTapeFromData("test.uef", uef1, true);
-            const tape2 = await loadTapeFromData("test.uef", uef2, true);
+            const tape1 = await loadTapeFromData("test.uef", uef1, AtomModel);
+            const tape2 = await loadTapeFromData("test.uef", uef2, AtomModel);
 
             expect(collectWavebits(tape1)).toEqual(collectWavebits(tape2));
         });
@@ -196,7 +223,7 @@ describe("tapes", () => {
             // Format detection uses readByte(0/1) without advancing the stream,
             // so the first poll still reads the 0xFF 0x04 carrier header.
             const tapefile = makeTapefile([0xff, 0x04]);
-            const tape = await loadTapeFromData("test.tape", tapefile);
+            const tape = await loadTapeFromData("test.tape", tapefile, BbcModel);
             let carrierSet = null;
             const acia = {
                 setTapeCarrier: (val) => {
@@ -211,21 +238,21 @@ describe("tapes", () => {
 
         it("should receive regular bytes after rewind", async () => {
             const tapefile = makeTapefile([0x41]);
-            const tape = await loadTapeFromData("test.tape", tapefile);
+            const tape = await loadTapeFromData("test.tape", tapefile, BbcModel);
             tape.rewind();
             expect(pollUntilReceived(tape, 1)).toBe(0x41);
         });
 
         it("should escape 0xFF as 0xFF 0xFF after rewind", async () => {
             const tapefile = makeTapefile([0xff, 0xff]);
-            const tape = await loadTapeFromData("test.tape", tapefile);
+            const tape = await loadTapeFromData("test.tape", tapefile, BbcModel);
             tape.rewind();
             expect(pollUntilReceived(tape, 1)).toBe(0xff);
         });
 
         it("should handle end of carrier (0xFF 0x00) after rewind", async () => {
             const tapefile = makeTapefile([0xff, 0x00]);
-            const tape = await loadTapeFromData("test.tape", tapefile);
+            const tape = await loadTapeFromData("test.tape", tapefile, BbcModel);
             tape.rewind();
             let carrierSet = null;
             const acia = {
@@ -241,7 +268,7 @@ describe("tapes", () => {
 
         it("should support rewind and replay", async () => {
             const tapefile = makeTapefile([0x41, 0x42]);
-            const tape = await loadTapeFromData("test.tape", tapefile);
+            const tape = await loadTapeFromData("test.tape", tapefile, BbcModel);
             tape.rewind();
             expect(pollUntilReceived(tape, 1)).toBe(0x41);
 
@@ -251,7 +278,7 @@ describe("tapes", () => {
 
         it("should return large cycle count at EOF", async () => {
             const tapefile = makeTapefile([0x41, 0x42, 0x43]);
-            const tape = await loadTapeFromData("test.tape", tapefile);
+            const tape = await loadTapeFromData("test.tape", tapefile, BbcModel);
             tape.rewind();
             // Consume all bytes
             for (let i = 0; i < 3; i++) tape.poll(mockAcia());


### PR DESCRIPTION
Closes most of #751: the sites that assumed 2MHz, or picked 1MHz from an `isAtom` flag, now ask the model. `Model` gains a `cyclesPerSecond` getter and it is threaded to:

- `6502.js` — `peripheralCyclesPerSecond` (the Atom's separate 1MHz override goes away), the one-second cycle-counter rollover, and `TouchScreen`
- `acia.js` — `secondsToCycles`. This converts a duration into scheduler ticks, and the scheduler counts CPU cycles, so it is the CPU clock rather than the serial clock
- `tapes.js` — `loadTapeFromData` takes the model instead of an `isAtom` flag; the flag only ever selected between two clocks and the Atom waveform encoding, and the model answers both. The `TapefileTape` bit rate and its five seconds of carrier come from the model too
- `econet.js` — the retry timeout, now half a second of whatever clock
- `6847.js` — the VDG advances `3.638004 / clockMhz` cycles per CPU cycle rather than a constant that quietly assumed 1MHz
- `main.js`, `touchscreen.js`, and the test harness's seconds-to-cycles conversions

Values are identical for every machine, checked mechanically across all models: for each site, the old constant equals what the model derives on the machines that site applies to.

### The one deliberate behaviour change

Second commit, on the Atom only. The rollover subtracted a fixed 2e6 whatever the machine, but consumers rebuild absolute time as `cycleSeconds * clock + currentCycles` — `AtomSoundChip.updateSpeaker` divides by 1MHz, as does `tests/test-machine.js`. So on the Atom, emulated time jumped backwards by 1e6 every 2e6 cycles. Demonstrated by running an Atom past the rollover before the change (time went backwards once) and after (it did not). `docs/snapshot-format.md` already describes `cycleSeconds` as elapsed seconds; now it is.

Also worth knowing: the ACIA and touchscreen are constructed on the Atom too, and now derive 1MHz there. Nothing on the Atom reaches either — its address decode has no 6850 or serial ULA, so no ACIA task is ever scheduled and the touchscreen is never put into poll mode — so this is inert, but it is a difference.

### Left alone

`soundchip.js`'s `sampleRate / 2000000`. The base `SoundChip` is only ever fitted to a 2MHz machine; the Atom gets `AtomSoundChip`, which already takes the clock from the model via `main.js`. Threading a clock there means a required option at five construction sites, two of them test helpers, for no change in any number. Happy to do it if you'd rather have no exceptions.

### Tests

New tests fail if the clock is wrong: tape gap and carrier lengths on a 1MHz vs 2MHz machine, ACIA byte time, VDG cycles per CPU cycle, and the rollover on both clocks. Verified by mutating `cyclesPerSecond` to a constant 2MHz and watching five of them fail.

Lint, 682 unit tests, all integration tests (`--no-file-parallelism`), and the CPU suite pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)




Copilot spotted that `TouchScreen` schedules its poll callback unbound. That is real, but pre-existing and untouched here: this PR only changed the `PollCycles` constant next door. Tracked separately in #758.
