### PR TITLE
fix: survive a bad start (bad image, bad model, unseen audio warning)

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -19,7 +19,7 @@ import { GoogleDriveLoader } from "./google-drive.js";
 import * as tokeniser from "./basic-tokenise.js";
 import * as canvasLib from "./canvas.js";
 import { Config } from "./config.js";
-import { tubeModelFor } from "./models.js";
+import { DefaultModel, findModel, tubeModelFor } from "./models.js";
 import { initialise as electron } from "./app/electron.js";
 import { AudioHandler } from "./web/audio-handler.js";
 import { Econet } from "./econet.js";
@@ -288,7 +288,13 @@ const config = new Config(
 // Perform mapping of legacy models to the new format
 config.mapLegacyModels(parsedQuery);
 
-config.setModel(parsedQuery.model || guessModelFromHostname(window.location.hostname));
+const requestedModelName = parsedQuery.model || guessModelFromHostname(window.location.hostname);
+const requestedModel = findModel(requestedModelName);
+if (!requestedModel)
+    toast(`There is no model called "${requestedModelName}". Using ${DefaultModel.name} instead.`, {
+        title: "Model",
+    });
+config.setModel((requestedModel ?? DefaultModel).name);
 config.setKeyLayout(keyLayout);
 config.setTubeCpuMultiplier(parsedQuery.tubeCpuMultiplier || 1);
 config.setMicrophoneChannel(parsedQuery.microphoneChannel);

--- a/src/main.js
+++ b/src/main.js
@@ -1812,7 +1812,7 @@ const startPromise = (async () => {
                 await load();
             } catch (error) {
                 console.error(`Error loading ${description}:`, error);
-                toast(`Could not load ${description}: ${error.message ?? error}`, { title: "Loading" });
+                toast(`Could not load ${description}: ${error?.message ?? error}`, { title: "Loading" });
             }
         })();
         imageLoads.push(loading);

--- a/src/main.js
+++ b/src/main.js
@@ -1806,90 +1806,85 @@ const startPromise = (async () => {
     // Ideally would start the loads first. But their completion needs the FDC from the processor
     const imageLoads = [];
 
+    function startImageLoad(description, load) {
+        const loading = (async () => {
+            try {
+                await load();
+            } catch (error) {
+                console.error(`Error loading ${description}:`, error);
+                toast(`Could not load ${description}: ${error.message ?? error}`, { title: "Loading" });
+            }
+        })();
+        imageLoads.push(loading);
+        return loading;
+    }
+
     if (discImage) {
-        imageLoads.push(
-            (async () => {
-                const loaded = await loadDiscImage(discImage, layoutForDrive(0));
-                putDiscIn(0, loaded);
-            })(),
+        startImageLoad(`disc ${discImage}`, async () =>
+            putDiscIn(0, await loadDiscImage(discImage, layoutForDrive(0))),
         );
     }
 
     if (secondDiscImage) {
-        imageLoads.push(
-            (async () => {
-                const loaded = await loadDiscImage(secondDiscImage, layoutForDrive(1));
-                putDiscIn(1, loaded);
-            })(),
+        startImageLoad(`disc ${secondDiscImage}`, async () =>
+            putDiscIn(1, await loadDiscImage(secondDiscImage, layoutForDrive(1))),
         );
     }
 
     if (parsedQuery.tape) {
-        imageLoads.push(
-            (async () => {
-                const tape = await loadTapeImage(parsedQuery.tape);
-                setProcessorTape(tape);
-            })(),
-        );
+        startImageLoad(`tape ${parsedQuery.tape}`, async () => setProcessorTape(await loadTapeImage(parsedQuery.tape)));
     }
 
     if (mmcImage && model.isAtom) {
-        imageLoads.push(
-            (async () => {
-                const files = await LoadSD(mmcImage);
-                processor.atommc.SetMMCData(files);
-            })(),
-        );
+        startImageLoad(`MMC image ${mmcImage}`, async () => processor.atommc.SetMMCData(await LoadSD(mmcImage)));
     }
 
     async function insertBasic(getBasicPromise, needsRun) {
-        const basicLoadPromise = (async () => {
-            const prog = await getBasicPromise;
-            const t = await tokeniser.create();
-            const tokenised = await t.tokenise(prog);
+        const prog = await getBasicPromise;
+        const t = await tokeniser.create();
+        const tokenised = await t.tokenise(prog);
 
-            const idleAddr = processor.model.isMaster ? 0xe7e6 : 0xe581;
-            const hook = processor.debugInstruction.add(function (addr) {
-                if (addr !== idleAddr) return;
-                const page = processor.readmem(0x18) << 8;
-                for (let i = 0; i < tokenised.length; ++i) {
-                    processor.writemem(page + i, tokenised.charCodeAt(i));
-                }
-                // Set VARTOP (0x12/3) and TOP(0x02/3)
-                const end = page + tokenised.length;
-                const endLow = end & 0xff;
-                const endHigh = (end >>> 8) & 0xff;
-                processor.writemem(0x02, endLow);
-                processor.writemem(0x03, endHigh);
-                processor.writemem(0x12, endLow);
-                processor.writemem(0x13, endHigh);
-                hook.remove();
-                if (needsRun) {
-                    autoRunBasic();
-                }
-            });
-            return tokenised; // Explicitly return the result
-        })();
-
-        imageLoads.push(basicLoadPromise);
-        return basicLoadPromise; // Return promise for caller to await if needed
+        const idleAddr = processor.model.isMaster ? 0xe7e6 : 0xe581;
+        const hook = processor.debugInstruction.add(function (addr) {
+            if (addr !== idleAddr) return;
+            const page = processor.readmem(0x18) << 8;
+            for (let i = 0; i < tokenised.length; ++i) {
+                processor.writemem(page + i, tokenised.charCodeAt(i));
+            }
+            // Set VARTOP (0x12/3) and TOP(0x02/3)
+            const end = page + tokenised.length;
+            const endLow = end & 0xff;
+            const endHigh = (end >>> 8) & 0xff;
+            processor.writemem(0x02, endLow);
+            processor.writemem(0x03, endHigh);
+            processor.writemem(0x12, endLow);
+            processor.writemem(0x13, endHigh);
+            hook.remove();
+            if (needsRun) {
+                autoRunBasic();
+            }
+        });
     }
 
     if (parsedQuery.loadBasic) {
         const needsRun = needsAutoboot === "run";
         needsAutoboot = "";
 
-        await insertBasic(
-            (async () => {
-                const data = await utils.loadData(parsedQuery.loadBasic);
-                return String.fromCharCode.apply(null, data);
-            })(),
-            needsRun,
+        await startImageLoad(`BASIC program ${parsedQuery.loadBasic}`, () =>
+            insertBasic(
+                (async () => {
+                    const data = await utils.loadData(parsedQuery.loadBasic);
+                    return String.fromCharCode.apply(null, data);
+                })(),
+                needsRun,
+            ),
         );
     }
 
     if (parsedQuery.embedBasic) {
-        await insertBasic(Promise.resolve(parsedQuery.embedBasic), true);
+        await startImageLoad("the BASIC program from the URL", () =>
+            insertBasic(Promise.resolve(parsedQuery.embedBasic), true),
+        );
     }
 
     return Promise.all(imageLoads);

--- a/src/models.js
+++ b/src/models.js
@@ -263,6 +263,8 @@ export function findModel(name) {
     return null;
 }
 
+export const DefaultModel = findModel("B-DFS1.2");
+
 export const TEST_6502 = new Model({
     name: "TEST",
     synonyms: ["TEST"],

--- a/src/web/audio-handler.js
+++ b/src/web/audio-handler.js
@@ -15,6 +15,7 @@ export class AudioHandler {
         this.cpuSpeed = cpuSpeed;
         this.isAtom = isAtom;
         this.warningNode = warningNode;
+        this.noAudioWorklet = false;
         toggle(this.warningNode, false);
         this.stats = {};
         if (statsNode) {
@@ -41,14 +42,15 @@ export class AudioHandler {
         } else {
             if (this.audioContext && !this.audioContext.audioWorklet) {
                 this.audioContext = null;
+                this.noAudioWorklet = true;
                 console.log("Unable to initialise audio: no audio worklet API");
-                toggle(this.warningNode, true);
                 const localhost = new URL(window.location);
                 localhost.hostname = "localhost";
                 this.warningNode.innerHTML = `No audio worklet API was found - there will be no audio.
                     If you are running a local jsbeeb, you must either use a host of
                     <a href="${localhost}">localhost</a>,
                     or serve the content over <em>https</em>.`;
+                toggle(this.warningNode, true);
             }
             this.soundChip = new FakeSoundChip();
             this.ddNoise = new FakeDdNoise();
@@ -56,7 +58,6 @@ export class AudioHandler {
         }
 
         this.warningNode.addEventListener("mousedown", () => this.tryResume());
-        toggle(this.warningNode, false);
 
         // Initialise Music 5000 audio context
         this.audioContextM5000 = createAudioContext({ sampleRate: 46875 });
@@ -145,6 +146,7 @@ export class AudioHandler {
     }
 
     checkStatus() {
+        if (this.noAudioWorklet) return;
         if (!this.audioContext && !this.audioContextM5000) return;
         const suspended =
             (this.audioContext && this.audioContext.state === "suspended") ||

--- a/tests/unit/test-audio-handler.js
+++ b/tests/unit/test-audio-handler.js
@@ -1,0 +1,129 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { AudioHandler } from "../../src/web/audio-handler.js";
+
+const SuspendedText = "Your browser has suspended audio";
+
+describe("AudioHandler", () => {
+    let contexts;
+
+    function fakeNode() {
+        return { connect: () => {}, gain: { value: 0 }, frequency: { value: 0 }, Q: { value: 0 }, type: "" };
+    }
+
+    function fakeContext(hasWorklet) {
+        return {
+            state: "running",
+            destination: {},
+            audioWorklet: hasWorklet ? { addModule: async () => {} } : undefined,
+            createGain: fakeNode,
+            createBiquadFilter: fakeNode,
+            resume: async () => {},
+        };
+    }
+
+    function stubAudio({ hasWorklet = true } = {}) {
+        vi.stubGlobal(
+            "AudioContext",
+            class {
+                constructor() {
+                    const context = fakeContext(hasWorklet);
+                    contexts.push(context);
+                    return context;
+                }
+            },
+        );
+        vi.stubGlobal(
+            "AudioWorkletNode",
+            class {
+                constructor() {
+                    this.port = { postMessage: () => {}, onmessage: null };
+                }
+                connect() {}
+            },
+        );
+    }
+
+    function makeHandler() {
+        return new AudioHandler({
+            warningNode: document.getElementById("audio-warning"),
+            audioFilterFreq: 0,
+            audioFilterQ: 0,
+            noSeek: true,
+            cpuSpeed: 2000000,
+        });
+    }
+
+    const warning = () => document.getElementById("audio-warning");
+    const warningShown = () => warning().style.display !== "none";
+
+    beforeEach(() => {
+        contexts = [];
+        document.body.innerHTML = `<div id="audio-warning">${SuspendedText}</div>`;
+        vi.stubGlobal("AudioContext", undefined);
+        vi.stubGlobal("webkitAudioContext", undefined);
+    });
+
+    afterEach(() => {
+        vi.unstubAllGlobals();
+        document.body.innerHTML = "";
+    });
+
+    describe("without an audio worklet API", () => {
+        beforeEach(() => stubAudio({ hasWorklet: false }));
+
+        it("says so in the warning banner", () => {
+            makeHandler();
+
+            expect(warningShown()).toBe(true);
+            expect(warning().textContent).toContain("No audio worklet API");
+        });
+
+        it("leaves the banner up when the audio status is checked", () => {
+            const handler = makeHandler();
+
+            handler.checkStatus();
+
+            expect(warningShown()).toBe(true);
+        });
+    });
+
+    describe("with an audio worklet API", () => {
+        beforeEach(() => stubAudio());
+
+        it("starts with no warning", () => {
+            makeHandler();
+
+            expect(warningShown()).toBe(false);
+            expect(warning().textContent).toContain(SuspendedText);
+        });
+
+        it("warns while the audio is suspended", () => {
+            const handler = makeHandler();
+
+            for (const context of contexts) context.state = "suspended";
+            handler.checkStatus();
+
+            expect(warningShown()).toBe(true);
+            expect(warning().textContent).toContain(SuspendedText);
+        });
+
+        it("fades the warning out once the audio is running again", () => {
+            const handler = makeHandler();
+
+            for (const context of contexts) context.state = "suspended";
+            handler.checkStatus();
+            for (const context of contexts) context.state = "running";
+            handler.checkStatus();
+
+            expect(warning().style.opacity).toBe("0");
+        });
+    });
+
+    it("shows no warning when there is no audio at all", () => {
+        makeHandler();
+
+        expect(warningShown()).toBe(false);
+    });
+});

--- a/tests/unit/test-models.js
+++ b/tests/unit/test-models.js
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
-import { allModels, basicOnly, findModel, TEST_6502, TEST_65C02, TEST_65C12 } from "../../src/models.js";
+import { allModels, basicOnly, DefaultModel, findModel, TEST_6502, TEST_65C02, TEST_65C12 } from "../../src/models.js";
 import { fake6502 } from "../../src/fake6502.js";
+import { guessModelFromHostname } from "../../src/url-params.js";
 
 describe("Model", () => {
     it("is frozen so per-session settings cannot be stored on it", () => {
@@ -29,6 +30,26 @@ describe("Model", () => {
         expect(master.hasEconet).toBeUndefined();
         expect(master.hasMusic5000).toBeUndefined();
         expect(master.hasTeletextAdaptor).toBeUndefined();
+    });
+});
+
+describe("findModel", () => {
+    it("finds models by name and by synonym", () => {
+        expect(findModel("BBC Master 128 (DFS)").name).toBe("BBC Master 128 (DFS)");
+        expect(findModel("master")).toBe(findModel("BBC Master 128 (DFS)"));
+    });
+
+    it("has nothing for a name it does not know", () => {
+        expect(findModel("bbcb")).toBeNull();
+    });
+
+    it("has a default to fall back on", () => {
+        expect(findModel(DefaultModel.name)).toBe(DefaultModel);
+    });
+
+    it("knows every model the hostname can ask for", () => {
+        for (const hostname of ["bbc.xania.org", "master.example.com", "atom.example.com", "localhost"])
+            expect(findModel(guessModelFromHostname(hostname)), hostname).not.toBeNull();
     });
 });
 


### PR DESCRIPTION
Three behaviour fixes from the audit in #798: item 1 of the "Top six", and both entries under "Two bugs found on the way". No `showError` call site becomes a toast here except the new one item 1 needs; the rest of the audit is left for the separate toast PR.

## A failed image load killed the boot

Every disc, tape, MMC and BASIC load went into one `Promise.all`, and the IIFE awaiting `startPromise` catches everything into `showError("initialising", error)`. One bad `?disc1=`, a 404 or an unrecognised zip therefore aborted startup: `go()` never ran and the user got a modal over a dead black screen (#795 is a live example).

Each load now goes through a `startImageLoad` helper that catches on its own, logs, and toasts what failed and why; startup carries on and the machine reaches the BASIC prompt. The two `insertBasic` call sites went through the same helper, since they `await` their load and would otherwise have rejected `startPromise` themselves. The catch around `startPromise` is untouched, so a genuine init failure (processor or audio) still reaches the modal.

## The no-audio-worklet banner has never been visible

`audio-handler.js` set `toggle(this.warningNode, true)` and wrote the explanatory HTML, then ran `toggle(this.warningNode, false)` unconditionally a few lines later, before the node was ever painted. That hide was only repeating the one at the top of the constructor, which is what keeps the node hidden after `main.js` strips `initially-hidden` from everything; dropping it costs nothing.

There was a second reason it could not stay up: with no worklet API, `audioContext` is nulled but the Music 5000 context is not, so the `checkStatus` poll a second after startup found a running context and faded the banner out. Missing worklet support is permanent and there is nothing for `tryResume` to do about it, so `checkStatus` now leaves the banner alone once it says so. Suspended-audio fading is otherwise unchanged.

## A typo in `?model=` gave a blank page

`findModel` returns `null` for a name it does not know, and `config.setModel` reads `this.model.name` straight away, at module scope and outside every try, so `?model=bbcb` threw before anything was drawn.

The fallback lives at the `main.js` call site rather than in `findModel` or `setModel`: `findModel` returning `null` is a useful answer that both `config.js` and the fallback itself need, and only the call site knows the name came from the URL and can say so. `models.js` gains a `DefaultModel` export for it to fall back to.

## Testing

`main.js` is browser glue and has no unit tests; the audio handler and the model lookup do.

- New `tests/unit/test-audio-handler.js`: the banner is shown and stays shown when there is no worklet API, is not shown when there is one, appears while a context is suspended and fades out when it is running again. The two banner tests fail on `main` (checked by stashing the fix).
- `tests/unit/test-models.js`: `findModel` finds by name and synonym, answers `null` for a name it does not know, resolves `DefaultModel`, and resolves every name `guessModelFromHostname` can produce.
- Ran only the touched files plus their neighbours: `test-audio-handler`, `test-models`, `test-config`, `test-url-params`, `test-toast`. The full suite was not run (it spends minutes on 6502 emulation nothing here touches); the pre-commit hook ran `vitest related` on each commit.
- Built with `npm run build` and drove the built app in headless Chrome over a plain static server:
  - `?disc1=nosuchdisc.ssd`: toast "Could not load disc nosuchdisc.ssd: Unable to load discs/nosuchdisc.ssd, http code 404", no modal, machine at the BASIC prompt.
  - `?loadBasic=nope.bas&tape=nosuchtape.uef`: both failures toasted separately, machine at the BASIC prompt.
  - `?model=bbcb`: toast "There is no model called "bbcb". Using BBC B with 8271 (DFS 1.2) instead.", machine boots on the default model.
  - Served over a LAN IP instead of localhost, so the page is not a secure context and has no worklet API: the banner is visible and stays visible past the one-second status check.
  - Regression checks: `?disc1=elite.ssd&autoboot` still boots Elite, `?embedBasic=...` still types and runs the program, and the banner stays hidden when audio works.
- Not verified by running: that a genuine init failure still reaches the modal. Nothing in the diff touches that catch, but I had no way to provoke a processor or audio failure in the browser.

Note: if the disc named in the URL fails to load, `?autoboot` still presses Shift+Break, so DFS reports a disc fault rather than showing a clean BASIC prompt. Skipping the autoboot in that case is a separate decision and is not part of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019CJ9csHch7kjzF3DKzR5DP
