### PR TITLE
fix: keep the unzipped name when loading from the STH archive

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -1247,8 +1247,10 @@ async function loadDiscImage(discImage, layout = DiscLayout.auto) {
     // * Dialog box (ugh) saying "is this ok?"
     switch (schema) {
         case "|":
-        case "sth":
-            return disc.discFor(processor.fdc, discImage, await discSth.fetch(discImage), undefined, layout);
+        case "sth": {
+            const { name, data } = await discSth.fetch(discImage);
+            return disc.discFor(processor.fdc, name, data, undefined, layout);
+        }
 
         case "gd": {
             const splat = discImage.match(/([^/]+)\/?(.*)/);
@@ -1293,8 +1295,10 @@ async function loadTapeImage(tapeImage) {
 
     switch (schema) {
         case "|":
-        case "sth":
-            return await loadTapeFromData(tapeImage, await tapeSth.fetch(tapeImage), model);
+        case "sth": {
+            const { name, data } = await tapeSth.fetch(tapeImage);
+            return await loadTapeFromData(name, data, model);
+        }
 
         case "data": {
             const arr = Array.prototype.map.call(atob(tapeImage), (x) => x.charCodeAt(0));

--- a/src/sth.js
+++ b/src/sth.js
@@ -53,7 +53,7 @@ export class StairwayToHell {
         const url = this._baseUrl + encodePath(file);
         console.log("Loading ZIP from " + url);
         const response = await fetch(url);
-        if (!response.ok) throw new Error("Network response was not ok");
+        if (!response.ok) throw new Error(`Unable to load ${url}, http code ${response.status}`);
         try {
             return await utils.unzipDiscImage(new Uint8Array(await response.arrayBuffer()));
         } catch (error) {

--- a/src/sth.js
+++ b/src/sth.js
@@ -50,12 +50,12 @@ export class StairwayToHell {
     }
 
     async fetch(file) {
-        const name = this._baseUrl + encodePath(file);
-        console.log("Loading ZIP from " + name);
-        const response = await fetch(name);
+        const url = this._baseUrl + encodePath(file);
+        console.log("Loading ZIP from " + url);
+        const response = await fetch(url);
         if (!response.ok) throw new Error("Network response was not ok");
         try {
-            return (await utils.unzipDiscImage(new Uint8Array(await response.arrayBuffer()))).data;
+            return await utils.unzipDiscImage(new Uint8Array(await response.arrayBuffer()));
         } catch (error) {
             console.error("Failed to fetch file:", error);
             throw error;

--- a/tests/unit/test-sth.js
+++ b/tests/unit/test-sth.js
@@ -1,8 +1,12 @@
 // @vitest-environment jsdom
 import { afterEach, describe, expect, it, vi } from "vitest";
+import * as fs from "fs";
+import { dirname, join } from "path";
+import { fileURLToPath } from "url";
 import { StairwayToHell } from "../../src/sth.js";
 
 const ARCHIVE_BASE = "https://bbc.xania.org/archive/sth";
+const __dirname = dirname(fileURLToPath(import.meta.url));
 
 function makeManifestResponse(files) {
     return {
@@ -116,5 +120,23 @@ describe("StairwayToHell", () => {
         await expect(sth.fetch("Unreleased/Daxis[droids]-demo.zip")).rejects.toBeDefined();
 
         expect(seen).toEqual([`${ARCHIVE_BASE}/diskimages/Unreleased/Daxis%5Bdroids%5D-demo.zip`]);
+    });
+
+    it("returns the name of the file found inside the zip, not the zip's own path", async () => {
+        const zip = new Uint8Array(fs.readFileSync(join(__dirname, "zip", "test-ssd.zip")));
+        vi.spyOn(globalThis, "fetch").mockResolvedValue(makeOk(zip));
+        vi.spyOn(console, "log").mockImplementation(() => {});
+
+        const sth = new StairwayToHell(
+            () => {},
+            () => {},
+            () => {},
+            false,
+        );
+        const { name, data } = await sth.fetch("Mandarin/Lancelot.zip");
+
+        expect(name).toBe("test.ssd");
+        expect(data instanceof Uint8Array).toBe(true);
+        expect(String.fromCharCode(...data)).toBe("This is a test SSD file\n");
     });
 });


### PR DESCRIPTION
Fixes #795.

## What was wrong

`StairwayToHell.fetch` unzipped the archive entry and returned only `.data`, throwing away the `name` that `utils.unzipDiscImage` had found. The callers in `main.js` then passed the *zip's* path to `disc.discFor`, so `guessDiscTypeFromName("Mandarin/Lancelot.zip")` matched none of the extensions and fell through to its SSD default. Every double-sided disc in the archive died with "SSD file is too large", and `.adf`/`.adm`/`.adl` entries were mis-typed the same way. Single-sided discs only worked because the wrong guess happened to be right.

## What changed

- `fetch` now returns the whole `{name, data}` from `unzipDiscImage`, matching what `loadDiscImage`'s `data:` and `http:` cases already do. The local holding the request URL was called `name` too, so it is now `url`.
- `loadDiscImage`'s `sth` case destructures the result and passes the inner name to `discFor`.
- `loadTapeImage`'s `sth` case does the same for consistency. Tape format detection is by content, not name, so this was not broken; the name is used for logging and error messages, which now name the file rather than the archive.

## Testing

- `npx vitest run tests/unit/test-sth.js tests/unit/test-zip.js`: all pass. The new `test-sth.js` case serves the existing `tests/unit/zip/test-ssd.zip` fixture from a mocked `fetch` and asserts that `sth.fetch("Mandarin/Lancelot.zip")` resolves to the inner name `test.ssd` plus its bytes; it fails against the old code, which resolved to a bare `Uint8Array`.
- `npm run lint` and `npm run format` clean; the pre-commit hook ran `vitest related` over the changed files.
- Not run: the full suite, which spends minutes on 6502 emulation untouched by this change.

Not fixed here, and worth a separate look: `knownDiscExtensions` in `src/utils.js` has no `hfe` entry, so a zip containing only an `.hfe` fails in `unzipImage` with "Couldn't find any compatible files in the archive" before naming ever comes into it. `guessDiscTypeFromName` handles `.hfe` fine, so it is only the unzip filter that is missing it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019CJ9csHch7kjzF3DKzR5DP
