### PR TITLE
fix: handle every 1770 force interrupt condition instead of throwing

### DIFF
--- a/src/wd-fdc.js
+++ b/src/wd-fdc.js
@@ -47,6 +47,18 @@ const CommandBits = Object.freeze({
 });
 
 /**
+ * Type IV (force interrupt) condition bits, taken from the command's low nibble. Bits 0 and 1
+ * select the not-ready to ready and ready to not-ready transitions.
+ *
+ * @readonly
+ * @enum {Number}
+ */
+const ForceInterruptBits = Object.freeze({
+    indexPulse: 0x04,
+    immediate: 0x08,
+});
+
+/**
  * The drive control register is documented here:
  * https://www.cloud9.co.uk/james/BBCMicro/Documentation/wd1770.html
  *
@@ -512,6 +524,8 @@ export class WdFdc {
         //   insofar as index pulse appears to be reported in the status register.
         // - Interrupt on index pulse is only active for the current command.
         if (this._statusRegister & Status.busy) {
+            // Any settle or seek timer belongs to the command being aborted.
+            this._clearTimer();
             this._commandDone(false);
         } else {
             if (this._state !== State.idle) throw new Error(`Unexpected state when force interrupt: ${this._state}`);
@@ -523,13 +537,10 @@ export class WdFdc {
                 this._currentDrive.startSpinning();
             }
         }
-        if (forceInterruptBits === 0) {
-            this._isInterruptOnIndexPulse = false;
-        } else if (forceInterruptBits === 4) {
-            this._isInterruptOnIndexPulse = true;
-        } else {
-            throw new Error(`1700 force interrupt flags not handled: ${forceInterruptBits}`);
-        }
+        if (forceInterruptBits & ForceInterruptBits.immediate) this._setIntRq(true);
+        this._isInterruptOnIndexPulse = !!(forceInterruptBits & ForceInterruptBits.indexPulse);
+        // The remaining two bits select interrupts on the ready line's transitions. The BBC ties
+        // the 1770's READY input active, so neither transition can ever occur.
     }
 
     _timerFired() {

--- a/src/wd-fdc.js
+++ b/src/wd-fdc.js
@@ -47,8 +47,7 @@ const CommandBits = Object.freeze({
 });
 
 /**
- * Type IV (force interrupt) condition bits, taken from the command's low nibble. Bits 0 and 1
- * select the not-ready to ready and ready to not-ready transitions.
+ * Type IV (force interrupt) condition bits, taken from the command's low nibble.
  *
  * @readonly
  * @enum {Number}
@@ -524,7 +523,7 @@ export class WdFdc {
         //   insofar as index pulse appears to be reported in the status register.
         // - Interrupt on index pulse is only active for the current command.
         if (this._statusRegister & Status.busy) {
-            // Any settle or seek timer belongs to the command being aborted.
+            // Any pending timer belongs to the command being aborted.
             this._clearTimer();
             this._commandDone(false);
         } else {

--- a/tests/unit/test-wd-fdc.js
+++ b/tests/unit/test-wd-fdc.js
@@ -18,16 +18,14 @@ const ControlRunningDrive0 = 0x21;
 const StatusBusy = 0x01;
 
 const ForceInterrupt = 0xd0;
+// The whole low nibble, including the ready line bits the BBC can never exercise.
+const AllFlagCombinations = [...Array(16).keys()];
 // Seek, with the spin-up wait disabled so the seek starts without six revolutions of delay.
 const SeekCommand = 0x18;
 
-// The drive schedules its first pulse callback one tick after it starts spinning.
-const TicksForFirstPulse = 1;
-// Half way into a seek step, which at the default 6ms rate and two ticks per microsecond is
-// 12000 ticks.
-const TicksMidSeekStep = 6000;
-// Comfortably more than the 32us the controller takes to report a command as complete.
-const TicksForCommandCompletion = 1000;
+// Long enough to reach the drive's first pulse callback and to outlast the 32us the controller
+// takes to report a command as complete, but still well inside a seek's first step.
+const ShortWaitTicks = 1000;
 
 /**
  * A drive with no disc holds its index line permanently asserted, so the controller sees exactly
@@ -64,14 +62,14 @@ describe("WD1770 FDC tests", () => {
             fdc.write(TrackRegister, 0);
             fdc.write(DataRegister, 40);
             fdc.write(CommandRegister, SeekCommand);
-            scheduler.polltime(TicksMidSeekStep);
+            scheduler.polltime(ShortWaitTicks);
             expect(fdc.read(StatusRegister) & StatusBusy).toBe(StatusBusy);
 
             fdc.write(CommandRegister, ForceInterrupt | 0x08);
             expect(cpu.nmi).toBe(true);
 
             // The completion timer must clear busy without swallowing the interrupt.
-            scheduler.polltime(TicksForCommandCompletion);
+            scheduler.polltime(ShortWaitTicks);
             expect(cpu.nmi).toBe(true);
             expect(fdc.read(StatusRegister) & StatusBusy).toBe(0);
         });
@@ -80,7 +78,7 @@ describe("WD1770 FDC tests", () => {
             const { cpu, scheduler, fdc } = makeFdc();
             fdc.write(CommandRegister, ForceInterrupt | 0x04);
             expect(cpu.nmi).toBe(false);
-            scheduler.polltime(TicksForFirstPulse);
+            scheduler.polltime(ShortWaitTicks);
             expect(cpu.nmi).toBe(true);
         });
 
@@ -92,7 +90,7 @@ describe("WD1770 FDC tests", () => {
             // Reading the status register drops INTRQ, so a second one must be the index pulse.
             fdc.read(StatusRegister);
             expect(cpu.nmi).toBe(false);
-            scheduler.polltime(TicksForFirstPulse);
+            scheduler.polltime(ShortWaitTicks);
             expect(cpu.nmi).toBe(true);
         });
 
@@ -100,22 +98,26 @@ describe("WD1770 FDC tests", () => {
             const { cpu, scheduler, fdc } = makeFdc();
             fdc.write(CommandRegister, ForceInterrupt | 0x04);
             fdc.write(CommandRegister, ForceInterrupt);
-            scheduler.polltime(TicksForFirstPulse);
+            scheduler.polltime(ShortWaitTicks);
             expect(cpu.nmi).toBe(false);
         });
 
-        it.each([...Array(16).keys()])("accepts force interrupt flags %i when idle", (bits) => {
-            const { fdc } = makeFdc();
-            expect(() => fdc.write(CommandRegister, ForceInterrupt | bits)).not.toThrow();
+        it("accepts every combination of flags when idle", () => {
+            for (const bits of AllFlagCombinations) {
+                const { fdc } = makeFdc();
+                expect(() => fdc.write(CommandRegister, ForceInterrupt | bits)).not.toThrow();
+            }
         });
 
-        it.each([...Array(16).keys()])("accepts force interrupt flags %i during a seek", (bits) => {
-            const { scheduler, fdc } = makeFdc(true);
-            fdc.write(TrackRegister, 0);
-            fdc.write(DataRegister, 40);
-            fdc.write(CommandRegister, SeekCommand);
-            scheduler.polltime(TicksMidSeekStep);
-            expect(() => fdc.write(CommandRegister, ForceInterrupt | bits)).not.toThrow();
+        it("accepts every combination of flags during a seek", () => {
+            for (const bits of AllFlagCombinations) {
+                const { scheduler, fdc } = makeFdc(true);
+                fdc.write(TrackRegister, 0);
+                fdc.write(DataRegister, 40);
+                fdc.write(CommandRegister, SeekCommand);
+                scheduler.polltime(ShortWaitTicks);
+                expect(() => fdc.write(CommandRegister, ForceInterrupt | bits)).not.toThrow();
+            }
         });
     });
 });

--- a/tests/unit/test-wd-fdc.js
+++ b/tests/unit/test-wd-fdc.js
@@ -22,8 +22,9 @@ const ForceInterrupt = 0xd0;
 const SeekCommand = 0x18;
 
 // The drive schedules its first pulse callback one tick after it starts spinning.
-const TicksForFirstPulse = 1000;
-// Part way into a seek step, which is 6ms at the default rate and two ticks per microsecond.
+const TicksForFirstPulse = 1;
+// Half way into a seek step, which at the default 6ms rate and two ticks per microsecond is
+// 12000 ticks.
 const TicksMidSeekStep = 6000;
 // Comfortably more than the 32us the controller takes to report a command as complete.
 const TicksForCommandCompletion = 1000;

--- a/tests/unit/test-wd-fdc.js
+++ b/tests/unit/test-wd-fdc.js
@@ -1,0 +1,120 @@
+import { describe, it, expect } from "vitest";
+
+import { Scheduler } from "../../src/scheduler.js";
+import { WdFdc } from "../../src/wd-fdc.js";
+import { DiscDrive } from "../../src/disc-drive.js";
+import { Disc, DiscConfig } from "../../src/disc.js";
+import { fake6502 } from "../../src/fake6502.js";
+
+const ControlRegister = 0;
+const CommandRegister = 4;
+const StatusRegister = 4;
+const TrackRegister = 5;
+const DataRegister = 7;
+
+// Reset is active low, so 0x20 releases it; 0x01 selects drive 0.
+const ControlRunningDrive0 = 0x21;
+
+const StatusBusy = 0x01;
+
+const ForceInterrupt = 0xd0;
+// Seek, with the spin-up wait disabled so the seek starts without six revolutions of delay.
+const SeekCommand = 0x18;
+
+// The drive schedules its first pulse callback one tick after it starts spinning.
+const TicksForFirstPulse = 1000;
+// Part way into a seek step, which is 6ms at the default rate and two ticks per microsecond.
+const TicksMidSeekStep = 6000;
+// Comfortably more than the 32us the controller takes to report a command as complete.
+const TicksForCommandCompletion = 1000;
+
+/**
+ * A drive with no disc holds its index line permanently asserted, so the controller sees exactly
+ * one index pulse edge: the first callback after the motor starts.
+ *
+ * @param {boolean} withDisc whether to load a blank disc, needed for anything that reads the surface
+ */
+function makeFdc(withDisc = false) {
+    const cpu = fake6502();
+    const scheduler = new Scheduler();
+    const drives = [new DiscDrive(0, scheduler), new DiscDrive(1, scheduler)];
+    if (withDisc) drives[0].setDisc(new Disc(true, new DiscConfig(), "test.ssd"));
+    const fdc = new WdFdc(cpu, scheduler, drives, {});
+    fdc.write(ControlRegister, ControlRunningDrive0);
+    return { cpu, scheduler, fdc };
+}
+
+describe("WD1770 FDC tests", () => {
+    describe("force interrupt", () => {
+        it("does not interrupt for &D0", () => {
+            const { cpu, fdc } = makeFdc();
+            fdc.write(CommandRegister, ForceInterrupt);
+            expect(cpu.nmi).toBe(false);
+        });
+
+        it("interrupts immediately for &D8", () => {
+            const { cpu, fdc } = makeFdc();
+            fdc.write(CommandRegister, ForceInterrupt | 0x08);
+            expect(cpu.nmi).toBe(true);
+        });
+
+        it("aborts a seek in progress and interrupts for &D8", () => {
+            const { cpu, scheduler, fdc } = makeFdc(true);
+            fdc.write(TrackRegister, 0);
+            fdc.write(DataRegister, 40);
+            fdc.write(CommandRegister, SeekCommand);
+            scheduler.polltime(TicksMidSeekStep);
+            expect(fdc.read(StatusRegister) & StatusBusy).toBe(StatusBusy);
+
+            fdc.write(CommandRegister, ForceInterrupt | 0x08);
+            expect(cpu.nmi).toBe(true);
+
+            // The completion timer must clear busy without swallowing the interrupt.
+            scheduler.polltime(TicksForCommandCompletion);
+            expect(cpu.nmi).toBe(true);
+            expect(fdc.read(StatusRegister) & StatusBusy).toBe(0);
+        });
+
+        it("interrupts on the next index pulse for &D4", () => {
+            const { cpu, scheduler, fdc } = makeFdc();
+            fdc.write(CommandRegister, ForceInterrupt | 0x04);
+            expect(cpu.nmi).toBe(false);
+            scheduler.polltime(TicksForFirstPulse);
+            expect(cpu.nmi).toBe(true);
+        });
+
+        it("interrupts immediately and on the next index pulse for &DC", () => {
+            const { cpu, scheduler, fdc } = makeFdc();
+            fdc.write(CommandRegister, ForceInterrupt | 0x0c);
+            expect(cpu.nmi).toBe(true);
+
+            // Reading the status register drops INTRQ, so a second one must be the index pulse.
+            fdc.read(StatusRegister);
+            expect(cpu.nmi).toBe(false);
+            scheduler.polltime(TicksForFirstPulse);
+            expect(cpu.nmi).toBe(true);
+        });
+
+        it("stops interrupting on index pulses once &D0 disarms it", () => {
+            const { cpu, scheduler, fdc } = makeFdc();
+            fdc.write(CommandRegister, ForceInterrupt | 0x04);
+            fdc.write(CommandRegister, ForceInterrupt);
+            scheduler.polltime(TicksForFirstPulse);
+            expect(cpu.nmi).toBe(false);
+        });
+
+        it.each([...Array(16).keys()])("accepts force interrupt flags %i when idle", (bits) => {
+            const { fdc } = makeFdc();
+            expect(() => fdc.write(CommandRegister, ForceInterrupt | bits)).not.toThrow();
+        });
+
+        it.each([...Array(16).keys()])("accepts force interrupt flags %i during a seek", (bits) => {
+            const { scheduler, fdc } = makeFdc(true);
+            fdc.write(TrackRegister, 0);
+            fdc.write(DataRegister, 40);
+            fdc.write(CommandRegister, SeekCommand);
+            scheduler.polltime(TicksMidSeekStep);
+            expect(() => fdc.write(CommandRegister, ForceInterrupt | bits)).not.toThrow();
+        });
+    });
+});


### PR DESCRIPTION
Fixes #761.

`WdFdc._handleForceInterrupt` threw for any type IV low nibble other than 0 or 4, so a single guest store of `&D8` took the whole emulator down. `&D8` is the ordinary way for software to abort a command and get an interrupt, so this is reachable from real code (`?&FE28=&D8` on a Master, `?&FE84=&D8` on a Model B once the DFS has released reset).

Bit 3 now raises INTRQ immediately, on top of the command abort that was already happening. Bit 2 keeps arming interrupt-on-index-pulse and now composes with bit 3, so `&DC` does both. Bits 0 and 1 select the ready line's transitions, which cannot occur on a BBC because READY is tied active, so they are accepted and do nothing. The `&D0` case from the existing EMU NOTE, where command completion does *not* raise INTRQ, is preserved.

That left a second crash on the same path: aborting a seek is the canonical use of force interrupt, but `_commandDone` hit `Timer started but still running` because the seek's step timer was still pending. The busy branch now cancels it first.

### Other emulators

- **beebjit** (`wd_fdc.c`) has the same gap and `util_bail`s on anything but 0 or 4. Its EMU NOTE is where the `&D0` inhibition comes from.
- **b-em** (`wd1770.c`) raises NMI on completion of a force interrupt whenever the command byte has bit 2 or bit 3 set, so `&D4`, `&D8` and `&DC` all interrupt. It does not wait for an index pulse for `&D4`.
- **b2** (`1770.cpp`) raises INTRQ for bit 3 immediately and for bit 2 after waiting one index pulse, matching this change. It differs on the busy case: when a force interrupt arrives while the controller is busy, b2 clears busy and idles without raising INTRQ at all, even for `&D8`. b-em and this change both interrupt there.

### Tests

New `tests/unit/test-wd-fdc.js` drives the controller through its registers and watches the CPU's NMI line: `&D0` silent, `&D8` immediate, `&D4` on the next index pulse only, `&DC` both, `&D0` disarming a previously armed `&D4`, `&D8` aborting a seek without the completion timer swallowing the interrupt, and all 16 flag values accepted both when idle and mid-seek.


### Not settled by this

Whether `&D8` raises INTRQ when it arrives *while the controller is busy* has no hardware evidence behind it. b-em interrupts, b2 does not, and beebjit's tested note ("command completion INTRQ is inhibited for `$D0`", implying not for the others) leans towards interrupting, so that is what this does. It is one line in `_handleForceInterrupt` if a real 1770 or 1772 says otherwise.

The `NMI.WD` program on the tests.ssd in #204 exercises exactly this path and would settle it, along with the interrupt latency none of the three emulators agree on. It has never been run against jsbeeb because it crashed before producing a number, which is the bug this fixes.

`src/wd-fdc.js` had no unit tests before this. `tests/integration/protection.js` looks like coverage but runs on the default `B-DFS1.2`, an 8271 machine, and the Master-based integration tests never load a disc. So the new file is a first leg rather than a complete suite for a 1446 line device.
