### PR TITLE
fix: toast the notices that were using the error dialog

### DIFF
--- a/src/canvas.js
+++ b/src/canvas.js
@@ -213,11 +213,19 @@ export class GlCanvas {
     }
 }
 
+/** Leaves what stopped the asked-for filter on the canvas, for main.js to quote. */
+function fellBackBecause(canvas, reason) {
+    canvas.fallbackReason = reason;
+    return canvas;
+}
+
 export function bestCanvas(canvas, filterClass) {
+    let reason;
     try {
         return new GlCanvas(canvas, filterClass);
     } catch (e) {
         // Either WebGL is unavailable or this particular filter declined it.
+        reason = e.message;
         console.log(`Unable to use ${filterClass.getDisplayConfig().name} with WebGL: ${e}`);
     }
 
@@ -226,11 +234,11 @@ export function bestCanvas(canvas, filterClass) {
     // 2D fallback below would throw and take the emulator with it.
     if (filterClass !== PassthroughFilter) {
         try {
-            return new GlCanvas(canvas, PassthroughFilter);
+            return fellBackBecause(new GlCanvas(canvas, PassthroughFilter), reason);
         } catch (e) {
             console.log("Unable to fall back to the passthrough filter: " + e);
         }
     }
 
-    return new Canvas(canvas);
+    return fellBackBecause(new Canvas(canvas), reason);
 }

--- a/src/canvas.js
+++ b/src/canvas.js
@@ -224,7 +224,7 @@ export function bestCanvas(canvas, filterClass) {
         return new GlCanvas(canvas, filterClass);
     } catch (e) {
         // Either WebGL is unavailable or this particular filter declined it.
-        reason = e.message;
+        reason = e?.message ?? e;
         console.log(`Unable to use ${filterClass.getDisplayConfig().name} with WebGL: ${e}`);
     }
 

--- a/src/canvas.js
+++ b/src/canvas.js
@@ -213,7 +213,6 @@ export class GlCanvas {
     }
 }
 
-/** Leaves what stopped the asked-for filter on the canvas, for main.js to quote. */
 function fellBackBecause(canvas, reason) {
     canvas.fallbackReason = reason;
     return canvas;

--- a/src/keyboard.js
+++ b/src/keyboard.js
@@ -43,6 +43,7 @@ export class Keyboard extends EventTarget {
         this.pauseEmu = false;
         this.stepEmuWhenPaused = false;
         this.keyLayout = keyLayout;
+        this.saidCapsLockIsTapped = false;
 
         // Modifier key states
         this.lastShiftLocation = 1;
@@ -315,21 +316,19 @@ export class Keyboard extends EventTarget {
         // Simulate a key release after a short delay
         setTimeout(() => this.keyInterface.keyUp(utils.keyCodes.CAPSLOCK), CAPS_LOCK_DELAY);
 
-        if (isMac && window.localStorage && !window.localStorage.getItem("warnedAboutRubbishMacs")) {
-            this.dispatchEvent(
-                new CustomEvent("showError", {
-                    detail: {
-                        context: "handling caps lock on Mac OS X",
-                        error: `Mac OS X does not generate key up events for caps lock presses.
-                jsbeeb can only simulate a 'tap' of the caps lock key. This means it doesn't work well for games
-                that use caps lock for left or fire, as we can't tell if it's being held down. If you need to play
-                such a game, please see the documentation about remapping keys.
-                Close this window to continue (you won't see this error again)`,
-                    },
-                }),
-            );
-            window.localStorage.setItem("warnedAboutRubbishMacs", "true");
-        }
+        if (this.saidCapsLockIsTapped) return;
+        this.saidCapsLockIsTapped = true;
+        this.dispatchEvent(
+            new CustomEvent("notice", {
+                detail: {
+                    message:
+                        "macOS sends no key up for caps lock, so jsbeeb can only tap it. " +
+                        "For a game that holds caps lock for left or fire, remap that key instead.",
+                    title: "Keyboard",
+                    quietKey: "warnedAboutRubbishMacs",
+                },
+            }),
+        );
     }
 
     /**

--- a/src/main.js
+++ b/src/main.js
@@ -389,12 +389,23 @@ function showError(context, error) {
     errorDialogModal.show();
 }
 
+const errorText = (error) => error?.message ?? `${error}`;
+
+function showNotice(event) {
+    const { message, title, quietKey } = event.detail;
+    toast(message, { title, quietKey });
+}
+
 if (keyMappingWarnings.length) {
-    showError("applying the key mappings in the URL", keyMappingWarnings.join(" "));
+    toast(`${keyMappingWarnings.join(" ")} The key names are listed in the README.`, {
+        title: "Mappings in the URL",
+    });
 }
 
 if (driveTrackWarnings.length) {
-    showError("setting the disc drives up from the URL", driveTrackWarnings.join(" "));
+    toast(`${driveTrackWarnings.join(" ")} Auto is in use instead; pick 40 or 80 from the Discs menu.`, {
+        title: "Disc drives",
+    });
 }
 
 /** @returns {string} the DiscLayout to load an image for this drive with */
@@ -454,10 +465,11 @@ function createCanvasForFilter(filterClass) {
     // filter can decline a context that works perfectly well for other modes,
     // in which case bestCanvas quietly gives us an unfiltered GL canvas.
     if (newCanvas.filterClass !== filterClass) {
-        showError(
-            `enabling ${displayConfig.name} mode`,
-            `${displayConfig.name} is not available on this device. Using standard display instead.`,
-        );
+        const reason = newCanvas.fallbackReason ? ` (${newCanvas.fallbackReason})` : "";
+        toast(`${displayConfig.name} is not available on this device, so the standard display is in use${reason}.`, {
+            title: "Display",
+            quietKey: "quietDisplayFallback",
+        });
     }
 
     return newCanvas;
@@ -748,14 +760,14 @@ processor = new CpuClass(model, {
     econet,
 });
 
-processor.teletextAdaptor?.addEventListener("showError", (e) => showError(e.detail.context, e.detail.error));
+processor.teletextAdaptor?.addEventListener("notice", showNotice);
 
 // Create input sources
 const gamepadSource = new GamepadSource(emulationConfig.getGamepads);
 // Create MicrophoneInput but don't enable by default
 const microphoneInput = new MicrophoneInput();
 microphoneInput.setErrorCallback((message) => {
-    showError("accessing microphone", message);
+    toast(`${message} The microphone channel has been turned off.`, { title: "Microphone" });
 });
 
 // Create MouseJoystickSource but don't enable by default
@@ -856,7 +868,7 @@ keyboard = new Keyboard({
     keyLayout,
     dbgr,
 });
-keyboard.addEventListener("showError", (e) => showError(e.detail.context, e.detail.error));
+keyboard.addEventListener("notice", showNotice);
 keyboard.addEventListener("pause", () => stop(false));
 keyboard.addEventListener("resume", () => go());
 keyboard.addEventListener("break", (e) => {
@@ -1021,7 +1033,7 @@ async function discSthClick(item) {
         }
     } catch (err) {
         console.error("Error loading disc image:", err);
-        loadingFinished(err);
+        loadingFinished(`Unable to load ${item} from the STH archive: ${errorText(err)}`);
     }
 }
 
@@ -1036,7 +1048,7 @@ async function tapeSthClick(item) {
         loadingFinished();
     } catch (err) {
         console.error("Error loading tape image:", err);
-        loadingFinished(err);
+        loadingFinished(`Unable to load ${item} from the STH archive: ${errorText(err)}`);
     }
 }
 
@@ -1213,9 +1225,9 @@ async function reloadSnapshotMedia(media) {
         // Verify CRC32 if present
         if (media[crcKey] != null && loadedDisc.originalImageCrc32 != null) {
             if (loadedDisc.originalImageCrc32 !== media[crcKey]) {
-                showError(
-                    "loading state",
-                    "The disc image appears to have changed since this snapshot was saved. The restored state may not work correctly.",
+                toast(
+                    `${loadedDisc.name} has changed since this state was saved. The state has been restored anyway and may not run correctly.`,
+                    { title: "Restoring state" },
                 );
             }
         }
@@ -1392,17 +1404,10 @@ function popupLoading(msg) {
     loadingDialogModal.show();
 }
 
-function loadingFinished(error) {
+function loadingFinished(message) {
     googleDriveAuth.style.display = "none";
-    if (error) {
-        loadingDialogModal.show();
-        loadingDialog.querySelector(".loading").textContent = "Error: " + error;
-        setTimeout(function () {
-            loadingDialogModal.hide();
-        }, 5000);
-    } else {
-        loadingDialogModal.hide();
-    }
+    loadingDialogModal.hide();
+    if (message) toast(message);
 }
 
 const googleDrive = new GoogleDriveLoader();
@@ -1457,7 +1462,7 @@ async function gdLoad(cat, layout) {
         return ssd;
     } catch (error) {
         console.error("Google Drive loading error:", error);
-        loadingFinished(error);
+        loadingFinished(`Unable to load ${cat.name} from Google Drive: ${errorText(error)}`);
     }
 }
 
@@ -1531,7 +1536,7 @@ document.querySelector("#google-drive form").addEventListener("submit", async fu
         try {
             data = discType.saver(processor.fdc.drives[0].disc);
         } catch (e) {
-            loadingFinished(`Create failed: ${e.message}`);
+            loadingFinished(`Unable to create ${name} on Google Drive: ${errorText(e)}`);
             return;
         }
         name = replaceOrAddExtension(name, discType.extension);
@@ -1556,7 +1561,7 @@ document.querySelector("#google-drive form").addEventListener("submit", async fu
         loadingFinished();
     } catch (error) {
         console.error(`Error creating Google Drive disc: ${error}`, error);
-        loadingFinished(`Create failed: ${error}`);
+        loadingFinished(`Unable to create ${name} on Google Drive: ${errorText(error)}`);
     }
 });
 

--- a/src/teletext_adaptor.js
+++ b/src/teletext_adaptor.js
@@ -35,8 +35,8 @@ Status register:
 */
 
 /**
- * Emulates the Acorn teletext adaptor. Dispatches a `showError` CustomEvent, carrying
- * `context` and `error` in its detail, when a channel's stream cannot be loaded.
+ * Emulates the Acorn teletext adaptor. Dispatches a `notice` CustomEvent, carrying a
+ * `message` in its detail, when a channel's stream cannot be loaded.
  */
 export class TeletextAdaptor extends EventTarget {
     constructor(cpu) {
@@ -79,8 +79,10 @@ export class TeletextAdaptor extends EventTarget {
             if (request !== this.streamRequest) return;
             console.error(`Teletext adaptor: failed to load channel ${channel}`, error);
             this.dispatchEvent(
-                new CustomEvent("showError", {
-                    detail: { context: `loading teletext channel ${channel}`, error },
+                new CustomEvent("notice", {
+                    detail: {
+                        message: `Teletext channel ${channel} could not be loaded (${error.message}). The adaptor carries on with nothing to show.`,
+                    },
                 }),
             );
             return;

--- a/src/teletext_adaptor.js
+++ b/src/teletext_adaptor.js
@@ -81,7 +81,7 @@ export class TeletextAdaptor extends EventTarget {
             this.dispatchEvent(
                 new CustomEvent("notice", {
                     detail: {
-                        message: `Teletext channel ${channel} could not be loaded (${error.message}). The adaptor carries on with nothing to show.`,
+                        message: `Teletext channel ${channel} could not be loaded (${error?.message ?? error}). The adaptor carries on with nothing to show.`,
                     },
                 }),
             );

--- a/tests/unit/test-canvas.js
+++ b/tests/unit/test-canvas.js
@@ -157,7 +157,10 @@ describe("bestCanvas", () => {
         gl.shaderSource = (shader, source) => sources.set(shader, source);
         gl.getShaderParameter = (shader) => sources.get(shader) !== PAL_FRAG_SHADER;
 
-        expect(bestCanvas(fakeCanvasElement(gl), PALCompositeFilter).filterClass).toBe(PassthroughFilter);
+        const canvas = bestCanvas(fakeCanvasElement(gl), PALCompositeFilter);
+
+        expect(canvas.filterClass).toBe(PassthroughFilter);
+        expect(canvas.fallbackReason).toMatch(/Failed to compile PAL composite/);
     });
 });
 

--- a/tests/unit/test-keyboard.js
+++ b/tests/unit/test-keyboard.js
@@ -529,7 +529,18 @@ describe("Keyboard", () => {
         expect(keyboard.pauseEmu).toBe(false);
     });
 
-    // We don't test Mac-specific code as it requires global mocking
+    test("handleMacCapsLock taps the key and says why, however often it is pressed", () => {
+        const notices = [];
+        keyboard.addEventListener("notice", (e) => notices.push(e.detail));
+
+        keyboard.handleMacCapsLock();
+        keyboard.handleMacCapsLock();
+
+        expect(mockSysvia.keyDown).toHaveBeenCalledWith(utils.keyCodes.CAPSLOCK);
+        expect(notices).toHaveLength(1);
+        expect(notices[0].message).toContain("caps lock");
+        expect(notices[0].quietKey).toBe("warnedAboutRubbishMacs");
+    });
 });
 
 describe("Keyboard Atom adapter", () => {

--- a/tests/unit/test-teletext-adaptor.js
+++ b/tests/unit/test-teletext-adaptor.js
@@ -244,10 +244,10 @@ describe("TeletextAdaptor", () => {
 
         const settle = () => new Promise((resolve) => setTimeout(resolve));
 
-        const listenForErrors = () => {
-            const errors = [];
-            adaptor.addEventListener("showError", (e) => errors.push(e.detail));
-            return errors;
+        const listenForNotices = () => {
+            const notices = [];
+            adaptor.addEventListener("notice", (e) => notices.push(e.detail));
+            return notices;
         };
 
         it("should ignore a response that arrives after a newer channel's", async () => {
@@ -271,19 +271,20 @@ describe("TeletextAdaptor", () => {
             expect(adaptor.totalFrames).toBe(2);
         });
 
-        it("should report a failed load", async () => {
-            const errors = listenForErrors();
-            const failure = new Error("404");
+        it("should report a failed load, saying which channel and why", async () => {
+            const notices = listenForNotices();
 
             adaptor.write(0, 0x04 | 1); // Teletext enable, channel 1
-            failChannel(1, failure);
+            failChannel(1, new Error("http code 404"));
             await settle();
 
-            expect(errors).toEqual([{ context: "loading teletext channel 1", error: failure }]);
+            expect(notices).toHaveLength(1);
+            expect(notices[0].message).toContain("channel 1");
+            expect(notices[0].message).toContain("http code 404");
         });
 
         it("should not report a failure from a superseded request", async () => {
-            const errors = listenForErrors();
+            const notices = listenForNotices();
 
             adaptor.write(0, 0x04 | 1); // Teletext enable, channel 1
             adaptor.write(0, 0x04 | 2); // Teletext enable, channel 2
@@ -291,7 +292,7 @@ describe("TeletextAdaptor", () => {
             resolveChannel(2);
             await settle();
 
-            expect(errors).toEqual([]);
+            expect(notices).toEqual([]);
             expect(adaptor.totalFrames).toBe(1);
         });
 


### PR DESCRIPTION
Part of #798: the toast conversion pass. The behaviour bugs in that issue (the boot-killing image load, the audio banner, the `?model=` crash) are being fixed separately, and none of them is touched here.

`showError` put up a modal titled "An error occurred - sorry!" for eleven things, and stopped the machine while it was up. Seven of them were not errors: the emulator carried on regardless and there was nothing for the user to act on. Those now arrive as toasts.

## Moved from modal to toast

| Site | What it says now |
|---|---|
| `keyMappingWarnings` | the parser's warnings, plus "The key names are listed in the README." Title: Mappings in the URL |
| `driveTrackWarnings` | the parser's warnings, plus "Auto is in use instead; pick 40 or 80 from the Discs menu." Title: Disc drives |
| `createCanvasForFilter` | "PAL TV is not available on this device, so the standard display is in use (Unable to create a GL context)." Title: Display, `quietKey: quietDisplayFallback` |
| teletext channel | "Teletext channel 0 could not be loaded (Unable to load teletext/txt0.dat, http code 404). The adaptor carries on with nothing to show." |
| microphone | the microphone's own message, plus "The microphone channel has been turned off." Title: Microphone |
| Mac caps lock | "macOS sends no key up for caps lock, so jsbeeb can only tap it. For a game that holds caps lock for left or fire, remap that key instead." Title: Keyboard, `quietKey: warnedAboutRubbishMacs` |
| snapshot disc CRC | "&lt;disc&gt; has changed since this state was saved. The state has been restored anyway and may not run correctly." Title: Restoring state |

Plus item 6 of the top six: `loadingFinished(error)` showed the loading modal, wrote "Error: ..." into it and hid it five seconds later, blocking the machine throughout. It now hides the loading dialog and toasts. Its five callers used to pass a bare error or "Create failed: ...", which read as nothing in particular once the dialog was gone, so each now says what it was doing: "Unable to load &lt;item&gt; from the STH archive: ...", "Unable to load &lt;disc&gt; from Google Drive: ...", "Unable to create &lt;name&gt; on Google Drive: ...".

## Supporting changes

- `bestCanvas` kept the reason a filter would not build in the console only. It now leaves it on the canvas as `fallbackReason`, so the display notice can quote it and a bug report has something to go on.
- `keyboard.js` hand-rolled the toast's `quietKey` through `warnedAboutRubbishMacs` in local storage. The toast is now given that same key, so anyone who has already silenced the notice stays silenced. Because `quietKey` only takes effect once the user asks it to, and caps lock is pressed mid-game, the notice also goes up at most once per session. The "Close this window to continue" line is gone, being no longer true.
- Both `keyboard.js` and `teletext_adaptor.js` dispatched a `showError` CustomEvent, named for the handler it happened to reach rather than for what it carries. It is now a `notice` event whose detail is the toast's arguments (`message`, `title`, `quietKey`), so the sender no longer names its recipient.

## Deliberately still modal

`saving state`, `loading state`, `restoring pending state` and `initialising`. Each is a genuine failure with something for the user to do, and the dialog's title is true of all four. The two `areYouSure` uses are real questions and are untouched, as are the `window.alert` in `fdc.js`, the disc-not-saved notices, the commented-out `beforeunload` block and everything on the "silent or console-only" list.

## Testing

- `vitest run` over `test-keyboard.js`, `test-teletext-adaptor.js`, `test-canvas.js` and `test-toast.js`: green. New coverage for the caps lock notice (dispatched once, with the right `quietKey`), the teletext notice (names the channel and the reason), and `bestCanvas` recording `fallbackReason`. The full suite was not run; the pre-commit hook's `vitest related` passed.
- `npm run lint`, `npm run format`, `npm run build`: clean.
- Ran the built page in headless Chrome over a static server and read the DOM back. Confirmed by observation: `?drive0Tracks=99&KEY.WIBBLE=A` produces two toasts with the wording above and no modal; `?displayMode=pal` produces the display toast with the GL reason folded in and the "stop telling me this" checkbox present; `?hasTeletextAdaptor` with `txt0.dat` moved aside produces the teletext toast and the machine keeps running. The error dialog stayed hidden in all three.
- Not verified by running: the microphone notice (needs a real permission prompt), the Mac caps lock notice end to end (needs a Mac; the event it dispatches is unit tested), the snapshot CRC notice, and the `loadingFinished` callers, which need an STH catalogue click or a Google Drive account. Those were checked by reading only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019CJ9csHch7kjzF3DKzR5DP
