### PR TITLE
fix: stop the unstyled flash on load

### DIFF
--- a/.github/workflows/test-and-deploy.yml
+++ b/.github/workflows/test-and-deploy.yml
@@ -84,6 +84,11 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           AWS_REGION: us-east-1
         run: |
-          aws s3 sync dist s3://bbc.xania.org \
+          # Names under assets/ contain a content hash, so they can be cached forever. Upload them
+          # first: index.html must never reach a browser before the assets it names.
+          aws s3 sync dist/assets s3://bbc.xania.org/assets \
             --no-progress \
+            --cache-control "max-age=31536000,immutable" --metadata-directive REPLACE
+          aws s3 sync dist s3://bbc.xania.org \
+            --no-progress --exclude "assets/*" \
             --cache-control max-age=30 --metadata-directive REPLACE

--- a/index.html
+++ b/index.html
@@ -21,6 +21,17 @@
       content="script-src 'self' 'unsafe-inline' 'unsafe-eval' *.google-analytics.com *.google.com;"
     />
     <title>jsbeeb - Javascript BBC Micro emulator</title>
+    <style>
+      /* The document is laid out entirely by the stylesheet; painting it before that arrives shows
+         every modal and debug panel as a wall of text. jsbeeb.css makes the body visible again. */
+      html {
+        background: #222;
+        color-scheme: dark;
+      }
+      body {
+        visibility: hidden;
+      }
+    </style>
     <link rel="shortcut icon" href="/favicon.ico" />
     <script type="module" src="/src/main.js"></script>
   </head>

--- a/src/jsbeeb.css
+++ b/src/jsbeeb.css
@@ -1,5 +1,6 @@
 body {
   overflow: hidden;
+  visibility: visible; /* undoes the anti-flash rule in index.html */
 }
 #outer {
   display: block;


### PR DESCRIPTION
The whole UI lives in `index.html` and is laid out entirely by CSS, so any paint before the stylesheet applies shows every modal and debug panel as a wall of text. Always visible on the dev server (Vite injects the CSS from JS); in production it needs a slow connection or a browser with a FOUC timeout, since the stylesheet is render-blocking there.

An inline `<style>` in the head hides the body and paints `#222` (bootswatch darkly's `--bs-body-bg`) from the first frame; `jsbeeb.css` reveals it. If the stylesheet ever fails outright you now get a dark blank page rather than the wall of text.

Separately: everything was deployed with `max-age=30`, including the content-hashed `assets/`, so every visit refetched the CSS and JS. Those now get an immutable year-long cache, and upload first so `index.html` can't reference a file that isn't in the bucket yet.

Checked on a local build that a normal load is unchanged, and that a copy with the stylesheet link stripped out stays dark and empty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)