### PR TITLE
ci: cache content-hashed assets forever

### DIFF
--- a/.github/workflows/test-and-deploy.yml
+++ b/.github/workflows/test-and-deploy.yml
@@ -84,6 +84,10 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           AWS_REGION: us-east-1
         run: |
-          aws s3 sync dist s3://bbc.xania.org \
+          # Names under assets/ contain a content hash. Upload before the html that names them.
+          aws s3 sync dist/assets s3://bbc.xania.org/assets \
             --no-progress \
+            --cache-control "max-age=31536000,immutable" --metadata-directive REPLACE
+          aws s3 sync dist s3://bbc.xania.org \
+            --no-progress --exclude "assets/*" \
             --cache-control max-age=30 --metadata-directive REPLACE


### PR DESCRIPTION
The deploy sync applies `max-age=30` to everything, including `assets/`, whose names already contain a content hash. So every visit refetches the CSS and JS for nothing.

Split into two syncs: `assets/` with an immutable year-long cache, everything else unchanged at 30s. Assets upload first, so `index.html` can no longer reach a browser before the files it names are in the bucket.

Pairs with #844 (which shortens the same unstyled window from the other end), but the two are independent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)