### PR TITLE
test: fix testTimout typo so the 15s test timeout applies

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -14,7 +14,7 @@ export default defineConfig({
     },
     test: {
         include: [...configDefaults.include, "tests/unit/**/*.js", "tests/integration/**/*.js"],
-        testTimout: 15000,
+        testTimeout: 15000,
         slowTestThreshold: 1000,
         coverage: {
             provider: "v8",


### PR DESCRIPTION
`vite.config.js` has always spelled it `testTimout`. vitest ignores the unknown key, so every test has run on the default 5s rather than the intended 15s.

Confirmed by A/B rather than by reading: a deliberately 6s test fails at 5015ms with the typo present and passes with it fixed.

Spotted while reviewing #762, and unrelated to it, so it is here on its own.

Unit tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)