### PR TITLE
fix: model teletext conceal as a state, not a recolour

### DIFF
--- a/src/teletext.js
+++ b/src/teletext.js
@@ -11,6 +11,7 @@ export class Teletext {
         this.sep = false;
         this.dbl = this.oldDbl = this.secondHalfOfDouble = this.wasDbl = false;
         this.gfx = false;
+        this.conceal = false;
         this.flash = this.flashOn = false;
         this.flashTime = 0;
         this.heldChar = 0;
@@ -172,6 +173,7 @@ export class Teletext {
             secondHalfOfDouble: this.secondHalfOfDouble,
             wasDbl: this.wasDbl,
             gfx: this.gfx,
+            conceal: this.conceal,
             flash: this.flash,
             flashOn: this.flashOn,
             flashTime: this.flashTime,
@@ -198,6 +200,7 @@ export class Teletext {
         this.secondHalfOfDouble = state.secondHalfOfDouble;
         this.wasDbl = state.wasDbl;
         this.gfx = state.gfx;
+        this.conceal = state.conceal ?? false;
         this.flash = state.flash;
         this.flashOn = state.flashOn;
         this.flashTime = state.flashTime;
@@ -245,6 +248,7 @@ export class Teletext {
             case 7:
                 this.gfx = false;
                 this.col = data;
+                this.conceal = false;
                 this.setNextChars();
                 break;
             case 8:
@@ -267,10 +271,11 @@ export class Teletext {
             case 23:
                 this.gfx = true;
                 this.col = data & 7;
+                this.conceal = false;
                 this.setNextChars();
                 break;
             case 24:
-                this.col = this.prevCol = this.bg;
+                this.conceal = true;
                 break;
             case 25:
                 this.sep = false;
@@ -358,6 +363,7 @@ export class Teletext {
         this.flash = false;
         this.sep = false;
         this.gfx = false;
+        this.conceal = false;
         this.dbl = false;
 
         this.scanlineCounter++;
@@ -396,6 +402,7 @@ export class Teletext {
         this.curGlyphs = this.nextGlyphs;
 
         let flashThisCell = this.flash;
+        let concealThisCell = this.conceal;
         if (data < 0x20) {
             data = this.handleControlCode(data);
         } else if (this.gfx) {
@@ -419,7 +426,10 @@ export class Teletext {
         // Steady (code 9) is "Set At" — update so this cell stops flashing immediately.
         if (flashThisCell && !this.flash) flashThisCell = false;
 
-        if ((flashThisCell && this.flashOn) || (this.secondHalfOfDouble && !this.dbl)) {
+        // Conceal (code 24) is "Set At", and a colour code only reveals from the cell after itself.
+        if (this.conceal) concealThisCell = true;
+
+        if (concealThisCell || (flashThisCell && this.flashOn) || (this.secondHalfOfDouble && !this.dbl)) {
             const backgroundColour = this.colour[(this.bg & 7) << 5];
             for (let i = 0; i < 16; ++i) {
                 buf[offset++] = backgroundColour;

--- a/tests/unit/test-teletext.js
+++ b/tests/unit/test-teletext.js
@@ -1,0 +1,100 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { Teletext } from "../../src/teletext.js";
+import { makeFast32 } from "../../src/utils.js";
+
+const PixelsPerCell = 16;
+const PipelineDelay = 3;
+
+const WhiteGraphics = 0x17;
+const BlueGraphics = 0x14;
+const Conceal = 0x18;
+const HoldGraphics = 0x1e;
+const BlackBackground = 0x1c;
+const NewBackground = 0x1d;
+const Space = 0x20;
+const SolidBlock = 0x7f;
+const Blue = 4;
+
+describe("Teletext", () => {
+    let teletext;
+
+    beforeEach(() => {
+        teletext = new Teletext();
+    });
+
+    function renderCells(bytes) {
+        const padded = [...bytes, ...Array(PipelineDelay).fill(Space)];
+        const buffer = makeFast32(new Uint32Array(padded.length * PixelsPerCell));
+        padded.forEach((byte, index) => {
+            teletext.fetchData(byte);
+            teletext.render(buffer, index * PixelsPerCell);
+        });
+        return bytes.map((_, index) =>
+            buffer.subarray((index + PipelineDelay) * PixelsPerCell, (index + PipelineDelay + 1) * PixelsPerCell),
+        );
+    }
+
+    function backgroundOnly(cell, backgroundIndex = 0) {
+        const background = teletext.colour[(backgroundIndex & 7) << 5];
+        return cell.every((pixel) => pixel === background);
+    }
+
+    function endScanline() {
+        teletext.setDISPTMG(true);
+        teletext.setDISPTMG(false);
+    }
+
+    describe("conceal", () => {
+        it("blanks graphics until a colour code reveals them", () => {
+            const cells = renderCells([WhiteGraphics, SolidBlock, Conceal, SolidBlock, WhiteGraphics, SolidBlock]);
+
+            expect(backgroundOnly(cells[1])).toBe(false);
+            expect(backgroundOnly(cells[3])).toBe(true);
+            expect(backgroundOnly(cells[5])).toBe(false);
+        });
+
+        it("stays concealed when the background changes afterwards", () => {
+            const cells = renderCells([BlueGraphics, NewBackground, Conceal, BlackBackground, SolidBlock, SolidBlock]);
+
+            expect(backgroundOnly(cells[4])).toBe(true);
+            expect(backgroundOnly(cells[5])).toBe(true);
+        });
+
+        it("conceals the cell holding the conceal code, and the one holding the revealing code", () => {
+            const cells = renderCells([WhiteGraphics, SolidBlock, HoldGraphics, Conceal, WhiteGraphics, SolidBlock]);
+
+            expect(backgroundOnly(cells[2])).toBe(false);
+            expect(backgroundOnly(cells[3])).toBe(true);
+            expect(backgroundOnly(cells[4])).toBe(true);
+            expect(backgroundOnly(cells[5])).toBe(false);
+        });
+
+        it("does not survive into the next row", () => {
+            const concealed = renderCells([WhiteGraphics, Conceal, SolidBlock]);
+            expect(backgroundOnly(concealed[2])).toBe(true);
+
+            endScanline();
+
+            const revealed = renderCells([WhiteGraphics, SolidBlock]);
+            expect(backgroundOnly(revealed[1])).toBe(false);
+        });
+
+        it("leaves the foreground colour alone", () => {
+            const cells = renderCells([BlueGraphics, Conceal, SolidBlock, NewBackground, WhiteGraphics, Space]);
+
+            expect(backgroundOnly(cells[2])).toBe(true);
+            expect(backgroundOnly(cells[5], Blue)).toBe(true);
+        });
+
+        it("round-trips through a snapshot", () => {
+            renderCells([WhiteGraphics, Conceal, SolidBlock]);
+            const state = teletext.snapshotState();
+
+            const restored = new Teletext();
+            restored.restoreState(state);
+
+            expect(restored.snapshotState()).toEqual(state);
+            expect(state.conceal).toBe(true);
+        });
+    });
+});


### PR DESCRIPTION
Conceal (control code 24) was faked by setting the foreground to the current background. That only looks concealed while the background stays put, and it destroys the foreground colour on the way: a later "black background" (28) or "new background" (29) brings the text straight back, which is exactly what a random-byte fill of screen memory hits.

Conceal is now a state, alongside `flash`, `gfx`, `sep` and `holdChar`. The glyph is suppressed at output time (the cell shows whatever the background currently is), and the foreground colour is left alone.

## When conceal clears

- On any alpha (1-7) or graphics (17-23) colour code, and on nothing else. Background codes (28, 29), hold/release graphics and the flash codes leave it alone.
- With the rest of the row state at the start of each character row. The old code left nothing to clear, so this was accidental before rather than deliberate.
- Conceal is Set-At: the cell holding code 24 is concealed. The reveal is delayed by one cell, so the cell holding the revealing colour code (which shows the held mosaic under hold graphics) is still concealed.

That matches beebjit's tested fix in scarybeasts/beebjit@47995878 and Clock Signal's `SAA5050Serialiser`, and the SAA5050 documentation describing conceal as Set-At, lasting "up to the end of the row, or until a Colour Code attribute is encountered".

## Testing

- New `tests/unit/test-teletext.js` drives the SAA5050 a cell at a time and checks which cells come out as background only. Reverting `src/teletext.js` alone fails the "background changes while concealed", "leaves the foreground colour alone" and snapshot round-trip cases, and passes the rest, which are behaviour locks rather than regressions.
- Ran beebjit's teletext test disc (`test/display/teletest_v1.ssd` at 47995878, `CH."TELETST"`) headless and sampled the CONCEAL row cell by cell against the control codes in screen memory. Before: the row went black from the "new background" cell onwards, with only the magenta `A` and the yellow held mosaic visible. After: the blue background runs from the "new background" cell to the end of the row with the concealed cells showing blue, the magenta `A` and yellow mosaic still where they belong, matching a hand-trace of the row.
- `tests/integration/teletext.js` (Ceefax page pixel comparisons) still passes, as do `tests/unit/test-video.js` and `tests/unit/test-snapshot.js`.
- Not checked: the JCB Digger intro. I could not find that disc image locally.

Fixes #833

🤖 Generated with [Claude Code](https://claude.com/claude-code)
