### PR TITLE
fix: repaint displays that run with the CRTC's R4 at zero

### DIFF
--- a/src/video.js
+++ b/src/video.js
@@ -16,6 +16,12 @@ export const EVERYTHINGENABLED =
 export const OPAQUE_BLACK = 0xff000000;
 export const OPAQUE_WHITE = 0xffffffff;
 
+// Smallest gap, in 2MHz video clocks, between two host repaints: 5ms, so at
+// most 200 a second, comfortably above the 50Hz a sane display asks for. A CRTC
+// with small R0 or R4 can fly back every scanline or even every character, and
+// painting that often would swamp the host.
+export const MinPaintIntervalClocks = 10000;
+
 ////////////////////
 // VideoNULA - programmable 12-bit RGB palette extension (RobC hardware mod).
 // Reference: b-em src/video.c (stardot/b-em).
@@ -386,6 +392,8 @@ export class Video {
         this.doubledScanlines = true;
         this.frameSkipCount = 0;
         this.screenSubtract = 0;
+        // Host paint pacing, not machine state, so deliberately not snapshotted.
+        this.paintCooldown = 0;
 
         this.topBorder = 12;
         this.bottomBorder = 13;
@@ -567,8 +575,16 @@ export class Video {
         }
     }
 
-    paintAndClear() {
-        if (this.dispEnabled & FRAMESKIPENABLE) {
+    // Return the beam to the top of the frame, painting the frame we just
+    // finished unless we are painting too often to be worth showing the host.
+    flyback() {
+        const paintNow = this.paintCooldown === 0;
+        if (paintNow) this.paintCooldown = MinPaintIntervalClocks;
+        this.paintAndClear(paintNow);
+    }
+
+    paintAndClear(paintToHost) {
+        if (paintToHost && this.dispEnabled & FRAMESKIPENABLE) {
             this.paint();
             this.clearPaintBuffer();
         }
@@ -819,7 +835,7 @@ export class Video {
             // If no VSync occurs this frame, go back to the top and force a repaint
             if (this.bitmapY >= 768) {
                 // Arbitrary moment when TV will give up and start flyback in the absence of an explicit VSync signal
-                this.paintAndClear();
+                this.flyback();
             }
         } else if (this.hpulseCounter === (this.regs[3] & 0x0f)) {
             this.inHSync = false;
@@ -860,6 +876,7 @@ export class Video {
     // Main drawing routine
     polltime(clocks) {
         while (clocks--) {
+            if (this.paintCooldown > 0) this.paintCooldown--;
             this.oddClock = !this.oddClock;
             // Advance CRT beam.
             this.bitmapX += 8;
@@ -935,11 +952,7 @@ export class Video {
                 this.hadVSyncThisRow = true;
                 this.vpulseCounter = 0;
 
-                // Avoid intense painting if registers have boot-up or
-                // otherwise small values.
-                if (this.regs[0] && this.regs[4]) {
-                    this.paintAndClear();
-                }
+                this.flyback();
             }
 
             if (vSyncStarting || vSyncEnding) {

--- a/src/video.js
+++ b/src/video.js
@@ -389,9 +389,8 @@ export class Video {
         this.doubledScanlines = true;
         this.frameSkipCount = 0;
         this.screenSubtract = 0;
-        this.videoClocks = 0;
         // Host paint pacing, not machine state, so deliberately not snapshotted.
-        this.nextPaintClock = 0;
+        this.clocksToNextPaint = 0;
 
         this.topBorder = 12;
         this.bottomBorder = 13;
@@ -573,9 +572,9 @@ export class Video {
         }
     }
 
-    flyback(now) {
-        if (now >= this.nextPaintClock && this.dispEnabled & FRAMESKIPENABLE) {
-            this.nextPaintClock = now + MinPaintIntervalClocks;
+    flyback(clocksLeft) {
+        if (this.clocksToNextPaint + clocksLeft <= 0 && this.dispEnabled & FRAMESKIPENABLE) {
+            this.clocksToNextPaint = MinPaintIntervalClocks - clocksLeft;
             this.paint();
             this.clearPaintBuffer();
         }
@@ -864,7 +863,7 @@ export class Video {
     ////////////////////
     // Main drawing routine
     polltime(clocks) {
-        const endClock = this.videoClocks + clocks;
+        this.clocksToNextPaint -= clocks;
         while (clocks--) {
             this.oddClock = !this.oddClock;
             // Advance CRT beam.
@@ -877,7 +876,7 @@ export class Video {
             // This emulates the Hitachi 6845SP CRTC.
             // Other variants have different quirks.
             // Handle HSync
-            if (this.inHSync && this.handleHSync()) this.flyback(endClock - clocks);
+            if (this.inHSync && this.handleHSync()) this.flyback(clocks);
 
             // Handle delayed display enable due to skew
             const displayEnablePos = this.displayEnableSkew + (this.teletextMode ? 2 : 0);
@@ -941,7 +940,7 @@ export class Video {
                 this.hadVSyncThisRow = true;
                 this.vpulseCounter = 0;
 
-                this.flyback(endClock - clocks);
+                this.flyback(clocks);
             }
 
             if (vSyncStarting || vSyncEnding) {
@@ -1092,7 +1091,6 @@ export class Video {
                 this.doEvenFrameLogic = !!(this.frameCount & 1);
             }
         } // matches while
-        this.videoClocks = endClock;
     }
 }
 

--- a/src/video.js
+++ b/src/video.js
@@ -389,8 +389,9 @@ export class Video {
         this.doubledScanlines = true;
         this.frameSkipCount = 0;
         this.screenSubtract = 0;
+        this.videoClocks = 0;
         // Host paint pacing, not machine state, so deliberately not snapshotted.
-        this.paintCooldown = 0;
+        this.lastPaintClock = -MinPaintIntervalClocks;
 
         this.topBorder = 12;
         this.bottomBorder = 13;
@@ -574,9 +575,9 @@ export class Video {
 
     // Return the beam to the top of the frame, painting the frame we just
     // finished unless we are painting too often to be worth showing the host.
-    flyback() {
-        const paintNow = this.paintCooldown === 0;
-        if (paintNow) this.paintCooldown = MinPaintIntervalClocks;
+    flyback(now) {
+        const paintNow = now - this.lastPaintClock >= MinPaintIntervalClocks;
+        if (paintNow) this.lastPaintClock = now;
         this.paintAndClear(paintNow);
     }
 
@@ -829,14 +830,12 @@ export class Video {
             // an approximation that works if hsyncs are spaced evenly.
             this.bitmapY += 2;
 
-            // If no VSync occurs this frame, go back to the top and force a repaint
-            if (this.bitmapY >= 768) {
-                // Arbitrary moment when TV will give up and start flyback in the absence of an explicit VSync signal
-                this.flyback();
-            }
+            // Arbitrary moment when TV will give up and start flyback in the absence of an explicit VSync signal
+            return this.bitmapY >= 768;
         } else if (this.hpulseCounter === (this.regs[3] & 0x0f)) {
             this.inHSync = false;
         }
+        return false;
     }
 
     cb2changed(level, output) {
@@ -872,8 +871,10 @@ export class Video {
     ////////////////////
     // Main drawing routine
     polltime(clocks) {
+        // `clocks` is already decremented in the loop body, so `endClock - clocks`
+        // is the absolute video clock of the tick being handled.
+        const endClock = this.videoClocks + clocks;
         while (clocks--) {
-            if (this.paintCooldown > 0) this.paintCooldown--;
             this.oddClock = !this.oddClock;
             // Advance CRT beam.
             this.bitmapX += 8;
@@ -885,7 +886,7 @@ export class Video {
             // This emulates the Hitachi 6845SP CRTC.
             // Other variants have different quirks.
             // Handle HSync
-            if (this.inHSync) this.handleHSync();
+            if (this.inHSync && this.handleHSync()) this.flyback(endClock - clocks);
 
             // Handle delayed display enable due to skew
             const displayEnablePos = this.displayEnableSkew + (this.teletextMode ? 2 : 0);
@@ -949,7 +950,7 @@ export class Video {
                 this.hadVSyncThisRow = true;
                 this.vpulseCounter = 0;
 
-                this.flyback();
+                this.flyback(endClock - clocks);
             }
 
             if (vSyncStarting || vSyncEnding) {
@@ -1100,6 +1101,7 @@ export class Video {
                 this.doEvenFrameLogic = !!(this.frameCount & 1);
             }
         } // matches while
+        this.videoClocks = endClock;
     }
 }
 

--- a/src/video.js
+++ b/src/video.js
@@ -16,10 +16,7 @@ export const EVERYTHINGENABLED =
 export const OPAQUE_BLACK = 0xff000000;
 export const OPAQUE_WHITE = 0xffffffff;
 
-// Smallest gap, in 2MHz video clocks, between two host repaints: 5ms, so at
-// most 200 a second, comfortably above the 50Hz a sane display asks for. A CRTC
-// with small R0 or R4 can fly back every scanline or even every character, and
-// painting that often would swamp the host.
+// 5ms in 2MHz video clocks: at most 200 host repaints a second.
 export const MinPaintIntervalClocks = 10000;
 
 ////////////////////

--- a/src/video.js
+++ b/src/video.js
@@ -573,8 +573,6 @@ export class Video {
         }
     }
 
-    // Return the beam to the top of the frame, painting the frame we just
-    // finished unless we are painting too often to be worth showing the host.
     flyback(now) {
         if (now - this.lastPaintClock >= MinPaintIntervalClocks && this.dispEnabled & FRAMESKIPENABLE) {
             this.lastPaintClock = now;

--- a/src/video.js
+++ b/src/video.js
@@ -16,8 +16,7 @@ export const EVERYTHINGENABLED =
 export const OPAQUE_BLACK = 0xff000000;
 export const OPAQUE_WHITE = 0xffffffff;
 
-// 5ms in 2MHz video clocks: at most 200 host repaints a second.
-export const MinPaintIntervalClocks = 10000;
+export const MinPaintedFrameRows = 64;
 
 ////////////////////
 // VideoNULA - programmable 12-bit RGB palette extension (RobC hardware mod).
@@ -389,8 +388,6 @@ export class Video {
         this.doubledScanlines = true;
         this.frameSkipCount = 0;
         this.screenSubtract = 0;
-        // Host paint pacing, not machine state, so deliberately not snapshotted.
-        this.clocksToNextPaint = 0;
 
         this.topBorder = 12;
         this.bottomBorder = 13;
@@ -572,9 +569,8 @@ export class Video {
         }
     }
 
-    flyback(clocksLeft) {
-        if (this.clocksToNextPaint + clocksLeft <= 0 && this.dispEnabled & FRAMESKIPENABLE) {
-            this.clocksToNextPaint = MinPaintIntervalClocks - clocksLeft;
+    flyback() {
+        if (this.bitmapY >= MinPaintedFrameRows && this.dispEnabled & FRAMESKIPENABLE) {
             this.paint();
             this.clearPaintBuffer();
         }
@@ -863,7 +859,6 @@ export class Video {
     ////////////////////
     // Main drawing routine
     polltime(clocks) {
-        this.clocksToNextPaint -= clocks;
         while (clocks--) {
             this.oddClock = !this.oddClock;
             // Advance CRT beam.
@@ -876,7 +871,7 @@ export class Video {
             // This emulates the Hitachi 6845SP CRTC.
             // Other variants have different quirks.
             // Handle HSync
-            if (this.inHSync && this.handleHSync()) this.flyback(clocks);
+            if (this.inHSync && this.handleHSync()) this.flyback();
 
             // Handle delayed display enable due to skew
             const displayEnablePos = this.displayEnableSkew + (this.teletextMode ? 2 : 0);
@@ -940,7 +935,7 @@ export class Video {
                 this.hadVSyncThisRow = true;
                 this.vpulseCounter = 0;
 
-                this.flyback(clocks);
+                this.flyback();
             }
 
             if (vSyncStarting || vSyncEnding) {

--- a/src/video.js
+++ b/src/video.js
@@ -391,7 +391,7 @@ export class Video {
         this.screenSubtract = 0;
         this.videoClocks = 0;
         // Host paint pacing, not machine state, so deliberately not snapshotted.
-        this.lastPaintClock = -MinPaintIntervalClocks;
+        this.nextPaintClock = 0;
 
         this.topBorder = 12;
         this.bottomBorder = 13;
@@ -574,8 +574,8 @@ export class Video {
     }
 
     flyback(now) {
-        if (now - this.lastPaintClock >= MinPaintIntervalClocks && this.dispEnabled & FRAMESKIPENABLE) {
-            this.lastPaintClock = now;
+        if (now >= this.nextPaintClock && this.dispEnabled & FRAMESKIPENABLE) {
+            this.nextPaintClock = now + MinPaintIntervalClocks;
             this.paint();
             this.clearPaintBuffer();
         }

--- a/src/video.js
+++ b/src/video.js
@@ -576,13 +576,8 @@ export class Video {
     // Return the beam to the top of the frame, painting the frame we just
     // finished unless we are painting too often to be worth showing the host.
     flyback(now) {
-        const paintNow = now - this.lastPaintClock >= MinPaintIntervalClocks;
-        if (paintNow) this.lastPaintClock = now;
-        this.paintAndClear(paintNow);
-    }
-
-    paintAndClear(paintToHost) {
-        if (paintToHost && this.dispEnabled & FRAMESKIPENABLE) {
+        if (now - this.lastPaintClock >= MinPaintIntervalClocks && this.dispEnabled & FRAMESKIPENABLE) {
+            this.lastPaintClock = now;
             this.paint();
             this.clearPaintBuffer();
         }
@@ -871,8 +866,6 @@ export class Video {
     ////////////////////
     // Main drawing routine
     polltime(clocks) {
-        // `clocks` is already decremented in the loop body, so `endClock - clocks`
-        // is the absolute video clock of the tick being handled.
         const endClock = this.videoClocks + clocks;
         while (clocks--) {
             this.oddClock = !this.oddClock;

--- a/tests/unit/test-video.js
+++ b/tests/unit/test-video.js
@@ -1,5 +1,12 @@
 import { describe, it, expect, beforeEach, vi, afterEach } from "vitest";
-import { Video, HDISPENABLE, VDISPENABLE, USERDISPENABLE, EVERYTHINGENABLED } from "../../src/video.js";
+import {
+    Video,
+    HDISPENABLE,
+    VDISPENABLE,
+    USERDISPENABLE,
+    EVERYTHINGENABLED,
+    MinPaintIntervalClocks,
+} from "../../src/video.js";
 import * as utils from "../../src/utils.js";
 
 // Setup with focus on testing behavior rather than implementation details
@@ -611,6 +618,119 @@ describe("Video", () => {
             // Expected: ((0x8 << 11) | (0x00 << 3) | 0x5) = 0x4005
             // Matches beebjit: (0x1000 * 8) - 0x4000 + 5 = 0x8000 - 0x4000 + 5 = 0x4005
             expect(mockCpu.videoRead).toHaveBeenCalledWith(0x4005);
+        });
+    });
+
+    describe("Repaint rate limiting", () => {
+        // A freshly constructed Video runs a 2MHz character clock, so with
+        // R0=127 a scanline is 128 characters of one video clock each.
+        const ClocksPerScanline = 128;
+        const ScanlinesPerFrame = 312;
+        const ClocksPerFrame = ClocksPerScanline * ScanlinesPerFrame;
+        const ClocksPerSecond = 2 * 1000 * 1000;
+
+        // These tests run millions of video clocks, so they use plain callbacks
+        // instead of the shared vi.fn() mocks, which would record every call.
+        function makeVideo() {
+            let paintCount = 0;
+            const v = new Video(false, new Uint32Array(1024 * 768), () => paintCount++);
+            v.reset({ videoRead: () => 0, interrupt: 0 }, { cb2changecallback: null, setVBlankInt: () => {} });
+            const self = {
+                paints: () => paintCount,
+                resetPaints: () => (paintCount = 0),
+                run: (clocks) => v.polltime(clocks),
+                writeCrtc: (reg, val) => {
+                    v.crtc.write(0, reg);
+                    v.crtc.write(1, val);
+                },
+                // Aim R7 at the current row for a scanline, the way a program
+                // driving vsync from a VIA timer does.
+                forceVSync: () => {
+                    self.writeCrtc(7, 0);
+                    self.run(ClocksPerScanline);
+                    self.writeCrtc(7, 0x7f);
+                },
+            };
+            return self;
+        }
+
+        function programCommonTiming(v) {
+            v.writeCrtc(0, 127); // Horizontal total
+            v.writeCrtc(1, 80); // Horizontal displayed
+            v.writeCrtc(2, 98); // Hsync position
+            v.writeCrtc(3, 0x24); // Sync widths
+            v.writeCrtc(5, 0); // Vertical adjust
+            v.writeCrtc(6, 32); // Vertical displayed
+            v.writeCrtc(8, 0); // No interlace
+        }
+
+        // R4=0 gives no CRTC-generated vertical structure, so vsync only
+        // happens when the program asks for it.
+        function programExternallySyncedTiming(v) {
+            programCommonTiming(v);
+            v.writeCrtc(4, 0); // Vertical total
+            v.writeCrtc(9, 0); // One scanline per character row
+            v.writeCrtc(7, 0x7f); // Out of reach, so the CRTC never syncs itself
+        }
+
+        it("should paint once per frame for a normally programmed display", () => {
+            const v = makeVideo();
+            programCommonTiming(v);
+            v.writeCrtc(4, 38); // Vertical total
+            v.writeCrtc(7, 34); // Vsync position
+            v.writeCrtc(9, 7); // Scanlines per character row
+            v.resetPaints();
+
+            v.run(10 * ClocksPerFrame);
+
+            expect(v.paints()).toBe(10);
+        });
+
+        it("should paint for an R4=0 display whose vsync is driven externally", () => {
+            const v = makeVideo();
+            programExternallySyncedTiming(v);
+
+            const paintsPerFrame = [];
+            for (let frame = 0; frame < 10; ++frame) {
+                v.resetPaints();
+                v.forceVSync();
+                paintsPerFrame.push(v.paints());
+                v.run(ClocksPerFrame - ClocksPerScanline);
+            }
+
+            expect(paintsPerFrame).toEqual(Array(10).fill(1));
+        });
+
+        it("should coalesce vsyncs that arrive within the minimum paint interval", () => {
+            const v = makeVideo();
+            programExternallySyncedTiming(v);
+            v.forceVSync();
+            v.resetPaints();
+
+            v.run(MinPaintIntervalClocks / 2);
+            v.forceVSync();
+            expect(v.paints()).toBe(0);
+
+            v.run(MinPaintIntervalClocks);
+            v.forceVSync();
+            expect(v.paints()).toBe(1);
+        });
+
+        it("should bound the paint rate for a pathologically small R0 and R4", () => {
+            const v = makeVideo();
+            programCommonTiming(v);
+            v.writeCrtc(0, 0);
+            v.writeCrtc(4, 0);
+            v.writeCrtc(7, 0);
+            v.writeCrtc(9, 0);
+            v.resetPaints();
+
+            v.run(ClocksPerSecond);
+
+            // Vsync restarts every character here, which unchecked would be
+            // hundreds of thousands of paints per emulated second.
+            expect(v.paints()).toBeLessThanOrEqual(ClocksPerSecond / MinPaintIntervalClocks);
+            expect(v.paints()).toBeGreaterThan(0);
         });
     });
 

--- a/tests/unit/test-video.js
+++ b/tests/unit/test-video.js
@@ -1,12 +1,5 @@
 import { describe, it, expect, beforeEach, vi, afterEach } from "vitest";
-import {
-    Video,
-    HDISPENABLE,
-    VDISPENABLE,
-    USERDISPENABLE,
-    EVERYTHINGENABLED,
-    MinPaintIntervalClocks,
-} from "../../src/video.js";
+import { Video, HDISPENABLE, VDISPENABLE, USERDISPENABLE, EVERYTHINGENABLED } from "../../src/video.js";
 import * as utils from "../../src/utils.js";
 
 // Setup with focus on testing behavior rather than implementation details
@@ -621,7 +614,7 @@ describe("Video", () => {
         });
     });
 
-    describe("Repaint rate limiting", () => {
+    describe("Painting short frames", () => {
         // A freshly constructed Video runs a 2MHz character clock, so with
         // R0=127 a scanline is 128 characters of one video clock each.
         const ClocksPerScanline = 128;
@@ -686,51 +679,45 @@ describe("Video", () => {
             expect(v.paints()).toBe(10);
         });
 
-        it("should paint for an R4=0 display whose vsync is driven externally", () => {
+        it("should paint once per frame for an R4=0 display synced externally", () => {
             const v = makeVideo();
             programExternallySyncedTiming(v);
 
             const paintsPerFrame = [];
             for (let frame = 0; frame < 10; ++frame) {
+                v.run(ClocksPerFrame - ClocksPerScanline);
+                // Count only the paints the vsync itself produces.
                 v.resetPaints();
                 v.forceVSync();
                 paintsPerFrame.push(v.paints());
-                v.run(ClocksPerFrame - ClocksPerScanline);
             }
 
             expect(paintsPerFrame).toEqual(Array(10).fill(1));
         });
 
-        it("should coalesce vsyncs that arrive within the minimum paint interval", () => {
+        it("should not paint frames too short to hold a picture", () => {
             const v = makeVideo();
             programExternallySyncedTiming(v);
-            v.forceVSync();
             v.resetPaints();
 
-            v.run(MinPaintIntervalClocks / 2);
-            v.forceVSync();
-            expect(v.paints()).toBe(0);
+            // A vsync every few scanlines, as the boot-up register values give.
+            for (let frame = 0; frame < 1000; ++frame) {
+                v.run(4 * ClocksPerScanline);
+                v.forceVSync();
+            }
 
-            v.run(MinPaintIntervalClocks);
-            v.forceVSync();
-            expect(v.paints()).toBe(1);
+            expect(v.paints()).toBe(0);
         });
 
-        it("should bound the paint rate for a pathologically small R0 and R4", () => {
+        it("should paint when the beam runs off the bottom without a vsync", () => {
             const v = makeVideo();
-            programCommonTiming(v);
-            v.writeCrtc(0, 0);
-            v.writeCrtc(4, 0);
-            v.writeCrtc(7, 0);
-            v.writeCrtc(9, 0);
+            programExternallySyncedTiming(v);
             v.resetPaints();
 
             v.run(ClocksPerSecond);
 
-            // Vsync restarts every character here, which unchecked would be
-            // hundreds of thousands of paints per emulated second.
-            expect(v.paints()).toBeLessThanOrEqual(ClocksPerSecond / MinPaintIntervalClocks);
-            expect(v.paints()).toBeGreaterThan(0);
+            // The beam gives up and flies back every 384 scanlines.
+            expect(v.paints()).toBe(Math.floor(ClocksPerSecond / (384 * ClocksPerScanline)));
         });
     });
 


### PR DESCRIPTION
Fixes #765.

The vsync repaint was gated on `regs[0] && regs[4]`: a rate limiter written as a register test. A display deliberately programmed with R4=0, taking its vsync from elsewhere (poking R7 once per VIA T1 period, say), traverses the full height of the screen but never repainted.

Gate on how tall the frame actually turned out instead, which is what the register check was proxying for. An externally synced R4=0 display has a full-height frame and paints; boot-up garbage flies back after a handful of scanlines and does not. `handleHSync` now reports that the beam has run off the bottom rather than painting itself, so both flyback sites go through one method. Nothing is added to `polltime` or to the per-clock loop.

The threshold of 64 rows is measured rather than guessed. Paints per emulated second, the test disc against power-on garbage:

| threshold | disc | garbage |
| --- | --- | --- |
| 2, 4, 8, 16 | 50 | 7810 |
| 24, 32, 64, 128 | 50 | 1 |

Garbage frames are 8 to 11 scanlines tall and `bitmapY` counts two rows per scanline, so the cliff is around 20. A real frame is 624 rows. 64 sits an order of magnitude clear of both edges.

Checked by hand against a test disc that programs MODE 4 with R0=&3F, R4=0, R9=0 and forces vsync from a T1 loop: previously the picture rolled at the ~40Hz the runaway path happened to give, now it is stable at 50Hz.

Unit tests cover a normally programmed display painting once per frame, an externally synced R4=0 display painting once per frame, a short-frame configuration not painting, and the runaway path still painting when no vsync ever arrives.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
