### PR TITLE
refactor: drop the unreachable held-character clamp

### DIFF
--- a/src/teletext.js
+++ b/src/teletext.js
@@ -300,7 +300,6 @@ export class Teletext {
         }
         if (wasGfx && (wasHoldChar || this.holdChar) && this.dbl === this.oldDbl) {
             data = this.heldChar;
-            if (data >= 0x40 && data < 0x60) data = 0x20;
             this.curGlyphs = this.heldGlyphs;
         } else {
             this.heldChar = 0x20;


### PR DESCRIPTION
`handleControlCode` clamps a held character in `0x40-0x5f` to a space. That line can never run.

`heldChar` has exactly four assignment sites, and none of them can produce a value in that range:

| site | value |
| --- | --- |
| `render`, graphics character | `data`, guarded by `if (data & 0x20)` |
| `render`, alphanumeric character | `32` |
| `handleControlCode`, no held character | `0x20` |
| `setDISPTMG`, start of row | `0x20` |

`0x40-0x5f` all have bit 5 clear, so the guarded assignment excludes them and the other three are a space. The clamp is the same rule as the `data & 0x20` guard, applied a second time to a value that has already passed it.

## Where it came from

b-em, which jsbeeb's teletext borrows from in several places. There the equivalent line is live:

```c
case 12: /* 140: normal height */
    if (mode7_dbl) { mode7_dbl = 0; mode7_heldchar = 0; }
...
    dat = mode7_heldchar;
    if (!(dat & 0x20)) dat = 0x20;
```

b-em sets `mode7_heldchar = 0` on a size change, so its clamp catches that 0. jsbeeb models the same rule differently, with `this.dbl === this.oldDbl` in the surrounding condition and `heldChar = 0x20` in the else branch, so the value never reaches the clamp.

beebjit and b2 also express the mosaic rule once, at the point of assignment.

## Testing

Full unit suite (1031) and the teletext integration goldens (7) pass with the line removed. #849 adds a test for the behaviour that makes it unnecessary: an alphanumeric character seen in graphics mode does not become the held character, so the previous mosaic stays held.

🤖 Generated with [Claude Code](https://claude.com/claude-code)