### PR TITLE
fix: restore the emulator display

### DIFF
--- a/index.html
+++ b/index.html
@@ -24,10 +24,12 @@
     <style>
       /* Unstyled, the document is a wall of modal text; jsbeeb.css reveals the body. */
       html {
-        background: #222;
         color-scheme: dark;
       }
+      /* The colour goes here, not on html: #screen is at z-index -1, so it only stays visible
+         while body's background propagates to the canvas instead of painting a box over it. */
       body {
+        background: #222;
         visibility: hidden;
       }
     </style>


### PR DESCRIPTION
Regression from #844. `#screen` is at `z-index: -1` and the sidebars at `-2`, so they paint below the background of their stacking-context ancestor but above the root canvas. That worked because `html` had no background: `body`'s `#222` propagated to the canvas, and `body` itself painted nothing. Setting a background on `html` stopped the propagation, so `body` began painting an opaque box over the display.

Embed mode broke the same way: `main.js:201` clears `body`'s background so the host page shows through, which `html`'s background then covered.

The colour moves to `body`, where bootswatch already puts it, leaving `color-scheme: dark` on `html`.

Verified on a local build:

- display renders (BASIC prompt visible); re-applying `html { background: #222 }` in the console makes it vanish again, and removing it brings it back
- the stylesheet-stripped copy is still dark and empty, so the anti-flash behaviour survives (a hidden body still propagates its background to the canvas)
- `?embed=1` has a transparent body again

🤖 Generated with [Claude Code](https://claude.com/claude-code)