### PR TITLE
fix: say when a load fails instead of failing silently

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -1685,7 +1685,7 @@ for (const image of availableImages) {
         try {
             putDiscIn(0, await loadDiscImage(parsedQuery.disc1, layoutForDrive(0)));
         } catch (error) {
-            reportLoadFailure(image.name, error);
+            reportLoadFailure(`${image.name} (${image.file})`, error);
         }
     });
 }

--- a/src/main.js
+++ b/src/main.js
@@ -397,6 +397,11 @@ function showError(context, error) {
 
 const errorText = (error) => error?.message ?? `${error}`;
 
+function reportLoadFailure(description, error) {
+    console.error(`Error loading ${description}:`, error);
+    toast(`Could not load ${description}: ${errorText(error)}`, { title: "Loading" });
+}
+
 function showNotice(event) {
     const { message, title, quietKey } = event.detail;
     toast(message, { title, quietKey });
@@ -641,14 +646,19 @@ pastetext.addEventListener("dragover", function (event) {
 pastetext.addEventListener("drop", async function (event) {
     utils.noteEvent("local", "drop");
     const file = event.dataTransfer.files[0];
-    const arrayBuffer = await file.arrayBuffer();
-    if (isSnapshotFile(file.name, arrayBuffer)) {
-        await loadStateFromFile(file, arrayBuffer);
-    } else if (file.name.toLowerCase().endsWith(".uef")) {
-        // Regular UEF tape image (not a BeebEm save state)
-        setProcessorTape(await loadTapeFromData(file.name, new Uint8Array(arrayBuffer), model));
-    } else {
-        await loadHTMLFile(file);
+    if (!file) return;
+    try {
+        const arrayBuffer = await file.arrayBuffer();
+        if (isSnapshotFile(file.name, arrayBuffer)) {
+            await loadStateFromFile(file, arrayBuffer);
+        } else if (file.name.toLowerCase().endsWith(".uef")) {
+            // Regular UEF tape image (not a BeebEm save state)
+            setProcessorTape(await loadTapeFromData(file.name, new Uint8Array(arrayBuffer), model));
+        } else {
+            await loadHTMLFile(file);
+        }
+    } catch (error) {
+        reportLoadFailure(file.name, error);
     }
 });
 
@@ -1479,7 +1489,11 @@ document.getElementById("disc_load").addEventListener("change", async function (
     if (evt.target.files.length === 0) return;
     utils.noteEvent("local", "click"); // NB no filename here
     const file = evt.target.files[0];
-    await loadHTMLFile(file);
+    try {
+        await loadHTMLFile(file);
+    } catch (error) {
+        reportLoadFailure(file.name, error);
+    }
     evt.target.value = ""; // clear so if the user picks the same file again after a reset we get a "change"
 });
 
@@ -1487,7 +1501,11 @@ document.getElementById("fs_load").addEventListener("change", async function (ev
     if (evt.target.files.length === 0) return;
     utils.noteEvent("local", "click"); // NB no filename here
     const file = evt.target.files[0];
-    await loadSCSIFile(file);
+    try {
+        await loadSCSIFile(file);
+    } catch (error) {
+        reportLoadFailure(file.name, error);
+    }
     evt.target.value = ""; // clear so if the user picks the same file again after a reset we get a "change"
 });
 
@@ -1496,17 +1514,21 @@ document.getElementById("tape_load").addEventListener("change", async function (
     const file = evt.target.files[0];
     utils.noteEvent("local", "clickTape"); // NB no filename here
 
-    let tapeData = await readFileAsBinaryString(file);
-    let tapeName = file.name;
-    if (/\.zip/i.test(tapeName)) {
-        const unzipped = await utils.unzipDiscImage(utils.stringToUint8Array(tapeData));
-        tapeData = unzipped.data;
-        tapeName = unzipped.name;
+    try {
+        let tapeData = await readFileAsBinaryString(file);
+        let tapeName = file.name;
+        if (/\.zip/i.test(tapeName)) {
+            const unzipped = await utils.unzipDiscImage(utils.stringToUint8Array(tapeData));
+            tapeData = unzipped.data;
+            tapeName = unzipped.name;
+        }
+        setProcessorTape(await loadTapeFromData(tapeName, tapeData, model));
+        delete parsedQuery.tape;
+        updateUrl();
+        bootstrap.Modal.getInstance(document.getElementById("tapes"))?.hide();
+    } catch (error) {
+        reportLoadFailure(file.name, error);
     }
-    setProcessorTape(await loadTapeFromData(tapeName, tapeData, model));
-    delete parsedQuery.tape;
-    updateUrl();
-    bootstrap.Modal.getInstance(document.getElementById("tapes"))?.hide();
 
     evt.target.value = ""; // clear so if the user picks the same file again after a reset we get a "change"
 });
@@ -1623,7 +1645,14 @@ googleDriveEl.addEventListener("show.bs.modal", async function () {
     gdLoading.textContent = "Loading...";
     gdLoading.style.display = "";
     for (const el of googleDriveEl.querySelectorAll("li:not(.template)")) el.remove();
-    const cat = await googleDrive.listFiles();
+    let cat;
+    try {
+        cat = await googleDrive.listFiles();
+    } catch (error) {
+        console.error("Error listing Google Drive files:", error);
+        gdLoading.textContent = `Unable to list your Google Drive files: ${errorText(error)}`;
+        return;
+    }
     const dbList = googleDriveEl.querySelector(".list");
     gdLoading.style.display = "none";
     const template = dbList.querySelector(".template");
@@ -1653,7 +1682,11 @@ for (const image of availableImages) {
         utils.noteEvent("images", "click", image.file);
         setDisc1Image(image.file);
         $discsModal.hide();
-        putDiscIn(0, await loadDiscImage(parsedQuery.disc1, layoutForDrive(0)));
+        try {
+            putDiscIn(0, await loadDiscImage(parsedQuery.disc1, layoutForDrive(0)));
+        } catch (error) {
+            reportLoadFailure(image.name, error);
+        }
     });
 }
 
@@ -1946,8 +1979,7 @@ const startPromise = (async () => {
             try {
                 await load();
             } catch (error) {
-                console.error(`Error loading ${description}:`, error);
-                toast(`Could not load ${description}: ${error?.message ?? error}`, { title: "Loading" });
+                reportLoadFailure(description, error);
             }
         })();
         imageLoads.push(loading);


### PR DESCRIPTION
Fixes #827.

Six `async` event handlers awaited a load with no `try`/`catch`, so a rejection became an unhandled promise rejection: no dialog, no toast, nothing the user would ever see. Pick a corrupt file and the emulator carried on as though nothing had been clicked.

| site | what failed silently |
|---|---|
| paste area drop handler | snapshots, UEF tapes and disc images dropped on the page |
| `disc_load` change | opening a local disc image |
| `fs_load` change | opening a local SCSI/MMC image |
| `tape_load` change | opening a local tape image |
| built-in disc list click | the bundled example discs in the Discs menu |
| Google Drive modal `show.bs.modal` | listing your Drive files |

The first five are the ones #827 lists. The sixth came from the sweep that issue asked for, and is the same bug wearing different clothes: if `listFiles` throws, the modal sits on "Loading..." for ever.

`reportLoadFailure` is lifted out of the `startImageLoad` closure added in #808, so the startup path and these handlers now report identically rather than by coincidence. The Drive listing keeps its own idiom instead, writing the reason into the modal where "Loading..." was, matching what `gdAuth` already does a few lines above.

The dropped-file handler also gained a guard for `dataTransfer.files[0]` being undefined, which happens when what was dropped is not a file at all.

## Sites deliberately left alone

The sweep found four more `async` handlers with no `try`, all of which turned out to report properly already:

- `#google-drive-auth` submit and `open-drive-link` click both await `gdAuth`, which catches internally and returns undefined, so the caller sees a falsy result rather than a rejection
- the Drive file row click awaits `gdLoad`, which catches, toasts through `loadingFinished` and returns undefined, and the caller already guards on it
- `load-state` change awaits `loadStateFromFile`, which has its own try and keeps the error dialog, correctly: an unusable state file is one of the four cases #798 decided should stay modal

## Testing

`npm run build` clean, lint and format clean, `test-toast` and `test-url-params` pass. These are `main.js` event handlers with no unit test seam, so the change is verified by reading each path against the helper it now calls, and by confirming the four untouched handlers already have a reporting route. No behaviour changes when a load succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)