### PR TITLE
fix: bind the touchscreen poll callback to its instance

### DIFF
--- a/src/touchscreen.js
+++ b/src/touchscreen.js
@@ -3,7 +3,7 @@
 import * as utils from "./utils.js";
 
 const PollHz = 8; // Made up
-const PollCycles = (2 * 1000 * 1000) / PollHz;
+export const PollCycles = (2 * 1000 * 1000) / PollHz;
 
 function doScale(val, scale, margin) {
     val = (val - margin) / (1 - 2 * margin);
@@ -13,11 +13,11 @@ function doScale(val, scale, margin) {
 export class TouchScreen {
     constructor(scheduler) {
         this.scheduler = scheduler;
-        this.mouse = [];
+        this.mouse = { x: 0, y: 0, button: 0 };
         this.outBuffer = new utils.Fifo(16);
         this.delay = 0;
         this.mode = 0;
-        this.pollTask = this.scheduler.newTask(this.poll);
+        this.pollTask = this.scheduler.newTask(() => this.poll());
     }
 
     tryReceive(rts) {

--- a/tests/unit/test-touchscreen.js
+++ b/tests/unit/test-touchscreen.js
@@ -1,0 +1,70 @@
+import { describe, it, expect, beforeEach } from "vitest";
+
+import { Scheduler } from "../../src/scheduler.js";
+import { TouchScreen, PollCycles } from "../../src/touchscreen.js";
+
+/** Drain everything the touchscreen has to send. */
+function readAll(touchScreen) {
+    const bytes = [];
+    for (;;) {
+        const byte = touchScreen.tryReceive(true);
+        if (byte < 0) return bytes;
+        bytes.push(byte);
+    }
+}
+
+/** Send a command string to the touchscreen, as the guest would over RS-423. */
+function transmit(touchScreen, command) {
+    for (const char of command) touchScreen.onTransmit(char.charCodeAt(0));
+}
+
+describe("TouchScreen", () => {
+    let scheduler;
+    let touchScreen;
+
+    beforeEach(() => {
+        scheduler = new Scheduler();
+        touchScreen = new TouchScreen(scheduler);
+    });
+
+    it("polls repeatedly once the guest selects mode 129", () => {
+        touchScreen.onMouse(0.5, 0.5, true);
+        transmit(touchScreen, "M129.");
+
+        scheduler.polltime(PollCycles);
+        // Centre of the screen, with the button down.
+        expect(readAll(touchScreen)).toEqual([0x43, 0x4c, 0x43, 0x42, 0x2e]);
+
+        scheduler.polltime(PollCycles);
+        expect(readAll(touchScreen)).toEqual([0x43, 0x4c, 0x43, 0x42, 0x2e]);
+    });
+
+    it("reports nothing touched before the mouse is ever moved", () => {
+        transmit(touchScreen, "M130.");
+
+        scheduler.polltime(PollCycles);
+        expect(readAll(touchScreen)).toEqual([0x4f, 0x4f, 0x4f, 0x4f, 0x2e]);
+    });
+
+    it("does not poll in other modes", () => {
+        transmit(touchScreen, "M128.");
+
+        scheduler.polltime(10 * PollCycles);
+        expect(readAll(touchScreen)).toEqual([]);
+    });
+
+    it("responds to a single-shot read request in mode 1", () => {
+        touchScreen.onMouse(0.5, 0.5, true);
+        transmit(touchScreen, "M1?");
+
+        expect(readAll(touchScreen)).toEqual([0x43, 0x4c, 0x43, 0x42, 0x2e]);
+    });
+
+    it("holds off sending until RTS is asserted", () => {
+        touchScreen.onMouse(0.5, 0.5, true);
+        transmit(touchScreen, "M1?");
+
+        expect(touchScreen.tryReceive(false)).toBe(-1);
+        expect(touchScreen.tryReceive(true)).toBe(0x43);
+    });
+});


### PR DESCRIPTION
The scheduler calls tasks as `task.onExpire()`, so passing the unbound `this.poll` meant `this` was the `ScheduledTask` and `doRead()` threw out of the emulation loop the first time a guest selected touchscreen mode 129 or 130. Because the throw came before the reschedule, polling stopped for good.

The path is live, and I checked it end to end with a headless machine: a BASIC program doing `*FX 2,1` / `*FX 3,1`, sending `M129.`, then reading with `GET` gets a continuous stream of position reports after this change, and an uncaught `TypeError` out of the CPU loop before it.

Also gives `mouse` the shape the rest of the class expects; it was `[]`, which was only ever harmless because the untouched case never reads the coordinates.

Fixes #758

🤖 Generated with [Claude Code](https://claude.com/claude-code)
