### PR TITLE
fix: decode every member of a multi-member gzip

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v7
         with:
-          node-version: 24
+          node-version: 24.19.0
           cache: npm
       - name: npm install
         run: npm install
@@ -64,7 +64,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v7
         with:
-          node-version: 24
+          node-version: 24.19.0
           cache: npm
       - name: npm install
         run: npm install
@@ -85,7 +85,7 @@ jobs:
       - uses: actions/checkout@v7
       - uses: actions/setup-node@v7
         with:
-          node-version: 24
+          node-version: 24.19.0
           cache: npm
           registry-url: "https://registry.npmjs.org"
       - run: npm ci

--- a/.github/workflows/test-and-deploy.yml
+++ b/.github/workflows/test-and-deploy.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v7
         with:
-          node-version: 24
+          node-version: 24.19.0
           cache: npm
       - name: npm install
         run: npm install
@@ -34,7 +34,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v7
         with:
-          node-version: 24
+          node-version: 24.19.0
           cache: npm
       - name: npm install
         run: npm install
@@ -48,7 +48,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v7
         with:
-          node-version: 24
+          node-version: 24.19.0
           cache: npm
       - name: npm install
         run: npm install
@@ -72,7 +72,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v7
         with:
-          node-version: 24
+          node-version: 24.19.0
           cache: npm
       - name: Build distribution
         run: |

--- a/src/utils.js
+++ b/src/utils.js
@@ -64,10 +64,10 @@ function* candidateMemberEnds(buf, start) {
 // deflate stream, which always fails, so the first candidate that decodes is the boundary.
 async function decompressGzip(data) {
     const members = [];
-    let firstError = null;
     let start = 0;
     do {
         let end = -1;
+        let firstError = null;
         for (const candidate of candidateMemberEnds(data, start)) {
             try {
                 members.push(await decompressOne(data.subarray(start, candidate), "gzip"));

--- a/src/utils.js
+++ b/src/utils.js
@@ -35,12 +35,76 @@ function findEocd(buf) {
     throw new Error("Not a ZIP file: EOCD not found");
 }
 
+const GzipId1 = 0x1f;
+const GzipId2 = 0x8b;
+const GzipDeflateMethod = 8;
+const GzipReservedFlags = 0xe0;
+const GzipHeaderSize = 10;
+const GzipTrailerSize = 8;
+
+function looksLikeGzipMember(buf, off) {
+    return (
+        off + GzipHeaderSize + GzipTrailerSize <= buf.length &&
+        buf[off] === GzipId1 &&
+        buf[off + 1] === GzipId2 &&
+        buf[off + 2] === GzipDeflateMethod &&
+        (buf[off + 3] & GzipReservedFlags) === 0
+    );
+}
+
+// Positions a member starting at `start` could end at, in increasing order.
+function* candidateMemberEnds(buf, start) {
+    for (let off = start + GzipHeaderSize; off < buf.length; ++off) if (looksLikeGzipMember(buf, off)) yield off;
+    yield buf.length;
+}
+
+// A gzip file is a sequence of members (RFC 1952 section 2.2) but DecompressionStream decodes
+// exactly one and treats the rest as junk, so members are split here. A member's end is
+// the next member's header; a candidate that falls inside a member instead truncates its
+// deflate stream, which always fails, so the first candidate that decodes is the boundary.
+async function decompressGzip(data) {
+    const members = [];
+    let firstError = null;
+    let start = 0;
+    do {
+        let end = -1;
+        for (const candidate of candidateMemberEnds(data, start)) {
+            try {
+                members.push(await decompressOne(data.subarray(start, candidate), "gzip"));
+                end = candidate;
+                break;
+            } catch (e) {
+                if (!firstError) firstError = e;
+            }
+        }
+        if (end < 0) throw firstError;
+        start = end;
+    } while (start < data.length);
+    return members.length === 1 ? members[0] : concatChunks(members);
+}
+
+function concatChunks(chunks) {
+    const totalLen = chunks.reduce((s, c) => s + c.length, 0);
+    const out = new Uint8Array(totalLen);
+    let offset = 0;
+    for (const chunk of chunks) {
+        out.set(chunk, offset);
+        offset += chunk.length;
+    }
+    return out;
+}
+
+export async function decompress(data, format) {
+    if (!(data instanceof Uint8Array)) data = new Uint8Array(data);
+    return format === "gzip" ? await decompressGzip(data) : await decompressOne(data, format);
+}
+
 // Pipe data through a DecompressionStream and return the result.
 // Starts the read loop before writing to avoid backpressure deadlock.
 // On error, Node's DecompressionStream rejects multiple internal promises
 // (write, close, and closed); we catch the write side to prevent unhandled
 // rejections and let the error surface through the read side.
-export async function decompress(data, format) {
+async function decompressOne(data, format) {
     const ds = new DecompressionStream(format);
     const writer = ds.writable.getWriter();
     const reader = ds.readable.getReader();
@@ -65,15 +129,7 @@ export async function decompress(data, format) {
     writer.closed.catch(() => {});
     await readPromise;
     await writePromise;
-    if (chunks.length === 1) return chunks[0];
-    const totalLen = chunks.reduce((s, c) => s + c.length, 0);
-    const out = new Uint8Array(totalLen);
-    let offset = 0;
-    for (const chunk of chunks) {
-        out.set(chunk, offset);
-        offset += chunk.length;
-    }
-    return out;
+    return chunks.length === 1 ? chunks[0] : concatChunks(chunks);
 }
 
 // Extract all files from a ZIP archive.  Returns {filename: Uint8Array}.

--- a/src/utils.js
+++ b/src/utils.js
@@ -62,22 +62,24 @@ function* candidateMemberEnds(buf, start) {
 // exactly one and treats the rest as junk, so members are split here. A member's end is
 // the next member's header; a candidate that falls inside a member instead truncates its
 // deflate stream, which always fails, so the first candidate that decodes is the boundary.
+// The last candidate is the whole remaining buffer, so on failure its error is the one to report:
+// it is what the platform says without any splitting of ours in the way.
 async function decompressGzip(data) {
     const members = [];
     let start = 0;
     do {
         let end = -1;
-        let firstError = null;
+        let lastError = null;
         for (const candidate of candidateMemberEnds(data, start)) {
             try {
                 members.push(await decompressOne(data.subarray(start, candidate), "gzip"));
                 end = candidate;
                 break;
             } catch (e) {
-                if (!firstError) firstError = e;
+                lastError = e;
             }
         }
-        if (end < 0) throw firstError;
+        if (end < 0) throw lastError;
         start = end;
     } while (start < data.length);
     return members.length === 1 ? members[0] : concatChunks(members);

--- a/tests/unit/test-gzip.js
+++ b/tests/unit/test-gzip.js
@@ -7,6 +7,21 @@ import { fileURLToPath } from "url";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
+// "hello world" gzip-compressed with gzip(1): echo -n "hello world" | gzip
+// prettier-ignore
+const helloWorldMember = new Uint8Array([
+    0x1f, 0x8b, 0x08, 0x08, 0xc1, 0x3b, 0xd0, 0x69, 0x00, 0x03, 0x74, 0x65,
+    0x73, 0x74, 0x2d, 0x73, 0x69, 0x6e, 0x67, 0x6c, 0x65, 0x00, 0xcb, 0x48,
+    0xcd, 0xc9, 0xc9, 0x57, 0x28, 0xcf, 0x2f, 0xca, 0x49, 0x01, 0x00, 0x85,
+    0x11, 0x4a, 0x0d, 0x0b, 0x00, 0x00, 0x00,
+]);
+
+function repeatMember(times) {
+    const result = new Uint8Array(helloWorldMember.length * times);
+    for (let i = 0; i < times; ++i) result.set(helloWorldMember, i * helloWorldMember.length);
+    return result;
+}
+
 async function testOneFile(file) {
     const compressed = new Uint8Array(fs.readFileSync(`${file}.gz`));
     const expected = new Uint8Array(fs.readFileSync(file));
@@ -21,16 +36,18 @@ describe("gzip tests", function () {
     }
 
     it("should handle single-member gzip", async () => {
-        // "hello world" gzip-compressed with gzip(1): echo -n "hello world" | gzip
-        // prettier-ignore
-        const compressed = new Uint8Array([
-            0x1f, 0x8b, 0x08, 0x08, 0xc1, 0x3b, 0xd0, 0x69, 0x00, 0x03, 0x74, 0x65,
-            0x73, 0x74, 0x2d, 0x73, 0x69, 0x6e, 0x67, 0x6c, 0x65, 0x00, 0xcb, 0x48,
-            0xcd, 0xc9, 0xc9, 0x57, 0x28, 0xcf, 0x2f, 0xca, 0x49, 0x01, 0x00, 0x85,
-            0x11, 0x4a, 0x0d, 0x0b, 0x00, 0x00, 0x00,
-        ]);
-        const result = await utils.ungzip(compressed);
+        const result = await utils.ungzip(helloWorldMember);
         expect(new TextDecoder().decode(result)).toBe("hello world");
+    });
+
+    it("should concatenate the members of a multi-member gzip", async () => {
+        const result = await utils.ungzip(repeatMember(3));
+        expect(new TextDecoder().decode(result)).toBe("hello worldhello worldhello world");
+    });
+
+    it("should reject a multi-member gzip with a truncated final member", async () => {
+        const truncated = repeatMember(2).subarray(0, helloWorldMember.length + 20);
+        await expect(utils.ungzip(truncated)).rejects.toThrow();
     });
 
     it("should reject non-gzip data", async () => {


### PR DESCRIPTION
Fixes #821.

## Browsers were already broken

The issue suspected this; it is confirmed. Chrome 149.0.7827.155 (headless, driven over CDP against a built `dist`) fed `tests/unit/gzip/test-1.gz` to a `DecompressionStream("gzip")`:

```
TypeError: Junk found after end of compressed data.
```

after emitting 36 bytes, the first member only, out of 23873. Two "hello world" members concatenated behave the same way: 11 bytes out, then the same error. A single member decodes cleanly.

So this is not a Node 24.19 regression that arrived this week. Multi-member gzipped tapes have never loaded in a browser; the Node-only tests were passing on Node's leniency and hiding it. Node 24.19.0 just stopped being the odd one out.

## The fix

`utils.decompress` now splits gzip members itself, so the behaviour is ours and the same everywhere.

A member ends where the next member's header begins (RFC 1952 section 2.2). The catch is that `DecompressionStream` never reports how much input it consumed, so the end of a member cannot be asked for; it has to be found. What makes finding it cheap is that a wrong guess is never ambiguous: a candidate boundary that falls inside a member truncates its deflate stream, and a truncated deflate stream always fails. So the code scans for plausible member headers (magic, CM=8, no reserved flags set) and tries candidate boundaries in increasing order; the first one that decodes is the real boundary. On a strict platform only the true boundary decodes at all; on a lenient one, taking candidates in increasing order means the earliest, i.e. correct, boundary is the one accepted.

Approaches weighed and rejected:

- **Track consumption through a `TransformStream`.** Consumption is only observable at chunk granularity, and the stream buffers ahead, so it would need one-byte chunks to be exact. Far too slow for the 273-member fixture.
- **Parse the framing to find each boundary directly.** The gzip *header* is parseable, but the deflate payload's length is not knowable without inflating it, which is the whole problem. Header parsing alone cannot find a member end, which is why this lands on candidate-and-verify rather than a pure parse.
- **`node:zlib` on Node, `DecompressionStream` in the browser.** This would have left the two platforms doing different things, which is exactly the class of bug being fixed here: the browser path would have stayed untested by CI and, on this evidence, stayed broken.

Single-member gzip, the common case, still does exactly one `DecompressionStream` pass. The added cost is one linear scan of the compressed bytes looking for headers. On an 8 MB single-member file that scan finds zero false candidates and decompression takes ~75 ms, unchanged. `deflate` and `deflate-raw` (used by the ZIP reader and `bem-snapshot.js`) bypass all of this and go straight to a single stream as before.

`main.js`'s own `decompressBlob` is left alone: it only reads snapshots jsbeeb itself wrote with `CompressionStream`, which are always single-member.

## CI pinning

`node-version: 24` becomes `node-version: 24.19.0` in both workflows (7 places). A floating major is what let `build-and-test` resolve to 24.19.0 and fail while `cpu-test` in the same run resolved to 24.18.0 and passed. Pinning to the newest 24.x means CI exercises the strict behaviour rather than hiding behind a lenient runtime. `.nvmrc` and the Dockerfile still say `24`; left as they are, since the point of pinning is reproducible CI.

## Testing

- `tests/unit/test-gzip.js`, `test-zip.js`, `test-tapes.js`, `test-bem-snapshot.js`, `test-bem-v3-real.js`: 62 tests pass on **Node 22.17.1** (local) and on **Node 24.19.0** (official binary downloaded and run directly against vitest). Not the full suite.
- Confirmed the bug first: on Node 24.19.0 before the change, all four fixtures threw `Unable to ungzip: Trailing junk found after the end of the compressed stream`. After the change all four decode byte-identically to their expected files on both Node versions.
- Browser: `src/utils.js` imported directly into Chrome 149 over CDP, all four fixtures decode byte-identically, and garbage input still throws. Verified before the fix (fails, as quoted above) and after.
- New tests pin the intent rather than relying on the fixtures happening to be multi-member: a three-member gzip must concatenate, and a multi-member gzip whose last member is truncated must still throw.
- Not verified: whether any UEF in general circulation is multi-member. That question from the issue is still open; the browser evidence says that if any exist, they were already broken.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
