### PR TITLE
fix: snapshot the teletext adaptor, and return after rejecting a failed load

### DIFF
--- a/docs/snapshot-format.md
+++ b/docs/snapshot-format.md
@@ -253,6 +253,26 @@ Contains ~20 scalar fields for SAA5050 rendering state. Glyph table references a
 | `high`       | number       | High byte of conversion result |
 | `taskOffset` | number\|null | Conversion task offset         |
 
+### Teletext adaptor (`state.teletextAdaptor`)
+
+Present only when the Acorn teletext adaptor was fitted. Absent means the adaptor, if one is fitted now, keeps its current state, the same fallback as a v1 snapshot's missing FDC. Because absence is already the well-defined case, adding this field did not need a format version bump: v3 readers that predate it ignore it, and readers that know it treat an older v3 snapshot as "adaptor state unchanged".
+
+| Field            | Type       | Description                                              |
+| ---------------- | ---------- | -------------------------------------------------------- |
+| `teletextStatus` | number     | Status register, including the INT, DOR and FSYN latches |
+| `teletextInts`   | boolean    | Whether interrupts are enabled                           |
+| `teletextEnable` | boolean    | Whether the adaptor is enabled                           |
+| `channel`        | number     | Selected channel, 0-3                                    |
+| `currentFrame`   | number     | Playback position within the channel's stream            |
+| `rowPtr`         | number     | Row register                                             |
+| `colPtr`         | number     | Column pointer within the current row                    |
+| `pollCount`      | number     | Cycles accumulated towards the next field                |
+| `frameBuffer`    | number[][] | 16 rows of 64 bytes as the adaptor last filled them      |
+
+The IRQ line is not saved: it follows from `teletextInts` and the INT latch in `teletextStatus`, in the same way the host's `interrupt` follows from the VIA and ACIA state.
+
+The broadcast stream itself (`teletext/txtN.dat`, around 5MB a channel) is not saved. On restore, a channel differing from the one already loaded is fetched again and its playback restarts from the beginning of the stream, exactly as switching channel does on a running machine. `totalFrames` follows from the stream and is likewise recomputed rather than saved.
+
 ### FDC (`state.fdc`) — _v2+_
 
 The FDC field is present in v2+ snapshots. When loading a v1 snapshot, `state.fdc` is absent and the FDC retains its current state.

--- a/src/6502.js
+++ b/src/6502.js
@@ -1241,6 +1241,7 @@ export class Cpu6502 extends Base6502 {
             acia: this.acia.snapshotState(),
             adc: this.adconverter.snapshotState(),
             fdc: this.fdc.snapshotState(),
+            teletextAdaptor: this.teletextAdaptor ? this.teletextAdaptor.snapshotState() : undefined,
             tube: this.hasTube ? this.tube.snapshotState({ includeRoms }) : undefined,
         };
     }
@@ -1297,6 +1298,7 @@ export class Cpu6502 extends Base6502 {
         this.soundChip.restoreState(state.soundChip);
         this.acia.restoreState(state.acia);
         this.adconverter.restoreState(state.adc);
+        if (this.teletextAdaptor && state.teletextAdaptor) this.teletextAdaptor.restoreState(state.teletextAdaptor);
 
         // FDC state (v2+). If absent (v1 snapshot), FDC keeps its current state.
         if (state.fdc) {

--- a/src/teletext_adaptor.js
+++ b/src/teletext_adaptor.js
@@ -94,6 +94,45 @@ export class TeletextAdaptor extends EventTarget {
         this.currentFrame = 0;
     }
 
+    updateIrq() {
+        if (this.teletextInts && this.teletextStatus & 0x80) {
+            this.cpu.interrupt |= 1 << TELETEXT_IRQ;
+        } else {
+            this.cpu.interrupt &= ~(1 << TELETEXT_IRQ);
+        }
+    }
+
+    snapshotState() {
+        return {
+            teletextStatus: this.teletextStatus,
+            teletextInts: this.teletextInts,
+            teletextEnable: this.teletextEnable,
+            channel: this.channel,
+            currentFrame: this.currentFrame,
+            rowPtr: this.rowPtr,
+            colPtr: this.colPtr,
+            pollCount: this.pollCount,
+            frameBuffer: this.frameBuffer.map((row) => row.slice()),
+        };
+    }
+
+    restoreState(state) {
+        this.teletextStatus = state.teletextStatus;
+        this.teletextInts = state.teletextInts;
+        this.teletextEnable = state.teletextEnable;
+        this.currentFrame = state.currentFrame;
+        this.rowPtr = state.rowPtr;
+        this.colPtr = state.colPtr;
+        this.pollCount = state.pollCount;
+        this.frameBuffer = state.frameBuffer.map((row) => row.slice());
+        this.updateIrq();
+        // Refetching the multi-megabyte stream on every restore would be ruinous for rewind.
+        if (this.channel !== state.channel) {
+            this.channel = state.channel;
+            this.loadChannelStream(this.channel);
+        }
+    }
+
     read(addr) {
         let data = 0x00;
 
@@ -120,11 +159,7 @@ export class TeletextAdaptor extends EventTarget {
             case 0x00:
                 // Status register
                 this.teletextInts = (value & 0x08) === 0x08;
-                if (this.teletextInts && this.teletextStatus & 0x80) {
-                    this.cpu.interrupt |= 1 << TELETEXT_IRQ; // Interrupt if INT and interrupts enabled
-                } else {
-                    this.cpu.interrupt &= ~(1 << TELETEXT_IRQ); // Clear interrupt
-                }
+                this.updateIrq();
                 this.teletextEnable = (value & 0x04) === 0x04;
                 if ((value & 0x03) !== this.channel && this.teletextEnable) {
                     this.channel = value & 0x03;

--- a/src/utils.js
+++ b/src/utils.js
@@ -1013,7 +1013,10 @@ function loadDataHttp(url) {
         request.open("GET", baseUrl + url, true);
         request.overrideMimeType("text/plain; charset=x-user-defined");
         request.onload = function () {
-            if (request.status !== 200) reject(new Error("Unable to load " + url + ", http code " + request.status));
+            if (request.status !== 200) {
+                reject(new Error("Unable to load " + url + ", http code " + request.status));
+                return;
+            }
             if (typeof request.response !== "string") {
                 resolve(request.response);
             } else {

--- a/tests/unit/test-snapshot.js
+++ b/tests/unit/test-snapshot.js
@@ -212,6 +212,42 @@ describe("Snapshot coordinator", () => {
         });
     });
 
+    describe("Teletext adaptor snapshot", () => {
+        // The test model maps 0xfcxx as plain RAM, so the adaptor's registers are driven directly.
+        const StatusRegister = 0x00;
+        const RowRegister = 0x01;
+        const DataRegister = 0x02;
+
+        it("omits the adaptor when none is fitted", () => {
+            expect(createSnapshot(cpu, model).state.teletextAdaptor).toBeUndefined();
+        });
+
+        it("round-trips the fitted adaptor's channel and frame buffer", async () => {
+            const withAdaptor = makeCpu({ hasTeletextAdaptor: true });
+            await withAdaptor.initialise();
+            withAdaptor.teletextAdaptor.write(StatusRegister, 0x04 | 2); // Teletext enable, channel 2
+            withAdaptor.teletextAdaptor.write(RowRegister, 3);
+            withAdaptor.teletextAdaptor.write(DataRegister, 0xaa);
+
+            const snapshot = createSnapshot(withAdaptor, model);
+            const restored = makeCpu({ hasTeletextAdaptor: true });
+            await restored.initialise();
+            restoreSnapshot(restored, model, snapshot);
+
+            expect(snapshot.state.teletextAdaptor.channel).toBe(2);
+            restored.teletextAdaptor.write(RowRegister, 3);
+            expect(restored.teletextAdaptor.read(DataRegister)).toBe(0xaa);
+        });
+
+        it("leaves a fitted adaptor alone when the snapshot has no adaptor state", async () => {
+            const snapshot = createSnapshot(cpu, model);
+            const restored = makeCpu({ hasTeletextAdaptor: true });
+            await restored.initialise();
+
+            expect(() => restoreSnapshot(restored, model, snapshot)).not.toThrow();
+        });
+    });
+
     describe("FDC snapshot", () => {
         it("should round-trip Intel FDC state", () => {
             const snapshot = createSnapshot(cpu, model);

--- a/tests/unit/test-teletext-adaptor.js
+++ b/tests/unit/test-teletext-adaptor.js
@@ -328,6 +328,96 @@ describe("TeletextAdaptor", () => {
         });
     });
 
+    describe("Snapshots", () => {
+        let loadData;
+        let source;
+        let restoredCpu;
+        let restored;
+
+        beforeEach(() => {
+            loadData = vi.spyOn(utils, "loadData").mockImplementation(() => new Promise(() => {}));
+            source = new TeletextAdaptor(mockCpu);
+            restoredCpu = { interrupt: 0, resetLine: true };
+            restored = new TeletextAdaptor(restoredCpu);
+            loadData.mockClear();
+        });
+
+        it("should restore the channel, control bits and frame buffer", () => {
+            source.write(0, 0x0c | 2); // Teletext enable, interrupts, channel 2
+            source.write(1, 3);
+            source.write(2, 0xaa);
+            source.write(2, 0xbb);
+
+            restored.restoreState(source.snapshotState());
+
+            expect(restored.channel).toBe(2);
+            expect(restored.teletextEnable).toBe(true);
+            expect(restored.teletextInts).toBe(true);
+            restored.write(1, 3);
+            expect(restored.read(2)).toBe(0xaa);
+            expect(restored.read(2)).toBe(0xbb);
+        });
+
+        it("should restore the status register and its pointers", () => {
+            source.write(0, 0x0c); // Teletext enable, interrupts, channel 0
+            source.update();
+            source.write(1, 4);
+            source.read(2);
+
+            restored.restoreState(source.snapshotState());
+
+            expect(restored.teletextStatus).toBe(source.teletextStatus);
+            expect(restored.rowPtr).toBe(4);
+            expect(restored.colPtr).toBe(1);
+        });
+
+        it("should reassert an IRQ the adaptor was holding", () => {
+            source.write(0, 0x0c); // Teletext enable, interrupts, channel 0
+            source.update();
+            expect(mockCpu.interrupt & (1 << TELETEXT_IRQ)).toBe(1 << TELETEXT_IRQ);
+
+            restored.restoreState(source.snapshotState());
+
+            expect(restoredCpu.interrupt & (1 << TELETEXT_IRQ)).toBe(1 << TELETEXT_IRQ);
+        });
+
+        it("should clear an IRQ the adaptor was not holding", () => {
+            source.update();
+            restoredCpu.interrupt = 1 << TELETEXT_IRQ;
+
+            restored.restoreState(source.snapshotState());
+
+            expect(restoredCpu.interrupt & (1 << TELETEXT_IRQ)).toBe(0);
+        });
+
+        it("should not share the frame buffer with the snapshot it came from", () => {
+            source.write(1, 3);
+            source.write(2, 0xaa);
+            const state = source.snapshotState();
+
+            restored.restoreState(state);
+            restored.write(1, 3);
+            restored.write(2, 0x55);
+
+            expect(source.frameBuffer[3][0]).toBe(0xaa);
+            expect(state.frameBuffer[3][0]).toBe(0xaa);
+        });
+
+        it("should refetch the stream when the restored channel differs", () => {
+            source.write(0, 0x04 | 2); // Teletext enable, channel 2
+
+            restored.restoreState(source.snapshotState());
+
+            expect(loadData).toHaveBeenCalledWith("teletext/txt2.dat");
+        });
+
+        it("should leave the loaded stream alone when the channel is unchanged", () => {
+            restored.restoreState(source.snapshotState());
+
+            expect(loadData).not.toHaveBeenCalled();
+        });
+    });
+
     describe("Update and polling", () => {
         it("should update status and frame counter on update()", () => {
             // Set initial state


### PR DESCRIPTION
Two of the three things in #745. The third, the unmasked row register, is deliberately left alone.

### The adaptor is absent from snapshots (item 2)

`TeletextAdaptor` now owns `snapshotState`/`restoreState` and `Cpu6502` saves it under `state.teletextAdaptor`, so the channel, control bits, status register, pointers and frame buffer survive a save and load.

The IRQ line is not saved. It is rebuilt on restore from the interrupt enable bit and the INT latch in the status register, the same way the VIA and ACIA rebuild `cpu.interrupt`. The condition already existed in the status register write, so it moves into an `updateIrq()` the write path now calls too.

The broadcast stream stays out of the snapshot: it is about 5MB a channel and reloadable. On restore it is refetched only when the restored channel differs from the one already loaded, so a rewind restore does not refire a multi-megabyte fetch every frame. A refetched channel restarts at the beginning of its stream, exactly as switching channel does on a running machine.

**Format version: not bumped.** Absence of `state.teletextAdaptor` already has a well-defined meaning, "leave the adaptor as it is", which is the same fallback a v1 snapshot's missing FDC gets. Bumping to 4 would buy nothing and cost something real: `restoreSnapshot` throws on any version above the one it knows, so every older build would refuse the whole file over an optional peripheral field. `docs/snapshot-format.md` records the new field and that reasoning.

### `loadDataHttp` rejects and then keeps going (item 3)

Added the missing `return`. Behaviour is unchanged today, since the promise had already settled by the time `resolve` ran.

### The row register (item 1), untouched

Not fixed, and not guessed at. The issue is right that this needs the hardware pinned down first. The open question is what the adaptor's address counter actually is: if the row latch and column counter are one counter across the 1K of adaptor RAM, a column running past 63 carries into the row and a row above 15 wraps; if they are a separate latch and a 6-bit counter, the column wraps within its row and the row bits above 4 go nowhere. Those give different behaviour at both boundaries and pick different fixes. Nothing here establishes which, so nothing here changes it, and #745 stays open for it.

## Testing

- `tests/unit/test-teletext-adaptor.js`: a new `Snapshots` block covering the round trip of channel, control bits, status register, pointers and frame buffer; that a held IRQ is reasserted on restore and a not-held one is cleared; that the restored frame buffer does not share arrays with the snapshot; and that the stream is refetched on a changed channel but left alone on an unchanged one. All seven fail without the change.
- `tests/unit/test-snapshot.js`: the adaptor is omitted when none is fitted, round-trips through `createSnapshot`/`restoreSnapshot` when one is, and a snapshot without adaptor state restores into a machine that has one. The round-trip test fails without the `Cpu6502` wiring.
- Ran `tests/unit/test-teletext-adaptor.js`, `tests/unit/test-snapshot.js`, `tests/unit/test-utils.js` and `tests/integration/teletext-adaptor.js`: 124 passing. The full suite was not run.
- The `loadDataHttp` return has no test. It changes no observable behaviour, and there is no XHR harness in the unit tests to assert the fall-through against.

Refs #745.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
