### PR TITLE
fix: record tracks written to a disc with no write-track callback

### DIFF
--- a/src/disc.js
+++ b/src/disc.js
@@ -947,8 +947,6 @@ export class Disc {
         this.isDirty = false;
         this.dirtySide = -1;
         this.dirtyTrack = -1;
-        // Whether anyone is listening has no bearing on which of the surface now holds data, and
-        // snapshots cover only the tracks and sides marked used.
         this.setTrackUsed(dirtySide, dirtyTrack);
         if (!this.writeTrackCallback) return;
         this.writeTrackCallback(dirtySide, dirtyTrack, this.getTrack(dirtySide, dirtyTrack));

--- a/src/disc.js
+++ b/src/disc.js
@@ -948,8 +948,8 @@ export class Disc {
         this.dirtySide = -1;
         this.dirtyTrack = -1;
         this.setTrackUsed(dirtySide, dirtyTrack);
-        if (!this.writeTrackCallback) return;
-        this.writeTrackCallback(dirtySide, dirtyTrack, this.getTrack(dirtySide, dirtyTrack));
+        if (this.writeTrackCallback)
+            this.writeTrackCallback(dirtySide, dirtyTrack, this.getTrack(dirtySide, dirtyTrack));
     }
 
     /**

--- a/src/disc.js
+++ b/src/disc.js
@@ -947,10 +947,11 @@ export class Disc {
         this.isDirty = false;
         this.dirtySide = -1;
         this.dirtyTrack = -1;
-        if (!this.writeTrackCallback) return;
-        const trackObj = this.getTrack(dirtySide, dirtyTrack);
-        this.writeTrackCallback(dirtySide, dirtyTrack, trackObj);
+        // Whether anyone is listening has no bearing on which of the surface now holds data, and
+        // snapshots cover only the tracks and sides marked used.
         this.setTrackUsed(dirtySide, dirtyTrack);
+        if (!this.writeTrackCallback) return;
+        this.writeTrackCallback(dirtySide, dirtyTrack, this.getTrack(dirtySide, dirtyTrack));
     }
 
     /**

--- a/tests/unit/test-disc.js
+++ b/tests/unit/test-disc.js
@@ -294,3 +294,36 @@ describe("ADF loader tests", function () {
         }
     });
 });
+
+describe("flushWrites marks the surface used", () => {
+    /** Most discs have no write-track callback: fdc.js discards onChange for ADF, ADM and ADL, and
+     *  discFor is usually called without one. */
+    function callbackFreeDisc() {
+        const disc = new Disc(true, new DiscConfig(), "test.ssd");
+        loadSsd(disc, new Uint8Array(IbmDiscFormat.bytesPerTrack), false, null);
+        expect(disc.writeTrackCallback).toBeUndefined();
+        return disc;
+    }
+
+    it("notices a write to the upper side of a disc loaded as single sided", () => {
+        const disc = callbackFreeDisc();
+        expect(disc.isDoubleSided).toBe(false);
+
+        disc.writePulses(true, 0, 0, 0xffff);
+        disc.flushWrites();
+
+        // Without this, snapshotState() saves one side and the write is lost on rewind.
+        expect(disc.isDoubleSided).toBe(true);
+        expect(Object.keys(disc.snapshotState().tracks).some((key) => key.startsWith("true:"))).toBe(true);
+    });
+
+    it("extends the used tracks when written past the end of the image", () => {
+        const disc = callbackFreeDisc();
+        const beyond = disc.tracksUsed;
+
+        disc.writePulses(false, beyond, 0, 0xffff);
+        disc.flushWrites();
+
+        expect(disc.tracksUsed).toBe(beyond + 1);
+    });
+});


### PR DESCRIPTION
`flushWrites()` only marked a track used after invoking `writeTrackCallback`, and returned early when there was none.

**Most discs have no callback.** `fdc.js:143` and `:158` discard `onChange` outright for ADF, ADM and ADL, and `discFor` is usually called without one; only `localDisc` wires it up.

So for those discs, a write to the upper side of a disc loaded as single-sided never set `isDoubleSided`. `snapshotState()` then iterates one side, so the write is missing from the snapshot and lost on rewind or on restoring a saved state. Writes past the end of the loaded image went the same way, since snapshots cover only `tracksUsed` tracks.

Which part of the surface holds data does not depend on whether anyone is listening.

Two tests cover it; both fail against the old ordering.

Extracted from #774, which is where this turned up, so it can land on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)