### PR TITLE
refactor: compile display filter shaders in one place

### DIFF
--- a/src/video-filters/pal-composite.js
+++ b/src/video-filters/pal-composite.js
@@ -14,6 +14,7 @@
 
 import VERT_SHADER from "./shaders/pal-composite.vert.glsl?raw";
 import FRAG_SHADER from "./shaders/pal-composite.frag.glsl?raw";
+import { compileProgram } from "./shader-program.js";
 
 export class PALCompositeFilter {
     static requiresGl() {
@@ -36,63 +37,13 @@ export class PALCompositeFilter {
 
     constructor(gl) {
         this.gl = gl;
-        this.program = null;
-        this.locations = {};
-
-        this._init();
-    }
-
-    _init() {
-        const gl = this.gl;
-
-        // Compile shaders
-        const vertShader = this._compileShader(gl.VERTEX_SHADER, VERT_SHADER);
-        let fragShader = null;
-        try {
-            fragShader = this._compileShader(gl.FRAGMENT_SHADER, FRAG_SHADER);
-
-            // Link program
-            this.program = gl.createProgram();
-            gl.attachShader(this.program, vertShader);
-            gl.attachShader(this.program, fragShader);
-            gl.linkProgram(this.program);
-
-            if (!gl.getProgramParameter(this.program, gl.LINK_STATUS)) {
-                const info = gl.getProgramInfoLog(this.program);
-                this.dispose();
-                throw new Error("Failed to link PAL shader program: " + info);
-            }
-
-            // Get uniform locations
-            this.locations.uFramebuffer = gl.getUniformLocation(this.program, "uFramebuffer");
-            this.locations.uResolution = gl.getUniformLocation(this.program, "uResolution");
-            this.locations.uTexelSize = gl.getUniformLocation(this.program, "uTexelSize");
-            this.locations.uFrameCount = gl.getUniformLocation(this.program, "uFrameCount");
-        } finally {
-            // Once linked the program holds its own reference, so releasing ours here means
-            // deleting the program later frees the shaders too. If we never got that far, ours
-            // was the only reference and they go now.
-            gl.deleteShader(vertShader);
-            gl.deleteShader(fragShader);
-        }
-
-        console.log("PAL composite filter initialized");
-    }
-
-    _compileShader(type, source) {
-        const gl = this.gl;
-        const shader = gl.createShader(type);
-        gl.shaderSource(shader, source);
-        gl.compileShader(shader);
-
-        if (!gl.getShaderParameter(shader, gl.COMPILE_STATUS)) {
-            const info = gl.getShaderInfoLog(shader);
-            const typeName = type === gl.VERTEX_SHADER ? "vertex" : "fragment";
-            gl.deleteShader(shader);
-            throw new Error(`Failed to compile ${typeName} shader: ${info}`);
-        }
-
-        return shader;
+        this.program = compileProgram(gl, VERT_SHADER, FRAG_SHADER, "PAL composite");
+        this.locations = {
+            uFramebuffer: gl.getUniformLocation(this.program, "uFramebuffer"),
+            uResolution: gl.getUniformLocation(this.program, "uResolution"),
+            uTexelSize: gl.getUniformLocation(this.program, "uTexelSize"),
+            uFrameCount: gl.getUniformLocation(this.program, "uFrameCount"),
+        };
     }
 
     /** Release the GL objects this filter owns. */

--- a/src/video-filters/passthrough-filter.js
+++ b/src/video-filters/passthrough-filter.js
@@ -2,6 +2,7 @@
 
 import VERT_SHADER from "./shaders/passthrough.vert.glsl?raw";
 import FRAG_SHADER from "./shaders/passthrough.frag.glsl?raw";
+import { compileProgram } from "./shader-program.js";
 
 export class PassthroughFilter {
     static requiresGl() {
@@ -24,54 +25,10 @@ export class PassthroughFilter {
 
     constructor(gl) {
         this.gl = gl;
-        this.program = null;
-        this.locations = {};
-
-        this._init();
-    }
-
-    _init() {
-        const gl = this.gl;
-
-        const vertexShader = this._compileShader(gl.VERTEX_SHADER, VERT_SHADER);
-        let fragmentShader = null;
-        try {
-            fragmentShader = this._compileShader(gl.FRAGMENT_SHADER, FRAG_SHADER);
-
-            this.program = gl.createProgram();
-            gl.attachShader(this.program, vertexShader);
-            gl.attachShader(this.program, fragmentShader);
-            gl.linkProgram(this.program);
-
-            if (!gl.getProgramParameter(this.program, gl.LINK_STATUS)) {
-                const info = gl.getProgramInfoLog(this.program);
-                this.dispose();
-                throw new Error("Failed to link passthrough shader program: " + info);
-            }
-
-            this.locations.tex = gl.getUniformLocation(this.program, "tex");
-        } finally {
-            // Once linked the program holds its own reference, so releasing ours here means
-            // deleting the program later frees the shaders too. If we never got that far, ours
-            // was the only reference and they go now.
-            gl.deleteShader(vertexShader);
-            gl.deleteShader(fragmentShader);
-        }
-    }
-
-    _compileShader(type, source) {
-        const gl = this.gl;
-        const shader = gl.createShader(type);
-        gl.shaderSource(shader, source);
-        gl.compileShader(shader);
-
-        if (!gl.getShaderParameter(shader, gl.COMPILE_STATUS)) {
-            const error = gl.getShaderInfoLog(shader);
-            gl.deleteShader(shader);
-            throw new Error("Shader compilation failed: " + error);
-        }
-
-        return shader;
+        this.program = compileProgram(gl, VERT_SHADER, FRAG_SHADER, "passthrough");
+        this.locations = {
+            tex: gl.getUniformLocation(this.program, "tex"),
+        };
     }
 
     /** Release the GL objects this filter owns. */

--- a/src/video-filters/shader-program.js
+++ b/src/video-filters/shader-program.js
@@ -1,0 +1,53 @@
+"use strict";
+
+/**
+ * Compile and link a shader program, throwing with the driver's own message if
+ * either step fails.
+ *
+ * @param {WebGLRenderingContext} gl
+ * @param {string} vertexSource
+ * @param {string} fragmentSource
+ * @param {string} name used in error messages, e.g. "xBR"
+ * @returns {WebGLProgram}
+ */
+export function compileProgram(gl, vertexSource, fragmentSource, name) {
+    const vertexShader = compileShader(gl, gl.VERTEX_SHADER, vertexSource, name);
+    let fragmentShader = null;
+    try {
+        fragmentShader = compileShader(gl, gl.FRAGMENT_SHADER, fragmentSource, name);
+
+        const program = gl.createProgram();
+        gl.attachShader(program, vertexShader);
+        gl.attachShader(program, fragmentShader);
+        gl.linkProgram(program);
+
+        if (!gl.getProgramParameter(program, gl.LINK_STATUS)) {
+            const info = gl.getProgramInfoLog(program);
+            gl.deleteProgram(program);
+            throw new Error(`Failed to link ${name} shader program: ${info}`);
+        }
+
+        return program;
+    } finally {
+        // Once linked the program holds its own reference, so releasing ours here means
+        // deleting the program later frees the shaders too. If we never got that far, ours
+        // was the only reference and they go now.
+        gl.deleteShader(vertexShader);
+        gl.deleteShader(fragmentShader);
+    }
+}
+
+function compileShader(gl, type, source, name) {
+    const shader = gl.createShader(type);
+    gl.shaderSource(shader, source);
+    gl.compileShader(shader);
+
+    if (!gl.getShaderParameter(shader, gl.COMPILE_STATUS)) {
+        const info = gl.getShaderInfoLog(shader);
+        const typeName = type === gl.VERTEX_SHADER ? "vertex" : "fragment";
+        gl.deleteShader(shader);
+        throw new Error(`Failed to compile ${name} ${typeName} shader: ${info}`);
+    }
+
+    return shader;
+}


### PR DESCRIPTION
Both display filters keep their own copy of the compile, link and cleanup dance, and any new filter would need a third.

It moves to `src/video-filters/shader-program.js`, which takes the filter name so a failure still says which shader it was. No behaviour change beyond the wording of two error messages and the loss of a `console.log` on PAL init.

The existing tests in `tests/unit/test-canvas.js` cover both failure paths for both filters, and pass unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)