### PR TITLE
fix: stop the unstyled flash on load

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,6 +21,16 @@
       content="script-src 'self' 'unsafe-inline' 'unsafe-eval' *.google-analytics.com *.google.com;"
     />
     <title>jsbeeb - Javascript BBC Micro emulator</title>
+    <style>
+      /* Unstyled, the document is a wall of modal text; jsbeeb.css reveals the body. */
+      html {
+        background: #222;
+        color-scheme: dark;
+      }
+      body {
+        visibility: hidden;
+      }
+    </style>
     <link rel="shortcut icon" href="/favicon.ico" />
     <script type="module" src="/src/main.js"></script>
   </head>

--- a/src/jsbeeb.css
+++ b/src/jsbeeb.css
@@ -1,6 +1,6 @@
 body {
   overflow: hidden;
-  visibility: visible; /* see index.html */
+  visibility: visible !important; /* see index.html */
 }
 #outer {
   display: block;

--- a/src/jsbeeb.css
+++ b/src/jsbeeb.css
@@ -1,5 +1,6 @@
 body {
   overflow: hidden;
+  visibility: visible; /* see index.html */
 }
 #outer {
   display: block;


### PR DESCRIPTION
The whole UI lives in `index.html` and is laid out entirely by CSS, so any paint before the stylesheet applies shows every modal and debug panel as a wall of text. Always visible on the dev server (Vite injects the CSS from JS); in production it needs a slow connection or a browser with a FOUC timeout, since the stylesheet is render-blocking there.

An inline `<style>` in the head hides the body and paints `#222` (bootswatch darkly's `--bs-body-bg`) from the first frame; `jsbeeb.css` reveals it. If the stylesheet ever fails outright you now get a dark blank page rather than the wall of text.

Checked on a local build that a normal load is unchanged, and that a copy with the stylesheet link stripped out stays dark and empty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)