### PR TITLE
feat: ask for a low latency canvas

### DIFF
--- a/src/canvas.js
+++ b/src/canvas.js
@@ -14,6 +14,15 @@ export function getFilterForMode(mode) {
     return DISPLAY_MODE_FILTERS[mode] || DISPLAY_MODE_FILTERS.rgb;
 }
 
+// The hint asks the browser to skip the renderer compositor queue and hand the buffer straight to
+// the display controller, saving a frame or so of output latency. It is only a hint, so read back
+// what we actually got.
+// https://developer.chrome.com/blog/desynchronized
+function reportDesynchronized(ctx) {
+    const honoured = ctx.getContextAttributes?.().desynchronized ?? false;
+    console.log(`Low latency canvas ${honoured ? "in use" : "not available"}`);
+}
+
 export class Canvas {
     /** The 2D canvas draws the framebuffer as-is, which is what this filter is. */
     get filterClass() {
@@ -21,8 +30,9 @@ export class Canvas {
     }
 
     constructor(canvas) {
-        this.ctx = canvas.getContext("2d", { alpha: false });
+        this.ctx = canvas.getContext("2d", { alpha: false, desynchronized: true });
         if (this.ctx === null) throw new Error("Unable to get a 2D context");
+        reportDesynchronized(this.ctx);
         this.ctx.fillStyle = "black";
         this.ctx.fillRect(0, 0, 1024, 625);
         this.backBuffer = window.document.createElement("canvas");
@@ -68,15 +78,19 @@ export class GlCanvas {
             alpha: false,
             antialias: false,
             depth: false,
-            preserveDrawingBuffer: false,
+            // A desynchronized context can be scanned out while it is cleared but not yet redrawn,
+            // which flickers unless the buffer is preserved between frames.
+            preserveDrawingBuffer: true,
             stencil: false,
             failIfMajorPerformanceCaveat: true,
+            desynchronized: true,
         };
         const gl = canvas.getContext("webgl", glAttrs) || canvas.getContext("experimental-webgl", glAttrs);
         this.gl = gl;
         if (!gl) {
             throw new Error("Unable to create a GL context");
         }
+        reportDesynchronized(gl);
         const checkedGl = webglDebug.makeDebugContext(gl, function (err, funcName) {
             throw new Error("Problem creating GL context: " + webglDebug.glEnumToString(err) + " in " + funcName);
         });

--- a/src/canvas.js
+++ b/src/canvas.js
@@ -19,7 +19,8 @@ export function getFilterForMode(mode) {
 // what we actually got.
 // https://developer.chrome.com/blog/desynchronized
 function reportDesynchronized(ctx, asked) {
-    const honoured = ctx.getContextAttributes?.().desynchronized ?? false;
+    // A lost context returns null here rather than an attributes object.
+    const honoured = ctx.getContextAttributes?.()?.desynchronized ?? false;
     if (!asked) console.log("Low latency canvas turned off");
     else console.log(`Low latency canvas ${honoured ? "in use" : "not available"}`);
 }

--- a/src/canvas.js
+++ b/src/canvas.js
@@ -18,9 +18,10 @@ export function getFilterForMode(mode) {
 // the display controller, saving a frame or so of output latency. It is only a hint, so read back
 // what we actually got.
 // https://developer.chrome.com/blog/desynchronized
-function reportDesynchronized(ctx) {
+function reportDesynchronized(ctx, asked) {
     const honoured = ctx.getContextAttributes?.().desynchronized ?? false;
-    console.log(`Low latency canvas ${honoured ? "in use" : "not available"}`);
+    if (!asked) console.log("Low latency canvas turned off");
+    else console.log(`Low latency canvas ${honoured ? "in use" : "not available"}`);
 }
 
 export class Canvas {
@@ -29,10 +30,10 @@ export class Canvas {
         return PassthroughFilter;
     }
 
-    constructor(canvas) {
-        this.ctx = canvas.getContext("2d", { alpha: false, desynchronized: true });
+    constructor(canvas, lowLatency = true) {
+        this.ctx = canvas.getContext("2d", { alpha: false, desynchronized: lowLatency });
         if (this.ctx === null) throw new Error("Unable to get a 2D context");
-        reportDesynchronized(this.ctx);
+        reportDesynchronized(this.ctx, lowLatency);
         this.ctx.fillStyle = "black";
         this.ctx.fillRect(0, 0, 1024, 625);
         this.backBuffer = window.document.createElement("canvas");
@@ -70,7 +71,7 @@ export class GlCanvas {
         return this.filter.constructor;
     }
 
-    constructor(canvas, filterClass) {
+    constructor(canvas, filterClass, lowLatency = true) {
         // failIfMajorPerformanceCaveat prevents the use of CPU based WebGL
         // rendering, which is much worse than simply using a 2D canvas for
         // rendering.
@@ -80,17 +81,17 @@ export class GlCanvas {
             depth: false,
             // A desynchronized context can be scanned out while it is cleared but not yet redrawn,
             // which flickers unless the buffer is preserved between frames.
-            preserveDrawingBuffer: true,
+            preserveDrawingBuffer: lowLatency,
             stencil: false,
             failIfMajorPerformanceCaveat: true,
-            desynchronized: true,
+            desynchronized: lowLatency,
         };
         const gl = canvas.getContext("webgl", glAttrs) || canvas.getContext("experimental-webgl", glAttrs);
         this.gl = gl;
         if (!gl) {
             throw new Error("Unable to create a GL context");
         }
-        reportDesynchronized(gl);
+        reportDesynchronized(gl, lowLatency);
         const checkedGl = webglDebug.makeDebugContext(gl, function (err, funcName) {
             throw new Error("Problem creating GL context: " + webglDebug.glEnumToString(err) + " in " + funcName);
         });
@@ -274,10 +275,10 @@ export function useBestFilter(canvas, filterClass) {
     return fellBackBecause(canvas, reason);
 }
 
-export function bestCanvas(canvas, filterClass) {
+export function bestCanvas(canvas, filterClass, lowLatency = true) {
     let reason;
     try {
-        return new GlCanvas(canvas, filterClass);
+        return new GlCanvas(canvas, filterClass, lowLatency);
     } catch (e) {
         // Either WebGL is unavailable or this particular filter declined it.
         reason = e?.message ?? e;
@@ -289,11 +290,11 @@ export function bestCanvas(canvas, filterClass) {
     // 2D fallback below would throw and take the emulator with it.
     if (filterClass !== PassthroughFilter) {
         try {
-            return fellBackBecause(new GlCanvas(canvas, PassthroughFilter), reason);
+            return fellBackBecause(new GlCanvas(canvas, PassthroughFilter, lowLatency), reason);
         } catch (e) {
             console.log("Unable to fall back to the passthrough filter: " + e);
         }
     }
 
-    return fellBackBecause(new Canvas(canvas), reason);
+    return fellBackBecause(new Canvas(canvas, lowLatency), reason);
 }

--- a/src/main.js
+++ b/src/main.js
@@ -374,6 +374,10 @@ let tryGl = true;
 if (parsedQuery.glEnabled !== undefined) {
     tryGl = parsedQuery.glEnabled === "true";
 }
+let lowLatency = true;
+if (parsedQuery.lowLatency !== undefined) {
+    lowLatency = parsedQuery.lowLatency === "true";
+}
 const screenCanvas = document.getElementById("screen");
 
 const errorDialog = document.getElementById("error-dialog");
@@ -516,7 +520,9 @@ function createCanvasForFilter(filterClass) {
     // creating the context, which fixes its initial viewport.
     sizeCanvasFor(filterClass);
 
-    const newCanvas = tryGl ? canvasLib.bestCanvas(screenCanvas, filterClass) : new canvasLib.Canvas(screenCanvas);
+    const newCanvas = tryGl
+        ? canvasLib.bestCanvas(screenCanvas, filterClass, lowLatency)
+        : new canvasLib.Canvas(screenCanvas, lowLatency);
     reportAnyFallback(newCanvas, filterClass);
     return newCanvas;
 }

--- a/tests/unit/test-canvas.js
+++ b/tests/unit/test-canvas.js
@@ -217,6 +217,13 @@ describe("low latency canvas", () => {
         expect(element.asked[0].preserveDrawingBuffer).toBe(false);
     });
 
+    it("survives a context that reports no attributes at all", () => {
+        const gl = recordingGl();
+        gl.getContextAttributes = () => null;
+
+        expect(() => new GlCanvas(attributeRecordingElement(gl), PassthroughFilter)).not.toThrow();
+    });
+
     it("passes the choice on through bestCanvas", () => {
         const element = attributeRecordingElement(recordingGl());
 

--- a/tests/unit/test-canvas.js
+++ b/tests/unit/test-canvas.js
@@ -184,6 +184,48 @@ describe("GlCanvas", () => {
     });
 });
 
+describe("low latency canvas", () => {
+    /** Records the attributes each context was asked for. */
+    function attributeRecordingElement(gl) {
+        const asked = [];
+        return {
+            asked,
+            width: 896,
+            height: 600,
+            getContext: (kind, attrs) => {
+                asked.push(attrs);
+                return kind === "2d" ? null : gl;
+            },
+        };
+    }
+
+    it("asks for a desynchronized context by default", () => {
+        const element = attributeRecordingElement(recordingGl());
+
+        new GlCanvas(element, PassthroughFilter);
+
+        expect(element.asked[0].desynchronized).toBe(true);
+        expect(element.asked[0].preserveDrawingBuffer).toBe(true);
+    });
+
+    it("does not when turned off", () => {
+        const element = attributeRecordingElement(recordingGl());
+
+        new GlCanvas(element, PassthroughFilter, false);
+
+        expect(element.asked[0].desynchronized).toBe(false);
+        expect(element.asked[0].preserveDrawingBuffer).toBe(false);
+    });
+
+    it("passes the choice on through bestCanvas", () => {
+        const element = attributeRecordingElement(recordingGl());
+
+        bestCanvas(element, PassthroughFilter, false);
+
+        expect(element.asked[0].desynchronized).toBe(false);
+    });
+});
+
 describe("bestCanvas", () => {
     it("falls back to the passthrough filter when the one asked for will not build", () => {
         // The 2D fallback is unreachable once a WebGL context exists, so a


### PR DESCRIPTION
Adds `desynchronized: true` to the displayed canvas, for both the 2D and WebGL paths, with a query parameter to turn it off for A/B measurement.

The hint asks the browser to skip the renderer compositor queue and, where it can, hand the canvas buffer straight to the display controller. That removes a stage from the frame-to-photons path, which is half of the ~87 ms of non-emulator latency measured in #857. See [Chrome's write-up](https://developer.chrome.com/blog/desynchronized).

WebGL also sets `preserveDrawingBuffer` alongside it. Chrome clears WebGL canvases between frames, and a desynchronized buffer can be scanned out in the window between the clear and our redraw, which flickers. Preserving the buffer closes that window; it is the documented pairing, and the cost is that the browser can no longer discard the buffer after compositing. Both flags follow the toggle together, so turning the feature off restores exactly the old attributes.

The offscreen back buffer in the 2D path is deliberately left alone: it is never presented, so the hint would mean nothing there.

## Toggling it

`?lowLatency=false` turns it off. Default on. The parameter follows the existing `glEnabled` idiom in `main.js`.

## It is only a hint

The UA may ignore it, so the code reads back what it actually got and logs one of:

```
Low latency canvas in use
Low latency canvas not available
Low latency canvas turned off
```

That matters for measurement: it is the only way to know which state a given run was actually in, and it distinguishes "asked and refused" from "not asked".

## Testing

`tests/unit/test-canvas.js` (24) passes, including three new tests that record the attributes each context is asked for: desynchronized and preserveDrawingBuffer both requested by default, both off when the toggle is off, and the choice passed through `bestCanvas`. Checked by mutation: hardcoding `desynchronized: true` fails exactly the two tests that assert the toggle.

Verified Chrome accepts the attribute, with a standalone page outside the repo:

```
2d=true gl=true
```

**What that does not prove:** that a frame is actually saved. The readback says the browser accepted the hint, not that the compositor stage disappeared, and it was checked headless rather than against a real display pipeline. The end-to-end number has to come from filming, which is what the toggle is for: same rig, same session, `?lowLatency=false` versus default, with the log line confirming which state each run was in.

Related: #857 has the measurement this is meant to improve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)