### PR TITLE
fix: size the audio start threshold from the latency target

### DIFF
--- a/src/web/audio-renderer.js
+++ b/src/web/audio-renderer.js
@@ -16,13 +16,13 @@ class SoundChipProcessor extends AudioWorkletProcessor {
         this._lastSample = 0;
         this._lastFilteredOutput = 0;
         this.queue = [];
-        this._queueSizeBytes = 0;
+        this._queueSizeSamples = 0;
         this.dropped = 0;
         this.underruns = 0;
         this.targetLatencyMs = 1000 * (1 / 50); // One frame
-        this.startQueueSizeBytes = samplesFor(this.targetLatencyMs);
+        this.startQueueSizeSamples = samplesFor(this.targetLatencyMs);
         this.running = false;
-        this.maxQueueSizeBytes = samplesFor(MaxQueuedMs);
+        this.maxQueueSizeSamples = samplesFor(MaxQueuedMs);
         this.port.onmessage = (event) => {
             // TODO: even better than this, send over register settings/catch up and run the audio work _here_
             this.onBuffer(event.data.time, event.data.buffer);
@@ -52,19 +52,19 @@ class SoundChipProcessor extends AudioWorkletProcessor {
 
     onBuffer(time, buffer) {
         this.queue.push({ offset: 0, time, buffer });
-        this._queueSizeBytes += buffer.length;
+        this._queueSizeSamples += buffer.length;
         this.cleanQueue();
-        if (!this.running && this._queueSizeBytes >= this.startQueueSizeBytes) this.running = true;
+        if (!this.running && this._queueSizeSamples >= this.startQueueSizeSamples) this.running = true;
     }
 
     _shift() {
         const dropped = this.queue.shift();
-        this._queueSizeBytes -= dropped.buffer.length;
+        this._queueSizeSamples -= dropped.buffer.length;
     }
 
     cleanQueue() {
         const maxLatency = this.targetLatencyMs * 2;
-        while (this._queueSizeBytes > this.maxQueueSizeBytes || this._queueAge() > maxLatency) {
+        while (this._queueSizeSamples > this.maxQueueSizeSamples || this._queueAge() > maxLatency) {
             this._shift();
             this.dropped++;
         }

--- a/src/web/audio-renderer.js
+++ b/src/web/audio-renderer.js
@@ -3,11 +3,16 @@
 const lowPassFilterFreq = sampleRate / 2;
 const RC = 1 / (2 * Math.PI * lowPassFilterFreq);
 
+const InputSampleRate = 4000000.0 / 8;
+const MaxQueuedMs = 250;
+
+const samplesFor = (ms) => (InputSampleRate * ms) / 1000;
+
 class SoundChipProcessor extends AudioWorkletProcessor {
     constructor(...args) {
         super(...args);
 
-        this.inputSampleRate = 4000000.0 / 8;
+        this.inputSampleRate = InputSampleRate;
         this._lastSample = 0;
         this._lastFilteredOutput = 0;
         this.queue = [];
@@ -15,9 +20,9 @@ class SoundChipProcessor extends AudioWorkletProcessor {
         this.dropped = 0;
         this.underruns = 0;
         this.targetLatencyMs = 1000 * (1 / 50); // One frame
-        this.startQueueSizeBytes = this.inputSampleRate / this.targetLatencyMs / 2;
+        this.startQueueSizeBytes = samplesFor(this.targetLatencyMs);
         this.running = false;
-        this.maxQueueSizeBytes = this.inputSampleRate * 0.25;
+        this.maxQueueSizeBytes = samplesFor(MaxQueuedMs);
         this.port.onmessage = (event) => {
             // TODO: even better than this, send over register settings/catch up and run the audio work _here_
             this.onBuffer(event.data.time, event.data.buffer);


### PR DESCRIPTION
Fixes #855.

```js
this.startQueueSizeBytes = this.inputSampleRate / this.targetLatencyMs / 2;
```

Divides a sample rate by a duration in milliseconds, where every other size in the file multiplies by a duration. Two consequences: the pre-roll was 25 ms against a 20 ms target, and it moved the **wrong way** when the target changed. Raising `targetLatencyMs` to cure underruns halved the pre-roll, so the change intended to add safety margin removed it.

Both sizes now go through one helper, so the units cannot drift apart again:

```js
const InputSampleRate = 4000000.0 / 8;
const MaxQueuedMs = 250;
const samplesFor = (ms) => (InputSampleRate * ms) / 1000;
...
this.startQueueSizeSamples = samplesFor(this.targetLatencyMs);
this.maxQueueSizeSamples = samplesFor(MaxQueuedMs);
```

`maxQueueSize` is unchanged in value at 125000 samples; it was already dimensionally correct as `inputSampleRate * 0.25`, and now says 250 ms in the same units as its neighbour rather than in seconds.

## What changes at runtime

| `targetLatencyMs` | pre-roll before | pre-roll after |
| --- | --- | --- |
| 10 ms | 50.0 ms | 10.0 ms |
| **20 ms (current)** | **25.0 ms** | **20.0 ms** |
| 40 ms | 12.5 ms | 40.0 ms |
| 80 ms | 6.3 ms | 80.0 ms |

At today's setting that is 5 ms less audio buffered before playback starts, which is a small move in the less-safe direction; the point is that it is now the amount the target asks for, and tuning the target does what it says. Steady state is untouched either way: `_queueAge()` is compared against `targetLatencyMs` in the resampler and `2 * targetLatencyMs` in the drop loop, so the feedback loop converges on the target regardless of where playback started.

## Second commit: the names

`_queueSizeBytes`, `startQueueSizeBytes` and `maxQueueSizeBytes` all count **samples** — `_queueSizeSamples += buffer.length`. Names saying bytes while holding samples are what let the dimensional error sit unnoticed, so they are renamed. Split into its own commit; the fix stands without it.

## Testing

Full unit suite (1067) passes, though it does not reach this file: `audio-renderer.js` is an AudioWorklet module that depends on `sampleRate`, `currentTime` and `AudioWorkletProcessor` as globals, so it is not importable under vitest as things stand. I deliberately did not move `samplesFor` into a shared, testable module: the worklet is loaded by URL through `addModule`, and adding an import to it risks a runtime-only breakage that no unit test would catch.

The arithmetic in the table above was computed directly from the two expressions rather than estimated. Lint and format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)