### PR TITLE
fix: put an HFE from the archive in the drive the same way as everything else

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -1368,7 +1368,7 @@ async function loadDiscImage(discImage, layout = DiscLayout.auto) {
         }
 
         case "hfe":
-            return disc.discFor(processor.fdc, discImage, await hfeArchive.fetch(discImage));
+            return disc.discFor(processor.fdc, discImage, await hfeArchive.fetch(discImage), undefined, layout);
 
         case "gd": {
             const splat = discImage.match(/([^/]+)\/?(.*)/);

--- a/src/main.js
+++ b/src/main.js
@@ -1178,13 +1178,13 @@ async function hfeClick(file) {
     const name = describeHfe(file).title;
     popupLoading("Loading " + name);
     try {
-        const disc = await loadDiscImage(parsedQuery.disc1);
-        processor.fdc.loadDisc(0, disc);
+        const loaded = await loadDiscImage(parsedQuery.disc1, layoutForDrive(0));
+        putDiscIn(0, loaded);
         loadingFinished();
         if (needsAutoboot) autoboot(name);
     } catch (err) {
         console.error("Error loading disc image:", err);
-        loadingFinished(err);
+        loadingFinished(`Unable to load ${name} from the HFE archive: ${errorText(err)}`);
     }
 }
 


### PR DESCRIPTION
Spotted while wiring up the unsaved-writes notice in #811.

`hfeClick` was copied from `discSthClick` before `putDiscIn` existed (#792) and never caught up with it. Four differences, all bugs:

- It called `processor.fdc.loadDisc(0, disc)` directly rather than `putDiscIn`, so a drive whose 40/80 switch the user had fixed with `?drive0Tracks=` or the Discs menu was **ignored**, and the menu's 40/80 display was never updated. Auto-detection still worked, since `fdc.loadDisc` defaults to what the disc says.
- It called `loadDiscImage(parsedQuery.disc1)` without `layoutForDrive(0)`, so setting a drive to 80 did not stop an HFE being expanded.
- Its failure path passed a raw error to `loadingFinished`, which since #807 toasts whatever it is handed. Every other archive path builds a sentence with `errorText`.
- The local was named `disc`, shadowing the `disc` module imported at the top of `main.js`. Harmless today because the function does not use the module, and a trap for whoever next edits it.

It now reads the same as `discSthClick`.

## Testing

`npm run lint` and `npm run format` clean; the pre-commit hook ran `vitest related`. The behaviour here is browser glue in `main.js` with no unit test seam, so this is verified by reading it against `discSthClick`, which is the shape it is being brought back to; the `putDiscIn` path it now takes is itself covered by the drive-track tests added in #792.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
