### PR TITLE
Fix the display filter fallback, and compile shaders in one place

### DIFF
--- a/src/canvas.js
+++ b/src/canvas.js
@@ -13,8 +13,9 @@ export function getFilterForMode(mode) {
 }
 
 export class Canvas {
-    isWebGl() {
-        return false;
+    /** The 2D canvas draws the framebuffer as-is, which is what this filter is. */
+    get filterClass() {
+        return PassthroughFilter;
     }
 
     constructor(canvas) {
@@ -46,8 +47,9 @@ export class Canvas {
 const width = 1024;
 const height = 1024;
 export class GlCanvas {
-    isWebGl() {
-        return true;
+    /** The filter actually built, which may not be the one that was asked for. */
+    get filterClass() {
+        return this.filter.constructor;
     }
 
     constructor(canvas, filterClass) {
@@ -189,11 +191,20 @@ export function bestCanvas(canvas, filterClass) {
     try {
         return new GlCanvas(canvas, filterClass);
     } catch (e) {
-        console.log("Unable to use OpenGL: " + e);
-        if (filterClass.requiresGl()) {
-            const config = filterClass.getDisplayConfig();
-            console.warn(`${config.name} requires WebGL. Falling back to standard 2D canvas.`);
+        // Either WebGL is unavailable or this particular filter declined it.
+        console.log(`Unable to use ${filterClass.getDisplayConfig().name} with WebGL: ${e}`);
+    }
+
+    // A canvas that has handed out a WebGL context can never hand out a 2D one,
+    // so if the failure came from the filter rather than from WebGL itself, the
+    // 2D fallback below would throw and take the emulator with it.
+    if (filterClass !== PassthroughFilter) {
+        try {
+            return new GlCanvas(canvas, PassthroughFilter);
+        } catch (e) {
+            console.log("Unable to fall back to the passthrough filter: " + e);
         }
     }
+
     return new Canvas(canvas);
 }

--- a/src/main.js
+++ b/src/main.js
@@ -388,9 +388,16 @@ if (keyMappingWarnings.length) {
 function createCanvasForFilter(filterClass) {
     const newCanvas = tryGl ? canvasLib.bestCanvas(screenCanvas, filterClass) : new canvasLib.Canvas(screenCanvas);
 
-    if (filterClass.requiresGl() && !newCanvas.isWebGl()) {
-        const config = filterClass.getDisplayConfig();
-        showError(`enabling ${config.name} mode`, `${config.name} requires WebGL. Using standard display instead.`);
+    // Test which filter was actually built, not merely whether we got WebGL: a
+    // filter can decline a context that works perfectly well for other modes,
+    // in which case bestCanvas quietly gives us an unfiltered GL canvas.
+    if (newCanvas.filterClass !== filterClass) {
+        // Not `config`: that is the emulator's live configuration object.
+        const displayConfig = filterClass.getDisplayConfig();
+        showError(
+            `enabling ${displayConfig.name} mode`,
+            `${displayConfig.name} is not available on this device. Using standard display instead.`,
+        );
     }
 
     return newCanvas;
@@ -411,11 +418,14 @@ function swapCanvas(newFilterClass) {
         newCanvas.paint(minx, miny, maxx, maxy, this.frameCount);
     };
     canvas = newCanvas;
-    displayModeFilter = newFilterClass;
+    // Follow the filter we ended up with, not the one we asked for: the monitor
+    // picture and the canvas geometry both come from its display config.
+    displayModeFilter = newCanvas.filterClass;
     window.setTimeout(() => window.dispatchEvent(new Event("resize")), 1);
 }
 
 let canvas = createCanvasForFilter(displayModeFilter);
+displayModeFilter = canvas.filterClass;
 
 video = new Video(
     model.isMaster,

--- a/src/video-filters/pal-composite.js
+++ b/src/video-filters/pal-composite.js
@@ -14,6 +14,7 @@
 
 import VERT_SHADER from "./shaders/pal-composite.vert.glsl?raw";
 import FRAG_SHADER from "./shaders/pal-composite.frag.glsl?raw";
+import { compileProgram } from "./shader-program.js";
 
 export class PALCompositeFilter {
     static requiresGl() {
@@ -36,63 +37,13 @@ export class PALCompositeFilter {
 
     constructor(gl) {
         this.gl = gl;
-        this.program = null;
-        this.locations = {};
-
-        this._init();
-    }
-
-    _init() {
-        const gl = this.gl;
-
-        // Compile shaders
-        const vertShader = this._compileShader(gl.VERTEX_SHADER, VERT_SHADER);
-        let fragShader = null;
-        try {
-            fragShader = this._compileShader(gl.FRAGMENT_SHADER, FRAG_SHADER);
-
-            // Link program
-            this.program = gl.createProgram();
-            gl.attachShader(this.program, vertShader);
-            gl.attachShader(this.program, fragShader);
-            gl.linkProgram(this.program);
-
-            if (!gl.getProgramParameter(this.program, gl.LINK_STATUS)) {
-                const info = gl.getProgramInfoLog(this.program);
-                this.dispose();
-                throw new Error("Failed to link PAL shader program: " + info);
-            }
-
-            // Get uniform locations
-            this.locations.uFramebuffer = gl.getUniformLocation(this.program, "uFramebuffer");
-            this.locations.uResolution = gl.getUniformLocation(this.program, "uResolution");
-            this.locations.uTexelSize = gl.getUniformLocation(this.program, "uTexelSize");
-            this.locations.uFrameCount = gl.getUniformLocation(this.program, "uFrameCount");
-        } finally {
-            // Once linked the program holds its own reference, so releasing ours here means
-            // deleting the program later frees the shaders too. If we never got that far, ours
-            // was the only reference and they go now.
-            gl.deleteShader(vertShader);
-            gl.deleteShader(fragShader);
-        }
-
-        console.log("PAL composite filter initialized");
-    }
-
-    _compileShader(type, source) {
-        const gl = this.gl;
-        const shader = gl.createShader(type);
-        gl.shaderSource(shader, source);
-        gl.compileShader(shader);
-
-        if (!gl.getShaderParameter(shader, gl.COMPILE_STATUS)) {
-            const info = gl.getShaderInfoLog(shader);
-            const typeName = type === gl.VERTEX_SHADER ? "vertex" : "fragment";
-            gl.deleteShader(shader);
-            throw new Error(`Failed to compile ${typeName} shader: ${info}`);
-        }
-
-        return shader;
+        this.program = compileProgram(gl, VERT_SHADER, FRAG_SHADER, "PAL composite");
+        this.locations = {
+            uFramebuffer: gl.getUniformLocation(this.program, "uFramebuffer"),
+            uResolution: gl.getUniformLocation(this.program, "uResolution"),
+            uTexelSize: gl.getUniformLocation(this.program, "uTexelSize"),
+            uFrameCount: gl.getUniformLocation(this.program, "uFrameCount"),
+        };
     }
 
     /** Release the GL objects this filter owns. */

--- a/src/video-filters/pal-composite.js
+++ b/src/video-filters/pal-composite.js
@@ -17,10 +17,6 @@ import FRAG_SHADER from "./shaders/pal-composite.frag.glsl?raw";
 import { compileProgram } from "./shader-program.js";
 
 export class PALCompositeFilter {
-    static requiresGl() {
-        return true;
-    }
-
     static getDisplayConfig() {
         return {
             name: "PAL TV",

--- a/src/video-filters/passthrough-filter.js
+++ b/src/video-filters/passthrough-filter.js
@@ -5,10 +5,6 @@ import FRAG_SHADER from "./shaders/passthrough.frag.glsl?raw";
 import { compileProgram } from "./shader-program.js";
 
 export class PassthroughFilter {
-    static requiresGl() {
-        return false;
-    }
-
     static getDisplayConfig() {
         return {
             name: "RGB Monitor",

--- a/src/video-filters/passthrough-filter.js
+++ b/src/video-filters/passthrough-filter.js
@@ -2,6 +2,7 @@
 
 import VERT_SHADER from "./shaders/passthrough.vert.glsl?raw";
 import FRAG_SHADER from "./shaders/passthrough.frag.glsl?raw";
+import { compileProgram } from "./shader-program.js";
 
 export class PassthroughFilter {
     static requiresGl() {
@@ -24,54 +25,10 @@ export class PassthroughFilter {
 
     constructor(gl) {
         this.gl = gl;
-        this.program = null;
-        this.locations = {};
-
-        this._init();
-    }
-
-    _init() {
-        const gl = this.gl;
-
-        const vertexShader = this._compileShader(gl.VERTEX_SHADER, VERT_SHADER);
-        let fragmentShader = null;
-        try {
-            fragmentShader = this._compileShader(gl.FRAGMENT_SHADER, FRAG_SHADER);
-
-            this.program = gl.createProgram();
-            gl.attachShader(this.program, vertexShader);
-            gl.attachShader(this.program, fragmentShader);
-            gl.linkProgram(this.program);
-
-            if (!gl.getProgramParameter(this.program, gl.LINK_STATUS)) {
-                const info = gl.getProgramInfoLog(this.program);
-                this.dispose();
-                throw new Error("Failed to link passthrough shader program: " + info);
-            }
-
-            this.locations.tex = gl.getUniformLocation(this.program, "tex");
-        } finally {
-            // Once linked the program holds its own reference, so releasing ours here means
-            // deleting the program later frees the shaders too. If we never got that far, ours
-            // was the only reference and they go now.
-            gl.deleteShader(vertexShader);
-            gl.deleteShader(fragmentShader);
-        }
-    }
-
-    _compileShader(type, source) {
-        const gl = this.gl;
-        const shader = gl.createShader(type);
-        gl.shaderSource(shader, source);
-        gl.compileShader(shader);
-
-        if (!gl.getShaderParameter(shader, gl.COMPILE_STATUS)) {
-            const error = gl.getShaderInfoLog(shader);
-            gl.deleteShader(shader);
-            throw new Error("Shader compilation failed: " + error);
-        }
-
-        return shader;
+        this.program = compileProgram(gl, VERT_SHADER, FRAG_SHADER, "passthrough");
+        this.locations = {
+            tex: gl.getUniformLocation(this.program, "tex"),
+        };
     }
 
     /** Release the GL objects this filter owns. */

--- a/src/video-filters/shader-program.js
+++ b/src/video-filters/shader-program.js
@@ -1,0 +1,53 @@
+"use strict";
+
+/**
+ * Compile and link a shader program, throwing with the driver's own message if
+ * either step fails.
+ *
+ * @param {WebGLRenderingContext} gl
+ * @param {string} vertexSource
+ * @param {string} fragmentSource
+ * @param {string} name used in error messages, e.g. "xBR"
+ * @returns {WebGLProgram}
+ */
+export function compileProgram(gl, vertexSource, fragmentSource, name) {
+    const vertexShader = compileShader(gl, gl.VERTEX_SHADER, vertexSource, name);
+    let fragmentShader = null;
+    try {
+        fragmentShader = compileShader(gl, gl.FRAGMENT_SHADER, fragmentSource, name);
+
+        const program = gl.createProgram();
+        gl.attachShader(program, vertexShader);
+        gl.attachShader(program, fragmentShader);
+        gl.linkProgram(program);
+
+        if (!gl.getProgramParameter(program, gl.LINK_STATUS)) {
+            const info = gl.getProgramInfoLog(program);
+            gl.deleteProgram(program);
+            throw new Error(`Failed to link ${name} shader program: ${info}`);
+        }
+
+        return program;
+    } finally {
+        // Once linked the program holds its own reference, so releasing ours here means
+        // deleting the program later frees the shaders too. If we never got that far, ours
+        // was the only reference and they go now.
+        gl.deleteShader(vertexShader);
+        gl.deleteShader(fragmentShader);
+    }
+}
+
+function compileShader(gl, type, source, name) {
+    const shader = gl.createShader(type);
+    gl.shaderSource(shader, source);
+    gl.compileShader(shader);
+
+    if (!gl.getShaderParameter(shader, gl.COMPILE_STATUS)) {
+        const info = gl.getShaderInfoLog(shader);
+        const typeName = type === gl.VERTEX_SHADER ? "vertex" : "fragment";
+        gl.deleteShader(shader);
+        throw new Error(`Failed to compile ${name} ${typeName} shader: ${info}`);
+    }
+
+    return shader;
+}

--- a/src/video.js
+++ b/src/video.js
@@ -970,7 +970,7 @@ export class Video {
                 // Render data depending on display enable state.
                 if (this.bitmapX >= 0 && this.bitmapX < 1024 && this.bitmapY < 625) {
                     let doubledLines = false;
-                    let offset = this.bitmapY;
+                    let row = this.bitmapY;
                     // There's a painting subtlety here: if we're in an
                     // interlace mode but R6>R4 then we'll get stuck
                     // painting just an odd or even frame, so we double up
@@ -980,10 +980,10 @@ export class Video {
                         this.isEvenRender === this.lastRenderWasEven
                     ) {
                         doubledLines = true;
-                        offset &= ~1;
+                        row &= ~1;
                     }
 
-                    offset = offset * 1024 + this.bitmapX;
+                    const offset = row * 1024 + this.bitmapX;
 
                     if ((this.dispEnabled & EVERYTHINGENABLED) === EVERYTHINGENABLED) {
                         if (this.teletextMode) {

--- a/tests/unit/test-canvas.js
+++ b/tests/unit/test-canvas.js
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
-import { GlCanvas, Canvas } from "../../src/canvas.js";
+import { GlCanvas, Canvas, bestCanvas } from "../../src/canvas.js";
+import PAL_FRAG_SHADER from "../../src/video-filters/shaders/pal-composite.frag.glsl?raw";
 import { PassthroughFilter } from "../../src/video-filters/passthrough-filter.js";
 import { PALCompositeFilter } from "../../src/video-filters/pal-composite.js";
 
@@ -130,6 +131,19 @@ describe("GlCanvas", () => {
 
         expect(() => new filterClass(gl)).toThrow(/Failed to link/);
         expect([...gl.live]).toEqual([]);
+    });
+});
+
+describe("bestCanvas", () => {
+    it("falls back to the passthrough filter when the one asked for will not build", () => {
+        // The 2D fallback is unreachable once a WebGL context exists, so a
+        // filter that fails to build has to be replaced on the context we have.
+        const gl = recordingGl();
+        const sources = new Map();
+        gl.shaderSource = (shader, source) => sources.set(shader, source);
+        gl.getShaderParameter = (shader) => sources.get(shader) !== PAL_FRAG_SHADER;
+
+        expect(bestCanvas(fakeCanvasElement(gl), PALCompositeFilter).filterClass).toBe(PassthroughFilter);
     });
 });
 


### PR DESCRIPTION
Three independent changes to the display filter plumbing.

### A filter that will not build no longer takes the emulator with it

`bestCanvas` catches a failure from `new GlCanvas(...)` and falls through to `new Canvas(canvas)`. If the failure came from WebGL being unavailable, that is right. If the context was created and the *filter* failed to compile or link, it is not: the canvas element has already handed out a WebGL context and can never hand out a 2D one, so the fallback throws out of `bestCanvas` and the emulator does not start at all.

It now retries the passthrough filter on the context it already has, and only reaches the 2D canvas when there was no WebGL to begin with. `tests/unit/test-canvas.js` covers it by failing the PAL fragment shader and nothing else; with the fallback removed that test throws, which is the bug.

Canvases gained a `filterClass` getter reporting what they actually built, replacing `isWebGl()`. That is also a truer test for whether to tell the user their mode is unavailable, since a filter can decline a context other modes are perfectly happy with. `requiresGl()` then had no callers left and is gone.

### One place to compile a shader program

Both filters kept their own copy of the compile, link and cleanup dance, and any future one would need a third. It moves to `src/video-filters/shader-program.js`, which takes the filter name so a failure still says which shader it was. No behaviour change beyond the wording of two error messages and the loss of a `console.log` on PAL init.

### A name in the render loop

The render loop reused one variable for the scanline and then for the byte offset derived from it.

### Test plan

- [x] `npm run lint` clean
- [x] 750 unit tests pass, including the new fallback case
- [x] Integration suite passes (15 files, 74 tests)
- [x] The new test is mutation-checked: removing the fallback makes it fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)