### PR TITLE
refactor: name the scanline and the framebuffer offset separately

### DIFF
--- a/src/video.js
+++ b/src/video.js
@@ -970,7 +970,7 @@ export class Video {
                 // Render data depending on display enable state.
                 if (this.bitmapX >= 0 && this.bitmapX < 1024 && this.bitmapY < 625) {
                     let doubledLines = false;
-                    let row = this.bitmapY;
+                    let bitmapRow = this.bitmapY;
                     // There's a painting subtlety here: if we're in an
                     // interlace mode but R6>R4 then we'll get stuck
                     // painting just an odd or even frame, so we double up
@@ -980,10 +980,10 @@ export class Video {
                         this.isEvenRender === this.lastRenderWasEven
                     ) {
                         doubledLines = true;
-                        row &= ~1;
+                        bitmapRow &= ~1;
                     }
 
-                    const offset = row * 1024 + this.bitmapX;
+                    const offset = bitmapRow * 1024 + this.bitmapX;
 
                     if ((this.dispEnabled & EVERYTHINGENABLED) === EVERYTHINGENABLED) {
                         if (this.teletextMode) {

--- a/src/video.js
+++ b/src/video.js
@@ -970,7 +970,7 @@ export class Video {
                 // Render data depending on display enable state.
                 if (this.bitmapX >= 0 && this.bitmapX < 1024 && this.bitmapY < 625) {
                     let doubledLines = false;
-                    let offset = this.bitmapY;
+                    let row = this.bitmapY;
                     // There's a painting subtlety here: if we're in an
                     // interlace mode but R6>R4 then we'll get stuck
                     // painting just an odd or even frame, so we double up
@@ -980,10 +980,10 @@ export class Video {
                         this.isEvenRender === this.lastRenderWasEven
                     ) {
                         doubledLines = true;
-                        offset &= ~1;
+                        row &= ~1;
                     }
 
-                    offset = offset * 1024 + this.bitmapX;
+                    const offset = row * 1024 + this.bitmapX;
 
                     if ((this.dispEnabled & EVERYTHINGENABLED) === EVERYTHINGENABLED) {
                         if (this.teletextMode) {


### PR DESCRIPTION
The render loop reused one variable for the scanline and then for the byte offset derived from it, in the hottest loop in the emulator.

Independent of the rest of the stack; it sits here only to keep one chain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)