### PR TITLE
fix: put port A data on the pins before the CA2 strobe falls

### DIFF
--- a/src/via.js
+++ b/src/via.js
@@ -154,6 +154,11 @@ class Via {
                 }
                 this.updateIFR();
 
+                // The strobe is "data ready": the port settles before CA2 falls.
+                // http://archive.6502.org/datasheets/wdc_w65c22s_mar_2004.pdf figures 3-6 and 3-7.
+                this.ora = val;
+                this.recalculatePortAPins();
+
                 mode = this.pcr & 0x0e;
                 if (mode === 8) {
                     // Handshake mode
@@ -163,7 +168,8 @@ class Via {
                     this.setca2(false);
                     this.setca2(true);
                 }
-            /* falls through */
+                break;
+
             case ORAnh:
                 this.ora = val;
                 this.recalculatePortAPins();

--- a/tests/unit/test-via.js
+++ b/tests/unit/test-via.js
@@ -200,6 +200,82 @@ describe("Via snapshotState / restoreState", () => {
     });
 });
 
+describe("Via CA2 write handshake", () => {
+    const ORB = 0x0,
+        ORA = 0x1,
+        DDRA = 0x3,
+        PCR = 0xc,
+        ORAnh = 0xf;
+    const PcrCa2Handshake = 0x08,
+        PcrCa2Pulse = 0x0a;
+    const SeededByte = 0x41,
+        WrittenByte = 0x42;
+
+    let via, events;
+
+    beforeEach(() => {
+        via = new UserVia(makeFakeCpu(), new Scheduler(), false, makeFakeUserPortPeripheral());
+        via.write(DDRA, 0xff);
+        via.write(ORAnh, SeededByte);
+        events = [];
+    });
+
+    function recordCa2Changes() {
+        via.ca2changecallback = (level, output) => events.push({ level, output, ora: via.ora, pins: via.portapins });
+    }
+
+    it("should present the new byte on port A before dropping CA2 in handshake mode", () => {
+        via.write(PCR, PcrCa2Handshake);
+        recordCa2Changes();
+
+        via.write(ORA, WrittenByte);
+
+        expect(events).toEqual([{ level: false, output: true, ora: WrittenByte, pins: WrittenByte }]);
+    });
+
+    it("should present the new byte on port A before pulsing CA2 in pulse mode", () => {
+        via.write(PCR, PcrCa2Pulse);
+        recordCa2Changes();
+
+        via.write(ORA, WrittenByte);
+
+        expect(events).toEqual([
+            { level: false, output: true, ora: WrittenByte, pins: WrittenByte },
+            { level: true, output: true, ora: WrittenByte, pins: WrittenByte },
+        ]);
+    });
+
+    it("should not touch CA2 when writing the no-handshake register", () => {
+        via.write(PCR, PcrCa2Handshake);
+        recordCa2Changes();
+
+        via.write(ORAnh, WrittenByte);
+
+        expect(events).toEqual([]);
+        expect(via.portapins).toBe(WrittenByte);
+    });
+
+    it("should leave CA2 alone when PCR selects a manual output level", () => {
+        via.write(PCR, 0x0e);
+        recordCa2Changes();
+
+        via.write(ORA, WrittenByte);
+
+        expect(events).toEqual([]);
+        expect(via.portapins).toBe(WrittenByte);
+    });
+
+    it("should present the new byte on port B before dropping CB2 in handshake mode", () => {
+        via.write(PCR, PcrCa2Handshake << 4);
+        const cb2Events = [];
+        via.cb2changecallback = (level, output) => cb2Events.push({ level, output, orb: via.orb });
+
+        via.write(ORB, WrittenByte);
+
+        expect(cb2Events).toEqual([{ level: false, output: true, orb: WrittenByte }]);
+    });
+});
+
 function makeMockButton(pressed) {
     return { pressed };
 }


### PR DESCRIPTION
A write to ORA strobed CA2 before the byte reached the port, so a peripheral sampling port A from `ca2changecallback` saw the previous byte. Reordered to match the `ORB` case, which was already right. That costs the fall-through into `ORAnh`, which keeps its data-only behaviour.

The evidence (datasheet figures, what MAME, b-em, CLK and beebjit do, and why the MOS printer driver never takes this path) is in #816; I read the code and agree with it.

Ordering only. The pulse width and the missing read handshake noted at the end of #816 are deliberately left alone.

Fixes #816

## Testing

- `tests/unit/test-via.js`: five new tests. Two assert the callback sees the new byte in `ora` and on `portapins`, in handshake (PCR `0x08`) and pulse (PCR `0x0a`) modes. Confirmed both fail against unmodified `src/via.js` (they see the seeded `0x41` instead of the written `0x42`) and pass with it. Three more are regression guards that pass either way: `ORAnh` strobes nothing, a manual CA2 output level strobes nothing, and the equivalent CB2 ordering on `ORB`.
- `tests/integration/via.js` (scarybeasts' timer suite): 22 passed, 1 skipped.
- `tests/unit/test-video.js`: 39 passed.
- `npm run lint` and `npm run format` clean.

Not run: the rest of the suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
