### PR TITLE
test: cover the teletext behaviour the golden images cannot

### DIFF
--- a/tests/unit/test-teletext.js
+++ b/tests/unit/test-teletext.js
@@ -218,6 +218,13 @@ describe("Teletext", () => {
 
             expect(bottom.every((cells) => backgroundOnly(cells[1]))).toBe(true);
         });
+
+        it("drops the held character when the size changes", () => {
+            const cells = renderCells([WhiteGraphics, SolidBlock, HoldGraphics, DoubleHeight, Flash]);
+
+            expect(backgroundOnly(cells[3])).toBe(true);
+            expect(backgroundOnly(cells[4])).toBe(true);
+        });
     });
 
     describe("start of row", () => {
@@ -253,5 +260,95 @@ describe("Teletext", () => {
         const cells = renderCells([0x80 | WhiteGraphics, 0x80 | SolidBlock]);
 
         expect(solidOnly(cells[1], White)).toBe(true);
+    });
+
+    it("shows a byte three cells after it is fetched", () => {
+        const bytes = [WhiteGraphics, SolidBlock, Space, Space, Space];
+        const buffer = makeFast32(new Uint32Array(bytes.length * PixelsPerCell));
+        bytes.forEach((byte, index) => {
+            teletext.fetchData(byte);
+            teletext.render(buffer, index * PixelsPerCell);
+        });
+        const cellAt = (index) => buffer.subarray(index * PixelsPerCell, (index + 1) * PixelsPerCell);
+
+        expect(backgroundOnly(cellAt(3))).toBe(true);
+        expect(solidOnly(cellAt(4), White)).toBe(true);
+    });
+
+    // Codes 0, 16 and 27 are reserved, 10 and 11 drive a boxing output the BBC has nothing wired to,
+    // and 14 and 15 select an alternate character set the chip does not carry. Pages rely on this:
+    // the Ceefax engineering page reveals its concealed text by rewriting code 24 as code 16.
+    describe.each([
+        ["alpha black (0)", 0x00],
+        ["end box (10)", 0x0a],
+        ["start box (11)", 0x0b],
+        ["shift out (14)", 0x0e],
+        ["shift in (15)", 0x0f],
+        ["graphics black (16)", 0x10],
+        ["escape (27)", 0x1b],
+    ])("%s", (_name, code) => {
+        it("is not implemented, and leaves every attribute alone", () => {
+            endFrame();
+            const cells = renderCells([WhiteGraphics, SolidBlock, code, SolidBlock]);
+
+            expect(solidOnly(cells[1], White)).toBe(true);
+            expect(backgroundOnly(cells[2])).toBe(true);
+            expect(solidOnly(cells[3], White)).toBe(true);
+        });
+    });
+
+    describe("scanlines", () => {
+        // Rows 0 and 1 of an "A" are both blank, so RA0 has nothing to choose between there.
+        it("takes the smoothing row from RA0", () => {
+            endScanline();
+            const evenRow = renderCells([LetterA]);
+            teletext.setRA0(true);
+            const oddRow = renderCells([LetterA]);
+
+            expect([...oddRow[0]]).not.toEqual([...evenRow[0]]);
+        });
+
+        it("wraps back to the top of the glyph after ten scanlines", () => {
+            const first = renderCells([LetterA]);
+            for (let scanline = 0; scanline < 10; ++scanline) endScanline();
+
+            expect([...renderCells([LetterA])[0]]).toEqual([...first[0]]);
+        });
+
+        it("restarts the glyph when a frame begins", () => {
+            const first = renderCells([LetterA]);
+            endScanline();
+            const second = renderCells([LetterA]);
+            endFrame();
+
+            expect([...second[0]]).not.toEqual([...first[0]]);
+            expect([...renderCells([LetterA])[0]]).toEqual([...first[0]]);
+        });
+    });
+
+    // A freshly built chip reports flash-on until the first frame ends, so start the count inside
+    // the cycle rather than at construction.
+    it("blanks flashing text for sixteen frames in every sixty-four", () => {
+        endFrame();
+
+        let blanked = 0;
+        for (let frame = 0; frame < 64; ++frame) {
+            if (backgroundOnly(renderCells([WhiteGraphics, Flash, SolidBlock])[2])) ++blanked;
+            endFrame();
+        }
+
+        expect(blanked).toBe(16);
+    });
+
+    it("continues identically from a restored snapshot", () => {
+        const continuation = [SolidBlock, WhiteGraphics, SolidBlock, NewBackground, Space, SolidBlock];
+        renderCells([BlueGraphics, Flash, SeparatedGraphics, SolidBlock, HoldGraphics, Conceal]);
+        const state = teletext.snapshotState();
+        const expected = renderCells(continuation).map((cell) => [...cell]);
+
+        teletext = new Teletext();
+        teletext.restoreState(state);
+
+        expect(renderCells(continuation).map((cell) => [...cell])).toEqual(expected);
     });
 });

--- a/tests/unit/test-teletext.js
+++ b/tests/unit/test-teletext.js
@@ -203,7 +203,9 @@ describe("Teletext", () => {
             expect(solidOnly(cells[5], White)).toBe(true);
         });
 
-        it("shows flashing text for the rest of the frame period", () => {
+        it("shows flashing text during the visible phase", () => {
+            for (let frame = 0; frame < 16; ++frame) endFrame();
+
             const cells = renderCells([WhiteGraphics, Flash, SolidBlock]);
 
             expect(solidOnly(cells[2], White)).toBe(true);

--- a/tests/unit/test-teletext.js
+++ b/tests/unit/test-teletext.js
@@ -5,15 +5,27 @@ import { makeFast32 } from "../../src/utils.js";
 const PixelsPerCell = 16;
 const PipelineDelay = 3;
 
-const WhiteGraphics = 0x17;
+const RedAlpha = 0x01;
+const Flash = 0x08;
+const Steady = 0x09;
+const DoubleHeight = 0x0d;
+const RedGraphics = 0x11;
 const BlueGraphics = 0x14;
+const WhiteGraphics = 0x17;
 const Conceal = 0x18;
-const HoldGraphics = 0x1e;
+const SeparatedGraphics = 0x1a;
 const BlackBackground = 0x1c;
 const NewBackground = 0x1d;
+const HoldGraphics = 0x1e;
+const ReleaseGraphics = 0x1f;
 const Space = 0x20;
+const Mosaic = 0x21;
+const LetterA = 0x41;
 const SolidBlock = 0x7f;
+const Black = 0;
+const Red = 1;
 const Blue = 4;
+const White = 7;
 
 describe("Teletext", () => {
     let teletext;
@@ -22,8 +34,10 @@ describe("Teletext", () => {
         teletext = new Teletext();
     });
 
-    function renderCells(bytes) {
-        const padded = [...bytes, ...Array(PipelineDelay).fill(Space)];
+    // A space is a blank mosaic in graphics mode, so it becomes the held character: tests that care
+    // what is held at the end of a row must flush the pipeline with something else.
+    function renderCells(bytes, flushWith = Space) {
+        const padded = [...bytes, ...Array(PipelineDelay).fill(flushWith)];
         const buffer = makeFast32(new Uint32Array(padded.length * PixelsPerCell));
         padded.forEach((byte, index) => {
             teletext.fetchData(byte);
@@ -39,9 +53,28 @@ describe("Teletext", () => {
         return cell.every((pixel) => pixel === background);
     }
 
+    function solidOnly(cell, foregroundIndex, backgroundIndex = 0) {
+        const solid = teletext.colour[((backgroundIndex & 7) << 5) | ((foregroundIndex & 7) << 2) | 3];
+        return cell.every((pixel) => pixel === solid);
+    }
+
     function endScanline() {
         teletext.setDISPTMG(true);
         teletext.setDISPTMG(false);
+    }
+
+    function renderCharacterRow(bytes) {
+        const scanlines = [];
+        for (let scanline = 0; scanline < 10; ++scanline) {
+            scanlines.push(renderCells(bytes));
+            endScanline();
+        }
+        return scanlines;
+    }
+
+    function endFrame() {
+        teletext.setDEW(true);
+        teletext.setDEW(false);
     }
 
     describe("conceal", () => {
@@ -96,5 +129,129 @@ describe("Teletext", () => {
             expect(restored.snapshotState()).toEqual(state);
             expect(state.conceal).toBe(true);
         });
+    });
+
+    describe("colour", () => {
+        it("takes effect from the cell after the code", () => {
+            const cells = renderCells([WhiteGraphics, SolidBlock, HoldGraphics, RedGraphics, SolidBlock]);
+
+            expect(solidOnly(cells[1], White)).toBe(true);
+            expect(solidOnly(cells[3], White)).toBe(true);
+            expect(solidOnly(cells[4], Red)).toBe(true);
+        });
+
+        it("takes a new background from the cell holding the code", () => {
+            const cells = renderCells([RedAlpha, NewBackground, Space, BlackBackground, Space]);
+
+            expect(backgroundOnly(cells[1], Red)).toBe(true);
+            expect(backgroundOnly(cells[2], Red)).toBe(true);
+            expect(backgroundOnly(cells[3], Black)).toBe(true);
+        });
+    });
+
+    describe("graphics", () => {
+        it("separates the blocks once code 26 is seen", () => {
+            const cells = renderCells([WhiteGraphics, SolidBlock, SeparatedGraphics, SolidBlock]);
+
+            expect(solidOnly(cells[1], White)).toBe(true);
+            expect(solidOnly(cells[3], White)).toBe(false);
+            expect(backgroundOnly(cells[3])).toBe(false);
+        });
+
+        it("holds the last block through a following control code", () => {
+            const cells = renderCells([WhiteGraphics, SolidBlock, HoldGraphics, Flash, ReleaseGraphics, Flash]);
+
+            expect(solidOnly(cells[3], White)).toBe(true);
+            expect(backgroundOnly(cells[5])).toBe(true);
+        });
+
+        it("holds nothing over from the previous row", () => {
+            renderCells([WhiteGraphics, SolidBlock, HoldGraphics], Steady);
+            endScanline();
+
+            const cells = renderCells([WhiteGraphics, Flash]);
+
+            expect(backgroundOnly(cells[0])).toBe(true);
+            expect(backgroundOnly(cells[1])).toBe(true);
+        });
+    });
+
+    describe("flash", () => {
+        it("starts flashing from the cell after the code", () => {
+            endFrame();
+            const cells = renderCells([WhiteGraphics, SolidBlock, HoldGraphics, Flash, SolidBlock]);
+
+            expect(solidOnly(cells[3], White)).toBe(true);
+            expect(backgroundOnly(cells[4])).toBe(true);
+        });
+
+        it("stops flashing at the cell holding the steady code", () => {
+            endFrame();
+            const cells = renderCells([WhiteGraphics, Flash, SolidBlock, HoldGraphics, Steady, SolidBlock]);
+
+            expect(backgroundOnly(cells[2])).toBe(true);
+            expect(solidOnly(cells[4], White)).toBe(true);
+            expect(solidOnly(cells[5], White)).toBe(true);
+        });
+
+        it("shows flashing text for the rest of the frame period", () => {
+            const cells = renderCells([WhiteGraphics, Flash, SolidBlock]);
+
+            expect(solidOnly(cells[2], White)).toBe(true);
+        });
+    });
+
+    describe("double height", () => {
+        it("draws a different half of the character on each row", () => {
+            const top = renderCharacterRow([DoubleHeight, LetterA]);
+            const bottom = renderCharacterRow([DoubleHeight, LetterA]);
+
+            const halfOf = (row) => row.map((cells) => [...cells[1]]);
+            expect(halfOf(bottom)).not.toEqual(halfOf(top));
+            expect(bottom.every((cells) => backgroundOnly(cells[1]))).toBe(false);
+        });
+
+        it("blanks a normal height character on the row carrying the bottom half", () => {
+            renderCharacterRow([DoubleHeight, Space]);
+
+            const bottom = renderCharacterRow([WhiteGraphics, SolidBlock]);
+
+            expect(bottom.every((cells) => backgroundOnly(cells[1]))).toBe(true);
+        });
+    });
+
+    describe("start of row", () => {
+        it("returns to white", () => {
+            renderCells([RedAlpha, NewBackground, Space]);
+            endScanline();
+
+            const cells = renderCells([NewBackground, Space]);
+
+            expect(backgroundOnly(cells[1], White)).toBe(true);
+        });
+
+        it("returns to a black background", () => {
+            renderCells([RedAlpha, NewBackground, Space]);
+            endScanline();
+
+            const cells = renderCells([Space]);
+
+            expect(backgroundOnly(cells[0], Black)).toBe(true);
+        });
+
+        it("returns to alphanumerics", () => {
+            const graphics = renderCells([WhiteGraphics, Mosaic]);
+            endScanline();
+
+            const alpha = renderCells([Mosaic]);
+
+            expect([...alpha[0]]).not.toEqual([...graphics[1]]);
+        });
+    });
+
+    it("sees only the low seven bits, as the SAA5050 has no eighth data pin", () => {
+        const cells = renderCells([0x80 | WhiteGraphics, 0x80 | SolidBlock]);
+
+        expect(solidOnly(cells[1], White)).toBe(true);
     });
 });

--- a/tests/unit/test-teletext.js
+++ b/tests/unit/test-teletext.js
@@ -337,8 +337,6 @@ describe("Teletext", () => {
         });
     });
 
-    // A freshly built chip reports flash-on until the first frame ends, so start the count inside
-    // the cycle rather than at construction.
     it("blanks flashing text for sixteen frames in every sixty-four", () => {
         endFrame();
 

--- a/tests/unit/test-teletext.js
+++ b/tests/unit/test-teletext.js
@@ -165,6 +165,15 @@ describe("Teletext", () => {
             expect(backgroundOnly(cells[5])).toBe(true);
         });
 
+        // The spec holds "the most recent mosaics character with bit 6 = 1 in its code", so an
+        // alphanumeric seen in graphics mode leaves the previous mosaic held.
+        it("does not hold an alphanumeric character", () => {
+            const cells = renderCells([WhiteGraphics, SolidBlock, LetterA, HoldGraphics, Flash]);
+
+            expect(solidOnly(cells[3], White)).toBe(true);
+            expect(solidOnly(cells[4], White)).toBe(true);
+        });
+
         it("holds nothing over from the previous row", () => {
             renderCells([WhiteGraphics, SolidBlock, HoldGraphics], Steady);
             endScanline();


### PR DESCRIPTION
Extends `tests/unit/test-teletext.js` from the 6 conceal tests in #840 to 35, and mutation-checks every one of them.

## Why

The Ceefax test page does exercise conceal, at `0x7C59` in the ENGINEERING banner row, and pressing space toggles those bytes between `0x18` and `0x10` (which is what the `expected_reveal_*` goldens capture). But every conceal on that page is the benign shape: the code followed almost immediately by a colour code, over a black background, with no held graphic in the concealed run. That renders identically whether conceal is a state or the old recolour hack, which is why #840 changed no golden and CI stayed green.

## What is covered

**Control code semantics.** Colour is Set-After while new background is Set-At; flash is Set-After and steady is Set-At, the asymmetry behind #611; hold graphics shows the last mosaic in a following control code's cell, drops it on a size change, does not hold an alphanumeric, and carries nothing over a row boundary; separated graphics puts gaps in an otherwise solid block; double height draws a different half on each row and suppresses a normal-height character on the row carrying the bottom half.

**Codes the SAA5050 does not implement**: 0, 10, 11, 14, 15, 16 and 27. This is load-bearing rather than trivia. The engineering page reveals its concealed text by rewriting code 24 as code 16, so a helpful implementation of "graphics black" would break real pages. b-em, b2, beebjit and CLK all ignore the same seven.

**The chip's pins**: a byte appears three cells after it is fetched, RA0 selects the smoothing row, the row is ten scanlines, and DEW restarts the glyph. This is the machinery #832 and #766 are about.

**Flash timing**: blanked for 16 frames in every 64, matching beebjit and b2.

**Snapshot replay**: render, snapshot, continue; separately restore and continue; the pixels must match. This is the property that would have caught the missing `conceal` field automatically, and it generalises to any component with a snapshot.

## Testing

Every test was checked against a mutated `src/teletext.js` and confirmed to fail when the behaviour it names is broken: colour made Set-At, flash made Set-At, steady made Set-After, bottom-half suppression removed, the eighth data pin wired up, separated graphics ignored, new and black background ignored, hold graphics ignored, the row reset removed, graphics black and alpha black implemented, the pipeline shortened, RA0 ignored, the row made twelve scanlines, DEW not resetting the scanline, the flash period halved, `conceal` dropped from the snapshot, the size-change guard removed, and the mosaic guard on the held character removed. Every mutation fails the test that names it.

Two findings from that exercise, neither a bug:

- `heldChar` and `holdChar` are reset in `setDISPTMG`, but removing either is unobservable: a row starts in alphanumerics, so the first control code hits the `wasGfx === false` branch and clears `heldChar` anyway. Clearing `gfx` there is likewise redundant, since glyph selection follows `nextGlyphs`, reset on the adjacent line. All three are cheap and defensive, and left alone.
- `flashOn` is true during the *blanked* phase, so the name reads backwards at the call site. Not renamed here.

`renderCells` gained a `flushWith` parameter. The three padding cells that flush the pipeline are real rendered cells, and a space in graphics mode is a blank mosaic, so it becomes the held character: a test about what survives to the end of a row has to flush with something that leaves it alone. Without this the cross-row hold test passed under every mutation.

Full unit suite and the teletext integration goldens pass.

Related: #851 removes a line this made provably dead; #852 covers the ULA side; #853 records a divergence found on the way and deliberately not pinned here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)