### PR TITLE
test: cover how the video ULA feeds the SAA5050

### DIFF
--- a/tests/unit/test-video.js
+++ b/tests/unit/test-video.js
@@ -500,6 +500,47 @@ describe("Video", () => {
 
             expect(mockTeletext.fetchData).toHaveBeenCalledWith(0x42);
         });
+
+        // IC37/IC36 force bit 6 high during H blanking, so the pipeline sees a graphics character
+        // rather than a control code. Gated here on DISPEN; issue #832 says hardware uses MA13.
+        it("should force bit 6 high when feeding the pipeline during H blanking", () => {
+            mockCpu.videoRead.mockReturnValue(0x05);
+            video.dispEnabled = VDISPENABLE;
+            mockTeletext.fetchData.mockClear();
+            video.horizCounter = 10;
+
+            video.polltime(1);
+
+            expect(mockTeletext.fetchData).toHaveBeenCalledWith(0x45);
+        });
+
+        it("should not feed the pipeline outside the vertical display", () => {
+            video.dispEnabled = 0;
+            mockTeletext.fetchData.mockClear();
+            video.horizCounter = 10;
+
+            video.polltime(1);
+
+            expect(mockTeletext.fetchData).not.toHaveBeenCalled();
+        });
+
+        // The "TTX trick": with the teletext bit set in a 2MHz mode the ULA holds the SAA5050's
+        // DISPEN low, so it outputs black rather than characters.
+        it("should draw black instead of characters with the teletext bit set at 2MHz", () => {
+            video.ula.write(0, 2 | 0x10);
+            expect(video.teletextMode).toBe(true);
+            expect(video.halfClock).toBe(false);
+
+            mockTeletext.render.mockClear();
+            video.horizCounter = 10;
+            video.bitmapX = 100;
+            video.bitmapY = 100;
+
+            video.polltime(1);
+
+            expect(mockTeletext.render).not.toHaveBeenCalled();
+            expect(mockFb32[TEST_FB_OFFSET]).toBe(0xff000000);
+        });
     });
 
     describe("NULA palette mode", () => {


### PR DESCRIPTION
Three tests in `tests/unit/test-video.js`, in the area #832 is about to change.

- **Bit 6 is forced high during H blanking.** IC37/IC36 feed the pipeline outside the horizontal display, with bit 6 set so the chip sees a graphics character rather than a control code. The existing tests cover the #546 feed inside the border but not this one.
- **Nothing is fed outside the vertical display.** The other half of that condition.
- **The TTX trick.** With the teletext bit set in a 2MHz mode the ULA holds the SAA5050's DISPEN low, so `teletext.render` is never called and the cell is filled with black.

The first is deliberately a characterisation test: #832 reports that hardware gates this on MA13 rather than DISPEN, so the condition is expected to change. Pinning it now means that change shows up in review as a behaviour change with a test to update, rather than passing silently.

## Testing

Each test was checked against a mutated `src/video.js`: the bit 6 mask removed, the `VDISPENABLE` half of the condition dropped, and the `halfClock` check forced true. Each mutation fails exactly the test that names it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)