### PR TITLE
fix: stop the disc panel's readout reflowing as it updates

### DIFF
--- a/index.html
+++ b/index.html
@@ -257,8 +257,11 @@
       </div>
       <div id="disc-panel" hidden>
         <div class="disc-header">
-          <button id="disc-close" class="btn btn-sm btn-outline-light">Close</button>
           <span class="disc-title">Disc surface</span>
+          <span class="disc-name" id="disc-name"></span>
+          <button id="disc-close" class="btn btn-sm btn-outline-light">Close</button>
+        </div>
+        <div class="disc-controls">
           <div class="btn-group btn-group-sm" role="group" aria-label="Drive">
             <button type="button" class="btn btn-outline-light" data-drive="0">Drive 0</button>
             <button type="button" class="btn btn-outline-light" data-drive="1">Drive 1</button>
@@ -278,7 +281,8 @@
         </div>
         <div class="disc-legend" id="disc-legend"></div>
         <div class="disc-status" id="disc-status"></div>
-        <div class="disc-status" id="disc-hover"></div>
+        <div class="disc-status" id="disc-hover-where"></div>
+        <div class="disc-status" id="disc-hover-what"></div>
       </div>
       <div id="leds">
         <table>

--- a/index.html
+++ b/index.html
@@ -258,7 +258,7 @@
       <div id="disc-panel" hidden>
         <div class="disc-header">
           <span class="disc-title">Disc surface</span>
-          <span class="disc-name" id="disc-name"></span>
+          <span id="disc-name"></span>
           <button id="disc-close" class="btn btn-sm btn-outline-light">Close</button>
         </div>
         <div class="disc-controls">

--- a/src/disc-visualiser.js
+++ b/src/disc-visualiser.js
@@ -520,8 +520,9 @@ export class DiscVisualiser {
         this._markActive("[data-side]", (button) => (button.dataset.side === "1") === this._isSideUpper);
         this._markActive("[data-view]", (button) => button.dataset.view === this._view);
 
-        setText(this.nameElem, disc?.name ?? "");
-        this.nameElem.title = disc?.name ?? "";
+        const name = disc?.name ?? "";
+        setText(this.nameElem, name);
+        if (this.nameElem.title !== name) this.nameElem.title = name;
         if (!disc) {
             setText(this.statusElem, `Drive ${this._driveIndex}: no disc`);
         } else {

--- a/src/disc-visualiser.js
+++ b/src/disc-visualiser.js
@@ -88,7 +88,9 @@ export class DiscVisualiser {
         this.surfaceCanvas = document.getElementById("disc-surface");
         this.overlayCanvas = document.getElementById("disc-overlay");
         this.statusElem = document.getElementById("disc-status");
-        this.hoverElem = document.getElementById("disc-hover");
+        this.nameElem = document.getElementById("disc-name");
+        this.hoverWhereElem = document.getElementById("disc-hover-where");
+        this.hoverWhatElem = document.getElementById("disc-hover-what");
         this.legendElem = document.getElementById("disc-legend");
         this.sideControls = document.getElementById("disc-side-controls");
         this.openBtn = document.getElementById("disc-visualiser-open");
@@ -518,17 +520,21 @@ export class DiscVisualiser {
         this._markActive("[data-side]", (button) => (button.dataset.side === "1") === this._isSideUpper);
         this._markActive("[data-view]", (button) => button.dataset.view === this._view);
 
+        setText(this.nameElem, disc?.name ?? "");
+        this.nameElem.title = disc?.name ?? "";
         if (!disc) {
             setText(this.statusElem, `Drive ${this._driveIndex}: no disc`);
         } else {
             const head = this._showingHead
-                ? `head at track ${drive.track}, ${(drive.positionFraction * RevolutionMs).toFixed(1)} ms`
-                : `head on the other side, track ${drive.track}`;
+                ? `head track ${drive.track} · ${(drive.positionFraction * RevolutionMs).toFixed(1)} ms`
+                : `head track ${drive.track}, other side`;
             const spin = drive.spinning ? "spinning" : "stopped";
             const zoom = this._geometry.zoom > 1 ? ` · ${this._geometry.zoom.toFixed(1)}x` : "";
-            setText(this.statusElem, `${disc.name ?? "disc"} · ${spin}, ${head}${zoom}${this._scanNote()}`);
+            setText(this.statusElem, `${spin} · ${head}${zoom}${this._scanNote()}`);
         }
-        setText(this.hoverElem, this._describeHover());
+        const { where, what } = this._describeHover();
+        setText(this.hoverWhereElem, where);
+        setText(this.hoverWhatElem, what);
     }
 
     _markActive(selector, isActive) {
@@ -542,14 +548,18 @@ export class DiscVisualiser {
         return ` · ${errors} CRC error${errors === 1 ? "" : "s"}`;
     }
 
+    /** @returns {{where: string, what: string}} the pointer's position, and what the surface holds */
     _describeHover() {
         const hover = this._hoverPosition();
-        if (!hover) return "Point at the surface to read it";
+        if (!hover) return { where: "Point at the surface to read it", what: "" };
         const info = this._info[hover.track];
-        if (!info?.codes?.length) return `Track ${hover.track} · not read yet`;
+        if (!info?.codes?.length) return { where: `Track ${hover.track}`, what: "not read yet" };
         const word = Math.min((hover.fraction * info.codes.length) | 0, info.codes.length - 1);
-        const at = `Track ${hover.track} · word ${word} of ${info.codes.length} · ${(hover.fraction * RevolutionMs).toFixed(1)} ms`;
-        return `${at} · ${Views[this._view].describe(info, word)}`;
+        const ms = (hover.fraction * RevolutionMs).toFixed(1);
+        return {
+            where: `Track ${hover.track} · word ${word} of ${info.codes.length} · ${ms} ms`,
+            what: Views[this._view].describe(info, word),
+        };
     }
 
     _buildLegend() {

--- a/src/jsbeeb.css
+++ b/src/jsbeeb.css
@@ -457,13 +457,20 @@ small {
 
 .disc-header {
   display: flex;
-  align-items: center;
-  flex-wrap: wrap;
+  align-items: baseline;
   gap: 8px;
   margin-bottom: 8px;
   cursor: move;
   user-select: none;
+  /* Claim touch gestures, or a drag scrolls the page instead. */
   touch-action: none;
+}
+
+.disc-controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-bottom: 8px;
 }
 
 .disc-header button {
@@ -474,6 +481,25 @@ small {
   color: #ccc;
   font-size: 12px;
   font-weight: bold;
+  flex: none;
+}
+
+/* A disc's name is the one thing here with no bound on its width, so it yields before anything
+   else does and keeps the full name on hover. */
+.disc-name {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: #888;
+  font-family: consolas, monospace;
+  font-size: 11px;
+}
+
+#disc-close {
+  flex: none;
+  margin-left: auto;
 }
 
 .disc-stack {
@@ -535,7 +561,11 @@ small {
   color: #ccc;
   font-family: consolas, monospace;
   font-size: 11px;
-  min-height: 14px;
+  /* These lines change every frame; wrapping one would resize the panel under the pointer. */
+  height: 14px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 div.smoothie-chart-tooltip {

--- a/src/jsbeeb.css
+++ b/src/jsbeeb.css
@@ -484,9 +484,8 @@ small {
   flex: none;
 }
 
-/* A disc's name is the one thing here with no bound on its width, so it yields before anything
-   else does and keeps the full name on hover. */
-.disc-name {
+/* The only item in the header with no bound on its width, so it is the one that yields. */
+#disc-name {
   flex: 1;
   min-width: 0;
   overflow: hidden;
@@ -561,8 +560,8 @@ small {
   color: #ccc;
   font-family: consolas, monospace;
   font-size: 11px;
-  /* These lines change every frame; wrapping one would resize the panel under the pointer. */
-  height: 14px;
+  /* Rewritten every frame, so the height must not depend on the content. */
+  min-height: 14px;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;


### PR DESCRIPTION
The status line ran onto a second row as soon as the head reached a two figure track or a disc had errors, so the panel resized under the pointer while you were using it. The header put its title, close button and three control groups through a single wrapping row, which came out three rows tall.

### What changed

The header is now a title row and a controls row, rather than one row left to wrap where it likes.

A disc's name is the only thing here with no bound on its width, so it moves out of the per-frame status line into that title row, where it truncates and keeps the full name on hover. That also stops a long name shoving the live telemetry around.

The three readout lines are pinned to one line each and clip rather than wrap. The hover readout was one long line running position and contents together; it now says where the pointer is on one line and what is under it on the next, which is two facts and fits.

The status wording is tighter for the same reason: `spinning · head track 34 · 127.4 ms` rather than `elite.hfe · spinning, head at track 34, 127.4 ms`.

### Measured

Header 70px tall over three rows, now 31px over one. Panel height held at 575px across forty frames of the head turning and two dozen pointer positions, where before it changed with the text. A 66 character disc name truncates with the full name in the tooltip and moves nothing. Squeezed to 300px the control groups and legend wrap as whole units and the height holds at 511px.

The longest status the panel can produce, zoomed with errors on the far side, is 402px in a 402px box.

🤖 Generated with [Claude Code](https://claude.com/claude-code)