### PR TITLE
refactor: let anything watch a disc's surface being written

### DIFF
--- a/src/disc-drive.js
+++ b/src/disc-drive.js
@@ -34,6 +34,11 @@ export class BaseDiscDrive extends EventTarget {
     }
 
     /** @returns {boolean} */
+    get isSideUpper() {
+        throw new Error("Not implemented: isSideUpper getter");
+    }
+
+    /** @returns {boolean} */
     get indexPulse() {
         throw new Error("Not implemented: indexPulse getter");
     }
@@ -238,6 +243,10 @@ export class DiscDrive extends BaseDiscDrive {
 
     get track() {
         return this._track;
+    }
+
+    get isSideUpper() {
+        return this._isSideUpper;
     }
 
     get positionFraction() {

--- a/src/disc-hfe.js
+++ b/src/disc-hfe.js
@@ -190,7 +190,6 @@ export function loadHfe(disc, data, onChange) {
         }
     }
 
-    // Set up write track callback if onChange is provided
     if (onChange) {
         disc.addTrackWriteListener((_side, _trackNum, _trackObj) => {
             // Generate a complete HFE image from the current disc state

--- a/src/disc-hfe.js
+++ b/src/disc-hfe.js
@@ -192,7 +192,7 @@ export function loadHfe(disc, data, onChange) {
 
     // Set up write track callback if onChange is provided
     if (onChange) {
-        disc.setWriteTrackCallback((_side, _trackNum, _trackObj) => {
+        disc.addTrackWriteListener((_side, _trackNum, _trackObj) => {
             // Generate a complete HFE image from the current disc state
             const hfeData = toHfe(disc);
             // Call the onChange handler with the updated HFE data

--- a/src/disc.js
+++ b/src/disc.js
@@ -257,10 +257,12 @@ class Sector {
      * @param {Track} track
      * @param {boolean} isMfm
      * @param {Number} idPosBitOffset
+     * @param {function(string): void} warn
      */
-    constructor(track, isMfm, idPosBitOffset) {
+    constructor(track, isMfm, idPosBitOffset, warn = console.log) {
         this.track = track;
         this.isMfm = isMfm;
+        this._warn = warn;
         this.idPosBitOffset = idPosBitOffset;
         this.dataPosBitOffset = null;
         this.isDeleted = false;
@@ -271,7 +273,7 @@ class Sector {
         const idReader = this._readerAt(this.idPosBitOffset);
         const { data: headerData, iffyPulses } = idReader.read(6);
         if (iffyPulses) {
-            console.log(`Iffy pulse in sector header ${this.description}`);
+            this._warn(`Iffy pulse in sector header ${this.description}`);
         }
         this.header = headerData;
         let crc = idReader.initialCrc;
@@ -304,7 +306,7 @@ class Sector {
     read(nextSector) {
         const pulsesPerByte = this.isMfm ? 16 : 32; // todo put in reader
         if (this.dataPosBitOffset === null) {
-            console.log(`"Sector header without data ${this.description}"`);
+            this._warn(`Sector header without data ${this.description}`);
             return;
         }
 
@@ -331,7 +333,7 @@ class Sector {
             sectorSize = sectorSize >>> 1;
         } while (sectorSize >= 128);
         if (seenIffyData) {
-            console.log(`"Iffy pulse in sector data ${this.description}"`);
+            this._warn(`Iffy pulse in sector data ${this.description}`);
         }
     }
 
@@ -428,8 +430,8 @@ class Track {
      * Debug functionality to try and interpret the track.
      * @returns {Sector[]}
      */
-    findSectors() {
-        const sectors = this.findSectorIds();
+    findSectors(warn = console.log) {
+        const sectors = this.findSectorIds(warn);
         for (let sectorIndex = 0; sectorIndex !== sectors.length; ++sectorIndex) {
             const nextSector = sectors[sectorIndex + 1]; // Will be unset for last
             sectors[sectorIndex].read(nextSector);
@@ -440,7 +442,7 @@ class Track {
     /**
      * @returns {Sector[]}
      */
-    findSectorIds() {
+    findSectorIds(warn = console.log) {
         const sectors = [];
         // Pass 1: walk the track and find header and data markers.
         const bitLength = this.length * 32;
@@ -469,7 +471,7 @@ class Track {
                 doMfmMarkerByte = false;
                 const num0s = FmSyncHiZeroBits + markDetectorPrev.countTrailingNibbles(FmZeroBitPulses);
                 if (num0s <= ShortSyncZeros) {
-                    console.log(`Short zeros sync ${this.description}`);
+                    warn(`Short zeros sync ${this.description}`);
                 }
                 dataByte = data;
             } else if (markDetector.equals(MfmMarkerHi, MfmMarkerLo)) {
@@ -487,7 +489,7 @@ class Track {
             }
             switch (dataByte) {
                 case IbmDiscFormat.idMarkDataPattern: {
-                    sector = new Sector(this, isMfm, pulseIndex + 1);
+                    sector = new Sector(this, isMfm, pulseIndex + 1, warn);
                     sectors.push(sector);
                     shiftRegister = 0;
                     numShifts = 0;
@@ -496,7 +498,7 @@ class Track {
                 case IbmDiscFormat.dataMarkDataPattern:
                 case IbmDiscFormat.deletedDataMarkDataPattern:
                     if (!sector || sector.dataPosBitOffset) {
-                        console.log(
+                        warn(
                             `Sector data without header ${this.description}; mark bitpos ${pulseIndex}; previous good sector ${sector ? sector.description : "none"}`,
                         );
                     } else {
@@ -509,7 +511,7 @@ class Track {
                     }
                     break;
                 default:
-                    console.log(`Unknown marker byte ${hexbyte(dataByte)} ${this.description}`);
+                    warn(`Unknown marker byte ${hexbyte(dataByte)} ${this.description}`);
             }
         }
         return sectors;
@@ -625,7 +627,7 @@ export function loadSsd(disc, data, isDsd, onChange) {
         // Create a dataCopy large enough for all the sectors and tracks.
         const dataCopy = new Uint8Array(maxSize);
         dataCopy.set(data);
-        disc.setWriteTrackCallback(
+        disc.addTrackWriteListener(
             /** @param {Track} trackObj  */
             (side, trackNum, trackObj) => {
                 const trackOffset =
@@ -809,7 +811,7 @@ export class Disc {
         this.tracksUsed = 0;
         this.isDoubleSided = false;
 
-        this.writeTrackCallback = undefined;
+        this._trackWriteListeners = new Set();
         this.isWriteable = isWriteable;
 
         // Track which tracks have been written since the last snapshot.
@@ -836,8 +838,14 @@ export class Disc {
         this.initSurface(0);
     }
 
-    setWriteTrackCallback(callback) {
-        this.writeTrackCallback = callback;
+    /** @param {function(boolean, Number, Track): void} listener called once per flushed track */
+    addTrackWriteListener(listener) {
+        this._trackWriteListeners.add(listener);
+    }
+
+    /** @param {function(boolean, Number, Track): void} listener */
+    removeTrackWriteListener(listener) {
+        this._trackWriteListeners.delete(listener);
     }
 
     /**
@@ -947,9 +955,9 @@ export class Disc {
         this.isDirty = false;
         this.dirtySide = -1;
         this.dirtyTrack = -1;
+        const trackObj = this.getTrack(dirtySide, dirtyTrack);
         this.setTrackUsed(dirtySide, dirtyTrack);
-        if (this.writeTrackCallback)
-            this.writeTrackCallback(dirtySide, dirtyTrack, this.getTrack(dirtySide, dirtyTrack));
+        for (const listener of this._trackWriteListeners) listener(dirtySide, dirtyTrack, trackObj);
     }
 
     /**

--- a/src/disc.js
+++ b/src/disc.js
@@ -257,7 +257,7 @@ class Sector {
      * @param {Track} track
      * @param {boolean} isMfm
      * @param {Number} idPosBitOffset
-     * @param {function(string): void} warn
+     * @param {function(string): void} [warn] where to report anomalies; the console by default
      */
     constructor(track, isMfm, idPosBitOffset, warn = console.log) {
         this.track = track;
@@ -428,6 +428,7 @@ class Track {
 
     /**
      * Debug functionality to try and interpret the track.
+     * @param {function(string): void} [warn] where to report anomalies; the console by default
      * @returns {Sector[]}
      */
     findSectors(warn = console.log) {
@@ -440,6 +441,7 @@ class Track {
     }
 
     /**
+     * @param {function(string): void} [warn] where to report anomalies; the console by default
      * @returns {Sector[]}
      */
     findSectorIds(warn = console.log) {

--- a/tests/unit/test-disc.js
+++ b/tests/unit/test-disc.js
@@ -330,15 +330,29 @@ describe("flushWrites marks the surface used", () => {
 });
 
 describe("track write listeners", () => {
-    it("reports each flushed track to every listener", () => {
+    it("reports the flushed track to every listener", () => {
         const disc = unobservedDisc();
         const seen = [];
-        disc.addTrackWriteListener((isSideUpper, trackNum, track) => seen.push([isSideUpper, trackNum, track.length]));
-        disc.addTrackWriteListener(() => seen.push("second"));
+        for (let i = 0; i < 2; ++i)
+            disc.addTrackWriteListener((isSideUpper, trackNum, track) =>
+                seen.push([isSideUpper, trackNum, track.length]),
+            );
         disc.writePulses(false, 3, 0, 0);
         disc.flushWrites();
 
-        expect(seen).toEqual([[false, 3, disc.getTrack(false, 3).length], "second"]);
+        const expected = [false, 3, disc.getTrack(false, 3).length];
+        expect(seen).toEqual([expected, expected]);
+    });
+
+    it("reports the side and track that were written, not the ones in progress", () => {
+        const disc = unobservedDisc();
+        const seen = [];
+        disc.addTrackWriteListener((isSideUpper, trackNum) => seen.push([isSideUpper, trackNum, disc.isDirty]));
+        disc.writePulses(true, 7, 0, 0);
+        disc.flushWrites();
+
+        // The dirty state is cleared before anyone is told, so a listener may write in turn.
+        expect(seen).toEqual([[true, 7, false]]);
     });
 
     it("says nothing when there was nothing to flush", () => {

--- a/tests/unit/test-disc.js
+++ b/tests/unit/test-disc.js
@@ -1,7 +1,9 @@
-import { describe, it, expect } from "vitest";
+import { afterEach, describe, it, expect, vi } from "vitest";
 
 import { BitWindow64, Disc, DiscConfig, IbmDiscFormat, loadSsd, loadAdf, toSsdOrDsd } from "../../src/disc.js";
 import * as fs from "node:fs";
+
+afterEach(() => vi.restoreAllMocks());
 
 describe("BitWindow64", function () {
     /** Shift the low `count` bits of a BigInt in, most significant first. */
@@ -295,18 +297,17 @@ describe("ADF loader tests", function () {
     });
 });
 
-describe("flushWrites marks the surface used", () => {
-    /** Most discs have no write-track callback: fdc.js discards onChange for ADF, ADM and ADL, and
-     *  discFor is usually called without one. */
-    function callbackFreeDisc() {
-        const disc = new Disc(true, new DiscConfig(), "test.ssd");
-        loadSsd(disc, new Uint8Array(IbmDiscFormat.bytesPerTrack), false, null);
-        expect(disc.writeTrackCallback).toBeUndefined();
-        return disc;
-    }
+/** Most discs have nothing watching them: fdc.js discards onChange for ADF, ADM and ADL, and
+ *  discFor is usually called without one. */
+function unobservedDisc() {
+    const disc = new Disc(true, new DiscConfig(), "test.ssd");
+    loadSsd(disc, new Uint8Array(IbmDiscFormat.bytesPerTrack), false, null);
+    return disc;
+}
 
+describe("flushWrites marks the surface used", () => {
     it("notices a write to the upper side of a disc loaded as single sided", () => {
-        const disc = callbackFreeDisc();
+        const disc = unobservedDisc();
         expect(disc.isDoubleSided).toBe(false);
 
         disc.writePulses(true, 0, 0, 0xffff);
@@ -318,12 +319,92 @@ describe("flushWrites marks the surface used", () => {
     });
 
     it("extends the used tracks when written past the end of the image", () => {
-        const disc = callbackFreeDisc();
+        const disc = unobservedDisc();
         const beyond = disc.tracksUsed;
 
         disc.writePulses(false, beyond, 0, 0xffff);
         disc.flushWrites();
 
         expect(disc.tracksUsed).toBe(beyond + 1);
+    });
+});
+
+describe("track write listeners", () => {
+    it("reports each flushed track to every listener", () => {
+        const disc = unobservedDisc();
+        const seen = [];
+        disc.addTrackWriteListener((isSideUpper, trackNum, track) => seen.push([isSideUpper, trackNum, track.length]));
+        disc.addTrackWriteListener(() => seen.push("second"));
+        disc.writePulses(false, 3, 0, 0);
+        disc.flushWrites();
+
+        expect(seen).toEqual([[false, 3, disc.getTrack(false, 3).length], "second"]);
+    });
+
+    it("says nothing when there was nothing to flush", () => {
+        const disc = unobservedDisc();
+        let calls = 0;
+        disc.addTrackWriteListener(() => calls++);
+        disc.flushWrites();
+        expect(calls).toBe(0);
+    });
+
+    it("stops reporting to a listener that has been removed", () => {
+        const disc = unobservedDisc();
+        let calls = 0;
+        const listener = () => calls++;
+        disc.addTrackWriteListener(listener);
+        disc.removeTrackWriteListener(listener);
+        disc.writePulses(false, 1, 0, 0);
+        disc.flushWrites();
+        expect(calls).toBe(0);
+    });
+
+    it("keeps an image loader's own writeback working when something else watches too", () => {
+        let imageUpdates = 0;
+        const disc = new Disc(true, new DiscConfig(), "test.ssd");
+        loadSsd(disc, new Uint8Array(IbmDiscFormat.bytesPerTrack), false, () => imageUpdates++);
+        let watcherCalls = 0;
+        disc.addTrackWriteListener(() => watcherCalls++);
+
+        disc.writePulses(false, 2, 0, 0);
+        disc.flushWrites();
+
+        expect(imageUpdates).toBe(1);
+        expect(watcherCalls).toBe(1);
+    });
+});
+
+/** Leaves a sector's header pointing at nothing, which the decoder complains about. */
+function eraseDataField(track, sectorNumber) {
+    const sector = track.findSectors(() => {})[sectorNumber];
+    // dataPosBitOffset is the offset after the address mark, so back up over the mark itself.
+    const start = Math.floor(sector.dataPosBitOffset / 32) - 1;
+    for (let word = start; word < start + 256; ++word) track.pulses2Us[word] = IbmDiscFormat.fmTo2usPulses(0xff, 0xff);
+}
+
+describe("sector decoding warnings", () => {
+    it("goes to the caller rather than the console", () => {
+        const disc = unobservedDisc();
+        const track = disc.getTrack(false, 0);
+        eraseDataField(track, 4);
+
+        const console = vi.spyOn(globalThis.console, "log");
+        const warnings = [];
+        track.findSectors((message) => warnings.push(message));
+
+        expect(warnings.length).toBeGreaterThan(0);
+        expect(console).not.toHaveBeenCalled();
+    });
+
+    it("goes to the console when no caller asks for it", () => {
+        const disc = unobservedDisc();
+        const track = disc.getTrack(false, 0);
+        eraseDataField(track, 4);
+
+        const console = vi.spyOn(globalThis.console, "log").mockImplementation(() => {});
+        track.findSectors();
+
+        expect(console).toHaveBeenCalled();
     });
 });


### PR DESCRIPTION
Everything here is to `Disc` and `DiscDrive`, and stands on its own. It is the layer #774's disc surface panel needs; that PR will rebase onto this and shed the same changes.

### One notification slot becomes a list

A `Disc` had a single `writeTrackCallback`, set by whichever loader owned rewriting the backing image. Anything else wanting to know a track had changed had nowhere to go, and adding a second mechanism beside it meant two things named almost identically for the same job.

The slot is now a listener list, and the SSD and HFE loaders register on it like any other observer. Nothing is lost: they were only ever one observer that happened to hold the only seat. Whether their writeback runs no longer depends on being the only thing watching.

Every use is covered: registration, removal, several listeners at once, no listeners at all, and a loader's writeback continuing to work while something else watches.

### Sector decoding can report to the caller

`findSectors` and the decoding it drives logged straight to the console. That is fine for the one-off diagnostic it was written for, but reading a whole disc to inspect it would fill the console with every anomaly on a protected disc. It now takes an optional callback and still logs by default, with both paths tested.

### DiscDrive.isSideUpper

The selected side was readable only from inside the drive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)