### PR TITLE
fix: let go of a toast once it has been and gone

### DIFF
--- a/src/web/toast.js
+++ b/src/web/toast.js
@@ -73,7 +73,11 @@ export function toast(message, { title = "", quietKey = "" } = {}) {
     quiet.querySelector("input").addEventListener("change", (event) => remember(quietKey, event.target.checked));
 
     toastContainer().appendChild(element);
-    element.addEventListener("hidden.bs.toast", () => element.remove());
+    // Bootstrap keys its instances by element, so one only removed stays held.
+    element.addEventListener("hidden.bs.toast", () => {
+        bootstrap.Toast.getInstance(element)?.dispose();
+        element.remove();
+    });
     bootstrap.Toast.getOrCreateInstance(element).show();
     return element;
 }

--- a/tests/unit/test-toast.js
+++ b/tests/unit/test-toast.js
@@ -1,15 +1,40 @@
 // @vitest-environment jsdom
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import * as bootstrap from "bootstrap";
 
 import { toast } from "../../src/web/toast.js";
 
 describe("toast", () => {
+    beforeEach(() => {
+        vi.useFakeTimers();
+    });
+
+    // A toast's timers left on the real clock outlive this file's jsdom
+    // window, and fail the run from outside any test when they fire.
     afterEach(() => {
+        vi.runAllTimers();
+        vi.useRealTimers();
         document.body.innerHTML = "";
         window.localStorage.clear();
     });
 
     const toasts = () => [...document.querySelectorAll(".toast")];
+
+    it("leaves no timer running once it has been and gone", () => {
+        toast("A disc was swapped.");
+        vi.runAllTimers();
+
+        expect(vi.getTimerCount()).toBe(0);
+        expect(toasts()).toHaveLength(0);
+    });
+
+    it("lets go of the toast it finished with", () => {
+        const element = toast("A disc was swapped.");
+        vi.runAllTimers();
+
+        expect(bootstrap.Toast.getInstance(element)).toBeNull();
+    });
 
     it("says what it was given", () => {
         toast("A disc was swapped.", { title: "Disc drive" });


### PR DESCRIPTION
Two bugs, found chasing a CI failure on an unrelated PR (#804) that reported **873 tests passed, 1 error**.

## The flake

```
TypeError: Failed to execute 'dispatchEvent' on 'EventTarget': parameter 1 is not of type 'Event'
  ❯ triggerTransitionEnd  bootstrap.js:145
  ❯ Timeout._onTimeout    bootstrap.js:295
This error originated in "tests/unit/test-toast.js"
```

Showing a toast starts bootstrap's emulated-transition timer, which on firing starts the autohide one. `test-toast.js` cleared the DOM but left those on the real clock, where they outlive the file's jsdom window. Whichever fires afterwards builds an `Event` in a different realm from the element, jsdom rejects it, and vitest counts the unhandled error as a failed run — with every test passing, from no test at all.

Deterministic, not luck: with fake timers, exactly one timer is pending after the file's own teardown for every `toast()` call. Whether it *fails* depends on when it lands, which is why it surfaced on someone else's PR.

Neither obvious fix works. `dispose()` leaves the timer (bootstrap doesn't track it), and `runOnlyPendingTimers()` leaves one too, because running the transition timer schedules the autohide. `runAllTimers()` drains the chain to zero.

## The leak

While proving that: bootstrap keeps its instances in a map keyed by element, and the toast was only ever removed, never disposed. So each one held its instance and its detached element for the life of the page. jsbeeb toasts on things like disc swaps, so they accumulate.

## Testing

Two tests, both of which fail without their fix:

- `leaves no timer running once it has been and gone` — pins the drain
- `lets go of the toast it finished with` — fails with `expected Toast{…} to be null` against the old code

Full unit suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)