### PR TITLE
refactor: derive the teletext flash phase instead of storing it as flashOn

### DIFF
--- a/src/snapshot-helpers.js
+++ b/src/snapshot-helpers.js
@@ -139,7 +139,6 @@ export function buildVideoState(ulaControl, ulaPalette, crtcRegs, nulaCollook, c
             wasDbl: false,
             gfx: false,
             flash: false,
-            flashBlanked: false,
             flashTime: 0,
             heldChar: 0,
             holdChar: false,

--- a/src/snapshot-helpers.js
+++ b/src/snapshot-helpers.js
@@ -139,7 +139,7 @@ export function buildVideoState(ulaControl, ulaPalette, crtcRegs, nulaCollook, c
             wasDbl: false,
             gfx: false,
             flash: false,
-            flashOn: false,
+            flashBlanked: false,
             flashTime: 0,
             heldChar: 0,
             holdChar: false,

--- a/src/teletext.js
+++ b/src/teletext.js
@@ -12,7 +12,7 @@ export class Teletext {
         this.dbl = this.oldDbl = this.secondHalfOfDouble = this.wasDbl = false;
         this.gfx = false;
         this.conceal = false;
-        this.flash = this.flashOn = false;
+        this.flash = this.flashBlanked = false;
         this.flashTime = 0;
         this.heldChar = 0;
         this.holdChar = false;
@@ -175,7 +175,7 @@ export class Teletext {
             gfx: this.gfx,
             conceal: this.conceal,
             flash: this.flash,
-            flashOn: this.flashOn,
+            flashBlanked: this.flashBlanked,
             flashTime: this.flashTime,
             heldChar: this.heldChar,
             holdChar: this.holdChar,
@@ -202,7 +202,7 @@ export class Teletext {
         this.gfx = state.gfx;
         this.conceal = state.conceal ?? false;
         this.flash = state.flash;
-        this.flashOn = state.flashOn;
+        this.flashBlanked = state.flashBlanked ?? state.flashOn ?? false;
         this.flashTime = state.flashTime;
         this.heldChar = state.heldChar;
         this.holdChar = state.holdChar;
@@ -339,7 +339,7 @@ export class Teletext {
         // TODO: this point is being reached a MOS-dependent number of times
         // before Video.frameCount rises.  The next line achieves initial
         // sync under MOS 1.20 only.
-        this.flashOn = this.flashTime < 16;
+        this.flashBlanked = this.flashTime < 16;
     }
 
     setDISPTMG(level) {
@@ -429,7 +429,7 @@ export class Teletext {
         // Conceal (code 24) is "Set At", and a colour code only reveals from the cell after itself.
         if (this.conceal) concealThisCell = true;
 
-        if (concealThisCell || (flashThisCell && this.flashOn) || (this.secondHalfOfDouble && !this.dbl)) {
+        if (concealThisCell || (flashThisCell && this.flashBlanked) || (this.secondHalfOfDouble && !this.dbl)) {
             const backgroundColour = this.colour[(this.bg & 7) << 5];
             for (let i = 0; i < 16; ++i) {
                 buf[offset++] = backgroundColour;

--- a/src/teletext.js
+++ b/src/teletext.js
@@ -12,7 +12,7 @@ export class Teletext {
         this.dbl = this.oldDbl = this.secondHalfOfDouble = this.wasDbl = false;
         this.gfx = false;
         this.conceal = false;
-        this.flash = this.flashBlanked = false;
+        this.flash = false;
         this.flashTime = 0;
         this.heldChar = 0;
         this.holdChar = false;
@@ -175,7 +175,6 @@ export class Teletext {
             gfx: this.gfx,
             conceal: this.conceal,
             flash: this.flash,
-            flashBlanked: this.flashBlanked,
             flashTime: this.flashTime,
             heldChar: this.heldChar,
             holdChar: this.holdChar,
@@ -202,7 +201,6 @@ export class Teletext {
         this.gfx = state.gfx;
         this.conceal = state.conceal ?? false;
         this.flash = state.flash;
-        this.flashBlanked = state.flashBlanked ?? state.flashOn ?? false;
         this.flashTime = state.flashTime;
         this.heldChar = state.heldChar;
         this.holdChar = state.holdChar;
@@ -333,13 +331,14 @@ export class Teletext {
 
         // 3:1 flash ratio.
         if (++this.flashTime === 64) this.flashTime = 0;
-        // Flashing text starts off in sync with a slow cursor, extinguished
-        // together.  Multiple MODE changes gradually desynchronise the
-        // frame counters.
-        // TODO: this point is being reached a MOS-dependent number of times
-        // before Video.frameCount rises.  The next line achieves initial
-        // sync under MOS 1.20 only.
-        this.flashBlanked = this.flashTime < 16;
+    }
+
+    // Flashing text starts off in sync with a slow cursor, extinguished together. Multiple MODE
+    // changes gradually desynchronise the frame counters.
+    // TODO: setDEW is reached a MOS-dependent number of times before Video.frameCount rises, so
+    // the initial sync here holds under MOS 1.20 only.
+    get hideFlashing() {
+        return this.flashTime < 16;
     }
 
     setDISPTMG(level) {
@@ -429,7 +428,7 @@ export class Teletext {
         // Conceal (code 24) is "Set At", and a colour code only reveals from the cell after itself.
         if (this.conceal) concealThisCell = true;
 
-        if (concealThisCell || (flashThisCell && this.flashBlanked) || (this.secondHalfOfDouble && !this.dbl)) {
+        if (concealThisCell || (flashThisCell && this.hideFlashing) || (this.secondHalfOfDouble && !this.dbl)) {
             const backgroundColour = this.colour[(this.bg & 7) << 5];
             for (let i = 0; i < 16; ++i) {
                 buf[offset++] = backgroundColour;

--- a/tests/integration/teletext.js
+++ b/tests/integration/teletext.js
@@ -127,7 +127,7 @@ describe("Test other teletext test pages", { timeout: 30000 }, () => {
         // but pos 5 (Steady+held) and pos 6-7 should show red (Steady applies "Set At").
         await testMachine.type("CLS:VDU &91,&88,&BF,&BF,&9E,&89,&BF,&BF");
         await testMachine.runUntilInput();
-        await testMachine.runToFlashState(true);
+        await testMachine.runUntilFlashHidden();
         await testMachine.runToCursorState(true);
         await compare(video, testMachine, `expected_steady_set_at_flash_1.png`);
     });

--- a/tests/test-machine.js
+++ b/tests/test-machine.js
@@ -137,16 +137,16 @@ export class TestMachine {
     }
 
     /**
-     * Run until the teletext flash state reaches the desired phase.
-     * @param {boolean} on - true for flash-on (flashing cells blanked), false for flash-off
+     * Run until the teletext flash phase reaches the desired state.
+     * @param {boolean} blanked - true to wait until flashing cells are blanked
      */
-    async runToFlashState(on) {
+    async runToFlashState(blanked) {
         const teletext = this.processor.video.teletext;
         for (let i = 0; i < 100; i++) {
-            if (teletext.flashOn === on) return;
+            if (teletext.flashBlanked === blanked) return;
             await this.runFor(40000);
         }
-        throw new Error(`Flash did not reach state ${on} in time (flashOn=${teletext.flashOn})`);
+        throw new Error(`Flash did not reach state ${blanked} in time (flashBlanked=${teletext.flashBlanked})`);
     }
 
     async runUntilVblank() {

--- a/tests/test-machine.js
+++ b/tests/test-machine.js
@@ -136,17 +136,13 @@ export class TestMachine {
         throw new Error(`Cursor did not reach state ${on} in time (cursorOnThisFrame=${video.cursorOnThisFrame})`);
     }
 
-    /**
-     * Run until the teletext flash phase reaches the desired state.
-     * @param {boolean} blanked - true to wait until flashing cells are blanked
-     */
-    async runToFlashState(blanked) {
+    async runUntilFlashHidden() {
         const teletext = this.processor.video.teletext;
         for (let i = 0; i < 100; i++) {
-            if (teletext.flashBlanked === blanked) return;
+            if (teletext.hideFlashing) return;
             await this.runFor(40000);
         }
-        throw new Error(`Flash did not reach state ${blanked} in time (flashBlanked=${teletext.flashBlanked})`);
+        throw new Error("Flashing text did not reach its hidden phase in time");
     }
 
     async runUntilVblank() {


### PR DESCRIPTION
`flashOn` was true during the phase where flashing cells are **blanked**:

```js
if (concealThisCell || (flashThisCell && this.flashOn) || ...) {
    // fill with background
```

So every read had to be mentally inverted, and `tests/test-machine.js` carried a comment to say which way round it went. Part of the confusion is that `this.flash` is the *per-cell* attribute set by codes 8 and 9, while this is a *per-frame* phase; sharing a prefix invited them to be read as a pair.

Renamed to `hideFlashing`, which reads as what the one call site is asking:

```js
if (concealThisCell || (flashThisCell && this.hideFlashing) || ...) {
```

## And then it stopped needing to be stored

The flag is a function of `flashTime`, so it is now a getter:

```js
get hideFlashing() {
    return this.flashTime < 16;
}
```

That removes the field, its `snapshotState` entry, its `restoreState` line, its entry in `snapshot-helpers.js`, and the assignment in `setDEW` — along with any chance of the two disagreeing. Same shape as `Disc.savesChanges`.

It also fixes a small inconsistency: a freshly built chip had `flashTime === 0` with the flag false, while the *same* `flashTime` after a wrap gave true. Now both say the same thing.

## Snapshots

The field simply leaves the format. No version bump. An older build reading a newer snapshot finds no `flashOn` and defaults to false; `setDEW` used to recompute it from `flashTime` on the next vsync, so the worst case was ever only one frame of a flashing cell in the wrong phase, and now the value is always in step with `flashTime`, which *is* saved. Newer builds ignore `flashOn` in older snapshots and derive the same answer from the `flashTime` beside it. `docs/snapshot-format.md` describes this component as "~20 scalar fields" without enumerating them, so it needs no change.

## Comments removed

- `runToFlashState(blanked)` became `runUntilFlashHidden()`. With no boolean parameter the JSDoc explaining which way the boolean went is gone, and so is the Copilot note asking for the `false` case to be documented — there is no longer a `false` case. Its one caller reads `await testMachine.runUntilFlashHidden()`.
- The `setDEW` comment about MOS-dependent sync moved to the getter, which is now the thing it describes, and lost the "the next line" phrasing that no longer pointed at anything.

## Testing

Full unit suite (1031) and the teletext integration goldens (7) pass, including `expected_steady_set_at_flash_1.png`, which is the golden that drives the flash phase helper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)