### PR TITLE
fix: release GL objects when the display mode changes

### DIFF
--- a/src/canvas.js
+++ b/src/canvas.js
@@ -32,6 +32,9 @@ export class Canvas {
 
         this.fb32 = new Uint32Array(this.imageData.data.buffer);
     }
+    /** Nothing to release: the 2D context owns no objects of ours. */
+    dispose() {}
+
     paint(minx, miny, maxx, maxy, _frameCount) {
         const width = maxx - minx;
         const height = maxy - miny;
@@ -98,8 +101,8 @@ export class GlCanvas {
 
         const vertexPositionAttrLoc = checkedGl.getAttribLocation(program, "pos");
         checkedGl.enableVertexAttribArray(vertexPositionAttrLoc);
-        const vertexPositionBuffer = checkedGl.createBuffer();
-        checkedGl.bindBuffer(checkedGl.ARRAY_BUFFER, vertexPositionBuffer);
+        this.vertexPositionBuffer = checkedGl.createBuffer();
+        checkedGl.bindBuffer(checkedGl.ARRAY_BUFFER, this.vertexPositionBuffer);
         checkedGl.bufferData(checkedGl.ARRAY_BUFFER, new Float32Array([0, 0, 0, 1, 1, 0, 1, 1]), checkedGl.STATIC_DRAW);
         checkedGl.vertexAttribPointer(vertexPositionAttrLoc, 2, checkedGl.FLOAT, false, 0, 0);
 
@@ -112,10 +115,29 @@ export class GlCanvas {
         checkedGl.activeTexture(gl.TEXTURE0);
         checkedGl.bindTexture(gl.TEXTURE_2D, this.texture);
 
+        this.checkedGl = checkedGl;
         this.uvFloatArray = new Float32Array(8);
         this.lastExtent = {};
 
         console.log("GL Canvas set up");
+    }
+
+    /**
+     * Release the GL objects this canvas owns.
+     *
+     * Switching display mode builds a new canvas over the same element, and a
+     * canvas only ever hands out one WebGL context — so the new one inherits
+     * the old one's context and the old one's objects stay resident unless
+     * they are deleted here. That is a megabytes-per-switch leak: the
+     * framebuffer texture alone is 1024x1024 RGBA.
+     */
+    dispose() {
+        const gl = this.checkedGl;
+        this.filter.dispose();
+        gl.deleteTexture(this.texture);
+        gl.deleteBuffer(this.vertexPositionBuffer);
+        gl.deleteBuffer(this.uvBuffer);
+        this.texture = this.vertexPositionBuffer = this.uvBuffer = null;
     }
 
     paint(minx, miny, maxx, maxy, frameCount) {

--- a/src/main.js
+++ b/src/main.js
@@ -398,7 +398,11 @@ function createCanvasForFilter(filterClass) {
 
 let displayModeFilter = canvasLib.getFilterForMode(parsedQuery.displayMode || "rgb");
 function swapCanvas(newFilterClass) {
+    const oldCanvas = canvas;
     const newCanvas = createCanvasForFilter(newFilterClass);
+    // Only once the replacement exists, so a failure to build it leaves the
+    // display we already had. The two share a GL context but no GL objects.
+    oldCanvas.dispose();
     video.fb32 = newCanvas.fb32;
     video.paint_ext = function paint(minx, miny, maxx, maxy) {
         frames++;

--- a/src/video-filters/pal-composite.js
+++ b/src/video-filters/pal-composite.js
@@ -47,29 +47,34 @@ export class PALCompositeFilter {
 
         // Compile shaders
         const vertShader = this._compileShader(gl.VERTEX_SHADER, VERT_SHADER);
-        const fragShader = this._compileShader(gl.FRAGMENT_SHADER, FRAG_SHADER);
+        let fragShader = null;
+        try {
+            fragShader = this._compileShader(gl.FRAGMENT_SHADER, FRAG_SHADER);
 
-        // Link program
-        this.program = gl.createProgram();
-        gl.attachShader(this.program, vertShader);
-        gl.attachShader(this.program, fragShader);
-        gl.linkProgram(this.program);
+            // Link program
+            this.program = gl.createProgram();
+            gl.attachShader(this.program, vertShader);
+            gl.attachShader(this.program, fragShader);
+            gl.linkProgram(this.program);
 
-        // Once linked the program holds its own reference, so releasing ours
-        // here means deleting the program later frees the shaders too.
-        gl.deleteShader(vertShader);
-        gl.deleteShader(fragShader);
+            if (!gl.getProgramParameter(this.program, gl.LINK_STATUS)) {
+                const info = gl.getProgramInfoLog(this.program);
+                this.dispose();
+                throw new Error("Failed to link PAL shader program: " + info);
+            }
 
-        if (!gl.getProgramParameter(this.program, gl.LINK_STATUS)) {
-            const info = gl.getProgramInfoLog(this.program);
-            throw new Error("Failed to link PAL shader program: " + info);
+            // Get uniform locations
+            this.locations.uFramebuffer = gl.getUniformLocation(this.program, "uFramebuffer");
+            this.locations.uResolution = gl.getUniformLocation(this.program, "uResolution");
+            this.locations.uTexelSize = gl.getUniformLocation(this.program, "uTexelSize");
+            this.locations.uFrameCount = gl.getUniformLocation(this.program, "uFrameCount");
+        } finally {
+            // Once linked the program holds its own reference, so releasing ours here means
+            // deleting the program later frees the shaders too. If we never got that far, ours
+            // was the only reference and they go now.
+            gl.deleteShader(vertShader);
+            gl.deleteShader(fragShader);
         }
-
-        // Get uniform locations
-        this.locations.uFramebuffer = gl.getUniformLocation(this.program, "uFramebuffer");
-        this.locations.uResolution = gl.getUniformLocation(this.program, "uResolution");
-        this.locations.uTexelSize = gl.getUniformLocation(this.program, "uTexelSize");
-        this.locations.uFrameCount = gl.getUniformLocation(this.program, "uFrameCount");
 
         console.log("PAL composite filter initialized");
     }
@@ -83,6 +88,7 @@ export class PALCompositeFilter {
         if (!gl.getShaderParameter(shader, gl.COMPILE_STATUS)) {
             const info = gl.getShaderInfoLog(shader);
             const typeName = type === gl.VERTEX_SHADER ? "vertex" : "fragment";
+            gl.deleteShader(shader);
             throw new Error(`Failed to compile ${typeName} shader: ${info}`);
         }
 

--- a/src/video-filters/pal-composite.js
+++ b/src/video-filters/pal-composite.js
@@ -55,6 +55,11 @@ export class PALCompositeFilter {
         gl.attachShader(this.program, fragShader);
         gl.linkProgram(this.program);
 
+        // Once linked the program holds its own reference, so releasing ours
+        // here means deleting the program later frees the shaders too.
+        gl.deleteShader(vertShader);
+        gl.deleteShader(fragShader);
+
         if (!gl.getProgramParameter(this.program, gl.LINK_STATUS)) {
             const info = gl.getProgramInfoLog(this.program);
             throw new Error("Failed to link PAL shader program: " + info);
@@ -82,6 +87,12 @@ export class PALCompositeFilter {
         }
 
         return shader;
+    }
+
+    /** Release the GL objects this filter owns. */
+    dispose() {
+        this.gl.deleteProgram(this.program);
+        this.program = null;
     }
 
     setUniforms(params) {

--- a/src/video-filters/passthrough-filter.js
+++ b/src/video-filters/passthrough-filter.js
@@ -34,23 +34,29 @@ export class PassthroughFilter {
         const gl = this.gl;
 
         const vertexShader = this._compileShader(gl.VERTEX_SHADER, VERT_SHADER);
-        const fragmentShader = this._compileShader(gl.FRAGMENT_SHADER, FRAG_SHADER);
+        let fragmentShader = null;
+        try {
+            fragmentShader = this._compileShader(gl.FRAGMENT_SHADER, FRAG_SHADER);
 
-        this.program = gl.createProgram();
-        gl.attachShader(this.program, vertexShader);
-        gl.attachShader(this.program, fragmentShader);
-        gl.linkProgram(this.program);
+            this.program = gl.createProgram();
+            gl.attachShader(this.program, vertexShader);
+            gl.attachShader(this.program, fragmentShader);
+            gl.linkProgram(this.program);
 
-        // Once linked the program holds its own reference, so releasing ours
-        // here means deleting the program later frees the shaders too.
-        gl.deleteShader(vertexShader);
-        gl.deleteShader(fragmentShader);
+            if (!gl.getProgramParameter(this.program, gl.LINK_STATUS)) {
+                const info = gl.getProgramInfoLog(this.program);
+                this.dispose();
+                throw new Error("Failed to link passthrough shader program: " + info);
+            }
 
-        if (!gl.getProgramParameter(this.program, gl.LINK_STATUS)) {
-            throw new Error("Failed to link passthrough shader program: " + gl.getProgramInfoLog(this.program));
+            this.locations.tex = gl.getUniformLocation(this.program, "tex");
+        } finally {
+            // Once linked the program holds its own reference, so releasing ours here means
+            // deleting the program later frees the shaders too. If we never got that far, ours
+            // was the only reference and they go now.
+            gl.deleteShader(vertexShader);
+            gl.deleteShader(fragmentShader);
         }
-
-        this.locations.tex = gl.getUniformLocation(this.program, "tex");
     }
 
     _compileShader(type, source) {

--- a/src/video-filters/passthrough-filter.js
+++ b/src/video-filters/passthrough-filter.js
@@ -41,6 +41,11 @@ export class PassthroughFilter {
         gl.attachShader(this.program, fragmentShader);
         gl.linkProgram(this.program);
 
+        // Once linked the program holds its own reference, so releasing ours
+        // here means deleting the program later frees the shaders too.
+        gl.deleteShader(vertexShader);
+        gl.deleteShader(fragmentShader);
+
         if (!gl.getProgramParameter(this.program, gl.LINK_STATUS)) {
             throw new Error("Failed to link passthrough shader program: " + gl.getProgramInfoLog(this.program));
         }
@@ -61,6 +66,12 @@ export class PassthroughFilter {
         }
 
         return shader;
+    }
+
+    /** Release the GL objects this filter owns. */
+    dispose() {
+        this.gl.deleteProgram(this.program);
+        this.program = null;
     }
 
     setUniforms(_params) {

--- a/tests/unit/test-canvas.js
+++ b/tests/unit/test-canvas.js
@@ -1,0 +1,160 @@
+import { describe, it, expect } from "vitest";
+import { GlCanvas, Canvas } from "../../src/canvas.js";
+import { PassthroughFilter } from "../../src/video-filters/passthrough-filter.js";
+import { PALCompositeFilter } from "../../src/video-filters/pal-composite.js";
+
+// A canvas element hands out a WebGL context once and returns that same context
+// for every later request, so switching display mode builds a new GlCanvas over
+// the old one's context. Anything the old one created stays resident until it
+// is deleted, and the framebuffer texture alone is 1024x1024 RGBA.
+
+/**
+ * A WebGL context that records the objects created and deleted through it.
+ * Every object it hands out is a distinct tagged token, so a test can tell not
+ * only how many were released but which.
+ */
+function recordingGl() {
+    const live = new Set();
+    let nextId = 0;
+    const create = (kind) => () => {
+        const object = { kind, id: nextId++ };
+        live.add(object);
+        return object;
+    };
+    const destroy = () => (object) => {
+        // WebGL ignores deleting null; a double delete would be a real bug.
+        if (object === null) return;
+        expect(live.has(object), `deleted a ${object.kind} that was not live`).toBe(true);
+        live.delete(object);
+    };
+    const gl = {
+        live,
+        // Enough of the enum for the calls below; the values are arbitrary.
+        TEXTURE_2D: 1,
+        ARRAY_BUFFER: 2,
+        RGBA: 3,
+        UNSIGNED_BYTE: 4,
+        FLOAT: 5,
+        STATIC_DRAW: 6,
+        DYNAMIC_DRAW: 7,
+        CLAMP_TO_EDGE: 8,
+        LINEAR: 9,
+        NEAREST: 10,
+        TEXTURE_WRAP_S: 11,
+        TEXTURE_WRAP_T: 12,
+        TEXTURE_MAG_FILTER: 13,
+        TEXTURE_MIN_FILTER: 14,
+        UNPACK_ALIGNMENT: 15,
+        VERTEX_SHADER: 16,
+        FRAGMENT_SHADER: 17,
+        COMPILE_STATUS: 18,
+        LINK_STATUS: 19,
+        TEXTURE0: 20,
+        TEXTURE1: 21,
+        TRIANGLE_STRIP: 22,
+        NO_ERROR: 0,
+        HIGH_FLOAT: 23,
+
+        createTexture: create("texture"),
+        createBuffer: create("buffer"),
+        createProgram: create("program"),
+        createShader: create("shader"),
+        deleteTexture: destroy(),
+        deleteBuffer: destroy(),
+        deleteProgram: destroy(),
+        deleteShader: destroy(),
+
+        // Everything else is a no-op or a fixed answer.
+        getError: () => 0,
+        getShaderParameter: () => true,
+        getProgramParameter: () => true,
+        getShaderInfoLog: () => "",
+        getProgramInfoLog: () => "",
+        getAttribLocation: () => 0,
+        getUniformLocation: () => ({}),
+        getShaderPrecisionFormat: () => ({ precision: 23 }),
+        shaderSource: () => {},
+        compileShader: () => {},
+        attachShader: () => {},
+        linkProgram: () => {},
+        useProgram: () => {},
+        depthMask: () => {},
+        viewport: () => {},
+        bindTexture: () => {},
+        bindBuffer: () => {},
+        bufferData: () => {},
+        texImage2D: () => {},
+        texSubImage2D: () => {},
+        texParameteri: () => {},
+        pixelStorei: () => {},
+        activeTexture: () => {},
+        enableVertexAttribArray: () => {},
+        vertexAttribPointer: () => {},
+        drawArrays: () => {},
+        uniform1i: () => {},
+        uniform1f: () => {},
+        uniform2f: () => {},
+    };
+    return gl;
+}
+
+/** A canvas element that hands out the same context however often it is asked. */
+function fakeCanvasElement(gl) {
+    return {
+        width: 896,
+        height: 600,
+        getContext: (kind) => (kind === "2d" ? null : gl),
+    };
+}
+
+describe("GlCanvas", () => {
+    const filters = [
+        ["passthrough", PassthroughFilter],
+        ["PAL composite", PALCompositeFilter],
+    ];
+
+    it.each(filters)("releases everything it created when disposed (%s)", (_name, filterClass) => {
+        const gl = recordingGl();
+        const canvas = new GlCanvas(fakeCanvasElement(gl), filterClass);
+        expect(gl.live.size).toBeGreaterThan(0);
+
+        canvas.dispose();
+        expect([...gl.live]).toEqual([]);
+    });
+
+    it("does not accumulate objects over repeated display mode switches", () => {
+        // This is the shape of the leak: swapping modes builds a new canvas over
+        // the same context, so without disposal each switch strands a texture,
+        // two buffers and a program.
+        const gl = recordingGl();
+        const element = fakeCanvasElement(gl);
+
+        let canvas = new GlCanvas(element, PassthroughFilter);
+        const afterFirst = gl.live.size;
+
+        for (let switches = 0; switches < 5; ++switches) {
+            const next = new GlCanvas(element, switches % 2 ? PassthroughFilter : PALCompositeFilter);
+            canvas.dispose();
+            canvas = next;
+            expect(gl.live.size).toBe(afterFirst);
+        }
+    });
+
+    it("frees its shaders as soon as they are linked", () => {
+        // The program keeps them alive; holding a second reference here would
+        // mean deleting the program never released them.
+        const gl = recordingGl();
+        new GlCanvas(fakeCanvasElement(gl), PassthroughFilter);
+        expect([...gl.live].filter((object) => object.kind === "shader")).toEqual([]);
+    });
+});
+
+describe("Canvas", () => {
+    it("can be disposed even though it owns no GL objects", () => {
+        // Callers should not have to know which sort of canvas they have.
+        const backing = { width: 1024, height: 625, getContext: () => null };
+        expect(() => new Canvas(backing)).toThrow(/2D context/);
+        expect(Canvas.prototype.dispose).toBeTypeOf("function");
+        expect(() => Canvas.prototype.dispose.call({})).not.toThrow();
+    });
+});

--- a/tests/unit/test-canvas.js
+++ b/tests/unit/test-canvas.js
@@ -10,61 +10,41 @@ import { PALCompositeFilter } from "../../src/video-filters/pal-composite.js";
 
 /**
  * A WebGL context that records the objects created and deleted through it.
- * Every object it hands out is a distinct tagged token, so a test can tell not
- * only how many were released but which.
+ * Everything except create/delete is a no-op, but the names have to be present:
+ * `makeDebugContext` wraps the context by enumerating it.
  */
 function recordingGl() {
     const live = new Set();
     let nextId = 0;
-    const create = (kind) => () => {
-        const object = { kind, id: nextId++ };
-        live.add(object);
-        return object;
-    };
-    const destroy = () => (object) => {
-        // WebGL ignores deleting null; a double delete would be a real bug.
-        if (object === null) return;
-        expect(live.has(object), `deleted a ${object.kind} that was not live`).toBe(true);
-        live.delete(object);
-    };
-    const gl = {
-        live,
-        // Enough of the enum for the calls below; the values are arbitrary.
-        TEXTURE_2D: 1,
-        ARRAY_BUFFER: 2,
-        RGBA: 3,
-        UNSIGNED_BYTE: 4,
-        FLOAT: 5,
-        STATIC_DRAW: 6,
-        DYNAMIC_DRAW: 7,
-        CLAMP_TO_EDGE: 8,
-        LINEAR: 9,
-        NEAREST: 10,
-        TEXTURE_WRAP_S: 11,
-        TEXTURE_WRAP_T: 12,
-        TEXTURE_MAG_FILTER: 13,
-        TEXTURE_MIN_FILTER: 14,
-        UNPACK_ALIGNMENT: 15,
-        VERTEX_SHADER: 16,
-        FRAGMENT_SHADER: 17,
-        COMPILE_STATUS: 18,
-        LINK_STATUS: 19,
-        TEXTURE0: 20,
-        TEXTURE1: 21,
-        TRIANGLE_STRIP: 22,
-        NO_ERROR: 0,
-        HIGH_FLOAT: 23,
+    const gl = { live };
 
-        createTexture: create("texture"),
-        createBuffer: create("buffer"),
-        createProgram: create("program"),
-        createShader: create("shader"),
-        deleteTexture: destroy(),
-        deleteBuffer: destroy(),
-        deleteProgram: destroy(),
-        deleteShader: destroy(),
+    // Constants: any stable value will do, since we only pass them back in.
+    for (const [index, name] of (
+        "TEXTURE_2D ARRAY_BUFFER RGBA UNSIGNED_BYTE FLOAT STATIC_DRAW DYNAMIC_DRAW " +
+        "CLAMP_TO_EDGE LINEAR NEAREST TEXTURE_WRAP_S TEXTURE_WRAP_T TEXTURE_MAG_FILTER TEXTURE_MIN_FILTER " +
+        "UNPACK_ALIGNMENT VERTEX_SHADER FRAGMENT_SHADER COMPILE_STATUS LINK_STATUS TEXTURE0 TEXTURE1 " +
+        "TRIANGLE_STRIP HIGH_FLOAT"
+    )
+        .split(" ")
+        .entries())
+        gl[name] = index + 1;
+    gl.NO_ERROR = 0;
 
-        // Everything else is a no-op or a fixed answer.
+    for (const kind of ["Texture", "Buffer", "Program", "Shader"]) {
+        gl[`create${kind}`] = () => {
+            const object = { kind, id: nextId++ };
+            live.add(object);
+            return object;
+        };
+        gl[`delete${kind}`] = (object) => {
+            if (object === null) return; // WebGL ignores this; a double delete would not be.
+            expect(live.has(object), `deleted a ${object.kind} that was not live`).toBe(true);
+            live.delete(object);
+        };
+    }
+
+    // Queries the canvas and filters make on the way up.
+    Object.assign(gl, {
         getError: () => 0,
         getShaderParameter: () => true,
         getProgramParameter: () => true,
@@ -73,28 +53,15 @@ function recordingGl() {
         getAttribLocation: () => 0,
         getUniformLocation: () => ({}),
         getShaderPrecisionFormat: () => ({ precision: 23 }),
-        shaderSource: () => {},
-        compileShader: () => {},
-        attachShader: () => {},
-        linkProgram: () => {},
-        useProgram: () => {},
-        depthMask: () => {},
-        viewport: () => {},
-        bindTexture: () => {},
-        bindBuffer: () => {},
-        bufferData: () => {},
-        texImage2D: () => {},
-        texSubImage2D: () => {},
-        texParameteri: () => {},
-        pixelStorei: () => {},
-        activeTexture: () => {},
-        enableVertexAttribArray: () => {},
-        vertexAttribPointer: () => {},
-        drawArrays: () => {},
-        uniform1i: () => {},
-        uniform1f: () => {},
-        uniform2f: () => {},
-    };
+    });
+
+    for (const name of (
+        "shaderSource compileShader attachShader linkProgram useProgram depthMask viewport " +
+        "bindTexture bindBuffer bufferData texImage2D texSubImage2D texParameteri pixelStorei activeTexture " +
+        "enableVertexAttribArray vertexAttribPointer drawArrays uniform1i uniform1f uniform2f"
+    ).split(" "))
+        gl[name] = () => {};
+
     return gl;
 }
 

--- a/tests/unit/test-canvas.js
+++ b/tests/unit/test-canvas.js
@@ -112,7 +112,24 @@ describe("GlCanvas", () => {
         // mean deleting the program never released them.
         const gl = recordingGl();
         new GlCanvas(fakeCanvasElement(gl), PassthroughFilter);
-        expect([...gl.live].filter((object) => object.kind === "shader")).toEqual([]);
+        expect([...gl.live].filter((object) => object.kind === "Shader")).toEqual([]);
+    });
+
+    it.each(filters)("releases its shaders when one will not compile (%s)", (_name, filterClass) => {
+        const gl = recordingGl();
+        let compiles = 0;
+        gl.getShaderParameter = () => ++compiles < 2;
+
+        expect(() => new filterClass(gl)).toThrow(/compil/i);
+        expect([...gl.live]).toEqual([]);
+    });
+
+    it.each(filters)("releases its program and shaders when linking fails (%s)", (_name, filterClass) => {
+        const gl = recordingGl();
+        gl.getProgramParameter = () => false;
+
+        expect(() => new filterClass(gl)).toThrow(/Failed to link/);
+        expect([...gl.live]).toEqual([]);
     });
 });
 


### PR DESCRIPTION
A pre-existing leak: switching between RGB Monitor and PAL TV already strands GPU memory.

### The leak

A canvas element hands out a WebGL context exactly once and returns that same context for every later `getContext` call. `swapCanvas` builds a whole new `GlCanvas` over the same element, so the new one inherits the old one's context — and everything the old one created stays resident, because nothing ever deleted it.

Per switch that strands:

| object | size |
| --- | --- |
| framebuffer texture | 1024x1024 RGBA, 4MB |
| vertex and uv buffers | small |
| program | small |
| its two shaders | small |

The shaders are a second-order case: they were never deleted after linking, so even deleting the program would not have freed them. WebGL's `deleteShader` marks a shader for deletion and the linked program keeps it alive until the program goes, which is exactly the idiom needed here.

### The fix

`GlCanvas.dispose()` releases the texture and buffers and asks the filter to release its program; the filters delete their shaders as soon as the program is linked. `swapCanvas` calls it *after* the replacement has been built, so a filter that fails to build leaves the display we already had rather than a disposed one. `Canvas` gains a no-op `dispose()` so callers do not have to know which sort of canvas they are holding.

### Test plan

- [x] New `tests/unit/test-canvas.js` drives `GlCanvas` against a context that records every object it hands out, and checks the live set is empty after disposal — for both filters
- [x] It also runs five display-mode switches and checks the live count after each is the same as after the first, which is the actual failure shape
- [x] Mutation-checked: dropping the `deleteTexture` or the `deleteShader` pair fails it (4 of 5 tests)
- [x] `npm run lint` clean, 733 unit tests pass, `npm run build` succeeds

Found while reviewing #762, which adds a third display mode and so one more texture per switch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
