### PR TITLE
refactor: decode gzip with pako and verify ZIP entry CRCs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "argparse": "^3.0.0",
         "bootstrap": "^5.3.8",
         "bootswatch": "^5.3.8",
+        "pako": "^3.0.1",
         "sharp": "^0.35.3",
         "smoothie": "^1.36.1"
       },
@@ -943,9 +944,6 @@
       "cpu": [
         "arm"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -961,9 +959,6 @@
       "integrity": "sha512-dqVSFynCox4C/J8kT16V7SIFAns0IjgLwkvYT7p8LQVmJ5OS5b6tI9IGflxTeuBS//zXeFIUbwt5dwxyZ17cnA==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -981,9 +976,6 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -999,9 +991,6 @@
       "integrity": "sha512-bsb4rI+NldGOsXuej2r8OdSS8+zXDVaCWxyWrcv6kneTOlgAHtZABRzBBCwdsPiD90J4myNJuHpg6kA20ImW/w==",
       "cpu": [
         "riscv64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -1019,9 +1008,6 @@
       "cpu": [
         "s390x"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1037,9 +1023,6 @@
       "integrity": "sha512-ITPEtgffGJ0S6G9dRyw/366tJQqFRcHWPHhC+Stpg3Z8AEMrDrTr2lhdz4f/Y/HMbRh//7Z5mBzEpVdi62Oc3w==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -1057,9 +1040,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1076,9 +1056,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1094,9 +1071,6 @@
       "integrity": "sha512-affVWCTLooy8TSxbDx2qkzuDeaWLNVBA+P//FNBirHsXpP2fuBhk5AuboYUnrDnzoXes8GFjpTx0SBFOCRg+FA==",
       "cpu": [
         "arm"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1120,9 +1094,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1144,9 +1115,6 @@
       "integrity": "sha512-sMd8rDxmpLOwv/7N44klFjOD5DUO7FLdjiXDI0hoxYaf7Ar262dQIEkosE98bps+5HPLtp/EvNqeqQtOycP/IA==",
       "cpu": [
         "ppc64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1170,9 +1138,6 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1194,9 +1159,6 @@
       "integrity": "sha512-KgAxQ0DxpNOq1rG2t5cgTgShJFGSuU7XO45cqC+1NVOuZnP6tlgZRuSYOfNupGkHID0o3cJOsw4DVeJpMovcGw==",
       "cpu": [
         "s390x"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1220,9 +1182,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1245,9 +1204,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1269,9 +1225,6 @@
       "integrity": "sha512-6O1NPKcDVj9QEdg7Hx549EX8U0rp6yXQERqru6yRN7fGBn32UvIRJUlWnk+8xDCiG76hXVBbX82NZ/ZKr0euIg==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1667,9 +1620,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1687,9 +1637,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1707,9 +1654,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1727,9 +1671,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1747,9 +1688,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1767,9 +1705,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4938,9 +4873,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -4962,9 +4894,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -4986,9 +4915,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -5010,9 +4936,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -5669,6 +5592,22 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/pako": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-3.0.1.tgz",
+      "integrity": "sha512-GupotUUI0mlhugKjUs4bjOwLt3nrehy9Ys2dxC0GtgVef5cnKggkDMmf2bq2poCCuVXopWPmqsc9VDT2iJUy+w==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "(MIT AND Zlib)"
     },
     "node_modules/papaparse": {
       "version": "5.5.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -944,6 +944,9 @@
       "cpu": [
         "arm"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -959,6 +962,9 @@
       "integrity": "sha512-dqVSFynCox4C/J8kT16V7SIFAns0IjgLwkvYT7p8LQVmJ5OS5b6tI9IGflxTeuBS//zXeFIUbwt5dwxyZ17cnA==",
       "cpu": [
         "arm64"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -976,6 +982,9 @@
       "cpu": [
         "ppc64"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -991,6 +1000,9 @@
       "integrity": "sha512-bsb4rI+NldGOsXuej2r8OdSS8+zXDVaCWxyWrcv6kneTOlgAHtZABRzBBCwdsPiD90J4myNJuHpg6kA20ImW/w==",
       "cpu": [
         "riscv64"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -1008,6 +1020,9 @@
       "cpu": [
         "s390x"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1023,6 +1038,9 @@
       "integrity": "sha512-ITPEtgffGJ0S6G9dRyw/366tJQqFRcHWPHhC+Stpg3Z8AEMrDrTr2lhdz4f/Y/HMbRh//7Z5mBzEpVdi62Oc3w==",
       "cpu": [
         "x64"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -1040,6 +1058,9 @@
       "cpu": [
         "arm64"
       ],
+      "libc": [
+        "musl"
+      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1056,6 +1077,9 @@
       "cpu": [
         "x64"
       ],
+      "libc": [
+        "musl"
+      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1071,6 +1095,9 @@
       "integrity": "sha512-affVWCTLooy8TSxbDx2qkzuDeaWLNVBA+P//FNBirHsXpP2fuBhk5AuboYUnrDnzoXes8GFjpTx0SBFOCRg+FA==",
       "cpu": [
         "arm"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1094,6 +1121,9 @@
       "cpu": [
         "arm64"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1115,6 +1145,9 @@
       "integrity": "sha512-sMd8rDxmpLOwv/7N44klFjOD5DUO7FLdjiXDI0hoxYaf7Ar262dQIEkosE98bps+5HPLtp/EvNqeqQtOycP/IA==",
       "cpu": [
         "ppc64"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1138,6 +1171,9 @@
       "cpu": [
         "riscv64"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1159,6 +1195,9 @@
       "integrity": "sha512-KgAxQ0DxpNOq1rG2t5cgTgShJFGSuU7XO45cqC+1NVOuZnP6tlgZRuSYOfNupGkHID0o3cJOsw4DVeJpMovcGw==",
       "cpu": [
         "s390x"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1182,6 +1221,9 @@
       "cpu": [
         "x64"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1204,6 +1246,9 @@
       "cpu": [
         "arm64"
       ],
+      "libc": [
+        "musl"
+      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1225,6 +1270,9 @@
       "integrity": "sha512-6O1NPKcDVj9QEdg7Hx549EX8U0rp6yXQERqru6yRN7fGBn32UvIRJUlWnk+8xDCiG76hXVBbX82NZ/ZKr0euIg==",
       "cpu": [
         "x64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1620,6 +1668,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1637,6 +1688,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1654,6 +1708,9 @@
         "ppc64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1671,6 +1728,9 @@
         "s390x"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1688,6 +1748,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1705,6 +1768,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4873,6 +4939,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -4894,6 +4963,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -4915,6 +4987,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -4936,6 +5011,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "argparse": "^3.0.0",
     "bootstrap": "^5.3.8",
     "bootswatch": "^5.3.8",
+    "pako": "^3.0.1",
     "sharp": "^0.35.3",
     "smoothie": "^1.36.1"
   },

--- a/src/bem-snapshot.js
+++ b/src/bem-snapshot.js
@@ -1,5 +1,5 @@
 "use strict";
-import { decompress } from "./utils.js";
+import { inflate } from "./utils.js";
 
 // B-em snapshot format parser (versions 1 and 3).
 // v1 (BEMSNAP1): Fixed-size 327,885 byte packed struct. Reference: beebjit state.c
@@ -334,7 +334,7 @@ async function parseBemTube(sections, tubeName) {
 
     // Those names come from a config file, so size is the real check. It cannot be exact: the
     // trailing ROM's size comes from that same config, and b-em records it as zero if unset.
-    const parasite = await decompress(sections["P"].data, "deflate");
+    const parasite = inflate(sections["P"].data);
     const romBytes = parasite.length - BemTubeRegisterBytes - BemTubeRamSize;
     if (romBytes < 0 || romBytes > BemTubeRamSize) {
         throw new Error(
@@ -449,9 +449,8 @@ async function parseBemV3(buffer) {
     let roms = null;
     const memSection = sections["M"];
     if (memSection) {
-        // Memory is zlib-compressed; decompression is async.
         // Decompressed layout: 2 bytes (fe30, fe34) + 64KB RAM + 256KB ROM
-        const memData = await decompress(memSection.data, "deflate");
+        const memData = inflate(memSection.data);
         cpuState.fe30 = memData[0];
         cpuState.fe34 = memData[1];
         const ramStart = 2;

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,7 +1,8 @@
 "use strict";
-// Minimal ZIP extractor using native DecompressionStream for deflate.
-// Supports methods 0 (stored) and 8 (deflate); other methods (bzip2,
-// lzma, etc.) will throw an error with the method number.
+// Minimal ZIP extractor. Supports methods 0 (stored) and 8 (deflate); other
+// methods (bzip2, lzma, etc.) will throw an error with the method number.
+
+import { inflate as pakoInflate, inflateRaw as pakoInflateRaw, ungzip as pakoUngzip } from "pako";
 
 const ZipLocalHeaderSig = 0x04034b50;
 const ZipCentralDirSig = 0x02014b50;
@@ -35,103 +36,17 @@ function findEocd(buf) {
     throw new Error("Not a ZIP file: EOCD not found");
 }
 
-const GzipId1 = 0x1f;
-const GzipId2 = 0x8b;
-const GzipDeflateMethod = 8;
-const GzipReservedFlags = 0xe0;
-const GzipHeaderSize = 10;
-const GzipTrailerSize = 8;
-
-function looksLikeGzipMember(buf, off) {
-    return (
-        off + GzipHeaderSize + GzipTrailerSize <= buf.length &&
-        buf[off] === GzipId1 &&
-        buf[off + 1] === GzipId2 &&
-        buf[off + 2] === GzipDeflateMethod &&
-        (buf[off + 3] & GzipReservedFlags) === 0
-    );
-}
-
-// Positions a member starting at `start` could end at, in increasing order.
-function* candidateMemberEnds(buf, start) {
-    for (let off = start + GzipHeaderSize; off < buf.length; ++off) if (looksLikeGzipMember(buf, off)) yield off;
-    yield buf.length;
-}
-
-// A gzip file is a sequence of members (RFC 1952 section 2.2) but DecompressionStream decodes
-// exactly one and treats the rest as junk, so members are split here. A member's end is
-// the next member's header; a candidate that falls inside a member instead truncates its
-// deflate stream, which always fails, so the first candidate that decodes is the boundary.
-// The last candidate is the whole remaining buffer, so on failure its error is the one to report:
-// it is what the platform says without any splitting of ours in the way.
-async function decompressGzip(data) {
-    const members = [];
-    let start = 0;
-    do {
-        let end = -1;
-        let lastError = null;
-        for (const candidate of candidateMemberEnds(data, start)) {
-            try {
-                members.push(await decompressOne(data.subarray(start, candidate), "gzip"));
-                end = candidate;
-                break;
-            } catch (e) {
-                lastError = e;
-            }
-        }
-        if (end < 0) throw lastError;
-        start = end;
-    } while (start < data.length);
-    return members.length === 1 ? members[0] : concatChunks(members);
-}
-
-function concatChunks(chunks) {
-    const totalLen = chunks.reduce((s, c) => s + c.length, 0);
-    const out = new Uint8Array(totalLen);
-    let offset = 0;
-    for (const chunk of chunks) {
-        out.set(chunk, offset);
-        offset += chunk.length;
-    }
-    return out;
-}
-
-export async function decompress(data, format) {
+function inflateWith(inflater, data, context) {
     if (!(data instanceof Uint8Array)) data = new Uint8Array(data);
-    return format === "gzip" ? await decompressGzip(data) : await decompressOne(data, format);
+    try {
+        return inflater(data);
+    } catch (cause) {
+        throw new Error(`${context}: ${cause.message || cause}`, { cause });
+    }
 }
 
-// Pipe data through a DecompressionStream and return the result.
-// Starts the read loop before writing to avoid backpressure deadlock.
-// On error, Node's DecompressionStream rejects multiple internal promises
-// (write, close, and closed); we catch the write side to prevent unhandled
-// rejections and let the error surface through the read side.
-async function decompressOne(data, format) {
-    const ds = new DecompressionStream(format);
-    const writer = ds.writable.getWriter();
-    const reader = ds.readable.getReader();
-    const chunks = [];
-    const readPromise = (async () => {
-        for (;;) {
-            const { done, value } = await reader.read();
-            if (done) break;
-            chunks.push(value);
-        }
-    })();
-    const writePromise = (async () => {
-        await writer.write(data);
-        await writer.close();
-    })().catch(() => {
-        // Intentionally empty.
-    });
-    // Intentionally empty: Node's DecompressionStream rejects multiple
-    // promises on error (write, close, closed). The read side surfaces
-    // the same error with proper context — catching these just prevents
-    // unhandled rejections from the write-side promises.
-    writer.closed.catch(() => {});
-    await readPromise;
-    await writePromise;
-    return chunks.length === 1 ? chunks[0] : concatChunks(chunks);
+export function inflate(data) {
+    return inflateWith(pakoInflate, data, "Unable to inflate");
 }
 
 // Extract all files from a ZIP archive.  Returns {filename: Uint8Array}.
@@ -170,7 +85,7 @@ export async function unzip(buf) {
         if (method === ZipMethodStored) {
             files[name] = raw.slice();
         } else if (method === ZipMethodDeflate) {
-            files[name] = await decompress(raw, "deflate-raw");
+            files[name] = inflateWith(pakoInflateRaw, raw, `Unable to inflate ZIP entry ${name}`);
         } else {
             throw new Error(`Unsupported ZIP compression method ${method} for ${name}`);
         }
@@ -1170,11 +1085,7 @@ export function readFloat32(data, offset) {
 }
 
 export async function ungzip(data) {
-    try {
-        return await decompress(data, "gzip");
-    } catch (cause) {
-        throw new Error("Unable to ungzip: " + (cause.message || cause), { cause });
-    }
+    return inflateWith(pakoUngzip, data, "Unable to ungzip");
 }
 
 export class DataStream {

--- a/src/utils.js
+++ b/src/utils.js
@@ -65,6 +65,7 @@ export async function unzip(buf) {
         const flags = readU16(buf, pos + 8);
         if (flags & 0x0001) throw new Error("Encrypted ZIP entries are not supported");
         const method = readU16(buf, pos + 10);
+        const expectedCrc = readU32(buf, pos + 16);
         const compressedSize = readU32(buf, pos + 20);
         const nameLen = readU16(buf, pos + 28);
         const extraLen = readU16(buf, pos + 30);
@@ -89,21 +90,21 @@ export async function unzip(buf) {
         } else {
             throw new Error(`Unsupported ZIP compression method ${method} for ${name}`);
         }
+        if (crc32(files[name]) >>> 0 !== expectedCrc) throw new Error(`Corrupt ZIP entry ${name}: CRC32 mismatch`);
     }
     return files;
 }
 
 // Standard CRC-32/ISO-HDLC.
+const Crc32Table = new Uint32Array(256).map((_, index) => {
+    let crc = index;
+    for (let bit = 0; bit < 8; ++bit) crc = crc & 1 ? (crc >>> 1) ^ 0xedb88320 : crc >>> 1;
+    return crc;
+});
+
 export function crc32(data) {
     let crc = 0xffffffff;
-    for (let i = 0; i < data.length; ++i) {
-        crc ^= data[i];
-        for (let j = 0; j < 8; ++j) {
-            const doEor = crc & 1;
-            crc = crc >>> 1;
-            if (doEor) crc ^= 0xedb88320;
-        }
-    }
+    for (let i = 0; i < data.length; ++i) crc = (crc >>> 8) ^ Crc32Table[(crc ^ data[i]) & 0xff];
     return ~crc;
 }
 

--- a/tests/unit/test-gzip.js
+++ b/tests/unit/test-gzip.js
@@ -22,6 +22,21 @@ function repeatMember(times) {
     return result;
 }
 
+async function gzipMember(text) {
+    const stream = new Blob([new TextEncoder().encode(text)]).stream().pipeThrough(new CompressionStream("gzip"));
+    return new Uint8Array(await new Response(stream).arrayBuffer());
+}
+
+function concat(parts) {
+    const result = new Uint8Array(parts.reduce((total, part) => total + part.length, 0));
+    let offset = 0;
+    for (const part of parts) {
+        result.set(part, offset);
+        offset += part.length;
+    }
+    return result;
+}
+
 async function testOneFile(file) {
     const compressed = new Uint8Array(fs.readFileSync(`${file}.gz`));
     const expected = new Uint8Array(fs.readFileSync(file));
@@ -45,9 +60,33 @@ describe("gzip tests", function () {
         expect(new TextDecoder().decode(result)).toBe("hello worldhello worldhello world");
     });
 
+    it("should concatenate members of differing contents", async () => {
+        const members = await Promise.all(["first ", "second ", "third"].map(gzipMember));
+        const result = await utils.ungzip(concat(members));
+        expect(new TextDecoder().decode(result)).toBe("first second third");
+    });
+
     it("should reject a multi-member gzip with a truncated final member", async () => {
         const truncated = repeatMember(2).subarray(0, helloWorldMember.length + 20);
         await expect(utils.ungzip(truncated)).rejects.toThrow();
+    });
+
+    it("should reject a corrupted payload", async () => {
+        const corrupted = helloWorldMember.slice();
+        corrupted[24] ^= 0x01;
+        await expect(utils.ungzip(corrupted)).rejects.toThrow(/Unable to ungzip: incorrect data check/);
+    });
+
+    it("should reject a corrupted member in the middle of a multi-member gzip", async () => {
+        const corrupted = repeatMember(3);
+        corrupted[helloWorldMember.length + 24] ^= 0x01;
+        await expect(utils.ungzip(corrupted)).rejects.toThrow(/Unable to ungzip/);
+    });
+
+    it("should accept a member followed by trailing zeros", async () => {
+        const padded = new Uint8Array(helloWorldMember.length + 8);
+        padded.set(helloWorldMember);
+        expect(new TextDecoder().decode(await utils.ungzip(padded))).toBe("hello world");
     });
 
     it("should reject non-gzip data", async () => {

--- a/tests/unit/test-zip.js
+++ b/tests/unit/test-zip.js
@@ -7,6 +7,19 @@ import { fileURLToPath } from "url";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
+function readZip(name) {
+    return new Uint8Array(fs.readFileSync(join(__dirname, "zip", name)));
+}
+
+// Flips one bit in the first entry's data, leaving the stored CRC32 intact.
+function corruptFirstEntry(zipData, offsetIntoData) {
+    const nameLen = zipData[26] | (zipData[27] << 8);
+    const extraLen = zipData[28] | (zipData[29] << 8);
+    const corrupted = zipData.slice();
+    corrupted[30 + nameLen + extraLen + offsetIntoData] ^= 0x01;
+    return corrupted;
+}
+
 describe("zip tests", function () {
     it("should unzip SSD files", async () => {
         const zipData = new Uint8Array(fs.readFileSync(join(__dirname, "zip", "test-ssd.zip")));
@@ -104,5 +117,23 @@ describe("zip tests", function () {
         const notZip = new Uint8Array([0, 1, 2, 3, 4, 5, 6, 7]);
 
         await expect(utils.unzipDiscImage(notZip)).rejects.toThrow(/Not a ZIP file/);
+    });
+
+    it("should throw for a stored entry whose data does not match its CRC32", async () => {
+        const zipData = corruptFirstEntry(readZip("test-ssd.zip"), 0);
+
+        await expect(utils.unzipDiscImage(zipData)).rejects.toThrow(/Corrupt ZIP entry test\.ssd: CRC32 mismatch/);
+    });
+
+    it("should throw for a deflated entry that inflates cleanly to the wrong bytes", async () => {
+        const zipData = corruptFirstEntry(readZip("test-deflated.zip"), 5);
+
+        await expect(utils.unzipDiscImage(zipData)).rejects.toThrow(/Corrupt ZIP entry test\.ssd: CRC32 mismatch/);
+    });
+
+    it("should throw for a deflated entry whose stream is damaged beyond inflating", async () => {
+        const zipData = corruptFirstEntry(readZip("test-deflated.zip"), 0);
+
+        await expect(utils.unzipDiscImage(zipData)).rejects.toThrow(/Unable to inflate ZIP entry test\.ssd/);
     });
 });


### PR DESCRIPTION
Overturns the recommendation in #825 and finishes the job #821 and #823 started. #825 has been edited in place to record why.

## What changed the answer

#825 concluded "keep what we have" because no single library covered gzip, ZIP, integrity and size at once. That is still true, and it is still true that pako replaces one hand-rolled thing rather than several. What the survey under-weighted is that the one thing pako replaces is the one nobody was comfortable with: a scan for candidate gzip member boundaries, verified by decoding each one. It works and it is provably correct, but a scan is a scan.

pako decodes multi-member gzip natively, so the scan is not needed rather than merely tidied. Re-verified on pako 3.0.1 here:

| case | pako |
|---|---|
| single member | ok |
| three concatenated members | ok, natively |
| bit-flipped payload | throws `incorrect data check` |
| member followed by random junk | throws `incorrect header check` |
| member followed by trailing zeros | ok |
| truncated member | throws `buffer error` |

That is GNU gunzip's behaviour, CRC verification included. Verification is the property the scan's correctness rested on ("a wrong boundary is impossible because the CRC catches it"), so switching to pako gives it up nowhere. The trailing-zeros row is a small behaviour improvement: the old code rejected such files because the last candidate boundary was the whole buffer including the padding. #825 called this out as a known wart.

zip.js was reconsidered and rejected again, on the same measured grounds: it has no gzip API at all, and replacing the 78-line ZIP reader with it cost **+31 KB gzipped**, measured end to end. The reader is not the problem; it needed three lines, not a library.

## One mechanism, not two

`utils.decompress` had two callers left once gzip and raw deflate moved: `bem-snapshot.js`, twice, with `"deflate"`. pako inflates zlib streams too, so those moved as well and `decompress`/`decompressOne` are gone entirely, taking the `DecompressionStream` backpressure dance and the multi-promise error catching with them. `src/utils.js` now decompresses through exactly one mechanism.

Deleted from `src/utils.js`: `decompressGzip`, `candidateMemberEnds`, `looksLikeGzipMember`, `decompressOne`, `decompress`, `concatChunks` and the six `Gzip*` constants. Added: one dependency, and `inflateWith`, a nine-line wrapper that coerces to `Uint8Array` and rethrows pako's terse message with context, in the style `ungzip` already used.

The exported `ungzip`, `unzip`, `unzipDiscImage` and `unzipRomImage` stay `async` even though pako is synchronous. Their callers all await them and nothing is gained by churning those call sites.

`CompressionStream` is still used by `main.js`'s `compressBlob`, with `decompressBlob` as its matched read side, both over jsbeeb's own snapshot JSON. Neither uses any of the plumbing deleted here, so leaving them alone does not keep anything alive; moving only the read half would split a matched pair for no gain. Compression stays out of scope, as does the brotli in `tools/`, which no candidate implements.

## The CRC hole

Separately, and the one change #825 did recommend: `unzip` never checked an entry's bytes against the CRC32 in the central directory. A corrupt `.zip` silently produced a wrong disc image and the emulator ran it. Both new ZIP tests were confirmed to fail without the check, returning wrong data rather than throwing.

`crc32` is now table-driven so it is affordable on every load. pako exposes no CRC32 in its public API (checked against the 3.0.1 tarball, not the README), so ours stays the only implementation; its exported result is unchanged and its existing callers in `disc.js` and `createZipBlob` get the speedup for free.

## Commit types

`fix:` for the CRC check: a corrupt archive silently yielding a wrong disc is a user-facing bug being closed. `refactor:` for the pako move: multi-member gzip already worked after #823, so no user-visible behaviour changes except the trailing-zeros case, for which no real file is known to exist.

## Testing

Not the full suite.

- `test-gzip.js`, `test-zip.js`, `test-utils.js`, `test-tapes.js`, `test-bem-snapshot.js`, `test-bem-v3-real.js`, `test-snapshot.js`, `test-sth.js`, `test-mmc.js`, `test-disc.js`, `test-sniff-disc-layout.js`: 224 tests pass on Node 22.17.1. Every pre-existing test in `test-gzip.js` and `test-zip.js` passes unchanged; none of them encoded the old mechanism, so none needed editing. The four `tests/unit/gzip/` fixtures, which are real multi-member UEF tapes, decode byte-identically.
- New: three distinct members concatenated and decoded in one call with no scan involved; a bit-flipped gzip payload rejected with `incorrect data check`; a corrupted member in the middle of a multi-member file rejected; trailing zeros accepted.
- New ZIP tests, each confirmed to fail before the change: a stored entry with one flipped payload byte, and a deflated entry corrupted such that it inflates cleanly to the wrong bytes, both now throw `Corrupt ZIP entry test.ssd: CRC32 mismatch`. Before the change both returned wrong data with no error. A third case, a deflated entry damaged badly enough that inflate itself fails, throws `Unable to inflate ZIP entry test.ssd: buffer error`.
- Browser, Chrome 149.0.7827.155 headless over CDP against a vite-built bundle served statically from `dist`, since browsers never handled multi-member gzip before #823 and this changes the mechanism again:
  - `test-1.gz`, 273 members, 24178 B, decodes to 23873 B byte-identical to the expected file. `test-3.gz` likewise.
  - a bit-flipped `test-1.gz` throws `Unable to ungzip: incorrect data check`.
  - `test-ssd.zip` reads correctly; the same archive with one flipped payload byte throws `Error unzipping Corrupt ZIP entry test.ssd: CRC32 mismatch`.

### Measured numbers

`crc32` over 115 KB, Node 22.17.1, median of 9 runs of 20 calls:

| | ms |
|---|---|
| bitwise, before | 3.346 |
| table-driven, after | 0.227 |

Bundle, `npm run build`, main chunk, same tree before and after:

| | raw | gzip |
|---|---|---|
| before | 520.84 KB | 150.89 KB |
| after | 550.76 KB | 160.82 KB |
| delta | **+29.92 KB** | **+9.93 KB** |

That matches the +9.89 KB gzipped #825 predicted for this exact variant.

Decode speed, Chrome 149, `test-1.gz`, warm median of 9 runs of 20 calls: **1.88 ms**, against 10.78 ms for the scan-based native path measured in #825. Sub-millisecond on ordinary single-member images either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
