### PR TITLE
fix: stop four silent failures failing silently

### DIFF
--- a/src/cmos.js
+++ b/src/cmos.js
@@ -37,15 +37,18 @@ export { defaultCmos };
  * CMOS persistence backed by a browser storage object, which can be unavailable, full or holding
  * something other than what was last saved.
  *
- * @param storage a `Storage`, typically `window.localStorage`
+ * @param {function(): Storage} getStorage typically `() => window.localStorage`. Reading that
+ *   property is itself what throws when a page is refused storage, so it happens per call, inside
+ *   the try.
  * @param {function(*)} onSaveFailure called with the error the first time a save fails
  */
-export function localStoragePersistence(storage, onSaveFailure) {
+export function localStoragePersistence(getStorage, onSaveFailure) {
     let saveFailureReported = false;
     return {
         load() {
             try {
-                return storage.cmosRam ? JSON.parse(storage.cmosRam) : null;
+                const stored = getStorage().cmosRam;
+                return stored ? JSON.parse(stored) : null;
             } catch (error) {
                 console.log(`Unable to read the stored CMOS settings: ${error?.message ?? error}`);
                 return null;
@@ -53,7 +56,7 @@ export function localStoragePersistence(storage, onSaveFailure) {
         },
         save(data) {
             try {
-                storage.cmosRam = JSON.stringify(data);
+                getStorage().cmosRam = JSON.stringify(data);
             } catch (error) {
                 console.log(`Unable to store the CMOS settings: ${error?.message ?? error}`);
                 if (saveFailureReported) return;

--- a/src/cmos.js
+++ b/src/cmos.js
@@ -33,6 +33,37 @@ function fromBcd(value) {
 
 export { defaultCmos };
 
+/**
+ * CMOS persistence backed by a browser storage object, which can be unavailable, full or holding
+ * something other than what was last saved.
+ *
+ * @param storage a `Storage`, typically `window.localStorage`
+ * @param {function(*)} onSaveFailure called with the error the first time a save fails
+ */
+export function localStoragePersistence(storage, onSaveFailure) {
+    let saveFailureReported = false;
+    return {
+        load() {
+            try {
+                return storage.cmosRam ? JSON.parse(storage.cmosRam) : null;
+            } catch (error) {
+                console.log(`Unable to read the stored CMOS settings: ${error?.message ?? error}`);
+                return null;
+            }
+        },
+        save(data) {
+            try {
+                storage.cmosRam = JSON.stringify(data);
+            } catch (error) {
+                console.log(`Unable to store the CMOS settings: ${error?.message ?? error}`);
+                if (saveFailureReported) return;
+                saveFailureReported = true;
+                onSaveFailure(error);
+            }
+        },
+    };
+}
+
 export class Cmos {
     constructor(persistence, cmosOverride, econet) {
         this.store = persistence ? persistence.load() : null;

--- a/src/cmos.js
+++ b/src/cmos.js
@@ -48,7 +48,11 @@ export function localStoragePersistence(getStorage, onSaveFailure) {
         load() {
             try {
                 const stored = getStorage().cmosRam;
-                return stored ? JSON.parse(stored) : null;
+                if (!stored) return null;
+                const parsed = JSON.parse(stored);
+                if (!Array.isArray(parsed) || parsed.length !== defaultCmos.length)
+                    throw new Error(`the stored settings are not ${defaultCmos.length} bytes`);
+                return parsed;
             } catch (error) {
                 console.log(`Unable to read the stored CMOS settings: ${error?.message ?? error}`);
                 return null;

--- a/src/google-drive.js
+++ b/src/google-drive.js
@@ -49,10 +49,11 @@ export class GoogleDriveLoader {
 
     _loadScript(src) {
         // https://github.com/google/google-api-javascript-client/issues/319
-        return new Promise((resolve) => {
+        return new Promise((resolve, reject) => {
             const script = document.createElement("script");
             script.src = src;
             script.onload = resolve;
+            script.onerror = () => reject(new Error(`Failed to fetch ${src}; a browser extension may be blocking it`));
             document.body.appendChild(script);
         });
     }

--- a/src/main.js
+++ b/src/main.js
@@ -10,7 +10,7 @@ import { Debugger } from "./web/debug.js";
 import { Cpu6502, AtomCpu6502 } from "./6502.js";
 import * as utils_atom from "./utils_atom.js";
 import { LoadSD } from "./mmc.js";
-import { Cmos } from "./cmos.js";
+import { Cmos, localStoragePersistence } from "./cmos.js";
 import { StairwayToHell } from "./sth.js";
 import { BbcDiscArchive, describe as describeHfe } from "./bbcdiscs.js";
 import { GamePad } from "./gamepads.js";
@@ -725,17 +725,12 @@ if (config.hasEconet) {
 }
 
 const cmos = new Cmos(
-    {
-        load: function () {
-            if (window.localStorage.cmosRam) {
-                return JSON.parse(window.localStorage.cmosRam);
-            }
-            return null;
-        },
-        save: function (data) {
-            window.localStorage.cmosRam = JSON.stringify(data);
-        },
-    },
+    localStoragePersistence(window.localStorage, (error) =>
+        toast(
+            `Settings changed with *CONFIGURE will not be kept (${errorText(error)}). Check that this site is allowed to store data, and that its storage is not full.`,
+            { title: "Settings", quietKey: "quietCmosSave" },
+        ),
+    ),
     model.cmosOverride,
     econet,
 );

--- a/src/main.js
+++ b/src/main.js
@@ -725,11 +725,13 @@ if (config.hasEconet) {
 }
 
 const cmos = new Cmos(
-    localStoragePersistence(window.localStorage, (error) =>
-        toast(
-            `Settings changed with *CONFIGURE will not be kept (${errorText(error)}). Check that this site is allowed to store data, and that its storage is not full.`,
-            { title: "Settings", quietKey: "quietCmosSave" },
-        ),
+    localStoragePersistence(
+        () => window.localStorage,
+        (error) =>
+            toast(
+                `Settings changed with *CONFIGURE will not be kept (${errorText(error)}). Check that this site is allowed to store data, and that its storage is not full.`,
+                { title: "Settings", quietKey: "quietCmosSave" },
+            ),
     ),
     model.cmosOverride,
     econet,

--- a/src/main.js
+++ b/src/main.js
@@ -742,6 +742,12 @@ function checkPrinterWindow() {
     if (printerWindow && !printerWindow.closed) return;
 
     printerWindow = window.open("", "_blank", "height=300,width=400");
+    if (!printerWindow) {
+        toast("The printer output window was blocked. Allow pop-up windows for this site, then press Ctrl-B again.", {
+            title: "Printer",
+        });
+        return;
+    }
     printerWindow.document.write(
         '<textarea id="text" rows="15" cols="40" placeholder="Printer outputs here..."></textarea>',
     );

--- a/src/main.js
+++ b/src/main.js
@@ -1573,10 +1573,14 @@ async function gdLoad(cat, layout) {
 
 for (const el of document.querySelectorAll(".if-drive-available")) el.style.display = "none";
 (async () => {
-    const available = await googleDrive.initialise();
-    if (available) {
-        for (const el of document.querySelectorAll(".if-drive-available")) el.style.display = "";
-        await gdAuth(true);
+    try {
+        const available = await googleDrive.initialise();
+        if (available) {
+            for (const el of document.querySelectorAll(".if-drive-available")) el.style.display = "";
+            await gdAuth(true);
+        }
+    } catch (error) {
+        console.log(`Google Drive is unavailable: ${errorText(error)}`);
     }
 })();
 const googleDriveModal = new bootstrap.Modal(googleDriveEl);

--- a/src/web/audio-handler.js
+++ b/src/web/audio-handler.js
@@ -4,6 +4,7 @@ import { RelayNoise, FakeRelayNoise } from "../relaynoise.js";
 import { Music5000, FakeMusic5000 } from "../music5000.js";
 import { createAudioContext } from "../audio-utils.js";
 import { toggle, fadeIn, fadeOut } from "../dom-utils.js";
+import { toast } from "./toast.js";
 
 // Using this approach means when jsbeeb is embedded in other projects, vite doesn't have a fit.
 // See https://github.com/vitejs/vite/discussions/6459
@@ -15,7 +16,7 @@ export class AudioHandler {
         this.cpuSpeed = cpuSpeed;
         this.isAtom = isAtom;
         this.warningNode = warningNode;
-        this.noAudioWorklet = false;
+        this.noAudio = false;
         toggle(this.warningNode, false);
         this.stats = {};
         if (statsNode) {
@@ -38,11 +39,11 @@ export class AudioHandler {
             this.masterGain.connect(this.audioContext.destination);
             this.ddNoise = noSeek ? new FakeDdNoise() : new DdNoise(this.audioContext, this.masterGain);
             this.relayNoise = new RelayNoise(this.audioContext, this.masterGain);
-            this._setup(audioFilterFreq, audioFilterQ).then();
+            this._setup(audioFilterFreq, audioFilterQ).catch((error) => this._audioUnavailable(error));
         } else {
             if (this.audioContext && !this.audioContext.audioWorklet) {
                 this.audioContext = null;
-                this.noAudioWorklet = true;
+                this.noAudio = true;
                 console.log("Unable to initialise audio: no audio worklet API");
                 const localhost = new URL(window.location);
                 localhost.hostname = "localhost";
@@ -66,12 +67,21 @@ export class AudioHandler {
             this.audioContextM5000.onstatechange = () => this.checkStatus();
             this.music5000 = new Music5000((buffer) => this._onBufferMusic5000(buffer));
 
-            this.audioContextM5000.audioWorklet.addModule(music5000WorkletUrl).then(() => {
-                this._music5000workletnode = new AudioWorkletNode(this.audioContextM5000, "music5000", {
-                    outputChannelCount: [2],
+            this.audioContextM5000.audioWorklet
+                .addModule(music5000WorkletUrl)
+                .then(() => {
+                    this._music5000workletnode = new AudioWorkletNode(this.audioContextM5000, "music5000", {
+                        outputChannelCount: [2],
+                    });
+                    this._music5000workletnode.connect(this.audioContextM5000.destination);
+                })
+                .catch((error) => {
+                    console.error("Unable to initialise Music 5000 audio", error);
+                    toast(
+                        `The Music 5000 will be silent: its audio could not be started (${error?.message ?? error}). Reloading the page may help.`,
+                        { title: "Music 5000", quietKey: "quietMusic5000Audio" },
+                    );
                 });
-                this._music5000workletnode.connect(this.audioContextM5000.destination);
-            });
         } else {
             this.music5000 = new FakeMusic5000();
         }
@@ -116,6 +126,13 @@ export class AudioHandler {
         };
     }
 
+    _audioUnavailable(error) {
+        console.error("Unable to initialise audio", error);
+        this.noAudio = true;
+        this.warningNode.textContent = `There will be no sound: the audio system could not be started (${error?.message ?? error}). Reloading the page may help.`;
+        fadeIn(this.warningNode);
+    }
+
     _addStat(stat, info) {
         const timeSeries = new this._TimeSeries();
         this.stats[stat] = timeSeries;
@@ -146,7 +163,7 @@ export class AudioHandler {
     }
 
     checkStatus() {
-        if (this.noAudioWorklet) return;
+        if (this.noAudio) return;
         if (!this.audioContext && !this.audioContextM5000) return;
         const suspended =
             (this.audioContext && this.audioContext.state === "suspended") ||

--- a/tests/unit/test-audio-handler.js
+++ b/tests/unit/test-audio-handler.js
@@ -12,23 +12,23 @@ describe("AudioHandler", () => {
         return { connect: () => {}, gain: { value: 0 }, frequency: { value: 0 }, Q: { value: 0 }, type: "" };
     }
 
-    function fakeContext(hasWorklet) {
+    function fakeContext(hasWorklet, addModule) {
         return {
             state: "running",
             destination: {},
-            audioWorklet: hasWorklet ? { addModule: async () => {} } : undefined,
+            audioWorklet: hasWorklet ? { addModule } : undefined,
             createGain: fakeNode,
             createBiquadFilter: fakeNode,
             resume: async () => {},
         };
     }
 
-    function stubAudio({ hasWorklet = true } = {}) {
+    function stubAudio({ hasWorklet = true, addModule = async () => {} } = {}) {
         vi.stubGlobal(
             "AudioContext",
             class {
                 constructor() {
-                    const context = fakeContext(hasWorklet);
+                    const context = fakeContext(hasWorklet, addModule);
                     contexts.push(context);
                     return context;
                 }
@@ -118,6 +118,37 @@ describe("AudioHandler", () => {
             handler.checkStatus();
 
             expect(warning().style.opacity).toBe("0");
+        });
+    });
+
+    describe("when a worklet module fails to load", () => {
+        const rejectModule = (name) => async (url) => {
+            if (url.includes(name)) throw new Error("Blocked by an extension");
+        };
+
+        beforeEach(() => vi.spyOn(console, "error").mockImplementation(() => {}));
+        afterEach(() => vi.restoreAllMocks());
+
+        it("says there will be no sound in the banner, and leaves it up", async () => {
+            stubAudio({ addModule: rejectModule("audio-renderer") });
+
+            const handler = makeHandler();
+
+            await vi.waitFor(() => expect(warningShown()).toBe(true));
+            expect(warning().textContent).toContain("no sound");
+            expect(warning().textContent).toContain("Blocked by an extension");
+            handler.checkStatus();
+            expect(warningShown()).toBe(true);
+        });
+
+        it("toasts about the Music 5000 and leaves the banner down", async () => {
+            stubAudio({ addModule: rejectModule("music5000") });
+
+            makeHandler();
+
+            await vi.waitFor(() => expect(document.querySelector(".toast .message")).not.toBeNull());
+            expect(document.querySelector(".toast .message").textContent).toContain("Music 5000 will be silent");
+            expect(warningShown()).toBe(false);
         });
     });
 

--- a/tests/unit/test-cmos.js
+++ b/tests/unit/test-cmos.js
@@ -255,15 +255,18 @@ describe("CMOS", () => {
 
         const onSaveFailure = vi.fn();
 
-        beforeEach(() => vi.spyOn(console, "log").mockImplementation(() => {}));
+        beforeEach(() => {
+            onSaveFailure.mockClear();
+            vi.spyOn(console, "log").mockImplementation(() => {});
+        });
         afterEach(() => vi.restoreAllMocks());
 
         it("keeps what was written for the next session", () => {
             const storage = {};
 
-            writeCmos(new Cmos(localStoragePersistence(storage, onSaveFailure)), CMOS_ADDR.CONFIG_1, 0x42);
+            writeCmos(new Cmos(localStoragePersistence(() => storage, onSaveFailure)), CMOS_ADDR.CONFIG_1, 0x42);
 
-            const reloaded = new Cmos(localStoragePersistence(storage, onSaveFailure));
+            const reloaded = new Cmos(localStoragePersistence(() => storage, onSaveFailure));
             expect(readCmos(reloaded, CMOS_ADDR.CONFIG_1)).toBe(0x42);
             expect(onSaveFailure).not.toHaveBeenCalled();
         });
@@ -271,9 +274,21 @@ describe("CMOS", () => {
         it("starts from the defaults when the stored settings are unreadable", () => {
             const storage = { cmosRam: "[0, 1, tru" };
 
-            const cmos = new Cmos(localStoragePersistence(storage, onSaveFailure));
+            const cmos = new Cmos(localStoragePersistence(() => storage, onSaveFailure));
 
             expect(readCmos(cmos, 25)).toBe(defaultCmos[25]);
+        });
+
+        it("starts from the defaults when the page is refused storage altogether", () => {
+            const refused = () => {
+                throw new Error("The operation is insecure");
+            };
+
+            const cmos = new Cmos(localStoragePersistence(refused, onSaveFailure));
+            writeCmos(cmos, CMOS_ADDR.CONFIG_1, 0x42);
+
+            expect(readCmos(cmos, 25)).toBe(defaultCmos[25]);
+            expect(onSaveFailure).toHaveBeenCalledTimes(1);
         });
 
         it("reports a save that fails once, however many writes follow", () => {
@@ -286,7 +301,7 @@ describe("CMOS", () => {
                 },
             };
 
-            const cmos = new Cmos(localStoragePersistence(storage, onSaveFailure));
+            const cmos = new Cmos(localStoragePersistence(() => storage, onSaveFailure));
             writeCmos(cmos, CMOS_ADDR.CONFIG_1, 0x42);
             writeCmos(cmos, CMOS_ADDR.CONFIG_2, 0x43);
 

--- a/tests/unit/test-cmos.js
+++ b/tests/unit/test-cmos.js
@@ -279,6 +279,13 @@ describe("CMOS", () => {
             expect(readCmos(cmos, 25)).toBe(defaultCmos[25]);
         });
 
+        it("starts from the defaults when the stored settings are the wrong shape", () => {
+            for (const cmosRam of ['"nonsense"', "[1, 2, 3]", '{"config": 1}', "null"]) {
+                const cmos = new Cmos(localStoragePersistence(() => ({ cmosRam }), onSaveFailure));
+                expect(readCmos(cmos, 25), cmosRam).toBe(defaultCmos[25]);
+            }
+        });
+
         it("starts from the defaults when the page is refused storage altogether", () => {
             const refused = () => {
                 throw new Error("The operation is insecure");

--- a/tests/unit/test-cmos.js
+++ b/tests/unit/test-cmos.js
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
-import { Cmos, defaultCmos } from "../../src/cmos.js";
+import { Cmos, defaultCmos, localStoragePersistence } from "../../src/cmos.js";
 
 describe("CMOS", () => {
     // Mock persistence
@@ -235,6 +235,64 @@ describe("CMOS", () => {
             // seeks within the vsync window on the Master 128.
             const fdriveBits = defaultCmos[25] & 0x03;
             expect(fdriveBits).toBe(0); // FDRIVE 0 = 6ms
+        });
+    });
+
+    describe("localStoragePersistence", () => {
+        function writeCmos(target, address, value) {
+            target.writeControl(PORT_B_ENABLE | PORT_B_ADDR_SEL, address, 0);
+            target.writeControl(PORT_B_ENABLE, address, 0);
+            target.writeControl(PORT_B_ENABLE, value, IC32_DATA_SEL);
+            target.writeControl(PORT_B_ENABLE, value, 0);
+        }
+
+        function readCmos(target, address) {
+            target.writeControl(PORT_B_ENABLE | PORT_B_ADDR_SEL, address, 0);
+            target.writeControl(PORT_B_ENABLE, address, 0);
+            target.writeControl(PORT_B_ENABLE, 0, IC32_READ | IC32_DATA_SEL);
+            return target.read();
+        }
+
+        const onSaveFailure = vi.fn();
+
+        beforeEach(() => vi.spyOn(console, "log").mockImplementation(() => {}));
+        afterEach(() => vi.restoreAllMocks());
+
+        it("keeps what was written for the next session", () => {
+            const storage = {};
+
+            writeCmos(new Cmos(localStoragePersistence(storage, onSaveFailure)), CMOS_ADDR.CONFIG_1, 0x42);
+
+            const reloaded = new Cmos(localStoragePersistence(storage, onSaveFailure));
+            expect(readCmos(reloaded, CMOS_ADDR.CONFIG_1)).toBe(0x42);
+            expect(onSaveFailure).not.toHaveBeenCalled();
+        });
+
+        it("starts from the defaults when the stored settings are unreadable", () => {
+            const storage = { cmosRam: "[0, 1, tru" };
+
+            const cmos = new Cmos(localStoragePersistence(storage, onSaveFailure));
+
+            expect(readCmos(cmos, 25)).toBe(defaultCmos[25]);
+        });
+
+        it("reports a save that fails once, however many writes follow", () => {
+            const storage = {
+                get cmosRam() {
+                    return undefined;
+                },
+                set cmosRam(value) {
+                    throw new Error("Storage is full");
+                },
+            };
+
+            const cmos = new Cmos(localStoragePersistence(storage, onSaveFailure));
+            writeCmos(cmos, CMOS_ADDR.CONFIG_1, 0x42);
+            writeCmos(cmos, CMOS_ADDR.CONFIG_2, 0x43);
+
+            expect(onSaveFailure).toHaveBeenCalledTimes(1);
+            expect(onSaveFailure.mock.calls[0][0].message).toBe("Storage is full");
+            expect(readCmos(cmos, CMOS_ADDR.CONFIG_1)).toBe(0x42);
         });
     });
 

--- a/tests/unit/test-google-drive.js
+++ b/tests/unit/test-google-drive.js
@@ -1,0 +1,24 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { GoogleDriveLoader } from "../../src/google-drive.js";
+
+describe("GoogleDriveLoader", () => {
+    beforeEach(() => vi.spyOn(console, "log").mockImplementation(() => {}));
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+        document.body.innerHTML = "";
+    });
+
+    it("gives up when the Google script cannot be fetched", async () => {
+        const loader = new GoogleDriveLoader();
+
+        const initialising = loader.initialise();
+        const script = document.querySelector("script");
+        script.dispatchEvent(new Event("error"));
+
+        expect(script.src).toContain("apis.google.com");
+        await expect(initialising).rejects.toThrow(/apis\.google\.com/);
+    });
+});


### PR DESCRIPTION
Four of the silent failures audited in #798, picked because each one is broken rather than merely quiet: two leave an unhandled rejection, one can take the page down at startup, one throws out of a key handler. One commit each.

## Audio worklet modules that fail to load (#798 item 12)

Both `addModule` calls in `audio-handler.js` ended in a bare `.then()`, so a module that failed to load gave silence, an unhandled rejection and no notice.

- The sound chip worklet is a permanent, whole-machine no-audio condition, which is what the `warningNode` banner is for (and which #808 made visible again), so it goes there next to the existing missing-worklet-API case. It reads: *"There will be no sound: the audio system could not be started (Unable to load a worklet's module.). Reloading the page may help."* The `noAudioWorklet` flag, which now means "leave the banner alone, there is no audio", is renamed `noAudio` and set here too, so a later `checkStatus` cannot fade the banner away.
- The Music 5000 worklet leaves the rest of the audio working, and its context is created whether or not the machine has a Music 5000 fitted, so the banner would be a lie and a modal would be noise. It toasts: *"The Music 5000 will be silent: its audio could not be started (Unable to load a worklet's module.). Reloading the page may help."* It carries a `quietKey`, since whatever blocks the module will block it every session and a user with no interest in the Music 5000 need not hear about it again.

## CMOS never persists (#798 item 13)

Neither direction had a try/catch. Stored settings that would not parse threw at module scope and took the whole page with them, and a failed write left `*CONFIGURE` on a Master silently not sticking.

The localStorage persistence moves out of `main.js` into `cmos.js` as `localStoragePersistence(storage, onSaveFailure)`, where it can be tested. A load that throws logs and falls back to the defaults. A save that throws logs and calls back, and the callback fires for the first failure of a session only, because CMOS writes arrive in bursts (one per byte of a `*CONFIGURE`). The toast reads: *"Settings changed with \*CONFIGURE will not be kept (reason). Check that this site is allowed to store data, and that its storage is not full."*, with a `quietKey`: storage that is off or full is the same every session.

## Google Drive hangs forever (#798 item 14)

The script tag had an `onload` and no `onerror`, so an ad blocker or a network failure left the promise unsettled and a `gd:` URL sat behind the loading modal permanently. It now rejects with *"Failed to fetch (url); a browser extension may be blocking it"*, which reaches `gdLoad`'s existing catch, so `loadingFinished` hides the dialog and toasts (as #807 arranged). The availability probe run at startup now catches too, and leaves the Drive menu items hidden as it did before rather than raising an unhandled rejection.

## Printer window blocked (#798 item 19)

`window.open` returns null when a pop-up blocker stops it, and the next line wrote to its document, throwing from inside the Ctrl-B key handler. Ctrl-B now toasts *"The printer output window was blocked. Allow pop-up windows for this site, then press Ctrl-B again."* and leaves `printerWindow` null, so pressing it again once pop-ups are allowed opens the window.

Note for whoever picks up #288 (buffer printer output written before the window is opened): it lives in these same few lines of `checkPrinterWindow`, and is deliberately not attempted here.

## Testing

- New unit tests: the two audio worklet failures (banner text, and that a later `checkStatus` leaves it up; the Music 5000 toast, and that it does not touch the banner), the CMOS persistence round trip, unreadable stored settings falling back to the defaults, and a burst of failing writes reporting once; and a Google Drive script that fails to fetch rejecting rather than hanging. Each new test was confirmed to fail against the unfixed code (the Google Drive one by hanging until vitest timed it out).
- `npm run lint` and `npm run format` are clean, and `npm run build` succeeds. The full suite was not run; the pre-commit hook ran `vitest related` on each commit.
- Checked by hand in headless Chrome against a production build, since none of the four is reachable from `main.js` in a unit test:
  - with pop-ups blocked, Ctrl-B toasts the printer message and throws nothing;
  - with the two worklet assets removed from the build, the banner and the Music 5000 toast both appear with the wording above;
  - with `apis.google.com` unresolvable, the startup probe logs "Google Drive is unavailable: Failed to fetch ..." and leaves the Drive menu hidden, and `?disc1=gd:...` toasts and ends with no loading dialog and no modal backdrop left on screen, where before it stayed up forever.
- Not exercised in a browser: the CMOS toast, which needs storage to be unavailable or full. Its persistence is unit tested in both directions; only the toast wiring in `main.js` is untested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
