### PR TITLE
ci: stop Copilot's reviews queueing no-op Claude Code runs

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -3,19 +3,13 @@ name: Claude Code
 on:
   issue_comment:
     types: [created]
-  pull_request_review_comment:
-    types: [created]
   issues:
     types: [opened, assigned]
-  pull_request_review:
-    types: [submitted]
 
 jobs:
   claude:
     if: |
       (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
       (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
Every Copilot review was firing `.github/workflows/claude.yml` **twice**, and both runs parked at `action_required` waiting for approval to do nothing.

Confirmed from the gated runs rather than guessed:

```
31716938009 event=pull_request_review_comment actor=Copilot
31716938002 event=pull_request_review         actor=Copilot
31716926141 event=pull_request_review_comment actor=Copilot
31716925544 event=pull_request_review         actor=Copilot
```

GitHub gates workflow runs whose triggering actor is a bot, and it decides that **before** evaluating the job's `if:`. So each run queued for permission to start a job that would immediately skip, because the condition needs `@claude` in the comment body and Copilot's reviews never contain it. Two entries per reviewed PR, accumulating forever, every one a no-op.

Dropping `pull_request_review` and `pull_request_review_comment` from the triggers removes them at source, with no change to what the workflow can do when it does run.

## What this gives up

Summoning Claude by writing `@claude` in a line comment on a diff, or in the body of a submitted review. `issue_comment` is unaffected and fires for comments on pull requests as well as issues, so `@claude` in a normal PR conversation comment still works, as does `@claude` in a new issue.

## Testing

Not directly testable without merging: the trigger list only takes effect once it is on the default branch. The change is a deletion from `on:` and the matching two clauses from the job's `if:`, leaving the `issue_comment` and `issues` paths byte-identical. Prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)