### PR TITLE
fix: give CA2/CB2 pulse mode a real width

### DIFF
--- a/docs/snapshot-format.md
+++ b/docs/snapshot-format.md
@@ -132,35 +132,39 @@ Scheduled tasks are not saved directly. Each component saves its task timing as 
 
 ### VIA (`state.sysvia`, `state.uservia`)
 
-| Field          | Type         | Description                                        |
-| -------------- | ------------ | -------------------------------------------------- |
-| `ora`          | number       | Output Register A                                  |
-| `orb`          | number       | Output Register B                                  |
-| `ira`          | number       | Input Register A                                   |
-| `irb`          | number       | Input Register B                                   |
-| `ddra`         | number       | Data Direction Register A                          |
-| `ddrb`         | number       | Data Direction Register B                          |
-| `sr`           | number       | Shift Register                                     |
-| `t1l`          | number       | Timer 1 Latch (doubled 2MHz ticks)                 |
-| `t2l`          | number       | Timer 2 Latch                                      |
-| `t1c`          | number       | Timer 1 Counter                                    |
-| `t2c`          | number       | Timer 2 Counter                                    |
-| `acr`          | number       | Auxiliary Control Register                         |
-| `pcr`          | number       | Peripheral Control Register                        |
-| `ifr`          | number       | Interrupt Flag Register                            |
-| `ier`          | number       | Interrupt Enable Register                          |
-| `t1hit`        | boolean      | Timer 1 has expired                                |
-| `t2hit`        | boolean      | Timer 2 has expired                                |
-| `portapins`    | number       | Port A pin levels                                  |
-| `portbpins`    | number       | Port B pin levels                                  |
-| `ca1`          | boolean      | CA1 line level                                     |
-| `ca2`          | boolean      | CA2 line level                                     |
-| `cb1`          | boolean      | CB1 line level                                     |
-| `cb2`          | boolean      | CB2 line level                                     |
-| `justhit`      | number       | Timer just-hit flags                               |
-| `t1_pb7`       | number       | Timer 1 PB7 output state                           |
-| `lastPolltime` | number       | Last polltime epoch                                |
-| `taskOffset`   | number\|null | Scheduled task offset from epoch (null if no task) |
+| Field                | Type         | Description                                                      |
+| -------------------- | ------------ | ---------------------------------------------------------------- |
+| `ora`                | number       | Output Register A                                                |
+| `orb`                | number       | Output Register B                                                |
+| `ira`                | number       | Input Register A                                                 |
+| `irb`                | number       | Input Register B                                                 |
+| `ddra`               | number       | Data Direction Register A                                        |
+| `ddrb`               | number       | Data Direction Register B                                        |
+| `sr`                 | number       | Shift Register                                                   |
+| `t1l`                | number       | Timer 1 Latch (doubled 2MHz ticks)                               |
+| `t2l`                | number       | Timer 2 Latch                                                    |
+| `t1c`                | number       | Timer 1 Counter                                                  |
+| `t2c`                | number       | Timer 2 Counter                                                  |
+| `acr`                | number       | Auxiliary Control Register                                       |
+| `pcr`                | number       | Peripheral Control Register                                      |
+| `ifr`                | number       | Interrupt Flag Register                                          |
+| `ier`                | number       | Interrupt Enable Register                                        |
+| `t1hit`              | boolean      | Timer 1 has expired                                              |
+| `t2hit`              | boolean      | Timer 2 has expired                                              |
+| `portapins`          | number       | Port A pin levels                                                |
+| `portbpins`          | number       | Port B pin levels                                                |
+| `ca1`                | boolean      | CA1 line level                                                   |
+| `ca2`                | boolean      | CA2 line level                                                   |
+| `cb1`                | boolean      | CB1 line level                                                   |
+| `cb2`                | boolean      | CB2 line level                                                   |
+| `justhit`            | number       | Timer just-hit flags                                             |
+| `t1_pb7`             | number       | Timer 1 PB7 output state                                         |
+| `lastPolltime`       | number       | Last polltime epoch                                              |
+| `taskOffset`         | number\|null | Scheduled task offset from epoch (null if no task)               |
+| `ca2PulseTaskOffset` | number\|null | Offset at which a pulse-mode CA2 returns high (null if no pulse) |
+| `cb2PulseTaskOffset` | number\|null | Offset at which a pulse-mode CB2 returns high (null if no pulse) |
+
+`ca2PulseTaskOffset` and `cb2PulseTaskOffset` are absent from snapshots written before CA2/CB2 pulses had a width, and from imported snapshots; absent means no pulse is in flight.
 
 System VIA additionally includes:
 

--- a/src/via.js
+++ b/src/via.js
@@ -24,8 +24,8 @@ const ORB = 0x0,
     INT_CB1 = 0x10,
     INT_CB2 = 0x08;
 
-// tRS3 holds a pulse-mode CA2/CB2 low for one 1MHz VIA cycle, here in the scheduler's 2MHz ticks.
-// http://archive.6502.org/datasheets/wdc_w65c22s_mar_2004.pdf
+// Pulse mode holds CA2/CB2 low for one 1MHz VIA cycle, here in the scheduler's 2MHz ticks.
+// Figures 3-4 and 3-6 of https://6502.org/documents/datasheets/wdc/wdc_w65c22s_mar_2004.pdf
 const PulseWidthCycles = 2;
 
 class Via {

--- a/src/via.js
+++ b/src/via.js
@@ -24,6 +24,10 @@ const ORB = 0x0,
     INT_CB1 = 0x10,
     INT_CB2 = 0x08;
 
+// tRS3 holds a pulse-mode CA2/CB2 low for one 1MHz VIA cycle, here in the scheduler's 2MHz ticks.
+// http://archive.6502.org/datasheets/wdc_w65c22s_mar_2004.pdf
+const PulseWidthCycles = 2;
+
 class Via {
     constructor(cpu, scheduler, irq) {
         this.cpu = cpu;
@@ -59,6 +63,8 @@ class Via {
         this.t1_pb7 = 0;
 
         this.task = this.scheduler.newTask(() => this._onTimeout());
+        this.ca2PulseTask = this.scheduler.newTask(() => this.setca2(true));
+        this.cb2PulseTask = this.scheduler.newTask(() => this.setcb2(true));
         this.lastPolltime = 0;
     }
 
@@ -72,6 +78,8 @@ class Via {
         this.t1hit = this.t2hit = true;
         this.acr = this.pcr = 0;
         this.t1_pb7 = 1;
+        this.ca2PulseTask.cancel();
+        this.cb2PulseTask.cancel();
         this.updateNextTime();
     }
 
@@ -166,7 +174,7 @@ class Via {
                 } else if (mode === 0x0a) {
                     // Pulse mode
                     this.setca2(false);
-                    this.setca2(true);
+                    this.ca2PulseTask.reschedule(PulseWidthCycles);
                 }
                 break;
 
@@ -193,7 +201,7 @@ class Via {
                 } else if (mode === 0x0a) {
                     // Pulse mode
                     this.setcb2(false);
-                    this.setcb2(true);
+                    this.cb2PulseTask.reschedule(PulseWidthCycles);
                 }
                 break;
 
@@ -408,6 +416,15 @@ class Via {
         this.portBUpdated();
     }
 
+    _taskOffset(task) {
+        return task.scheduled() ? task.expireEpoch - this.scheduler.epoch : null;
+    }
+
+    _restoreTask(task, offset) {
+        if (offset === null || offset === undefined) task.cancel();
+        else task.reschedule(offset);
+    }
+
     snapshotState() {
         return {
             ora: this.ora,
@@ -436,7 +453,9 @@ class Via {
             justhit: this.justhit,
             t1_pb7: this.t1_pb7,
             lastPolltime: this.lastPolltime,
-            taskOffset: this.task.scheduled() ? this.task.expireEpoch - this.scheduler.epoch : null,
+            taskOffset: this._taskOffset(this.task),
+            ca2PulseTaskOffset: this._taskOffset(this.ca2PulseTask),
+            cb2PulseTaskOffset: this._taskOffset(this.cb2PulseTask),
         };
     }
 
@@ -468,11 +487,9 @@ class Via {
         this.t1_pb7 = state.t1_pb7;
         this.lastPolltime = state.lastPolltime;
         this.updateIFR();
-        if (state.taskOffset !== null) {
-            this.task.reschedule(state.taskOffset);
-        } else {
-            this.task.cancel();
-        }
+        this._restoreTask(this.task, state.taskOffset);
+        this._restoreTask(this.ca2PulseTask, state.ca2PulseTaskOffset);
+        this._restoreTask(this.cb2PulseTask, state.cb2PulseTaskOffset);
     }
 
     setca1(level) {

--- a/tests/unit/test-via.js
+++ b/tests/unit/test-via.js
@@ -203,6 +203,7 @@ describe("Via snapshotState / restoreState", () => {
 describe("Via CA2 write handshake", () => {
     const ORB = 0x0,
         ORA = 0x1,
+        DDRB = 0x2,
         DDRA = 0x3,
         PCR = 0xc,
         ORAnh = 0xf;
@@ -210,12 +211,15 @@ describe("Via CA2 write handshake", () => {
         PcrCa2Pulse = 0x0a;
     const SeededByte = 0x41,
         WrittenByte = 0x42;
+    const PulseWidthCycles = 2;
 
-    let via, events;
+    let via, scheduler, events;
 
     beforeEach(() => {
-        via = new UserVia(makeFakeCpu(), new Scheduler(), false, makeFakeUserPortPeripheral());
+        scheduler = new Scheduler();
+        via = new UserVia(makeFakeCpu(), scheduler, false, makeFakeUserPortPeripheral());
         via.write(DDRA, 0xff);
+        via.write(DDRB, 0xff);
         via.write(ORAnh, SeededByte);
         events = [];
     });
@@ -238,11 +242,57 @@ describe("Via CA2 write handshake", () => {
         recordCa2Changes();
 
         via.write(ORA, WrittenByte);
+        scheduler.polltime(PulseWidthCycles);
 
         expect(events).toEqual([
             { level: false, output: true, ora: WrittenByte, pins: WrittenByte },
             { level: true, output: true, ora: WrittenByte, pins: WrittenByte },
         ]);
+    });
+
+    it("should hold CA2 low for a cycle in pulse mode", () => {
+        via.write(PCR, PcrCa2Pulse);
+        recordCa2Changes();
+
+        via.write(ORA, WrittenByte);
+        expect(via.ca2).toBe(false);
+
+        scheduler.polltime(PulseWidthCycles - 1);
+        expect(via.ca2).toBe(false);
+
+        scheduler.polltime(1);
+        expect(via.ca2).toBe(true);
+    });
+
+    it("should hold CB2 low for a cycle in pulse mode", () => {
+        via.write(PCR, PcrCa2Pulse << 4);
+        const cb2Events = [];
+        via.cb2changecallback = (level, output) => cb2Events.push({ level, output });
+
+        via.write(ORB, WrittenByte);
+        expect(cb2Events).toEqual([{ level: false, output: true }]);
+
+        scheduler.polltime(PulseWidthCycles - 1);
+        expect(via.cb2).toBe(false);
+
+        scheduler.polltime(1);
+        expect(cb2Events).toEqual([
+            { level: false, output: true },
+            { level: true, output: true },
+        ]);
+    });
+
+    it("should carry a pulse in flight across a snapshot", () => {
+        via.write(PCR, PcrCa2Pulse);
+        via.write(ORA, WrittenByte);
+        scheduler.polltime(PulseWidthCycles - 1);
+
+        const restored = new UserVia(makeFakeCpu(), scheduler, false, makeFakeUserPortPeripheral());
+        restored.restoreState(via.snapshotState());
+        expect(restored.ca2).toBe(false);
+
+        scheduler.polltime(1);
+        expect(restored.ca2).toBe(true);
     });
 
     it("should not touch CA2 when writing the no-handshake register", () => {


### PR DESCRIPTION
Pulse mode did `setca2(false); setca2(true)` back to back, so a consumer that samples the level rather than the edge saw nothing: by the time anything else ran, the line was back high.

The line now falls and a scheduler task restores it one VIA cycle later (tRS3 in the W65C22S datasheet), for CA2 and CB2 alike. That is what MAME does with its one-clock `m_ca2_timer`, and what CLK does in `do_phase2()`. The VIA already owns a scheduler, so this is two more tasks alongside the timer one.

`setca1`/`setcb1` did **not** need the same treatment. Handshake mode restores CA2/CB2 on the active CA1/CB1 edge rather than on a timer, so the low period there is already however long the peripheral takes to acknowledge: a signal of real width, not a glitch. Left alone.

The two pending-pulse tasks are snapshotted the way the existing timer task is, as an offset from `scheduler.epoch`, and `docs/snapshot-format.md` is updated. Older snapshots and snapshots imported from b-em and BeebEm have no such field; absent means no pulse in flight, so they restore unchanged and no version bump is needed.

Fixes #818

## Testing

- `tests/unit/test-via.js`: three new tests, all confirmed to fail against unmodified `src/via.js` and pass with it. Two drive the VIA through `write()` in pulse mode and observe the line still low a tick after the write and high a tick later, once for CA2 via `ca2changecallback` and `via.ca2`, once for CB2 via `cb2changecallback`. The third snapshots a VIA mid-pulse, restores into a fresh one, and checks the restored VIA still raises the line at the right moment. The existing "before pulsing CA2 in pulse mode" ordering test from #817 now has to run the scheduler on to see the rising edge; its assertions are otherwise unchanged.
- `tests/unit/test-via.js` and `tests/unit/test-video.js` (it stubs `cb2changecallback`): all pass.
- `tests/integration/via.js` (scarybeasts' timer suite): 22 passed, 1 skipped, unchanged from before.
- `tests/unit/test-snapshot.js`, `test-state-utils.js`, `test-bem-snapshot.js`, `test-uef-snapshot.js`: all pass, covering the import paths that build VIA state without the new fields.
- `npm run lint` and `npm run format` clean.

Not run: the rest of the suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)