### PR TITLE
fix: let sniff-disc-layout read a mirror's compressed blobs

### DIFF
--- a/tests/unit/test-sniff-disc-layout.js
+++ b/tests/unit/test-sniff-disc-layout.js
@@ -1,7 +1,7 @@
 import { brotliCompressSync } from "node:zlib";
 import { describe, expect, it } from "vitest";
 
-import { asFluxImage } from "../../tools/sniff-disc-layout.js";
+import { decompressedIfBrotli } from "../../tools/sniff-disc-layout.js";
 
 const hfe = (magic = "HXCHFEV3") => {
     const image = new Uint8Array(64);
@@ -10,25 +10,25 @@ const hfe = (magic = "HXCHFEV3") => {
     return image;
 };
 
-describe("asFluxImage", () => {
+describe("decompressedIfBrotli", () => {
     it("undoes the compression a mirror stores its blobs with", () => {
         const image = hfe();
-        expect(asFluxImage(new Uint8Array(brotliCompressSync(image)))).toEqual(image);
+        expect(decompressedIfBrotli(new Uint8Array(brotliCompressSync(image)))).toEqual(image);
     });
 
     it("leaves an image that is already an image alone", () => {
         const image = hfe();
-        expect(asFluxImage(image)).toBe(image);
+        expect(decompressedIfBrotli(image)).toBe(image);
     });
 
     it("knows the older HFE magic too", () => {
         const image = hfe("HXCPICFE");
-        expect(asFluxImage(image)).toBe(image);
+        expect(decompressedIfBrotli(image)).toBe(image);
     });
 
     // Whatever it is, the loader gives a better account of it than a decompressor would.
     it("hands back something that is neither, for the loader to complain about", () => {
         const rubbish = new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8, 9]);
-        expect(asFluxImage(rubbish)).toBe(rubbish);
+        expect(decompressedIfBrotli(rubbish)).toBe(rubbish);
     });
 });

--- a/tests/unit/test-sniff-disc-layout.js
+++ b/tests/unit/test-sniff-disc-layout.js
@@ -1,0 +1,34 @@
+import { brotliCompressSync } from "node:zlib";
+import { describe, expect, it } from "vitest";
+
+import { asFluxImage } from "../../tools/sniff-disc-layout.js";
+
+const hfe = (magic = "HXCHFEV3") => {
+    const image = new Uint8Array(64);
+    image.set([...magic].map((c) => c.charCodeAt(0)));
+    image[8] = 0x01;
+    return image;
+};
+
+describe("asFluxImage", () => {
+    it("undoes the compression a mirror stores its blobs with", () => {
+        const image = hfe();
+        expect(asFluxImage(new Uint8Array(brotliCompressSync(image)))).toEqual(image);
+    });
+
+    it("leaves an image that is already an image alone", () => {
+        const image = hfe();
+        expect(asFluxImage(image)).toBe(image);
+    });
+
+    it("knows the older HFE magic too", () => {
+        const image = hfe("HXCPICFE");
+        expect(asFluxImage(image)).toBe(image);
+    });
+
+    // Whatever it is, the loader gives a better account of it than a decompressor would.
+    it("hands back something that is neither, for the loader to complain about", () => {
+        const rubbish = new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8, 9]);
+        expect(asFluxImage(rubbish)).toBe(rubbish);
+    });
+});

--- a/tools/sniff-disc-layout.js
+++ b/tools/sniff-disc-layout.js
@@ -32,16 +32,8 @@ const known = (name) => SectorImages.has(extname(name).toLowerCase()) || FluxIma
 const HfeMagics = ["HXCPICFE", "HXCHFEV3"];
 const isHfe = (data) => HfeMagics.includes(Buffer.from(data.subarray(0, 8)).toString("latin1"));
 
-/**
- * A mirror of flux images keeps its blobs brotli-compressed, to be served with
- * `Content-Encoding: br` and undone by the browser, so what sits on disk is not
- * the image. Brotli has no magic number to test for, so the only way to know is
- * to try it on anything that is not an image already.
- *
- * @param {Uint8Array} data
- * @returns {Uint8Array} the image, decompressed if it needed to be
- */
-export function asFluxImage(data) {
+// Brotli has no magic number, so trying it is the only way to tell.
+export function decompressedIfBrotli(data) {
     if (isHfe(data)) return data;
     try {
         return new Uint8Array(brotliDecompressSync(data));
@@ -52,7 +44,7 @@ export function asFluxImage(data) {
 
 async function readImage(path) {
     const raw = new Uint8Array(await readFile(path));
-    return FluxImages.has(extname(path).toLowerCase()) ? asFluxImage(raw) : raw;
+    return FluxImages.has(extname(path).toLowerCase()) ? decompressedIfBrotli(raw) : raw;
 }
 
 async function* discImages(directory) {

--- a/tools/sniff-disc-layout.js
+++ b/tools/sniff-disc-layout.js
@@ -17,8 +17,9 @@
  */
 
 import { readdir, readFile } from "node:fs/promises";
-import { extname, join } from "node:path";
+import { basename, extname, join } from "node:path";
 import { argv, exit, stdout } from "node:process";
+import { brotliDecompressSync } from "node:zlib";
 
 import { Disc, DiscConfig, sniffDfsLayout, sniffSurfaceLayout } from "../src/disc.js";
 import { loadHfe, sniffHfeLayout } from "../src/disc-hfe.js";
@@ -27,6 +28,32 @@ import { unzipDiscImage } from "../src/utils.js";
 const SectorImages = new Set([".ssd", ".dsd"]);
 const FluxImages = new Set([".hfe"]);
 const known = (name) => SectorImages.has(extname(name).toLowerCase()) || FluxImages.has(extname(name).toLowerCase());
+
+const HfeMagics = ["HXCPICFE", "HXCHFEV3"];
+const isHfe = (data) => HfeMagics.includes(Buffer.from(data.subarray(0, 8)).toString("latin1"));
+
+/**
+ * A mirror of flux images keeps its blobs brotli-compressed, to be served with
+ * `Content-Encoding: br` and undone by the browser, so what sits on disk is not
+ * the image. Brotli has no magic number to test for, so the only way to know is
+ * to try it on anything that is not an image already.
+ *
+ * @param {Uint8Array} data
+ * @returns {Uint8Array} the image, decompressed if it needed to be
+ */
+export function asFluxImage(data) {
+    if (isHfe(data)) return data;
+    try {
+        return new Uint8Array(brotliDecompressSync(data));
+    } catch {
+        return data;
+    }
+}
+
+async function readImage(path) {
+    const raw = new Uint8Array(await readFile(path));
+    return FluxImages.has(extname(path).toLowerCase()) ? asFluxImage(raw) : raw;
+}
 
 async function* discImages(directory) {
     for (const entry of await readdir(directory, { withFileTypes: true })) {
@@ -43,7 +70,7 @@ async function* discImages(directory) {
                 stdout.write(`?? ${path}: ${e.message}\n`);
             }
         } else if (known(entry.name)) {
-            yield { path, name: entry.name, data: new Uint8Array(await readFile(path)) };
+            yield { path, name: entry.name, data: await readImage(path) };
         }
     }
 }
@@ -124,7 +151,10 @@ async function main() {
     }
 }
 
-main().catch((e) => {
-    stdout.write(`${e.stack}\n`);
-    exit(1);
-});
+// Only walk a directory when invoked as a script, so the helpers can be tested.
+if (basename(argv[1] ?? "") === "sniff-disc-layout.js") {
+    main().catch((e) => {
+        stdout.write(`${e.stack}\n`);
+        exit(1);
+    });
+}


### PR DESCRIPTION
Closes #805.

`--manifest` mode exists to check layout detection against a mirror of flux images, but pointed at one it read nothing: a mirror keeps its blobs brotli-compressed to serve with `Content-Encoding: br`, so all 656 came back as `HFE file bad header 'Ÿÿ…'` and the run found nothing to check.

```
$ node tools/sniff-disc-layout.js --manifest .bbcdiscs-mirror/hfe/manifest.json .bbcdiscs-mirror/hfe
656 images
   417  its header declares 41 tracks
   183  track 1 holds sectors of its own
    ...
654 of 656 agree with the manifest
  5E5687F4.hfe: catalogued as "80 (dual)", read as 40 (40 tracks sit at twice the number their sectors claim)
  CA34F39B.hfe: catalogued as "80 (dual)", read as 40 (39 tracks sit at twice the number their sectors claim)
```

Identical to what the same corpus gives after decompressing it into a scratch directory by hand, which is how it had to be done before and cost the archive's whole size again in disk.

## How it decides

Brotli has no magic number to test for, so the test is to try it on anything that is not already an image, and hand back what arrived if that fails. Whatever such a file is, the loader gives a better account of it than a decompressor would — a truncated HFE should be reported as a truncated HFE.

Only flux images are treated this way. A sector image has no magic to distinguish it from anything else, so there is nothing to test against.

`main()` now runs only when invoked as a script, as `mirror-sth.js` and `mirror-bbcdiscs.js` already do, so the helper can be imported by a test.

## Testing

`tests/unit/test-sniff-disc-layout.js` covers a compressed image, an uncompressed one, the older `HXCPICFE` magic, and bytes that are neither.

Checked by hand that a directory of plain HFEs still reads exactly as before, and that all three argument orders still work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)