### PR TITLE
refactor: swap the video filter in place instead of rebuilding the canvas

### DIFF
--- a/src/canvas.js
+++ b/src/canvas.js
@@ -38,6 +38,11 @@ export class Canvas {
     /** Nothing to release: the 2D context owns no objects of ours. */
     dispose() {}
 
+    setFilter(filterClass) {
+        if (filterClass !== PassthroughFilter)
+            throw new Error(`${filterClass.getDisplayConfig().name} needs WebGL, which is not in use here`);
+    }
+
     paint(minx, miny, maxx, maxy, _frame) {
         const width = maxx - minx;
         const height = maxy - miny;
@@ -78,23 +83,14 @@ export class GlCanvas {
 
         checkedGl.depthMask(false);
 
-        this.filter = new filterClass(checkedGl);
-        const program = this.filter.program;
-        checkedGl.useProgram(program);
-
-        // Filters that pick their own samples want the texels they asked for,
-        // not a hardware blend of the ones either side.
-        const sampling = filterClass.getDisplayConfig().nearestSampling ? checkedGl.NEAREST : checkedGl.LINEAR;
-
         this.fb8 = new Uint8Array(width * height * 4);
         this.fb32 = new Uint32Array(this.fb8.buffer);
         this.texture = checkedGl.createTexture();
+        checkedGl.activeTexture(checkedGl.TEXTURE0);
         checkedGl.bindTexture(checkedGl.TEXTURE_2D, this.texture);
         checkedGl.pixelStorei(checkedGl.UNPACK_ALIGNMENT, 4);
         checkedGl.texParameteri(checkedGl.TEXTURE_2D, checkedGl.TEXTURE_WRAP_S, checkedGl.CLAMP_TO_EDGE);
         checkedGl.texParameteri(checkedGl.TEXTURE_2D, checkedGl.TEXTURE_WRAP_T, checkedGl.CLAMP_TO_EDGE);
-        checkedGl.texParameteri(checkedGl.TEXTURE_2D, checkedGl.TEXTURE_MAG_FILTER, sampling);
-        checkedGl.texParameteri(checkedGl.TEXTURE_2D, checkedGl.TEXTURE_MIN_FILTER, sampling);
         checkedGl.texImage2D(
             checkedGl.TEXTURE_2D,
             0,
@@ -106,44 +102,72 @@ export class GlCanvas {
             checkedGl.UNSIGNED_BYTE,
             this.fb8,
         );
-        checkedGl.bindTexture(checkedGl.TEXTURE_2D, null);
 
-        const vertexPositionAttrLoc = checkedGl.getAttribLocation(program, "pos");
-        checkedGl.enableVertexAttribArray(vertexPositionAttrLoc);
         this.vertexPositionBuffer = checkedGl.createBuffer();
         checkedGl.bindBuffer(checkedGl.ARRAY_BUFFER, this.vertexPositionBuffer);
         checkedGl.bufferData(checkedGl.ARRAY_BUFFER, new Float32Array([0, 0, 0, 1, 1, 0, 1, 1]), checkedGl.STATIC_DRAW);
-        checkedGl.vertexAttribPointer(vertexPositionAttrLoc, 2, checkedGl.FLOAT, false, 0, 0);
-
-        const uvAttrLoc = checkedGl.getAttribLocation(program, "uvIn");
-        checkedGl.enableVertexAttribArray(uvAttrLoc);
         this.uvBuffer = checkedGl.createBuffer();
-        checkedGl.bindBuffer(checkedGl.ARRAY_BUFFER, this.uvBuffer);
-        checkedGl.vertexAttribPointer(uvAttrLoc, 2, checkedGl.FLOAT, false, 0, 0);
-
-        checkedGl.activeTexture(gl.TEXTURE0);
-        checkedGl.bindTexture(gl.TEXTURE_2D, this.texture);
 
         this.checkedGl = checkedGl;
+        this.filter = null;
+        this.attribLocations = [];
         this.viewportWidth = this.viewportHeight = 0;
         this.uvFloatArray = new Float32Array(8);
         this.lastExtent = {};
+
+        try {
+            this.setFilter(filterClass);
+        } catch (e) {
+            this.dispose();
+            throw e;
+        }
 
         console.log("GL Canvas set up");
     }
 
     /**
-     * Release the GL objects this canvas owns.
+     * Draw with `filterClass` from here on, keeping the framebuffer texture and
+     * the vertex buffers: only the program, the texture sampling mode and the
+     * attribute locations differ between filters.
      *
-     * Switching display mode builds a new canvas over the same element, and a
-     * canvas only ever hands out one WebGL context — so the new one inherits
-     * the old one's context and the old one's objects stay resident unless
-     * they are deleted here. That is a megabytes-per-switch leak: the
-     * framebuffer texture alone is 1024x1024 RGBA.
+     * The new filter is built before the old one is disposed, so a filter that
+     * will not build leaves the canvas drawing as it was.
+     */
+    setFilter(filterClass) {
+        const gl = this.checkedGl;
+        const filter = new filterClass(gl);
+        this.filter?.dispose();
+        this.filter = filter;
+        gl.useProgram(filter.program);
+
+        // Filters that pick their own samples want the texels they asked for,
+        // not a hardware blend of the ones either side.
+        const sampling = filterClass.getDisplayConfig().nearestSampling ? gl.NEAREST : gl.LINEAR;
+        gl.activeTexture(gl.TEXTURE0);
+        gl.bindTexture(gl.TEXTURE_2D, this.texture);
+        gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, sampling);
+        gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, sampling);
+
+        const bindAttribute = (name, buffer) => {
+            const location = gl.getAttribLocation(filter.program, name);
+            gl.enableVertexAttribArray(location);
+            gl.bindBuffer(gl.ARRAY_BUFFER, buffer);
+            gl.vertexAttribPointer(location, 2, gl.FLOAT, false, 0, 0);
+            return location;
+        };
+        for (const location of this.attribLocations) gl.disableVertexAttribArray(location);
+        this.attribLocations = [bindAttribute("pos", this.vertexPositionBuffer), bindAttribute("uvIn", this.uvBuffer)];
+    }
+
+    /**
+     * Release the GL objects this canvas owns. Nothing else will: a canvas
+     * element hands out one WebGL context for its lifetime, so anything created
+     * through that context stays resident however many wrappers come and go.
      */
     dispose() {
         const gl = this.checkedGl;
-        this.filter.dispose();
+        this.filter?.dispose();
+        this.filter = null;
         gl.deleteTexture(this.texture);
         gl.deleteBuffer(this.vertexPositionBuffer);
         gl.deleteBuffer(this.uvBuffer);
@@ -216,6 +240,24 @@ export class GlCanvas {
 function fellBackBecause(canvas, reason) {
     canvas.fallbackReason = reason;
     return canvas;
+}
+
+/**
+ * Draw with `filterClass`, or with the unfiltered display if it will not build,
+ * in which case `fallbackReason` says why.
+ */
+export function useBestFilter(canvas, filterClass) {
+    let reason;
+    try {
+        canvas.setFilter(filterClass);
+        return fellBackBecause(canvas, undefined);
+    } catch (e) {
+        console.log(`Unable to use ${filterClass.getDisplayConfig().name}: ${e}`);
+        if (filterClass === PassthroughFilter) throw e;
+        reason = e?.message ?? e;
+    }
+    canvas.setFilter(PassthroughFilter);
+    return fellBackBecause(canvas, reason);
 }
 
 export function bestCanvas(canvas, filterClass) {

--- a/src/main.js
+++ b/src/main.js
@@ -476,59 +476,57 @@ function noteDriveTracks(driveIndex, discName) {
     });
 }
 
-function createCanvasForFilter(filterClass) {
+// Test which filter is actually in use, not merely whether we got WebGL: a
+// filter can decline a context that works perfectly well for other modes, in
+// which case we are quietly left with an unfiltered display.
+function reportAnyFallback(displayCanvas, filterClass) {
+    if (displayCanvas.filterClass === filterClass) return;
+    const reason = displayCanvas.fallbackReason ? ` (${displayCanvas.fallbackReason})` : "";
+    const { name } = filterClass.getDisplayConfig();
+    toast(`${name} is not available on this device, so the standard display is in use${reason}.`, {
+        title: "Display",
+        quietKey: "quietDisplayFallback",
+    });
+}
+
+function sizeCanvasFor(filterClass) {
     // Not `config`: that is the emulator's live configuration object, declared
     // at module scope and used throughout this file.
     const displayConfig = filterClass.getDisplayConfig();
-    // Each mode says how many pixels it wants to draw into. Set this before
-    // creating the context, which fixes its initial viewport.
+    if (screenCanvas.width === displayConfig.canvasWidth && screenCanvas.height === displayConfig.canvasHeight) return;
     screenCanvas.width = displayConfig.canvasWidth;
     screenCanvas.height = displayConfig.canvasHeight;
+}
+
+function createCanvasForFilter(filterClass) {
+    // Each mode says how many pixels it wants to draw into. Set this before
+    // creating the context, which fixes its initial viewport.
+    sizeCanvasFor(filterClass);
 
     const newCanvas = tryGl ? canvasLib.bestCanvas(screenCanvas, filterClass) : new canvasLib.Canvas(screenCanvas);
-
-    // Test which filter was actually built, not merely whether we got WebGL: a
-    // filter can decline a context that works perfectly well for other modes,
-    // in which case bestCanvas quietly gives us an unfiltered GL canvas.
-    if (newCanvas.filterClass !== filterClass) {
-        const reason = newCanvas.fallbackReason ? ` (${newCanvas.fallbackReason})` : "";
-        toast(`${displayConfig.name} is not available on this device, so the standard display is in use${reason}.`, {
-            title: "Display",
-            quietKey: "quietDisplayFallback",
-        });
-    }
-
+    reportAnyFallback(newCanvas, filterClass);
     return newCanvas;
 }
 
 let displayModeFilter = canvasLib.getFilterForMode(parsedQuery.displayMode || "rgb");
 function swapCanvas(newFilterClass) {
-    const oldCanvas = canvas;
-    const newCanvas = createCanvasForFilter(newFilterClass);
-    // Carry the picture over; the buffers differ in height, so copy what fits.
-    newCanvas.fb32.set(oldCanvas.fb32.subarray(0, newCanvas.fb32.length));
-    // Only once the replacement exists, so a failure to build it leaves the
-    // display we already had. The two share a GL context but no GL objects.
-    oldCanvas.dispose();
-    video.fb32 = newCanvas.fb32;
-    video.paint_ext = function paint(minx, miny, maxx, maxy) {
-        frames++;
-        if (frames < frameSkip) return;
-        frames = 0;
-        newCanvas.paint(minx, miny, maxx, maxy, { frameCount: this.frameCount, lineGrid: this.lineGrid });
-    };
-    canvas = newCanvas;
+    // Everything but the filter is the same whatever the mode: the framebuffer
+    // texture, the vertex buffers and fb32 all carry over untouched.
+    canvasLib.useBestFilter(canvas, newFilterClass);
+    reportAnyFallback(canvas, newFilterClass);
     // Follow the filter we ended up with, not the one we asked for: everything
-    // downstream — the monitor picture, the canvas geometry, how large a
-    // drawing buffer to ask for — comes from its display config.
-    displayModeFilter = newCanvas.filterClass;
+    // downstream (the monitor picture, the canvas geometry, how large a drawing
+    // buffer to ask for) comes from its display config.
+    displayModeFilter = canvas.filterClass;
+    // Back to the mode's own size, undoing any scaling the last one asked for.
+    sizeCanvasFor(displayModeFilter);
     // Nothing else will redraw: the mode is changed from a modal, which stops
     // the emulator.
     video.paint();
     window.setTimeout(() => window.dispatchEvent(new Event("resize")), 1);
 }
 
-let canvas = createCanvasForFilter(displayModeFilter);
+const canvas = createCanvasForFilter(displayModeFilter);
 displayModeFilter = canvas.filterClass;
 
 video = new Video(

--- a/tests/unit/test-canvas.js
+++ b/tests/unit/test-canvas.js
@@ -1,14 +1,14 @@
 import { describe, it, expect } from "vitest";
-import { GlCanvas, Canvas, bestCanvas } from "../../src/canvas.js";
+import { GlCanvas, Canvas, bestCanvas, useBestFilter } from "../../src/canvas.js";
 import PAL_FRAG_SHADER from "../../src/video-filters/shaders/pal-composite.frag.glsl?raw";
 import { PassthroughFilter } from "../../src/video-filters/passthrough-filter.js";
 import { PALCompositeFilter } from "../../src/video-filters/pal-composite.js";
 import { XbrFilter } from "../../src/video-filters/xbr-filter.js";
 
 // A canvas element hands out a WebGL context once and returns that same context
-// for every later request, so switching display mode builds a new GlCanvas over
-// the old one's context. Anything the old one created stays resident until it
-// is deleted, and the framebuffer texture alone is 1024x1024 RGBA.
+// for every later request, so anything created through it stays resident until
+// it is deleted, whatever happens to the JS objects holding it. The framebuffer
+// texture alone is 1024x1024 RGBA.
 
 /**
  * A WebGL context that records the objects created and deleted through it.
@@ -60,7 +60,7 @@ function recordingGl() {
     for (const name of (
         "shaderSource compileShader attachShader linkProgram useProgram depthMask viewport " +
         "bindTexture bindBuffer bufferData texImage2D texSubImage2D texParameteri pixelStorei activeTexture " +
-        "enableVertexAttribArray vertexAttribPointer drawArrays uniform1i uniform1f uniform2f"
+        "enableVertexAttribArray disableVertexAttribArray vertexAttribPointer drawArrays uniform1i uniform1f uniform2f"
     ).split(" "))
         gl[name] = () => {};
 
@@ -74,6 +74,13 @@ function fakeCanvasElement(gl) {
         height: 600,
         getContext: (kind) => (kind === "2d" ? null : gl),
     };
+}
+
+/** Make `gl` reject one particular shader, as a device without the features for it would. */
+function failToCompile(gl, shaderSource) {
+    const sources = new Map();
+    gl.shaderSource = (shader, source) => sources.set(shader, source);
+    gl.getShaderParameter = (shader) => sources.get(shader) !== shaderSource;
 }
 
 describe("GlCanvas", () => {
@@ -93,12 +100,18 @@ describe("GlCanvas", () => {
         expect([...gl.live]).toEqual([]);
     });
 
+    it.each(filters)("releases what it created when the filter will not build (%s)", (_name, filterClass) => {
+        const gl = recordingGl();
+        gl.getProgramParameter = () => false;
+
+        expect(() => new GlCanvas(fakeCanvasElement(gl), filterClass)).toThrow(/Failed to link/);
+        expect([...gl.live]).toEqual([]);
+    });
+
     it("does not accumulate objects over repeated display mode switches", () => {
-        // This is the shape of the leak: swapping modes builds a new canvas over
-        // the same context, so without disposal each switch strands a texture,
-        // two buffers and a program. Filters own different numbers of objects —
-        // xBR has a second texture — so the invariant is that returning to a
-        // filter returns to its own count, not that every count is the same.
+        // Filters own different numbers of objects (xBR has a second texture),
+        // so the invariant is that returning to a filter returns to its own
+        // count, not that every count is the same.
         const gl = recordingGl();
         const element = fakeCanvasElement(gl);
 
@@ -112,14 +125,37 @@ describe("GlCanvas", () => {
             only.dispose();
         }
 
-        let canvas = new GlCanvas(element, filters[0][1]);
+        const canvas = new GlCanvas(element, filters[0][1]);
         for (let switches = 1; switches <= 3 * filters.length; ++switches) {
             const [name, filterClass] = filters[switches % filters.length];
-            const next = new GlCanvas(element, filterClass);
-            canvas.dispose();
-            canvas = next;
+            canvas.setFilter(filterClass);
             expect(gl.live.size, `after switching to ${name}`).toBe(expected.get(filterClass));
         }
+    });
+
+    it("keeps its framebuffer and vertex buffers when the filter changes", () => {
+        const gl = recordingGl();
+        const canvas = new GlCanvas(fakeCanvasElement(gl), PassthroughFilter);
+        const fb32 = canvas.fb32;
+        const kept = [...gl.live].filter((object) => object.kind !== "Program");
+        expect(kept.length).toBeGreaterThan(0);
+
+        canvas.setFilter(PALCompositeFilter);
+
+        expect(canvas.filterClass).toBe(PALCompositeFilter);
+        expect([...gl.live]).toEqual(expect.arrayContaining(kept));
+        expect(canvas.fb32).toBe(fb32);
+    });
+
+    it("goes on drawing with the filter it has when a new one will not build", () => {
+        const gl = recordingGl();
+        const canvas = new GlCanvas(fakeCanvasElement(gl), PassthroughFilter);
+        const live = gl.live.size;
+        gl.getProgramParameter = () => false;
+
+        expect(() => canvas.setFilter(PALCompositeFilter)).toThrow(/Failed to link/);
+        expect(canvas.filterClass).toBe(PassthroughFilter);
+        expect(gl.live.size).toBe(live);
     });
 
     it("frees its shaders as soon as they are linked", () => {
@@ -153,14 +189,47 @@ describe("bestCanvas", () => {
         // The 2D fallback is unreachable once a WebGL context exists, so a
         // filter that fails to build has to be replaced on the context we have.
         const gl = recordingGl();
-        const sources = new Map();
-        gl.shaderSource = (shader, source) => sources.set(shader, source);
-        gl.getShaderParameter = (shader) => sources.get(shader) !== PAL_FRAG_SHADER;
+        failToCompile(gl, PAL_FRAG_SHADER);
 
         const canvas = bestCanvas(fakeCanvasElement(gl), PALCompositeFilter);
 
         expect(canvas.filterClass).toBe(PassthroughFilter);
         expect(canvas.fallbackReason).toMatch(/Failed to compile PAL composite/);
+    });
+});
+
+describe("useBestFilter", () => {
+    it("falls back to the passthrough filter when the one asked for will not build", () => {
+        const gl = recordingGl();
+        const canvas = new GlCanvas(fakeCanvasElement(gl), PassthroughFilter);
+        failToCompile(gl, PAL_FRAG_SHADER);
+
+        useBestFilter(canvas, PALCompositeFilter);
+
+        expect(canvas.filterClass).toBe(PassthroughFilter);
+        expect(canvas.fallbackReason).toMatch(/Failed to compile PAL composite/);
+    });
+
+    it("forgets a previous fallback once a filter builds", () => {
+        const gl = recordingGl();
+        const canvas = new GlCanvas(fakeCanvasElement(gl), PassthroughFilter);
+        failToCompile(gl, PAL_FRAG_SHADER);
+        useBestFilter(canvas, PALCompositeFilter);
+
+        useBestFilter(canvas, XbrFilter);
+
+        expect(canvas.filterClass).toBe(XbrFilter);
+        expect(canvas.fallbackReason).toBeUndefined();
+    });
+
+    it("leaves a 2D canvas unfiltered, saying why", () => {
+        // Not a constructed one: it wants a document to build its back buffer.
+        const canvas = Object.create(Canvas.prototype);
+
+        useBestFilter(canvas, PALCompositeFilter);
+
+        expect(canvas.filterClass).toBe(PassthroughFilter);
+        expect(canvas.fallbackReason).toMatch(/WebGL/);
     });
 });
 


### PR DESCRIPTION
Fixes #773

Changing display mode rebuilt the whole `GlCanvas` over the same element. Almost none of it is
per-mode: the 1024x1024 RGBA framebuffer texture, the two vertex buffers and `fb32` are the same
whatever filter is drawing. Only the filter program, the texture sampling mode and the attribute
locations differ.

## What changed

- `GlCanvas.setFilter(filterClass)` builds the new filter, disposes the old one, re-applies
  `TEXTURE_MIN_FILTER`/`TEXTURE_MAG_FILTER` from the new display config and re-binds the vertex
  attributes for the new program. The new filter is built _before_ the old one is disposed, so a
  filter that will not build leaves the canvas drawing exactly as it was. The constructor now goes
  through the same path, and disposes what it created if the filter throws.
- `useBestFilter(canvas, filterClass)` applies the same fallback policy `bestCanvas` uses at
  construction: if the filter will not build, fall back to the passthrough filter and record
  `fallbackReason`. It also clears a stale `fallbackReason` when a later filter does build, so the
  "not available on this device" toast still fires exactly when it should and only then. The 2D
  `Canvas` implements `setFilter` by refusing anything but the passthrough filter, so the no-WebGL
  path reports the same way without a special case in `main.js`.
- `swapCanvas` no longer builds a canvas, copies the picture between framebuffers, or re-points
  `video.fb32`/`video.paint_ext`. Nothing is rebuilt, so there is nothing to carry over. The canvas
  element is still resized when the new mode's display config asks for different dimensions, which
  is how xBR's scaled drawing buffer gets undone on the way out of that mode; `paint` already picks
  up a resized drawing buffer.

No change to the render loop.

## Testing

`npm run test:unit` and `npm run test:shader` pass. `tests/unit/test-canvas.js` grew tests that the
framebuffer texture and vertex buffers survive a filter change, that repeated changes do not
accumulate GL objects, that a filter which will not build leaves the previous one drawing, and that
the fallback and its reason behave across a sequence of changes.

In the browser: production build, served statically, driven over CDP in headless Chrome
(`--use-angle=swiftshader`, so this is a software WebGL implementation, not a GPU).

- All three modes render the boot screen correctly after switching between them in any order, with
  the right bezel each time (screenshots checked by eye, not just pixel statistics).
- Switching with the emulator stopped keeps the still picture, which is the case the removed
  framebuffer copy used to serve.
- On a large window, xBR still scales the drawing buffer to 1792x1200, and leaving xBR puts it back
  to 896x600; previously that reset came from rebuilding the canvas.
- Over 30+ rapid mode changes: no console errors or exceptions, `gl.getError()` stays 0, the context
  is never lost, and the picture is intact at the end. Retained heap after a forced GC is the same
  as before the change (5.55MB vs 5.59MB), so this is not fixing a leak; the previous code disposed
  correctly.
- I could not measure a wall-clock win. Median time for the synchronous mode-change handler was
  unchanged within noise (RGB 145ms vs 146ms, PAL 57ms vs 55ms, xBR 284ms vs 360ms across 7 samples
  each, before/after). Under a software renderer that time is dominated by shader compilation and by
  the repaint, so the avoided texture allocation and 4MB copy do not show up. The saving is real but
  I have no GPU measurement to prove its size, which is why this is `refactor:` and not `perf:`.
