### PR TITLE
feat: add a toast, for saying something that needs nothing doing about it

### DIFF
--- a/src/web/toast.js
+++ b/src/web/toast.js
@@ -1,0 +1,67 @@
+import * as bootstrap from "bootstrap";
+
+/**
+ * Passing notices: something happened that is worth knowing and needs nothing doing about it.
+ * The error dialog is for the other kind.
+ */
+
+let nextQuietId = 0;
+
+function toastContainer() {
+    const existing = document.querySelector(".toast-container");
+    if (existing) return existing;
+    const container = document.createElement("div");
+    container.className = "toast-container position-fixed bottom-0 end-0 p-3";
+    document.body.appendChild(container);
+    return container;
+}
+
+/** @param {string} quietKey */
+export function isQuiet(quietKey) {
+    return !!window.localStorage[quietKey];
+}
+
+/**
+ * @param {string} message
+ * @param {object} [options]
+ * @param {string} [options.title] a heading, for a notice whose message does not say where it came from
+ * @param {string} [options.quietKey] offer to stop showing this kind of notice, remembering the answer here
+ */
+export function toast(message, { title = "", quietKey = "" } = {}) {
+    if (quietKey && isQuiet(quietKey)) return;
+
+    const element = document.createElement("div");
+    element.className = "toast text-bg-dark";
+    element.setAttribute("role", "status");
+    element.setAttribute("aria-live", "polite");
+    element.setAttribute("aria-atomic", "true");
+    const quietId = `toast-quiet-${nextQuietId++}`;
+    element.innerHTML = `
+        <div class="toast-header text-bg-dark">
+            <strong class="me-auto"></strong>
+            <button type="button" class="btn-close btn-close-white" data-bs-dismiss="toast" aria-label="Close"></button>
+        </div>
+        <div class="toast-body">
+            <div class="message"></div>
+            <div class="form-check mt-2">
+                <input class="form-check-input" type="checkbox" id="${quietId}" />
+                <label class="form-check-label small" for="${quietId}">Stop telling me this</label>
+            </div>
+        </div>`;
+    // Disc names and the like come from the outside world, so they are set as text, never as markup.
+    element.querySelector(".message").textContent = message;
+    element.querySelector(".toast-header strong").textContent = title;
+    element.querySelector(".toast-header").hidden = !title;
+
+    const quiet = element.querySelector(".form-check");
+    quiet.hidden = !quietKey;
+    quiet.querySelector("input").addEventListener("change", (event) => {
+        if (event.target.checked) window.localStorage[quietKey] = "yes";
+        else window.localStorage.removeItem(quietKey);
+    });
+
+    toastContainer().appendChild(element);
+    element.addEventListener("hidden.bs.toast", () => element.remove());
+    bootstrap.Toast.getOrCreateInstance(element).show();
+    return element;
+}

--- a/src/web/toast.js
+++ b/src/web/toast.js
@@ -16,9 +16,24 @@ function toastContainer() {
     return container;
 }
 
-/** @param {string} quietKey */
-export function isQuiet(quietKey) {
-    return !!window.localStorage[quietKey];
+// Storage can be unreachable or full, and a notice that nothing needs doing about is not worth
+// failing over: forget the answer and say the thing again.
+function remembered(key) {
+    try {
+        return !!window.localStorage.getItem(key);
+    } catch (e) {
+        console.log(`Unable to read ${key}: ${e}`);
+        return false;
+    }
+}
+
+function remember(key, wanted) {
+    try {
+        if (wanted) window.localStorage.setItem(key, "yes");
+        else window.localStorage.removeItem(key);
+    } catch (e) {
+        console.log(`Unable to remember ${key}: ${e}`);
+    }
 }
 
 /**
@@ -28,7 +43,7 @@ export function isQuiet(quietKey) {
  * @param {string} [options.quietKey] offer to stop showing this kind of notice, remembering the answer here
  */
 export function toast(message, { title = "", quietKey = "" } = {}) {
-    if (quietKey && isQuiet(quietKey)) return;
+    if (quietKey && remembered(quietKey)) return;
 
     const element = document.createElement("div");
     element.className = "toast text-bg-dark";
@@ -55,10 +70,7 @@ export function toast(message, { title = "", quietKey = "" } = {}) {
 
     const quiet = element.querySelector(".form-check");
     quiet.hidden = !quietKey;
-    quiet.querySelector("input").addEventListener("change", (event) => {
-        if (event.target.checked) window.localStorage[quietKey] = "yes";
-        else window.localStorage.removeItem(quietKey);
-    });
+    quiet.querySelector("input").addEventListener("change", (event) => remember(quietKey, event.target.checked));
 
     toastContainer().appendChild(element);
     element.addEventListener("hidden.bs.toast", () => element.remove());

--- a/tests/unit/test-toast.js
+++ b/tests/unit/test-toast.js
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 import { afterEach, describe, expect, it } from "vitest";
 
-import { isQuiet, toast } from "../../src/web/toast.js";
+import { toast } from "../../src/web/toast.js";
 
 describe("toast", () => {
     afterEach(() => {
@@ -54,9 +54,25 @@ describe("toast", () => {
         quiet.checked = true;
         quiet.dispatchEvent(new window.Event("change"));
 
-        expect(isQuiet("quietTest")).toBe(true);
+        expect(window.localStorage.quietTest).toBe("yes");
         expect(toast("Told again.", { quietKey: "quietTest" })).toBe(undefined);
         expect(toasts()).toHaveLength(1);
+    });
+
+    it("says its piece when it cannot remember whether it was told not to", () => {
+        const storage = window.localStorage;
+        Object.defineProperty(window, "localStorage", {
+            configurable: true,
+            get() {
+                throw new Error("no storage for you");
+            },
+        });
+        try {
+            expect(() => toast("Told anyway.", { quietKey: "quietTest" })).not.toThrow();
+            expect(toasts()).toHaveLength(1);
+        } finally {
+            Object.defineProperty(window, "localStorage", { configurable: true, value: storage });
+        }
     });
 
     it("says it again once it is allowed to", () => {

--- a/tests/unit/test-toast.js
+++ b/tests/unit/test-toast.js
@@ -1,0 +1,72 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it } from "vitest";
+
+import { isQuiet, toast } from "../../src/web/toast.js";
+
+describe("toast", () => {
+    afterEach(() => {
+        document.body.innerHTML = "";
+        window.localStorage.clear();
+    });
+
+    const toasts = () => [...document.querySelectorAll(".toast")];
+
+    it("says what it was given", () => {
+        toast("A disc was swapped.", { title: "Disc drive" });
+
+        expect(toasts()).toHaveLength(1);
+        expect(toasts()[0].querySelector(".message").textContent).toBe("A disc was swapped.");
+        expect(toasts()[0].querySelector(".toast-header strong").textContent).toBe("Disc drive");
+    });
+
+    it("keeps its head down when there is nothing to head it with", () => {
+        toast("A disc was swapped.");
+
+        expect(toasts()[0].querySelector(".toast-header").hidden).toBe(true);
+    });
+
+    it("stacks up in one container", () => {
+        toast("One.");
+        toast("Two.");
+
+        expect(document.querySelectorAll(".toast-container")).toHaveLength(1);
+        expect(toasts()).toHaveLength(2);
+    });
+
+    it("treats a disc's name as text, whatever it holds", () => {
+        toast(`Loaded <img src=x onerror="alert(1)">.`);
+
+        expect(toasts()[0].querySelectorAll("img")).toHaveLength(0);
+        expect(toasts()[0].querySelector(".message").textContent).toContain("onerror");
+    });
+
+    it("offers to stop only when there is somewhere to remember the answer", () => {
+        toast("Told once.", { quietKey: "quietTest" });
+        toast("Told again.");
+
+        expect(toasts()[0].querySelector(".form-check").hidden).toBe(false);
+        expect(toasts()[1].querySelector(".form-check").hidden).toBe(true);
+    });
+
+    it("remembers being told to stop, and stops", () => {
+        toast("Told once.", { quietKey: "quietTest" });
+        const quiet = toasts()[0].querySelector(".form-check input");
+        quiet.checked = true;
+        quiet.dispatchEvent(new window.Event("change"));
+
+        expect(isQuiet("quietTest")).toBe(true);
+        expect(toast("Told again.", { quietKey: "quietTest" })).toBe(undefined);
+        expect(toasts()).toHaveLength(1);
+    });
+
+    it("says it again once it is allowed to", () => {
+        window.localStorage.quietTest = "yes";
+        toast("Suppressed.", { quietKey: "quietTest" });
+        expect(toasts()).toHaveLength(0);
+
+        window.localStorage.removeItem("quietTest");
+        toast("Allowed.", { quietKey: "quietTest" });
+
+        expect(toasts()).toHaveLength(1);
+    });
+});


### PR DESCRIPTION
Extracted from #792, where I had welded it to one message. It belongs on its own, since you asked for a pass over the error dialog's other uses afterwards.

jsbeeb tells the user everything through a modal error dialog. That suits "this failed and here is why", and suits nothing else: a notice that the machine noticed something and carried on regardless has no business stopping anyone to say so.

```js
toast("Drive 0 switched to 40 track for elite.ssd.", { title: "Disc drive", quietKey: "quietDriveTracks" });
```

A message, optionally a heading, and optionally a local-storage key. Given a key, the toast carries a "stop telling me this" checkbox and honours it next time; given none, it just says its piece and goes. It makes its own container on first use and removes each toast once dismissed, so several can stack up without anyone owning the markup.

The message goes in as text, never as markup, since the ones I have in mind carry disc names that came from a URL. One of the tests loads `<img src=x onerror=...>` as a name to check that.

**No caller yet.** Its first is #792, which currently carries its own copy and will use this once this lands. If you would rather it arrived with a user, the obvious one is the key-mapping warning in `main.js`: a bad `KEY.X=Y` in the URL stops the machine with a modal today, having changed nothing about whether it boots. Say the word and I will move that across here rather than in the follow-up pass.

Seven tests, under jsdom.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019CJ9csHch7kjzF3DKzR5DP