### PR TITLE
fix: keep the display working when a filter will not build

### DIFF
--- a/src/canvas.js
+++ b/src/canvas.js
@@ -13,8 +13,9 @@ export function getFilterForMode(mode) {
 }
 
 export class Canvas {
-    isWebGl() {
-        return false;
+    /** The 2D canvas draws the framebuffer as-is, which is what this filter is. */
+    get filterClass() {
+        return PassthroughFilter;
     }
 
     constructor(canvas) {
@@ -46,8 +47,9 @@ export class Canvas {
 const width = 1024;
 const height = 1024;
 export class GlCanvas {
-    isWebGl() {
-        return true;
+    /** The filter actually built, which may not be the one that was asked for. */
+    get filterClass() {
+        return this.filter.constructor;
     }
 
     constructor(canvas, filterClass) {
@@ -189,11 +191,20 @@ export function bestCanvas(canvas, filterClass) {
     try {
         return new GlCanvas(canvas, filterClass);
     } catch (e) {
-        console.log("Unable to use OpenGL: " + e);
-        if (filterClass.requiresGl()) {
-            const config = filterClass.getDisplayConfig();
-            console.warn(`${config.name} requires WebGL. Falling back to standard 2D canvas.`);
+        // Either WebGL is unavailable or this particular filter declined it.
+        console.log(`Unable to use ${filterClass.getDisplayConfig().name} with WebGL: ${e}`);
+    }
+
+    // A canvas that has handed out a WebGL context can never hand out a 2D one,
+    // so if the failure came from the filter rather than from WebGL itself, the
+    // 2D fallback below would throw and take the emulator with it.
+    if (filterClass !== PassthroughFilter) {
+        try {
+            return new GlCanvas(canvas, PassthroughFilter);
+        } catch (e) {
+            console.log("Unable to fall back to the passthrough filter: " + e);
         }
     }
+
     return new Canvas(canvas);
 }

--- a/src/main.js
+++ b/src/main.js
@@ -388,9 +388,16 @@ if (keyMappingWarnings.length) {
 function createCanvasForFilter(filterClass) {
     const newCanvas = tryGl ? canvasLib.bestCanvas(screenCanvas, filterClass) : new canvasLib.Canvas(screenCanvas);
 
-    if (filterClass.requiresGl() && !newCanvas.isWebGl()) {
-        const config = filterClass.getDisplayConfig();
-        showError(`enabling ${config.name} mode`, `${config.name} requires WebGL. Using standard display instead.`);
+    // Test which filter was actually built, not merely whether we got WebGL: a
+    // filter can decline a context that works perfectly well for other modes,
+    // in which case bestCanvas quietly gives us an unfiltered GL canvas.
+    if (newCanvas.filterClass !== filterClass) {
+        // Not `config`: that is the emulator's live configuration object.
+        const displayConfig = filterClass.getDisplayConfig();
+        showError(
+            `enabling ${displayConfig.name} mode`,
+            `${displayConfig.name} is not available on this device. Using standard display instead.`,
+        );
     }
 
     return newCanvas;
@@ -411,11 +418,14 @@ function swapCanvas(newFilterClass) {
         newCanvas.paint(minx, miny, maxx, maxy, this.frameCount);
     };
     canvas = newCanvas;
-    displayModeFilter = newFilterClass;
+    // Follow the filter we ended up with, not the one we asked for: the monitor
+    // picture and the canvas geometry both come from its display config.
+    displayModeFilter = newCanvas.filterClass;
     window.setTimeout(() => window.dispatchEvent(new Event("resize")), 1);
 }
 
 let canvas = createCanvasForFilter(displayModeFilter);
+displayModeFilter = canvas.filterClass;
 
 video = new Video(
     model.isMaster,

--- a/src/video-filters/pal-composite.js
+++ b/src/video-filters/pal-composite.js
@@ -17,10 +17,6 @@ import FRAG_SHADER from "./shaders/pal-composite.frag.glsl?raw";
 import { compileProgram } from "./shader-program.js";
 
 export class PALCompositeFilter {
-    static requiresGl() {
-        return true;
-    }
-
     static getDisplayConfig() {
         return {
             name: "PAL TV",

--- a/src/video-filters/passthrough-filter.js
+++ b/src/video-filters/passthrough-filter.js
@@ -5,10 +5,6 @@ import FRAG_SHADER from "./shaders/passthrough.frag.glsl?raw";
 import { compileProgram } from "./shader-program.js";
 
 export class PassthroughFilter {
-    static requiresGl() {
-        return false;
-    }
-
     static getDisplayConfig() {
         return {
             name: "RGB Monitor",

--- a/tests/unit/test-canvas.js
+++ b/tests/unit/test-canvas.js
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
-import { GlCanvas, Canvas } from "../../src/canvas.js";
+import { GlCanvas, Canvas, bestCanvas } from "../../src/canvas.js";
+import PAL_FRAG_SHADER from "../../src/video-filters/shaders/pal-composite.frag.glsl?raw";
 import { PassthroughFilter } from "../../src/video-filters/passthrough-filter.js";
 import { PALCompositeFilter } from "../../src/video-filters/pal-composite.js";
 
@@ -130,6 +131,19 @@ describe("GlCanvas", () => {
 
         expect(() => new filterClass(gl)).toThrow(/Failed to link/);
         expect([...gl.live]).toEqual([]);
+    });
+});
+
+describe("bestCanvas", () => {
+    it("falls back to the passthrough filter when the one asked for will not build", () => {
+        // The 2D fallback is unreachable once a WebGL context exists, so a
+        // filter that fails to build has to be replaced on the context we have.
+        const gl = recordingGl();
+        const sources = new Map();
+        gl.shaderSource = (shader, source) => sources.set(shader, source);
+        gl.getShaderParameter = (shader) => sources.get(shader) !== PAL_FRAG_SHADER;
+
+        expect(bestCanvas(fakeCanvasElement(gl), PALCompositeFilter).filterClass).toBe(PassthroughFilter);
     });
 });
 


### PR DESCRIPTION
A canvas element that has handed out a WebGL context can never hand out a 2D one. `bestCanvas` catches a failure from `new GlCanvas(...)` and falls through to `new Canvas(canvas)`, which is right when the failure was WebGL being unavailable, and wrong when the context was created and the *filter* failed to compile or link: the 2D fallback throws out of `bestCanvas` and the emulator does not start at all.

It now retries the passthrough filter on the context it already has, and only reaches the 2D canvas when there was no WebGL to begin with.

Canvases gained a `filterClass` getter reporting the filter they actually built, replacing `isWebGl()`. That is also a truer test for whether to tell the user their mode is unavailable, since a filter can decline a context that other modes are perfectly happy with. `requiresGl()` then had no callers left and is gone.

`tests/unit/test-canvas.js` covers it by failing the PAL fragment shader and nothing else. With the fallback removed the test throws rather than failing an assertion, which is the bug itself.

Stacked on #779, which it touches the same files as.

🤖 Generated with [Claude Code](https://claude.com/claude-code)