### PR TITLE
docs: correct two claims about the teletext feed hardware

### DIFF
--- a/src/video.js
+++ b/src/video.js
@@ -984,10 +984,10 @@ export class Video {
                 // Read data from address pointer if both horizontal and vertical display enabled.
                 const dat = this.readVideoMem();
                 if (insideBorder) {
-                    // Always feed the SAA5050 pipeline: on real hardware IC15
-                    // permanently connects the video bus to the SAA5050 inputs
-                    // regardless of ULA mode. Required for the "TTX trick".
-                    // See https://github.com/mattgodbolt/jsbeeb/issues/546
+                    // Always feed the SAA5050 pipeline, whatever the ULA mode: IC15 latches the
+                    // video bus into the chip and it is MA13, not the ULA's teletext bit, that
+                    // gates it. We do not model the MA13 gate yet, so this feeds unconditionally.
+                    // See https://github.com/mattgodbolt/jsbeeb/issues/546 and #832
                     this.teletext.fetchData(dat);
 
                     // Check cursor start.
@@ -1035,10 +1035,10 @@ export class Video {
                                 // Proper MODE 7 (1MHz clock + teletext): render SAA5050 output normally.
                                 this.teletext.render(this.fb32, offset);
                             } else {
-                                // 2MHz clock + teletext bit set (the "TTX trick"): the Video ULA
-                                // forces DISPEN to the SAA5050 to 0 in 2MHz modes (0/1/2/3), so
-                                // the SAA5050 outputs black. Confirmed by Rich Talbot-Watkins (RTW)
-                                // at ABUG 2026-03-13.
+                                // 2MHz clock + teletext bit set (the "TTX trick"): the SAA5050
+                                // outputs black. Behaviour confirmed by Rich Talbot-Watkins (RTW)
+                                // at ABUG 2026-03-13; the mechanism is not established, as the
+                                // Model B ULA has no connection to the SAA5050 at all.
                                 // See https://github.com/mattgodbolt/jsbeeb/issues/546
                                 this.fb32.fill(OPAQUE_BLACK, offset, offset + this.pixelsPerChar);
                             }

--- a/src/video.js
+++ b/src/video.js
@@ -987,7 +987,8 @@ export class Video {
                     // Always feed the SAA5050 pipeline, whatever the ULA mode: IC15 latches the
                     // video bus into the chip and it is MA13, not the ULA's teletext bit, that
                     // gates it. We do not model the MA13 gate yet, so this feeds unconditionally.
-                    // See https://github.com/mattgodbolt/jsbeeb/issues/546 and #832
+                    // See https://github.com/mattgodbolt/jsbeeb/issues/546
+                    // and https://github.com/mattgodbolt/jsbeeb/issues/832
                     this.teletext.fetchData(dat);
 
                     // Check cursor start.


### PR DESCRIPTION
Two comments in `src/video.js` describe mechanisms that the Model B schematic does not support. The behaviour they justify is right in both cases; only the explanation was wrong. Comments only, no behaviour change.

Established while investigating #832, against the BBC Microcomputer Service Manual (Oct 1985), the Model B main PCB circuit diagram and the SAA5050 data sheet, and corroborated by hoglet67's BeebFpga. Full detail is on that issue.

## IC15 does not permanently connect anything

It said IC15 "permanently connects the video bus to the SAA5050 inputs regardless of ULA mode". IC15 is a **74LS273 octal latch with an asynchronous clear**, and that clear is wired to MA13. So it does gate, just not on what the ULA is doing.

The conclusion survives — we should feed the pipeline whatever the ULA mode, because the gate is MA13 rather than the ULA's teletext bit — so the code is unchanged. The comment now says which part we model and which we do not, and points at #832 where the MA13 gate is tracked.

## The ULA cannot be forcing the SAA5050's DISPEN

It said "the Video ULA forces DISPEN to the SAA5050 to 0 in 2MHz modes". On the Model B schematic the ULA's only outputs are R, G, B and CRTC CLK; it has no connection to the SAA5050, whose `LOSE` comes from IC15.

Rich Talbot-Watkins confirmed the *behaviour* at ABUG, and that attribution stays. The comment no longer claims a wiring path, and says the mechanism is not established.

## Left alone deliberately

The `IC37/IC36` comment on the H-blanking feed is **correct** and unchanged. IC36 is a 74LS10 whose output drives SAA5050 pin 10 — the `0x40` bit — computing `b6 OR NOT DISPEN`, so it is gated on DISPEN and not on ULA mode, exactly as written. The only inaccuracy is one of scope rather than attribution: hardware applies it combinationally at all times where we apply it during H blanking, which is part of #832 rather than a comment fix.

## Testing

`tests/unit/test-video.js` (42) passes; nothing executable changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)