### PR TITLE
fix: keep writing back a disc image with a damaged sector

### DIFF
--- a/src/disc.js
+++ b/src/disc.js
@@ -635,9 +635,8 @@ export function loadSsd(disc, data, isDsd, onChange) {
                 const trackOffset =
                     SsdFormat.sectorSize * SsdFormat.sectorsPerTrack * (trackNum * numSides + (side ? 1 : 0));
                 for (const sector of trackObj.findSectors()) {
-                    const sectorOffset = sector.sectorNumber * SsdFormat.sectorSize;
-                    for (let x = 0; x < SsdFormat.sectorSize; ++x)
-                        dataCopy[trackOffset + sectorOffset + x] = sector.sectorData[x];
+                    if (sectorShortfall(sector, trackNum)) continue;
+                    dataCopy.set(sector.sectorData, trackOffset + sector.sectorNumber * SsdFormat.sectorSize);
                 }
                 onChange(dataCopy);
             },

--- a/src/disc.js
+++ b/src/disc.js
@@ -634,10 +634,9 @@ export function loadSsd(disc, data, isDsd, onChange) {
             (side, trackNum, trackObj) => {
                 const trackOffset =
                     SsdFormat.sectorSize * SsdFormat.sectorsPerTrack * (trackNum * numSides + (side ? 1 : 0));
-                for (const sector of trackObj.findSectors()) {
-                    if (sectorShortfall(sector, trackNum)) continue;
-                    dataCopy.set(sector.sectorData, trackOffset + sector.sectorNumber * SsdFormat.sectorSize);
-                }
+                for (const sector of trackObj.findSectors())
+                    if (!sectorShortfall(sector, trackNum))
+                        dataCopy.set(sector.sectorData, trackOffset + sector.sectorNumber * SsdFormat.sectorSize);
                 onChange(dataCopy);
             },
         );

--- a/tests/unit/test-disc.js
+++ b/tests/unit/test-disc.js
@@ -305,6 +305,14 @@ function unobservedDisc() {
     return disc;
 }
 
+/** Leaves a sector's header pointing at nothing, which the decoder complains about. */
+function eraseDataField(track, sectorNumber) {
+    const sector = track.findSectors(() => {})[sectorNumber];
+    // dataPosBitOffset is the offset after the address mark, so back up over the mark itself.
+    const start = Math.floor(sector.dataPosBitOffset / 32) - 1;
+    for (let word = start; word < start + 256; ++word) track.pulses2Us[word] = IbmDiscFormat.fmTo2usPulses(0xff, 0xff);
+}
+
 describe("flushWrites marks the surface used", () => {
     it("notices a write to the upper side of a disc loaded as single sided", () => {
         const disc = unobservedDisc();
@@ -387,15 +395,24 @@ describe("track write listeners", () => {
         expect(imageUpdates).toBe(1);
         expect(watcherCalls).toBe(1);
     });
-});
 
-/** Leaves a sector's header pointing at nothing, which the decoder complains about. */
-function eraseDataField(track, sectorNumber) {
-    const sector = track.findSectors(() => {})[sectorNumber];
-    // dataPosBitOffset is the offset after the address mark, so back up over the mark itself.
-    const start = Math.floor(sector.dataPosBitOffset / 32) - 1;
-    for (let word = start; word < start + 256; ++word) track.pulses2Us[word] = IbmDiscFormat.fmTo2usPulses(0xff, 0xff);
-}
+    it("writes an image back for a track holding a sector it cannot read", () => {
+        vi.spyOn(globalThis.console, "log").mockImplementation(() => {});
+        const sectorsPerTrack = 10;
+        const sectorSize = 256;
+        const data = new Uint8Array(sectorsPerTrack * sectorSize).fill(0xa5);
+        let image = null;
+        const disc = new Disc(true, new DiscConfig(), "test.ssd");
+        loadSsd(disc, data, false, (updated) => (image = updated));
+        eraseDataField(disc.getTrack(false, 0), 4);
+
+        disc.writePulses(false, 0, 0, 0);
+        disc.flushWrites();
+
+        expect(image).not.toBeNull();
+        expect(image.slice(0, sectorsPerTrack * sectorSize)).toEqual(data);
+    });
+});
 
 describe("sector decoding warnings", () => {
     it("goes to the caller rather than the console", () => {


### PR DESCRIPTION
Found while starting on #775: the SSD/DSD writeback listener assumes every sector it finds has data. A sector whose data field never decodes (a header with no data mark, or a CRC error at every candidate size) has `sectorData` of `null`, so flushing a track that holds one threw a `TypeError` out of the emulator's write path.

Only discs loaded with an `onChange` handler carry that listener, which is browser-local and Google Drive discs, so it needs a damaged track on a writeable disc to hit. An interrupted format leaves exactly that.

`sectorShortfall` already decides what an SSD or DSD can hold, and the saver uses it; the listener now asks the same question. That also stops a sector numbered past the ten a track holds from writing into the following track's bytes, and a short sector from filling out its 256 bytes with zeros.

The test reuses the existing `eraseDataField` helper, which is moved up the file now that two blocks want it. It fails with `TypeError: Cannot read properties of null` before the change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019CJ9csHch7kjzF3DKzR5DP