### PR TITLE
fix: say when a disc write goes nowhere

### DIFF
--- a/src/disc-hfe.js
+++ b/src/disc-hfe.js
@@ -208,13 +208,12 @@ export function loadHfe(disc, data, onChange) {
     }
 
     if (onChange) {
-        disc.savesChanges = true;
         disc.addTrackWriteListener((_side, _trackNum, _trackObj) => {
             // Generate a complete HFE image from the current disc state
             const hfeData = toHfe(disc);
             // Call the onChange handler with the updated HFE data
             onChange(hfeData);
-        });
+        }, true);
     }
 
     return disc;

--- a/src/disc-hfe.js
+++ b/src/disc-hfe.js
@@ -208,6 +208,7 @@ export function loadHfe(disc, data, onChange) {
     }
 
     if (onChange) {
+        disc.savesChanges = true;
         disc.addTrackWriteListener((_side, _trackNum, _trackObj) => {
             // Generate a complete HFE image from the current disc state
             const hfeData = toHfe(disc);

--- a/src/disc.js
+++ b/src/disc.js
@@ -707,6 +707,7 @@ export function loadSsd(disc, data, isDsd, onChange) {
     }
 
     if (onChange) {
+        disc.savesChanges = true;
         // TODO, maybe construct the disc directly with this stuff?
         // TODO maybe change this entirely and make it lazy; and have the onChange "pull" the disc as the format it wants
         // instead of doing this here. Most stuff doesn't care about changes and only needs the image on save.
@@ -906,6 +907,8 @@ export class Disc {
 
         this._trackWriteListeners = new Set();
         this.isWriteable = isWriteable;
+        // Set by the loaders that honour onChange; a reload works it out afresh, so it is not snapshotted.
+        this.savesChanges = false;
 
         // Track which tracks have been written since the last snapshot.
         // Keys are numeric: (track | (isSideUpper ? 0x100 : 0)).
@@ -939,6 +942,15 @@ export class Disc {
     /** @param {function(boolean, Number, Track): void} listener */
     removeTrackWriteListener(listener) {
         this._trackWriteListeners.delete(listener);
+    }
+
+    /** @param {function(): void} listener called once, when a track is first written to this disc */
+    notifyOnFirstTrackWrite(listener) {
+        const onFirstWrite = () => {
+            this.removeTrackWriteListener(onFirstWrite);
+            listener();
+        };
+        this.addTrackWriteListener(onFirstWrite);
     }
 
     /**

--- a/src/disc.js
+++ b/src/disc.js
@@ -707,7 +707,6 @@ export function loadSsd(disc, data, isDsd, onChange) {
     }
 
     if (onChange) {
-        disc.savesChanges = true;
         // TODO, maybe construct the disc directly with this stuff?
         // TODO maybe change this entirely and make it lazy; and have the onChange "pull" the disc as the format it wants
         // instead of doing this here. Most stuff doesn't care about changes and only needs the image on save.
@@ -721,6 +720,7 @@ export function loadSsd(disc, data, isDsd, onChange) {
                     if (!sectorShortfall(sector)) dataCopy.set(sector.sectorData, ssdOffsetOf(sector, side, numSides));
                 onChange(dataCopy);
             },
+            true,
         );
     }
     return disc;
@@ -906,9 +906,8 @@ export class Disc {
         this.is40Track = false;
 
         this._trackWriteListeners = new Set();
+        this._savingListeners = new Set();
         this.isWriteable = isWriteable;
-        // Not snapshotted: a restore reloads through discFor and the loader decides again.
-        this.savesChanges = false;
 
         // Track which tracks have been written since the last snapshot.
         // Keys are numeric: (track | (isSideUpper ? 0x100 : 0)).
@@ -934,14 +933,23 @@ export class Disc {
         this.initSurface(0);
     }
 
-    /** @param {function(boolean, Number, Track): void} listener called once per flushed track */
-    addTrackWriteListener(listener) {
+    /**
+     * @param {function(boolean, Number, Track): void} listener called once per flushed track
+     * @param {boolean} [savesChanges] whether the listener puts the image somewhere it is read back from
+     */
+    addTrackWriteListener(listener, savesChanges = false) {
         this._trackWriteListeners.add(listener);
+        if (savesChanges) this._savingListeners.add(listener);
+    }
+
+    get savesChanges() {
+        return this._savingListeners.size > 0;
     }
 
     /** @param {function(boolean, Number, Track): void} listener */
     removeTrackWriteListener(listener) {
         this._trackWriteListeners.delete(listener);
+        this._savingListeners.delete(listener);
     }
 
     /** @param {function(): void} listener called once, when a track is first written to this disc */

--- a/src/disc.js
+++ b/src/disc.js
@@ -907,7 +907,7 @@ export class Disc {
 
         this._trackWriteListeners = new Set();
         this.isWriteable = isWriteable;
-        // Set by the loaders that honour onChange; a reload works it out afresh, so it is not snapshotted.
+        // Not snapshotted: a restore reloads through discFor and the loader decides again.
         this.savesChanges = false;
 
         // Track which tracks have been written since the last snapshot.

--- a/src/fdc.js
+++ b/src/fdc.js
@@ -289,7 +289,15 @@ export function discFor(fdc, name, stringData, onChange, layout = DiscLayout.aut
     return disc;
 }
 
-export function localDisc(fdc, name, layout = DiscLayout.auto) {
+/**
+ * Create or open a disc held in the browser's local storage.
+ * @param {Object} fdc - The FDC controller object
+ * @param {string} name - The file name with extension
+ * @param {string} [layout] - one of DiscLayout; by default the image is asked what it is
+ * @param {function(Error): void} [onSaveError] - called the first time a write cannot be stored
+ * @returns {Disc} The loaded disc object
+ */
+export function localDisc(fdc, name, layout = DiscLayout.auto, onSaveError = () => {}) {
     const discName = "disc_" + name;
     let data;
     const dataString = window.localStorage[discName];
@@ -307,12 +315,16 @@ export function localDisc(fdc, name, layout = DiscLayout.auto) {
         console.log("Loading browser-local disc " + name);
         data = utils.stringToUint8Array(dataString);
     }
+    let reportedSaveError = false;
     const onChange = (data) => {
         try {
             const str = utils.uint8ArrayToString(data);
             window.localStorage.setItem(discName, str);
         } catch (e) {
-            window.alert("Writing to localStorage failed: " + e);
+            console.log(`Unable to save browser-local disc ${name}: ${e}`);
+            if (reportedSaveError) return;
+            reportedSaveError = true;
+            onSaveError(e);
         }
     };
     return discFor(fdc, name, data, onChange, layout);

--- a/src/fdc.js
+++ b/src/fdc.js
@@ -294,7 +294,8 @@ export function discFor(fdc, name, stringData, onChange, layout = DiscLayout.aut
  * @param {Object} fdc - The FDC controller object
  * @param {string} name - The file name with extension
  * @param {string} [layout] - one of DiscLayout; by default the image is asked what it is
- * @param {function(Error): void} [onSaveError] - called the first time a write cannot be stored
+ * @param {function(*): void} [onSaveError] - called with whatever was thrown, the first time a write
+ *   cannot be stored
  * @returns {Disc} The loaded disc object
  */
 export function localDisc(fdc, name, layout = DiscLayout.auto, onSaveError = () => {}) {

--- a/src/main.js
+++ b/src/main.js
@@ -433,8 +433,19 @@ function putDiscIn(driveIndex, loadedDisc) {
     const was = drive.tracksPerStep;
     processor.fdc.loadDisc(driveIndex, loadedDisc, fixed);
     showDriveTracks(driveIndex);
+    noteUnsavedWrites(loadedDisc);
     // A switch the user fixed does not move, so anything it does is not news.
     if (fixed === undefined && drive.tracksPerStep !== was) noteDriveTracks(driveIndex, loadedDisc.name);
+}
+
+function noteUnsavedWrites(loadedDisc) {
+    if (loadedDisc.savesChanges) return;
+    loadedDisc.notifyOnFirstTrackWrite(() =>
+        toast(`Changes to ${loadedDisc.name} are not saved. Use Discs, Download to keep a copy.`, {
+            title: "Disc",
+            quietKey: "quietDiscNotSaved",
+        }),
+    );
 }
 
 const tracksPerStepFor = (tracks) => (tracks === "40" ? 2 : 1);
@@ -1352,7 +1363,12 @@ async function loadDiscImage(discImage, layout = DiscLayout.auto) {
     discImage = split.image;
     const schema = split.schema;
     if (schema[0] === "!" || schema === "local") {
-        return disc.localDisc(processor.fdc, discImage, layout);
+        return disc.localDisc(processor.fdc, discImage, layout, (error) =>
+            toast(
+                `Browser storage would not take changes to ${discImage} (${errorText(error)}). Use Discs, Download to keep a copy.`,
+                { title: "Disc", quietKey: "quietLocalDiscSaveFailed" },
+            ),
+        );
     }
     // TODO: come up with a decent UX for passing an 'onChange' parameter to each of these.
     // Consider:

--- a/src/main.js
+++ b/src/main.js
@@ -438,14 +438,18 @@ function putDiscIn(driveIndex, loadedDisc) {
     if (fixed === undefined && drive.tracksPerStep !== was) noteDriveTracks(driveIndex, loadedDisc.name);
 }
 
+let saidWritesAreNotKept = false;
+
 function noteUnsavedWrites(loadedDisc) {
-    if (loadedDisc.savesChanges) return;
-    loadedDisc.notifyOnFirstTrackWrite(() =>
+    if (loadedDisc.savesChanges || saidWritesAreNotKept) return;
+    loadedDisc.notifyOnFirstTrackWrite(() => {
+        if (saidWritesAreNotKept) return;
+        saidWritesAreNotKept = true;
         toast(`Changes to ${loadedDisc.name} are not saved. Use Discs, Download to keep a copy.`, {
             title: "Disc",
             quietKey: "quietDiscNotSaved",
-        }),
-    );
+        });
+    });
 }
 
 const tracksPerStepFor = (tracks) => (tracks === "40" ? 2 : 1);

--- a/tests/unit/test-disc.js
+++ b/tests/unit/test-disc.js
@@ -543,6 +543,30 @@ describe("track write listeners", () => {
         expect(watcherCalls).toBe(1);
     });
 
+    it("tells a first-write listener once, however many tracks are written", () => {
+        const disc = unobservedDisc();
+        let calls = 0;
+        disc.notifyOnFirstTrackWrite(() => calls++);
+
+        for (const trackNum of [0, 1, 2]) {
+            disc.writePulses(false, trackNum, 0, 0);
+            disc.flushWrites();
+        }
+
+        expect(calls).toBe(1);
+    });
+
+    it("counts first writes per disc, not once for all of them", () => {
+        let calls = 0;
+        for (const disc of [unobservedDisc(), unobservedDisc()]) {
+            disc.notifyOnFirstTrackWrite(() => calls++);
+            disc.writePulses(false, 0, 0, 0);
+            disc.flushWrites();
+        }
+
+        expect(calls).toBe(2);
+    });
+
     it("writes an image back for a track holding a sector it cannot read", () => {
         vi.spyOn(globalThis.console, "log").mockImplementation(() => {});
         const sectorsPerTrack = 10;

--- a/tests/unit/test-fdc.js
+++ b/tests/unit/test-fdc.js
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, it, expect, vi } from "vitest";
 
-import { discFor, guessDiscTypeFromName } from "../../src/fdc.js";
+import { discFor, guessDiscTypeFromName, localDisc } from "../../src/fdc.js";
 import { Disc, DiscConfig, DiscLayout, loadSsd } from "../../src/disc.js";
 import { IntelFdc } from "../../src/intel-fdc.js";
 import { Scheduler } from "../../src/scheduler.js";
@@ -50,6 +50,78 @@ describe("loading a disc image", () => {
 
     it("has nothing to go on for a format that cannot say", () => {
         expect(guessDiscTypeFromName("test.adf").sniffLayout(new Uint8Array(80 * 16 * SectorSize))).toBe(null);
+    });
+});
+
+describe("knowing whether a disc keeps its changes", () => {
+    beforeEach(() => vi.spyOn(globalThis.console, "log").mockImplementation(() => {}));
+    afterEach(() => vi.restoreAllMocks());
+
+    it("says no for a disc loaded without anywhere to write back to", () => {
+        expect(discFor(null, "test.ssd", catalogued(800), undefined, DiscLayout.contiguous).savesChanges).toBe(false);
+    });
+
+    it("says yes once a writeback is wired up", () => {
+        expect(discFor(null, "test.ssd", catalogued(800), () => {}, DiscLayout.contiguous).savesChanges).toBe(true);
+    });
+
+    it("says no for the ADFS formats, which discard the writeback they are handed", () => {
+        const adfsImage = new Uint8Array(80 * 16 * SectorSize);
+        for (const name of ["test.adf", "test.adl"])
+            expect(discFor(null, name, adfsImage, () => {}, DiscLayout.contiguous).savesChanges).toBe(false);
+    });
+});
+
+describe("a disc held in browser local storage", () => {
+    const stubStorage = (localStorage) => vi.stubGlobal("window", { localStorage });
+
+    const writeTrack = (created, trackNum) => {
+        created.writePulses(false, trackNum, 0, 0);
+        created.flushWrites();
+    };
+
+    beforeEach(() => vi.spyOn(globalThis.console, "log").mockImplementation(() => {}));
+    afterEach(() => {
+        vi.unstubAllGlobals();
+        vi.restoreAllMocks();
+    });
+
+    it("keeps its changes", () => {
+        const stored = {};
+        stubStorage({ setItem: (key, value) => (stored[key] = value) });
+
+        const created = localDisc(null, "kept.ssd", DiscLayout.contiguous);
+        writeTrack(created, 0);
+
+        expect(created.savesChanges).toBe(true);
+        expect(stored["disc_kept.ssd"]).toBeTypeOf("string");
+    });
+
+    it("reports a refused write once however many tracks are written", () => {
+        const refusal = new Error("QuotaExceededError");
+        stubStorage({
+            setItem: () => {
+                throw refusal;
+            },
+        });
+        const refused = [];
+
+        const created = localDisc(null, "full.ssd", DiscLayout.contiguous, (error) => refused.push(error));
+        for (const trackNum of [0, 1, 2]) writeTrack(created, trackNum);
+
+        expect(refused).toEqual([refusal]);
+    });
+
+    it("says nothing while the writes are being stored", () => {
+        stubStorage({ setItem: () => {} });
+        let refusals = 0;
+
+        writeTrack(
+            localDisc(null, "fine.ssd", DiscLayout.contiguous, () => refusals++),
+            0,
+        );
+
+        expect(refusals).toBe(0);
     });
 });
 


### PR DESCRIPTION
Items 2 and 3 of #798. Most of that issue is still open, so this does not close it.

## Writes to a disc that has nowhere to write back to

`loadDiscImage` passes no `onChange` for STH, `b64data`, `data`, `http(s)`, `file` or the bundled
`discs/` set, and `fdc.js` discards the one it is handed for `.adf` and `.adl`, so a browser-local
ADFS disc does not save either. DFS reports a successful `*SAVE` and the data is gone on reload.

The first track written to such a disc now raises a toast:

> Changes to elite.ssd are not saved. Use Discs, Download to keep a copy.

titled "Disc", with the `quietDiscNotSaved` quiet key. A single `*SAVE` writes several tracks, so the
notice is a one-shot: `Disc.notifyOnFirstTrackWrite` removes its own listener before calling out.
The guard belongs to the disc, not the session, so swapping in another unsaved disc can say it again
until the user asks it not to.

## The `window.alert` on a failed local storage write

It fired from inside the emulation write path, froze the browser, and could fire once per track
during one save. It is now a toast, raised at most once per disc:

> Browser storage would not take changes to myDisc.ssd (QuotaExceededError...). Use Discs, Download
> to keep a copy.

with the `quietLocalDiscSaveFailed` quiet key. Every failure is still logged; only the first is
announced. Writing carries on, in case a later, smaller write fits.

## The design call: where "does this disc save changes" lives

`Disc` gains a plain `savesChanges` field, default false, set true by the two loaders that actually
register a writeback listener (`loadSsd` and `loadHfe`, each inside its existing `if (onChange)`).

The alternative was for `discFor` to derive it from whether it was handed an `onChange`, or for
`main.js` to decide from the schema it loaded. Both would be wrong for ADFS: `discFor` does pass the
`onChange` on, and `main.js` does supply one for a browser-local disc, but `loadAdf` drops it on the
floor. Only the site that registers the listener knows the answer, and putting the fact there means
it cannot disagree with itself; a loader that grows a writeback later sets the flag in the same
block where it registers it. It sits with `isDirty`, `isWriteable` and `is40Track`, which are public
fields on `Disc` too.

It is deliberately not in `snapshotState()`: restoring a snapshot reloads the disc through
`discFor`, so the loader decides it afresh, and `docs/snapshot-format.md` needs no change.

## Keeping the toast out of `fdc.js`

`src/web/toast.js` imports bootstrap, and `fdc.js` is imported by `machine-session.js` (which runs
in node for the MCP server) and by its own unit test, so it cannot import the toast.

Of the two ways out, `localDisc` takes a callback rather than having its `onChange` moved into
`main.js`. Moving it would drag the `disc_` key naming and the string encoding out of `fdc.js` and
split one small function across two files; the callback leaves the local storage knowledge where it
already is and lets `main.js` own only the wording. The `notice` CustomEvent pattern needs a
dispatcher, and `localDisc` is a free function with nothing to dispatch from.

## Not in scope

The `// TODO: come up with a decent UX` in `main.js` and the `// TODO handle onChange` in `fdc.js`
are untouched. How writes should actually persist is a separate question; this change is only about
jsbeeb saying what it did.

One gap left alone deliberately: `hfeClick` calls `processor.fdc.loadDisc` directly instead of
`putDiscIn`, so an HFE picked from the archive dialog gets no notice. Routing it through `putDiscIn`
would also change its drive-track handling, which is a different fix.

## Testing

- `vitest run tests/unit/test-disc.js tests/unit/test-fdc.js tests/unit/test-disc-hfe.js
  tests/unit/test-toast.js tests/unit/test-snapshot.js`, all passing, plus whatever `vitest related`
  picked up in the pre-commit hook.
- New tests cover the fired-once listener (three track writes, one call) and that it counts per
  disc; that `discFor` reports `savesChanges` false with no writeback, true with one, and false for
  `.adf` and `.adl` even when handed one; and that `localDisc` stores its changes, reports a refused
  write once across three track writes, and says nothing while writes are landing.
- `npm run lint` and `npm run format` clean.
- Not verified in a browser: starting the dev server was blocked in this environment. The toast
  wording and options were read against `src/web/toast.js` and the existing `toast()` call sites in
  `main.js`, and the `putDiscIn` funnel was checked against every caller.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
