### PR TITLE
fix: apply teletext control codes seen while a bitmap mode is displayed

### DIFF
--- a/src/teletext.js
+++ b/src/teletext.js
@@ -16,15 +16,10 @@ export class Teletext {
         this.flashTime = 0;
         this.heldChar = 0;
         this.holdChar = false;
-        // Latched by `advance` for `emit` to paint. Not snapshotted: a cell is always
-        // advanced before it is emitted, within the same video poll.
         this.cellGlyphIndex = 0;
         this.cellFlash = false;
         this.cellConceal = false;
         this.cellPalette = 0;
-        // The three cell delay between the CRTC selecting a byte and it reaching the screen.
-        // Copied down rather than with `copyWithin`, which over four bytes is slower than the
-        // moves it saves.
         this.dataQueue = new Uint8Array(4);
         this.scanlineCounter = 0;
         this.levelDEW = false;
@@ -317,6 +312,7 @@ export class Teletext {
     }
 
     fetchData(data) {
+        // `copyWithin` over four bytes costs more than the moves it saves.
         this.dataQueue[0] = this.dataQueue[1];
         this.dataQueue[1] = this.dataQueue[2];
         this.dataQueue[2] = this.dataQueue[3];
@@ -436,8 +432,8 @@ export class Teletext {
     }
 
     /**
-     * Paint the cell most recently latched by `advance`. The `cell` fields come from that
-     * latch; everything else read here changes per scanline or per field, not per character.
+     * Paint the cell most recently latched by `advance`. Everything else read here changes
+     * per scanline or per field, not per character.
      */
     emit(buf, offset) {
         let scanline = this.scanlineCounter << 1;

--- a/src/teletext.js
+++ b/src/teletext.js
@@ -16,7 +16,13 @@ export class Teletext {
         this.flashTime = 0;
         this.heldChar = 0;
         this.holdChar = false;
-        this.dataQueue = [0, 0, 0, 0];
+        // The three cell delay between the CRTC selecting a byte and it reaching the
+        // screen, held as scalars: an Array here costs more per frame than the whole
+        // character state machine, and stops V8 inlining fetchData.
+        this.dataQueue0 = 0;
+        this.dataQueue1 = 0;
+        this.dataQueue2 = 0;
+        this.dataQueue3 = 0;
         this.scanlineCounter = 0;
         this.levelDEW = false;
         this.levelDISPTMG = false;
@@ -178,7 +184,7 @@ export class Teletext {
             flashTime: this.flashTime,
             heldChar: this.heldChar,
             holdChar: this.holdChar,
-            dataQueue: [...this.dataQueue],
+            dataQueue: [this.dataQueue0, this.dataQueue1, this.dataQueue2, this.dataQueue3],
             scanlineCounter: this.scanlineCounter,
             levelDEW: this.levelDEW,
             levelDISPTMG: this.levelDISPTMG,
@@ -204,7 +210,7 @@ export class Teletext {
         this.flashTime = state.flashTime;
         this.heldChar = state.heldChar;
         this.holdChar = state.holdChar;
-        this.dataQueue = [...state.dataQueue];
+        [this.dataQueue0, this.dataQueue1, this.dataQueue2, this.dataQueue3] = state.dataQueue;
         this.scanlineCounter = state.scanlineCounter;
         this.levelDEW = state.levelDEW;
         this.levelDISPTMG = state.levelDISPTMG;
@@ -308,8 +314,10 @@ export class Teletext {
     }
 
     fetchData(data) {
-        this.dataQueue.shift();
-        this.dataQueue.push(data & 0x7f);
+        this.dataQueue0 = this.dataQueue1;
+        this.dataQueue1 = this.dataQueue2;
+        this.dataQueue2 = this.dataQueue3;
+        this.dataQueue3 = data & 0x7f;
     }
 
     setDEW(level) {
@@ -387,7 +395,7 @@ export class Teletext {
     }
 
     render(buf, offset) {
-        let data = this.dataQueue[0];
+        let data = this.dataQueue0;
 
         let scanline = this.scanlineCounter << 1;
         if (this.levelRA0) {

--- a/src/teletext.js
+++ b/src/teletext.js
@@ -22,13 +22,10 @@ export class Teletext {
         this.cellFlash = false;
         this.cellConceal = false;
         this.cellPalette = 0;
-        // The three cell delay between the CRTC selecting a byte and it reaching the
-        // screen, held as scalars: an Array here costs more per frame than the whole
-        // character state machine, and stops V8 inlining fetchData.
-        this.dataQueue0 = 0;
-        this.dataQueue1 = 0;
-        this.dataQueue2 = 0;
-        this.dataQueue3 = 0;
+        // The three cell delay between the CRTC selecting a byte and it reaching the screen.
+        // Copied down rather than with `copyWithin`, which over four bytes is slower than the
+        // moves it saves.
+        this.dataQueue = new Uint8Array(4);
         this.scanlineCounter = 0;
         this.levelDEW = false;
         this.levelDISPTMG = false;
@@ -190,7 +187,7 @@ export class Teletext {
             flashTime: this.flashTime,
             heldChar: this.heldChar,
             holdChar: this.holdChar,
-            dataQueue: [this.dataQueue0, this.dataQueue1, this.dataQueue2, this.dataQueue3],
+            dataQueue: [...this.dataQueue],
             scanlineCounter: this.scanlineCounter,
             levelDEW: this.levelDEW,
             levelDISPTMG: this.levelDISPTMG,
@@ -216,7 +213,7 @@ export class Teletext {
         this.flashTime = state.flashTime;
         this.heldChar = state.heldChar;
         this.holdChar = state.holdChar;
-        [this.dataQueue0, this.dataQueue1, this.dataQueue2, this.dataQueue3] = state.dataQueue;
+        this.dataQueue.set(state.dataQueue);
         this.scanlineCounter = state.scanlineCounter;
         this.levelDEW = state.levelDEW;
         this.levelDISPTMG = state.levelDISPTMG;
@@ -320,10 +317,10 @@ export class Teletext {
     }
 
     fetchData(data) {
-        this.dataQueue0 = this.dataQueue1;
-        this.dataQueue1 = this.dataQueue2;
-        this.dataQueue2 = this.dataQueue3;
-        this.dataQueue3 = data & 0x7f;
+        this.dataQueue[0] = this.dataQueue[1];
+        this.dataQueue[1] = this.dataQueue[2];
+        this.dataQueue[2] = this.dataQueue[3];
+        this.dataQueue[3] = data & 0x7f;
     }
 
     setDEW(level) {
@@ -405,7 +402,7 @@ export class Teletext {
      * to the character state, and latch how the resulting cell should look.
      */
     advance() {
-        let data = this.dataQueue0;
+        let data = this.dataQueue[0];
 
         this.oldDbl = this.dbl;
 

--- a/src/teletext.js
+++ b/src/teletext.js
@@ -16,6 +16,12 @@ export class Teletext {
         this.flashTime = 0;
         this.heldChar = 0;
         this.holdChar = false;
+        // Latched by `advance` for `emit` to paint. Not snapshotted: a cell is always
+        // advanced before it is emitted, within the same video poll.
+        this.cellGlyphIndex = 0;
+        this.cellFlash = false;
+        this.cellConceal = false;
+        this.cellPalette = 0;
         // The three cell delay between the CRTC selecting a byte and it reaching the
         // screen, held as scalars: an Array here costs more per frame than the whole
         // character state machine, and stops V8 inlining fetchData.
@@ -394,13 +400,12 @@ export class Teletext {
         this.levelRA0 = level;
     }
 
-    render(buf, offset) {
+    /**
+     * Clock one character through the chip: take the oldest byte in the pipeline, apply it
+     * to the character state, and latch how the resulting cell should look.
+     */
+    advance() {
         let data = this.dataQueue0;
-
-        let scanline = this.scanlineCounter << 1;
-        if (this.levelRA0) {
-            scanline++;
-        }
 
         this.oldDbl = this.dbl;
 
@@ -420,14 +425,6 @@ export class Teletext {
             this.heldChar = 32;
         }
 
-        if (this.oldDbl) {
-            scanline = scanline >>> 1;
-            if (this.secondHalfOfDouble) {
-                scanline += 10;
-            }
-        }
-        let chardef = this.curGlyphs[(data - 32) * 20 + scanline];
-
         // Flash (code 8) is "Set After" — flashThisCell retains the pre-control-code state.
         // Steady (code 9) is "Set At" — update so this cell stops flashing immediately.
         if (flashThisCell && !this.flash) flashThisCell = false;
@@ -435,18 +432,47 @@ export class Teletext {
         // Conceal (code 24) is "Set At", and a colour code only reveals from the cell after itself.
         if (this.conceal) concealThisCell = true;
 
-        if (concealThisCell || (flashThisCell && this.hideFlashing) || (this.secondHalfOfDouble && !this.dbl)) {
-            const backgroundColour = this.colour[(this.bg & 7) << 5];
+        this.cellGlyphIndex = (data - 32) * 20;
+        this.cellFlash = flashThisCell;
+        this.cellConceal = concealThisCell;
+        this.cellPalette = ((this.bg & 7) << 5) | ((this.prevCol & 7) << 2);
+    }
+
+    /**
+     * Paint the cell most recently latched by `advance`. The `cell` fields come from that
+     * latch; everything else read here changes per scanline or per field, not per character.
+     */
+    emit(buf, offset) {
+        let scanline = this.scanlineCounter << 1;
+        if (this.levelRA0) {
+            scanline++;
+        }
+
+        if (this.oldDbl) {
+            scanline = scanline >>> 1;
+            if (this.secondHalfOfDouble) {
+                scanline += 10;
+            }
+        }
+
+        if (this.cellConceal || (this.cellFlash && this.hideFlashing) || (this.secondHalfOfDouble && !this.dbl)) {
+            const backgroundColour = this.colour[this.cellPalette & 0xe0];
             for (let i = 0; i < 16; ++i) {
                 buf[offset++] = backgroundColour;
             }
         } else {
-            const paletteIndex = ((this.bg & 7) << 5) | ((this.prevCol & 7) << 2);
+            let chardef = this.curGlyphs[this.cellGlyphIndex + scanline];
+            const paletteIndex = this.cellPalette;
 
             for (let pixel = 0; pixel < 16; ++pixel) {
                 buf[offset + pixel] = this.colour[paletteIndex + (chardef & 3)];
                 chardef >>>= 2;
             }
         }
+    }
+
+    render(buf, offset) {
+        this.advance();
+        this.emit(buf, offset);
     }
 }

--- a/src/video.js
+++ b/src/video.js
@@ -1063,6 +1063,10 @@ export class Video {
             // the SAA5050 pipeline with the video bus data, forcing bit 6 high.
             // On real hardware IC37/IC36 operates regardless of ULA mode —
             // it is wired to the CRTC DISPEN signal, not the ULA teletext bit.
+            // Hardware also clocks the chip here, which we do not: our row reset fires
+            // too early relative to the pipeline for that to come out right, and adding
+            // `advance()` alone moves three of the hardware reference pages. See
+            // https://github.com/mattgodbolt/jsbeeb/issues/874
             if (!(this.dispEnabled & HDISPENABLE) && this.dispEnabled & VDISPENABLE) {
                 this.teletext.fetchData(this.readVideoMem() | 0x40);
             }

--- a/src/video.js
+++ b/src/video.js
@@ -984,12 +984,15 @@ export class Video {
                 // Read data from address pointer if both horizontal and vertical display enabled.
                 const dat = this.readVideoMem();
                 if (insideBorder) {
-                    // Always feed the SAA5050 pipeline, whatever the ULA mode: IC15 latches the
-                    // video bus into the chip and it is MA13, not the ULA's teletext bit, that
-                    // gates it. We do not model the MA13 gate yet, so this feeds unconditionally.
+                    // Always clock the SAA5050, whatever the ULA mode: IC15 latches the video bus
+                    // into the chip and it is MA13, not the ULA's teletext bit, that gates it. We
+                    // do not model the MA13 gate yet, so this feeds unconditionally. The chip is
+                    // clocked here and painted later, so a control code seen while the ULA shows
+                    // bitmap still takes effect.
                     // See https://github.com/mattgodbolt/jsbeeb/issues/546
                     // and https://github.com/mattgodbolt/jsbeeb/issues/832
                     this.teletext.fetchData(dat);
+                    this.teletext.advance();
 
                     // Check cursor start.
                     if (
@@ -1034,7 +1037,7 @@ export class Video {
                         if (this.teletextMode) {
                             if (this.halfClock) {
                                 // Proper MODE 7 (1MHz clock + teletext): render SAA5050 output normally.
-                                this.teletext.render(this.fb32, offset);
+                                this.teletext.emit(this.fb32, offset);
                             } else {
                                 // 2MHz clock + teletext bit set (the "TTX trick"): the SAA5050
                                 // outputs black. Behaviour confirmed by Rich Talbot-Watkins (RTW)

--- a/tests/integration/teletext-hardware.js
+++ b/tests/integration/teletext-hardware.js
@@ -1,0 +1,65 @@
+import { describe, it } from "vitest";
+import assert from "assert";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import sharp from "sharp";
+import pixelmatch from "pixelmatch";
+import { MachineSession } from "../../src/machine-session.js";
+
+// The reference images were photographed against a real BBC Master 128 running
+// MOS 3.20 and agreed with it on every page, so they pin behaviour we have
+// measured rather than behaviour we have merely chosen. See
+// tests/hardware/teletext/README.md for what each page tests.
+const HardwareDir = path.join(path.dirname(fileURLToPath(import.meta.url)), "../hardware/teletext");
+const Disc = path.join(HardwareDir, "teletext-tests.ssd");
+const RefDir = path.join(HardwareDir, "refs");
+const OutputDir = "tests/integration/output";
+const Pages = ["T1", "T2", "T3", "T4", "T5", "T6"];
+
+async function renderPage(page) {
+    const session = new MachineSession("Master");
+    try {
+        await session.initialise();
+        await session.boot();
+        session.loadDisc(Disc);
+        await session.type(`CHAIN "${page}"`);
+        // Each page ends at a GET, so the OS reaching the keyboard is the page having
+        // finished drawing. This keeps the flash phase reproducible too.
+        await session.runUntilPrompt();
+        await session.runFrames(1);
+        return await session.screenshotActive();
+    } finally {
+        session.destroy();
+    }
+}
+
+async function compareToReference(page, actualPng) {
+    const name = page.toLowerCase();
+    const expectedFile = path.join(RefDir, `${name}.png`);
+    const actualFile = `${OutputDir}/actual_hardware_${name}.png`;
+    const diffFile = `${OutputDir}/actual_hardware_${name}.diff.png`;
+
+    await sharp(actualPng).toFile(actualFile);
+    const { data: expected, info } = await sharp(expectedFile)
+        .ensureAlpha()
+        .raw()
+        .toBuffer({ resolveWithObject: true });
+    const actual = await sharp(actualPng).ensureAlpha().raw().toBuffer();
+    const diff = new Uint8Array(info.width * info.height * info.channels);
+
+    const numDiffPixels = pixelmatch(expected, actual, diff, info.width, info.height, { threshold: 0.1 });
+    await sharp(diff, { raw: info }).removeAlpha().toFile(diffFile);
+    assert.equal(
+        numDiffPixels,
+        0,
+        `${page} does not match the hardware reference - expected ${expectedFile}, got ${actualFile}, diffs: ${diffFile}`,
+    );
+}
+
+describe("Teletext hardware test disc", { timeout: 120000 }, () => {
+    for (const page of Pages) {
+        it(`should render ${page} as the hardware does`, async () => {
+            await compareToReference(page, await renderPage(page));
+        });
+    }
+});

--- a/tests/unit/test-teletext.js
+++ b/tests/unit/test-teletext.js
@@ -149,6 +149,25 @@ describe("Teletext", () => {
         });
     });
 
+    describe("clocking without painting", () => {
+        // The ULA selects whether the chip's output reaches the screen; the chip itself keeps
+        // running either way, so codes seen while a bitmap mode is displayed still take effect.
+        // See https://github.com/mattgodbolt/jsbeeb/issues/832
+        it("applies a colour code clocked in while nothing was painted", () => {
+            const buffer = makeFast32(new Uint32Array(PixelsPerCell));
+            // The pipeline is three cells deep, so the code is consumed several advances after
+            // it is fetched, and every one of those happens with no call to emit.
+            const bytes = [RedGraphics, SolidBlock, Space, Space, Space];
+            bytes.forEach((byte, index) => {
+                teletext.fetchData(byte);
+                teletext.advance();
+                if (index === bytes.length - 1) teletext.emit(buffer, 0);
+            });
+
+            expect(solidOnly(buffer, Red)).toBe(true);
+        });
+    });
+
     describe("graphics", () => {
         it("separates the blocks once code 26 is seen", () => {
             const cells = renderCells([WhiteGraphics, SolidBlock, SeparatedGraphics, SolidBlock]);

--- a/tests/unit/test-video.js
+++ b/tests/unit/test-video.js
@@ -51,7 +51,8 @@ describe("Video", () => {
             setDISPTMG: vi.fn(),
             setRA0: vi.fn(),
             fetchData: vi.fn(),
-            render: vi.fn(),
+            advance: vi.fn(),
+            emit: vi.fn(),
         };
 
         // Replace the teletext instance
@@ -455,9 +456,9 @@ describe("Video", () => {
             expect(mockTeletext.fetchData).toHaveBeenCalledWith(0x42);
         });
 
-        it("should call render in teletext mode", () => {
+        it("should emit pixels in teletext mode", () => {
             // Clear mock history
-            mockTeletext.render.mockClear();
+            mockTeletext.emit.mockClear();
 
             // Set up horizCounter to avoid vsync logic
             video.horizCounter = 10;
@@ -465,17 +466,18 @@ describe("Video", () => {
             // Poll to trigger rendering
             video.polltime(1);
 
-            // Verify render was called with the expected parameters
-            expect(mockTeletext.render).toHaveBeenCalledWith(expect.any(Uint32Array), expect.any(Number));
+            // Verify emit was called with the expected parameters
+            expect(mockTeletext.emit).toHaveBeenCalledWith(expect.any(Uint32Array), expect.any(Number));
         });
 
-        it("should not render in non-teletext mode", () => {
+        it("should clock the SAA5050 but emit nothing in non-teletext mode", () => {
             // Switch to non-teletext mode
             video.ula.write(0, 0);
             expect(video.teletextMode).toBe(false);
 
             // Clear mock history
-            mockTeletext.render.mockClear();
+            mockTeletext.advance.mockClear();
+            mockTeletext.emit.mockClear();
 
             // Set up horizCounter to avoid vsync logic
             video.horizCounter = 10;
@@ -483,8 +485,11 @@ describe("Video", () => {
             // Poll to trigger rendering
             video.polltime(1);
 
-            // Verify render was not called
-            expect(mockTeletext.render).not.toHaveBeenCalled();
+            // The chip keeps running whatever the ULA shows, so a control code seen here
+            // still takes effect; only its output is switched away.
+            // See https://github.com/mattgodbolt/jsbeeb/issues/832
+            expect(mockTeletext.advance).toHaveBeenCalled();
+            expect(mockTeletext.emit).not.toHaveBeenCalled();
         });
 
         it("should call fetchData even in non-teletext mode (SAA5050 pipeline always runs)", () => {
@@ -531,14 +536,14 @@ describe("Video", () => {
             expect(video.teletextMode).toBe(true);
             expect(video.halfClock).toBe(false);
 
-            mockTeletext.render.mockClear();
+            mockTeletext.emit.mockClear();
             video.horizCounter = 10;
             video.bitmapX = 100;
             video.bitmapY = 100;
 
             video.polltime(1);
 
-            expect(mockTeletext.render).not.toHaveBeenCalled();
+            expect(mockTeletext.emit).not.toHaveBeenCalled();
             expect(mockFb32[TEST_FB_OFFSET]).toBe(0xff000000);
         });
     });


### PR DESCRIPTION
Fixes #832. A teletext control code seen while a bitmapped mode is on screen never took effect, so beebjit's `teletext_bytes_pipeline.ssd` rendered a column of white glyphs where a real Master shows red then white.

## The cause

We fed every byte to the SAA5050 but only interpreted the ones we were about to paint, because the character state machine lived inside `render`. Instrumented over two frames of that disc:

| | count |
| --- | --- |
| bytes clocked into the chip | 32,768 |
| interpreted | 1,536 (4.7%) |
| alpha red `&01` clocked in | 272 |
| alpha red `&01` interpreted | **0** |

On hardware the chip is clocked continuously and has no idea what the ULA is doing with its output; the ULA is a multiplexer downstream of it. Note this is *not* the MA13 gate the issue originally suspected: we already feed unconditionally.

## The change

`advance` runs the state machine at the fetch site, `emit` paints at the paint site. beebjit is the same shape, and this is the rework the TODO in `video.js` asked for.

Result: the red appears, occupying the top 30% of the glyph column against 33% measured off a photograph of a real Master. That also settles why the band stops a third of the way down, which we could only guess at before: it is simply where the control codes sit in the buffer.

## Performance

The state machine now runs on every latch rather than 4.7% of them, which in MODE 0 is about 32k times a frame instead of never. It is free, because `dataQueue.shift()/push()` on a four element Array cost more than the state machine does, and blocked V8 from inlining `fetchData`. Copying the four bytes down instead pays for the state machine outright.

Branch against main, three processes each, median of seven 200 frame reps per process:

| | main | branch | |
| --- | --- | --- | --- |
| MODE 7 | 2.821 | 2.489 ms/frame | -12%, runs do not overlap |
| MODE 0 | 4.482 | 4.247 ms/frame | no slower, probably a little better |

MODE 0 varies enough run to run (main 4.17 to 4.49, branch 4.11 to 4.29) that the ranges overlap, so that row is worth reading as "no worse" rather than as a speedup.

## The change

`Teletext.advance` runs the character state machine at the fetch site; `Teletext.emit` paints at the paint site. beebjit is the same shape, and this is the rework the TODO in `video.js` asked for.

Two things come with it:

- **The pipeline is copied down a `Uint8Array` rather than shifted with `shift`/`push`.** The snapshot keeps its four element `dataQueue`, so the format is untouched. Measured against four alternatives, three processes each: four scalar fields and a ring buffer land within the run to run spread of this one, and a plain Array is consistently a little behind. `copyWithin` is the surprise and the one to avoid, being slower than the `shift`/`push` it was meant to improve on, because over four bytes the call costs more than the moves it saves.
- **The six hardware reference pages are wired into a test.** They were referenced by nothing. They are the safety net for a change to the hottest loop in the video path, and they earned it immediately: they caught the hblank change described below.

`test-video.js` mocked `Teletext` and asserted the old gating, so the mock gains the two methods and the gating test now states what the split means: the chip advances in a bitmap mode, only its output is switched away.

## Verified against hardware

The red band on beebjit's pipeline test is 8 character rows with 17.5 below it, out of 25.5 visible. Counted independently on a photograph of a real Master: 8 and 17.5. Our render measures 7.7 and 17.8, the 7.7 being the last red pixel falling partway into the eighth glyph. The three cell pipeline alignment has to be right for the boundary to land in the same row.

## Left out on purpose

Clocking the chip during horizontal blanking as well. `fetchData` and `advance` are therefore separate calls, paired at the main fetch site and not at the hblank one, which is the only reason the two are not a single `clock(data)`.

Adding the missing `advance()` there is a trap: it invents a dashed line under the `ROW` label on T1 that a real Master does not show, and moves three of the six reference pages. #874 has the evidence and what the real fix needs: a 1MHz latch, a pipelined DISPEN driving the row reset, the bit 6 forcing moved inside the chip, and the MA13 gate that goes with them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
