### PR TITLE
docs: write down how a disc's track layout is worked out

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,7 +249,7 @@ sudo rpm -i out/dist/jsbeeb-1.0.1.x86_64.rpm
   a 40 track image is laid out the way a 40 track drive wrote it, on every other track of the surface, and the drive
   double steps to read it. `40` reads an 80 track disc through a double stepping head, which is as much of a mess as it
   was in 1985. `80` turns all of this off for that drive, loading every image the way jsbeeb did before it could tell
-  them apart.
+  them apart. [docs/disc-track-layouts.md](docs/disc-track-layouts.md) explains how an image's layout is worked out.
 - `tape=XXX` - loads tape XXX (from the `tapes/` directory)
 - `tape=sth:ZZZ` - loads tape ZZZ from the Stairway to Hell archive
 - `KEY.X=Y` - makes host key `X` press BBC key `Y`, e.g. `KEY.ENTER=COPY`. See

--- a/docs/disc-track-layouts.md
+++ b/docs/disc-track-layouts.md
@@ -60,12 +60,6 @@ truthfully declaring eighty or more tracks.
 
 ## Decisions worth knowing about
 
-**DFS keeps its catalogue entries in descending order of start sector, and we do not check that.**
-The rule is real, but images in the wild were not all written by DFS, and a wrong "yes" here cannot
-hurt: software reads the same logical tracks whichever pitch the image is laid out at, and the one
-case where expanding would lose data has its own rule. Over the STH archive the check cost one
-genuine 40 track disc, The Hobbit, and gained nothing.
-
 **Only the lower side of a flux image is asked.** Both heads are on the same cylinder at any
 instant, but a disc can be written in more than one pass, and some were: a **dual format** disc
 carries side 0 for a 40 track drive and side 1 for an 80 track one, the same game twice. Ten discs

--- a/docs/disc-track-layouts.md
+++ b/docs/disc-track-layouts.md
@@ -9,8 +9,8 @@ does, and what the guesses were checked against. The mechanics live in `src/disc
 A 40 track drive writes at 48 tracks per inch, an 80 track drive at 96. Both use the same media, so
 a 40 track disc's tracks sit on every other track of an 80 track drive's grid: logical track N at
 physical track 2N. An 80 track drive reads such a disc by **double stepping**, moving its head two
-positions for each track the controller asks for. Real drives had a switch for this, sometimes one
-per drive, and setting it wrong is how a disc read as noise.
+positions for each track the controller asks for. 80 track drives were switchable between the two,
+and setting the switch wrong is how a disc read as noise.
 
 The track pitch matters more than it first appears. At 48 tpi the pitch is 0.53mm and a written
 track is about 0.33mm wide, so the neighbouring 96 tpi position, 0.265mm away, falls outside
@@ -25,28 +25,38 @@ the 1770 ask for a track and the drive decides how far to move.
 
 ## The three kinds of evidence
 
-An image is either a list of sectors or a picture of the surface, and they are asked different
-questions. All of it happens once, in `discFor`, which every load path goes through, and the answer
-and its reason are logged.
+An image is either a list of sectors (SSD, DSD, ADF, ADM, ADL) or a picture of the surface (HFE),
+and the two are asked different questions. All of it happens once, in `discFor`, which every load
+path goes through, and the answer and its reason are logged.
 
-**A sector image (SSD, DSD) is asked its catalogue.** The DFS catalogue records how many sectors the
+**A DFS sector image (SSD, DSD) is asked its catalogue.** The DFS catalogue records how many sectors the
 disc has: 400 for 40 tracks, 800 for 80. An image whose catalogue is structurally sane, claims from
 1 to 400 sectors, and holds no data past where 40 tracks reach is laid out double spaced by
 `loadSsd`, logical track N built at physical 2N, with the tracks between left unformatted so they
 read as the weak bits an unwritten surface gives.
 
-**The file's size is not evidence.** Images are routinely padded out to a full 200K or cut short
-after the last used sector, in both directions, so size says nothing about pitch. Two real examples,
-both from the STH archive: `Plus3GamesDisc-ADFS_E.adf` is exactly the 160K of a 40 track ADFS disc
-while its map claims 1280 sectors, and `MelbourneHouse/TheHobbit-GameDisk.ssd` is exactly 100K with
-a catalogue that agrees. Size would have called the first 40 track and it is not.
+**The file's size is not evidence.** Images are routinely padded out to a full 200K, or cut short
+after the last sector holding anything, so size says nothing about pitch. Two real examples, both
+from the STH archive: `Plus3GamesDisc-ADFS_E.adf` is 160K, the size of a 40 track ADFS disc, but its
+map claims the 1280 sectors of an 80 track one, and it is the map that is right;
+`MelbourneHouse/TheHobbit-GameDisk.ssd` is 100K and really is 40 tracks. Going by size would have
+called both of them 40 track and been wrong about the first.
+
+**An ADFS sector image (ADF, ADM, ADL) is not asked anything**, and is always laid out
+contiguously. ADFS comes in three sizes: S is 40 tracks on one side, M is 80 on one, L is 80 on
+both, and only S is double spaced. The free space map would say which, holding the disc's total
+sectors at offset 0xFC of sector 0 as three bytes, little endian, where 640 means S. Nothing reads
+it, because no S turned up to test a rule against: of the 23 ADFS images in the Stairway to Hell
+archive, 22 are M and one is L. An ADFS disc held in a flux image is covered anyway, since the
+surface is read without reference to any filesystem.
 
 **A flux image (HFE) is asked its header, then its surface.** A capture that declares no more tracks
 than half a surface cannot be of an 80 track disc, so it is expanded on load. Otherwise the surface
 itself is read: a track written by a 48 tpi head sits at twice the number its own sector headers
 claim, with nothing readable on the tracks between. That question needs no filesystem behind it, so
-it serves ADFS as well as DFS, and it is the only way to spot the common case of a 40 track disc
-captured by stepping every position of an 80 track drive, which declares 80 odd tracks honestly.
+it serves ADFS as well as DFS. It is also the only way to spot a 40 track disc captured by stepping
+every position of an 80 track drive, which is the usual way to take one and leaves a header
+truthfully declaring eighty or more tracks.
 
 ## Decisions worth knowing about
 
@@ -56,19 +66,21 @@ hurt: software reads the same logical tracks whichever pitch the image is laid o
 case where expanding would lose data has its own rule. Over the STH archive the check cost one
 genuine 40 track disc, The Hobbit, and gained nothing.
 
-**Only the lower side of a flux image is asked.** Both heads move together, so a disc has one pitch
-at any instant, but a disc can be written in two passes and some were: a **dual format** disc carries
-side 0 for a 40 track drive and side 1 for an 80 track one, the same game twice. Ten discs in
-scarybeasts' archive are catalogued that way, five of them Elite, and `public/discs/elite.hfe` is
-one. Since a drive's switch is not per side, side 0, the one DFS boots from, decides; reaching the
-other side means setting the switch by hand, exactly as it would on real hardware.
+**Only the lower side of a flux image is asked.** Both heads are on the same cylinder at any
+instant, but a disc can be written in more than one pass, and some were: a **dual format** disc
+carries side 0 for a 40 track drive and side 1 for an 80 track one, the same game twice. Ten discs
+in scarybeasts' archive are catalogued that way, five of them Elite, and `public/discs/elite.hfe` is
+one of them. A drive's switch is not per side, so the side DFS boots from decides. Reaching the
+other side means setting the switch by hand, which is what it would take on real hardware too.
 
-**A wrong guess cannot lose data.** For a sector image, expanding only changes where the loader puts
-tracks it was going to write anyway, and an image with content past track 42 is refused. For a flux
-image nothing is moved at all: only the drive's switch changes. This is why the sector-image rules
-can afford to be relaxed and the surface rule cannot, since double stepping a genuine 80 track disc
-would land the head between its tracks. The surface rule therefore refuses on the first odd track
-holding sectors of its own, and wants four tracks agreeing before it believes.
+**A wrong guess about a sector image cannot lose anything; a wrong guess about a flux image can
+stop the disc reading.** Expanding a sector image only changes where the loader puts tracks it was
+going to write anyway, and one with content past track 42 is refused, so the worst a mistake costs
+is where the tracks sit on a surface nobody was looking at. A flux image is not moved at all, and
+only the drive's switch changes, but double stepping a disc that was never written that way lands
+the head between its tracks and it reads nothing. That is why the sector rules can afford to be
+relaxed and the surface rule cannot: it refuses on the first odd track holding sectors of its own,
+and wants four tracks agreeing before it believes.
 
 ## What the guesses were checked against
 
@@ -87,7 +99,7 @@ position and nothing on the odd ones. One of them is The Hobbit, whose own DFS c
 track, which may itself be protection, since a copier that believes the catalogue will look for 40
 tracks that are not there.
 
-That archive is mostly protected discs, which is why it exists: 40% of it has deleted-data sectors,
+Much of that archive is protected discs, which is why it exists: 40% of it has deleted-data sectors,
 24% has a formatted track past 79, and 18% has a sector numbered past 9. Layout detection has to
 survive all of that, which is the main reason it asks narrow questions.
 

--- a/docs/disc-track-layouts.md
+++ b/docs/disc-track-layouts.md
@@ -1,0 +1,99 @@
+# 40 and 80 track discs
+
+How jsbeeb works out where a disc image's tracks belong on the surface, why it guesses the way it
+does, and what the guesses were checked against. The mechanics live in `src/disc.js`,
+`src/disc-drive.js` and `src/fdc.js`; this is the reasoning behind them.
+
+## The physical thing being modelled
+
+A 40 track drive writes at 48 tracks per inch, an 80 track drive at 96. Both use the same media, so
+a 40 track disc's tracks sit on every other track of an 80 track drive's grid: logical track N at
+physical track 2N. An 80 track drive reads such a disc by **double stepping**, moving its head two
+positions for each track the controller asks for. Real drives had a switch for this, sometimes one
+per drive, and setting it wrong is how a disc read as noise.
+
+The track pitch matters more than it first appears. At 48 tpi the pitch is 0.53mm and a written
+track is about 0.33mm wide, so the neighbouring 96 tpi position, 0.265mm away, falls outside
+anything the write puts down: it is guard band. A 40 track write therefore leaves **nothing
+readable** on the track next to it, rather than a fainter copy of itself. That is why `Disc` models
+a fat write as erasing its neighbour, and why an 80 track drive single stepping across a 40 track
+disc finds empty space rather than data.
+
+`Disc` holds the physical surface: 84 slots at 96 tpi spacing. The drive owns the stepping, as
+`tracksPerStep`, which is 1 or 2. Nothing else in the emulator knows about any of this: the 8271 and
+the 1770 ask for a track and the drive decides how far to move.
+
+## The three kinds of evidence
+
+An image is either a list of sectors or a picture of the surface, and they are asked different
+questions. All of it happens once, in `discFor`, which every load path goes through, and the answer
+and its reason are logged.
+
+**A sector image (SSD, DSD) is asked its catalogue.** The DFS catalogue records how many sectors the
+disc has: 400 for 40 tracks, 800 for 80. An image whose catalogue is structurally sane, claims from
+1 to 400 sectors, and holds no data past where 40 tracks reach is laid out double spaced by
+`loadSsd`, logical track N built at physical 2N, with the tracks between left unformatted so they
+read as the weak bits an unwritten surface gives.
+
+**The file's size is not evidence.** Images are routinely padded out to a full 200K or cut short
+after the last used sector, in both directions, so size says nothing about pitch. Two real examples,
+both from the STH archive: `Plus3GamesDisc-ADFS_E.adf` is exactly the 160K of a 40 track ADFS disc
+while its map claims 1280 sectors, and `MelbourneHouse/TheHobbit-GameDisk.ssd` is exactly 100K with
+a catalogue that agrees. Size would have called the first 40 track and it is not.
+
+**A flux image (HFE) is asked its header, then its surface.** A capture that declares no more tracks
+than half a surface cannot be of an 80 track disc, so it is expanded on load. Otherwise the surface
+itself is read: a track written by a 48 tpi head sits at twice the number its own sector headers
+claim, with nothing readable on the tracks between. That question needs no filesystem behind it, so
+it serves ADFS as well as DFS, and it is the only way to spot the common case of a 40 track disc
+captured by stepping every position of an 80 track drive, which declares 80 odd tracks honestly.
+
+## Decisions worth knowing about
+
+**DFS keeps its catalogue entries in descending order of start sector, and we do not check that.**
+The rule is real, but images in the wild were not all written by DFS, and a wrong "yes" here cannot
+hurt: software reads the same logical tracks whichever pitch the image is laid out at, and the one
+case where expanding would lose data has its own rule. Over the STH archive the check cost one
+genuine 40 track disc, The Hobbit, and gained nothing.
+
+**Only the lower side of a flux image is asked.** Both heads move together, so a disc has one pitch
+at any instant, but a disc can be written in two passes and some were: a **dual format** disc carries
+side 0 for a 40 track drive and side 1 for an 80 track one, the same game twice. Ten discs in
+scarybeasts' archive are catalogued that way, five of them Elite, and `public/discs/elite.hfe` is
+one. Since a drive's switch is not per side, side 0, the one DFS boots from, decides; reaching the
+other side means setting the switch by hand, exactly as it would on real hardware.
+
+**A wrong guess cannot lose data.** For a sector image, expanding only changes where the loader puts
+tracks it was going to write anyway, and an image with content past track 42 is refused. For a flux
+image nothing is moved at all: only the drive's switch changes. This is why the sector-image rules
+can afford to be relaxed and the surface rule cannot, since double stepping a genuine 80 track disc
+would land the head between its tracks. The surface rule therefore refuses on the first odd track
+holding sectors of its own, and wants four tracks agreeing before it believes.
+
+## What the guesses were checked against
+
+`tools/sniff-disc-layout.js` walks a directory of images and reports the verdict and reason for
+each, so any change to this can be tried against a corpus first.
+
+Over a full mirror of the **Stairway to Hell** disc archive, 1607 sector images: 10 read as 40 track
+and 1597 as 80, which is the shape you would expect of a BBC archive.
+
+Over a full mirror of **scarybeasts' HFE archive**, 656 flux images, checked against the `tracks`
+column its catalogue records with `--manifest`: **654 agree**, including every one of the 429 discs
+catalogued as 40 track. The two that disagree are both catalogued `80 (dual)` and both are, on the
+surface, unarguably double stepped, with every even track holding sectors numbered half its
+position and nothing on the odd ones. One of them is The Hobbit, whose own DFS catalogue also says
+400 sectors; the other is Quest, whose catalogue claims 800 while its data sits on every other
+track, which may itself be protection, since a copier that believes the catalogue will look for 40
+tracks that are not there.
+
+That archive is mostly protected discs, which is why it exists: 40% of it has deleted-data sectors,
+24% has a formatted track past 79, and 18% has a sector numbered past 9. Layout detection has to
+survive all of that, which is the main reason it asks narrow questions.
+
+## The switch
+
+`drive0Tracks` and `drive1Tracks` fix a drive's switch from the URL, and the Discs menu shows and
+sets it. A drive left alone follows whatever disc is loaded into it, which no real drive does: it is
+jsbeeb doing the user a favour, and `fdc.loadDisc` is where the favour is done. `80` turns the whole
+business off for that drive, loading every image the way jsbeeb did before it could tell them apart.

--- a/tests/unit/test-disc-hfe.js
+++ b/tests/unit/test-disc-hfe.js
@@ -124,6 +124,31 @@ describe("telling a 40 track HFE from an 80 track one", () => {
         expect(sniffSurfaceLayout(disc).is40Track).toBe(false);
     });
 
+    it("judges a disc whose sides disagree on the one that boots", { timeout: 30000 }, () => {
+        // Elite is a dual format disc: side 0 written for a 40 track drive, side 1 for an 80 track
+        // one, the same game on both. A drive's 40/80 switch is not per side, so the side DFS boots
+        // from decides, and reaching the other one means setting the switch by hand.
+        const disc = new Disc(true, new DiscConfig(), "test.hfe");
+        loadHfe(disc, fs.readFileSync("public/discs/elite.hfe"));
+
+        const lower = disc.getTrack(false, 78).findSectors(() => {});
+        const upper = disc.getTrack(true, 39).findSectors(() => {});
+        expect(lower[0].trackNumber).toBe(39);
+        expect(upper[0].trackNumber).toBe(39);
+
+        expect(sniffSurfaceLayout(disc).is40Track).toBe(true);
+    });
+
+    it("wants more than a track or two before it believes", () => {
+        const config = new DiscConfig();
+        config.expandTo80 = true;
+        const disc = loadSsd(new Disc(true, config, "test.ssd"), new Uint8Array(40 * 10 * 256), false, null);
+        // A capture holding only the first couple of tracks cannot say which pitch it was at.
+        for (let trackNum = 4; trackNum < disc.tracksUsed; ++trackNum) disc.eraseTrack(false, trackNum);
+
+        expect(sniffSurfaceLayout(disc).is40Track).toBe(false);
+    });
+
     it("expands a 40 track capture across the surface", { timeout: 30000 }, () => {
         const source = new Disc(true, new DiscConfig(), "source.adf");
         loadAdf(source, new Uint8Array(40 * 16 * 256), false);

--- a/tools/sniff-disc-layout.js
+++ b/tools/sniff-disc-layout.js
@@ -59,21 +59,30 @@ function sniff({ name, data }) {
     return header.is40Track ? header : sniffSurfaceLayout(disc);
 }
 
-/** The tracks an archive manifest records for a disc, which is what its cataloguer saw. */
-function claimedTracks(manifest, name) {
-    const entry = manifest?.files?.find((file) => file.path === name);
-    return entry ? ((entry.tracks ?? [])[0] ?? "") : null;
+/**
+ * The tracks an archive manifest records per disc, which is what its cataloguer saw. A row without
+ * one is left out rather than read as anything, since "nothing recorded" is not a claim.
+ */
+function claimedTracks(manifest) {
+    const claims = new Map();
+    for (const file of manifest?.files ?? []) {
+        const claimed = (file.tracks ?? [])[0];
+        if (claimed) claims.set(file.path, claimed);
+    }
+    return claims;
 }
 
 async function main() {
-    const directory = argv[2];
-    const verbose = argv.includes("--verbose");
-    const manifestPath = argv[argv.indexOf("--manifest") + 1];
-    if (!directory || directory.startsWith("--")) {
+    const args = argv.slice(2);
+    const verbose = args.includes("--verbose");
+    const manifestAt = args.indexOf("--manifest");
+    const manifestPath = manifestAt === -1 ? null : args[manifestAt + 1];
+    const directory = args.find((arg, index) => !arg.startsWith("--") && index !== manifestAt + 1);
+    if (!directory || (manifestAt !== -1 && (!manifestPath || manifestPath.startsWith("--")))) {
         stdout.write("Usage: node tools/sniff-disc-layout.js <directory> [--verbose] [--manifest <path>]\n");
         exit(1);
     }
-    const manifest = argv.includes("--manifest") ? JSON.parse(await readFile(manifestPath, "utf8")) : null;
+    const claims = manifestPath ? claimedTracks(JSON.parse(await readFile(manifestPath, "utf8"))) : new Map();
     // The loaders narrate what they are doing, which would bury the report.
     console.log = () => {};
 
@@ -92,8 +101,8 @@ async function main() {
         total++;
         counts.set(reason, (counts.get(reason) ?? 0) + 1);
         if (is40Track || verbose) stdout.write(`${is40Track ? "40" : "80"} ${image.path}: ${reason}\n`);
-        const claimed = claimedTracks(manifest, image.name);
-        if (claimed === null) continue;
+        const claimed = claims.get(image.name);
+        if (!claimed) continue;
         if (claimed.startsWith("40") === is40Track) agreed++;
         else
             disagreements.push(
@@ -105,7 +114,7 @@ async function main() {
     for (const [reason, count] of [...counts].sort(([, a], [, b]) => b - a)) {
         stdout.write(`${String(count).padStart(6)}  ${reason}\n`);
     }
-    if (manifest) {
+    if (claims.size) {
         stdout.write(`\n${agreed} of ${agreed + disagreements.length} agree with the manifest\n`);
         for (const disagreement of disagreements) stdout.write(`  ${disagreement}\n`);
     }

--- a/tools/sniff-disc-layout.js
+++ b/tools/sniff-disc-layout.js
@@ -1,23 +1,32 @@
 #!/usr/bin/env node
 /**
  * Report what jsbeeb makes of the track layout of a pile of disc images, so a change to the
- * detection can be checked against a corpus (an STH mirror, say) before it reaches anyone.
+ * detection can be checked against a corpus before it reaches anyone.
  *
- * Usage: node tools/sniff-disc-layout.js <directory> [--verbose]
+ * Usage: node tools/sniff-disc-layout.js <directory> [--verbose] [--manifest <path>]
  *
- * Walks the directory for .ssd, .dsd and .zip files, and prints one line per image: the verdict,
- * the path and the reason. Without --verbose only the 40 track verdicts are listed, since they
- * are the ones a change makes or loses.
+ * Walks the directory for .ssd, .dsd, .hfe and .zip files and prints one line per image: the
+ * verdict, the path and the reason. Sector images are judged by their catalogue and flux images by
+ * their surface, which is what jsbeeb itself does. Without --verbose only the 40 track verdicts are
+ * listed, since they are the ones a change makes or loses.
+ *
+ * --manifest takes the archive manifest that came with a mirror of flux images and compares each
+ * verdict against the tracks its catalogue records, which is the only ground truth there is for
+ * this. Disagreements are printed whether or not --verbose is given, and are worth reading: a
+ * disc's layout and the row describing it can each be wrong.
  */
 
 import { readdir, readFile } from "node:fs/promises";
 import { extname, join } from "node:path";
 import { argv, exit, stdout } from "node:process";
 
-import { sniffDfsLayout } from "../src/disc.js";
+import { Disc, DiscConfig, sniffDfsLayout, sniffSurfaceLayout } from "../src/disc.js";
+import { loadHfe, sniffHfeLayout } from "../src/disc-hfe.js";
 import { unzipDiscImage } from "../src/utils.js";
 
-const DiscExtensions = new Set([".ssd", ".dsd"]);
+const SectorImages = new Set([".ssd", ".dsd"]);
+const FluxImages = new Set([".hfe"]);
+const known = (name) => SectorImages.has(extname(name).toLowerCase()) || FluxImages.has(extname(name).toLowerCase());
 
 async function* discImages(directory) {
     for (const entry of await readdir(directory, { withFileTypes: true })) {
@@ -26,42 +35,79 @@ async function* discImages(directory) {
             yield* discImages(path);
             continue;
         }
-        const extension = extname(entry.name).toLowerCase();
-        if (extension === ".zip") {
+        if (extname(entry.name).toLowerCase() === ".zip") {
             try {
                 const { name, data } = await unzipDiscImage(new Uint8Array(await readFile(path)));
-                if (DiscExtensions.has(extname(name).toLowerCase())) yield { path: `${path}!${name}`, name, data };
+                if (known(name)) yield { path: `${path}!${name}`, name, data };
             } catch (e) {
                 stdout.write(`?? ${path}: ${e.message}\n`);
             }
-        } else if (DiscExtensions.has(extension)) {
+        } else if (known(entry.name)) {
             yield { path, name: entry.name, data: new Uint8Array(await readFile(path)) };
         }
     }
 }
 
+/** What jsbeeb would make of one image, by the same route discFor takes. */
+function sniff({ name, data }) {
+    if (SectorImages.has(extname(name).toLowerCase()))
+        return sniffDfsLayout(data, extname(name).toLowerCase() === ".dsd");
+    const header = sniffHfeLayout(data);
+    const disc = new Disc(true, new DiscConfig(), name);
+    disc.config.expandTo80 = header.is40Track;
+    loadHfe(disc, data);
+    return header.is40Track ? header : sniffSurfaceLayout(disc);
+}
+
+/** The tracks an archive manifest records for a disc, which is what its cataloguer saw. */
+function claimedTracks(manifest, name) {
+    const entry = manifest?.files?.find((file) => file.path === name);
+    return entry ? ((entry.tracks ?? [])[0] ?? "") : null;
+}
+
 async function main() {
     const directory = argv[2];
     const verbose = argv.includes("--verbose");
-    if (!directory) {
-        stdout.write("Usage: node tools/sniff-disc-layout.js <directory> [--verbose]\n");
+    const manifestPath = argv[argv.indexOf("--manifest") + 1];
+    if (!directory || directory.startsWith("--")) {
+        stdout.write("Usage: node tools/sniff-disc-layout.js <directory> [--verbose] [--manifest <path>]\n");
         exit(1);
     }
-    // The unzipper narrates what it is doing, which would bury the report.
+    const manifest = argv.includes("--manifest") ? JSON.parse(await readFile(manifestPath, "utf8")) : null;
+    // The loaders narrate what they are doing, which would bury the report.
     console.log = () => {};
 
     const counts = new Map();
+    const disagreements = [];
     let total = 0;
-    for await (const { path, name, data } of discImages(directory)) {
-        const { is40Track, reason } = sniffDfsLayout(data, extname(name).toLowerCase() === ".dsd");
+    let agreed = 0;
+    for await (const image of discImages(directory)) {
+        let is40Track, reason;
+        try {
+            ({ is40Track, reason } = sniff(image));
+        } catch (e) {
+            stdout.write(`?? ${image.path}: ${e.message}\n`);
+            continue;
+        }
         total++;
         counts.set(reason, (counts.get(reason) ?? 0) + 1);
-        if (is40Track || verbose) stdout.write(`${is40Track ? "40" : "80"} ${path}: ${reason}\n`);
+        if (is40Track || verbose) stdout.write(`${is40Track ? "40" : "80"} ${image.path}: ${reason}\n`);
+        const claimed = claimedTracks(manifest, image.name);
+        if (claimed === null) continue;
+        if (claimed.startsWith("40") === is40Track) agreed++;
+        else
+            disagreements.push(
+                `${image.name}: catalogued as "${claimed}", read as ${is40Track ? "40" : "80"} (${reason})`,
+            );
     }
 
     stdout.write(`\n${total} images\n`);
     for (const [reason, count] of [...counts].sort(([, a], [, b]) => b - a)) {
         stdout.write(`${String(count).padStart(6)}  ${reason}\n`);
+    }
+    if (manifest) {
+        stdout.write(`\n${agreed} of ${agreed + disagreements.length} agree with the manifest\n`);
+        for (const disagreement of disagreements) stdout.write(`  ${disagreement}\n`);
     }
 }
 


### PR DESCRIPTION
You asked whether the good behaviour is locked in well enough that we could change our mind later and know where we stood. Mostly it was, in the mechanics; what was missing was the reasoning and two of the decisions the archives taught us.

## docs/disc-track-layouts.md

`docs/` already holds this sort of thing (`pal-simulation-design.md`, `pal-comb-filter-research.md`), and the reasoning here was spread across #789 to #792, #799 and a pile of one-off scripts in a scratch directory. It covers the physical thing being modelled, what each kind of image is asked and why, the decisions that look arbitrary without their evidence, what a wrong guess can and cannot cost, and the corpus results. The README's `drive0Tracks` entry points at it.

The section worth reading before changing any of this is "a wrong guess cannot lose data": the sector-image rules can afford to be relaxed because expanding only moves tracks the loader was going to write anyway, while the surface rule cannot, since double stepping a genuine 80 track disc lands the head between its tracks. That asymmetry is why one set of rules is loose and the other is strict.

## The corpus check, reproducible

`tools/sniff-disc-layout.js` now reads flux images as well as sector ones, taking the same route `discFor` does: header first, then the surface. `--manifest` compares each verdict against the `tracks` column an archive records, which is the only ground truth available.

```
$ node tools/sniff-disc-layout.js <mirror>/hfe --manifest <mirror>/hfe/manifest.json
...
654 of 656 agree with the manifest
  5E5687F4.hfe: catalogued as "80 (dual)", read as 40 (40 tracks sit at twice the number their sectors claim)
  CA34F39B.hfe: catalogued as "80 (dual)", read as 40 (39 tracks sit at twice the number their sectors claim)
```

That is the check I ran by hand while reviewing #799, now a command anyone can repeat.

## Two tests

Both hold down decisions that only make sense once you have seen the archive:

- **A disc whose sides disagree is judged on the side that boots.** `elite.hfe` is a dual format disc: side 0 written for a 40 track drive, side 1 for an 80 track one, the same game twice. Ten discs in scarybeasts' archive are catalogued that way, five of them Elite. The test asserts both sides hold track 39 and that the verdict is 40, so anyone "fixing" the sniff to consider both sides gets told why not.
- **A capture of a track or two is not enough to go on.** Four agreeing tracks are required; without that a two track test image would read as 40 track on the strength of one coincidence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019CJ9csHch7kjzF3DKzR5DP