### PR TITLE
fix: let the Video ULA switch its output at 2MHz in 1MHz modes

### DIFF
--- a/src/teletext.js
+++ b/src/teletext.js
@@ -431,11 +431,7 @@ export class Teletext {
         this.cellPalette = ((this.bg & 7) << 5) | ((this.prevCol & 7) << 2);
     }
 
-    /**
-     * Paint the cell most recently latched by `advance`. Everything else read here changes
-     * per scanline or per field, not per character.
-     */
-    emit(buf, offset) {
+    glyphScanline() {
         let scanline = this.scanlineCounter << 1;
         if (this.levelRA0) {
             scanline++;
@@ -447,6 +443,15 @@ export class Teletext {
                 scanline += 10;
             }
         }
+        return scanline;
+    }
+
+    /**
+     * Paint the cell most recently latched by `advance`. Everything else read here changes
+     * per scanline or per field, not per character.
+     */
+    emit(buf, offset) {
+        const scanline = this.glyphScanline();
 
         if (this.cellConceal || (this.cellFlash && this.hideFlashing) || (this.secondHalfOfDouble && !this.dbl)) {
             const backgroundColour = this.colour[this.cellPalette & 0xe0];
@@ -458,6 +463,24 @@ export class Teletext {
             const paletteIndex = this.cellPalette;
 
             for (let pixel = 0; pixel < 16; ++pixel) {
+                buf[offset + pixel] = this.colour[paletteIndex + (chardef & 3)];
+                chardef >>>= 2;
+            }
+        }
+    }
+
+    // The second half of the cell `emit` last painted, for the render loop's 1MHz repaint.
+    emitSecondHalf(buf, offset) {
+        const scanline = this.glyphScanline();
+        if (this.cellConceal || (this.cellFlash && this.hideFlashing) || (this.secondHalfOfDouble && !this.dbl)) {
+            const backgroundColour = this.colour[this.cellPalette & 0xe0];
+            for (let pixel = 8; pixel < 16; ++pixel) {
+                buf[offset + pixel] = backgroundColour;
+            }
+        } else {
+            let chardef = this.curGlyphs[this.cellGlyphIndex + scanline] >>> 16;
+            const paletteIndex = this.cellPalette;
+            for (let pixel = 8; pixel < 16; ++pixel) {
                 buf[offset + pixel] = this.colour[paletteIndex + (chardef & 3)];
                 chardef >>>= 2;
             }

--- a/src/teletext.js
+++ b/src/teletext.js
@@ -469,7 +469,7 @@ export class Teletext {
         }
     }
 
-    // The second half of the cell `emit` last painted, for the render loop's 1MHz repaint.
+    // The second half of the cell `emit` last painted, for the ULA's 1MHz repaint.
     emitSecondHalf(buf, offset) {
         const scanline = this.glyphScanline();
         if (this.cellConceal || (this.cellFlash && this.hideFlashing) || (this.secondHalfOfDouble && !this.dbl)) {

--- a/src/video.js
+++ b/src/video.js
@@ -549,6 +549,8 @@ export class Video {
         this.cursorOn = state.cursorOn;
         this.cursorOff = state.cursorOff;
         this.cursorOnThisFrame = state.cursorOnThisFrame;
+        this.cursorInvertedOffset = -1;
+        this.cellData = 0;
         this.cursorDrawIndex = state.cursorDrawIndex;
         this.cursorPos = state.cursorPos;
         this.interlacedSyncAndVideo = state.interlacedSyncAndVideo;

--- a/src/video.js
+++ b/src/video.js
@@ -714,7 +714,7 @@ export class Video {
     repaintSecondHalfOfCell() {
         if (!this.halfClock || !this.oddClock) return;
         if ((this.dispEnabled & EVERYTHINGENABLED) !== EVERYTHINGENABLED) return;
-        if (this.bitmapX < 0 || this.bitmapX >= 1024 || this.bitmapY >= 625) return;
+        if (this.bitmapX < 0 || this.bitmapX >= 1024 || this.bitmapY < 0 || this.bitmapY >= 625) return;
         // The same line doubling decision as the render loop, which inlines it for speed.
         const doubledLines =
             (this.doubledScanlines && !this.interlacedSyncAndVideo) || this.isEvenRender === this.lastRenderWasEven;

--- a/src/video.js
+++ b/src/video.js
@@ -84,6 +84,7 @@ class Ula {
                 this._writeNulaPalette(val);
                 break;
         }
+        this.video.repaintSecondHalfOfCell();
     }
 
     snapshotState() {
@@ -385,7 +386,9 @@ export class Video {
         this.cursorOff = false;
         this.cursorOnThisFrame = false;
         this.cursorDrawIndex = 0;
+        this.cursorInvertedOffset = -1;
         this.cursorPos = 0;
+        this.cellData = 0;
         this.interlacedSyncAndVideo = false;
         this.doubledScanlines = true;
         this.frameSkipCount = 0;
@@ -599,6 +602,7 @@ export class Video {
             if (this.frameCount % this.frameSkipCount) enable = 0;
         }
         this.dispEnabled |= enable;
+        this.cursorInvertedOffset = -1;
 
         this.bitmapY = 0;
         // Interlace even frame fires vsync midway through a scanline.
@@ -650,11 +654,7 @@ export class Video {
         destOffset |= 0;
         const offset = table4bppOffset(this.ulaMode, dat);
         const fb32 = this.fb32;
-        // In NULA palette mode, bypass the ULA palette (ulaPal) and look up
-        // pixel colours directly from the NULA 12-bit colour table (collook).
-        // This skips the XOR-7 logical↔physical colour mapping that the
-        // standard ULA applies.  Reference: b-em src/video.c lines 1083, 1117.
-        const colourLookup = this.ula.paletteMode ? this.ula.collook : this.ulaPal;
+        const colourLookup = this.pixelColours();
         const table4bpp = this.table4bpp;
         // Take advantage of numPixels being either 8 or 16
         if (numPixels === 8) {
@@ -668,18 +668,68 @@ export class Video {
         }
     }
 
+    // The second half of a 16 pixel cell, for the 1MHz repaint.
+    blitFbSecondHalf(dat, destOffset) {
+        const offset = table4bppOffset(this.ulaMode, dat);
+        const colourLookup = this.pixelColours();
+        for (let i = 8; i < 16; ++i) {
+            this.fb32[destOffset + i] = colourLookup[this.table4bpp[offset + i]];
+        }
+    }
+
+    // In NULA palette mode, bypass the ULA palette (ulaPal) and look up
+    // pixel colours directly from the NULA 12-bit colour table (collook).
+    // This skips the XOR-7 logical↔physical colour mapping that the
+    // standard ULA applies.  Reference: b-em src/video.c lines 1083, 1117.
+    pixelColours() {
+        return this.ula.paletteMode ? this.ula.collook : this.ulaPal;
+    }
+
     handleCursor(offset) {
         if (this.cursorOnThisFrame && this.ulactrl & this.cursorTable[this.cursorDrawIndex]) {
-            for (let i = 0; i < this.pixelsPerChar; ++i) {
-                this.fb32[offset + i] ^= 0x00ffffff;
-            }
-            if (this.doubledScanlines && !this.interlacedSyncAndVideo) {
-                for (let i = 0; i < this.pixelsPerChar; ++i) {
-                    this.fb32[offset + 1024 + i] ^= 0x00ffffff;
-                }
-            }
+            this.invertForCursor(offset, 0);
+            this.cursorInvertedOffset = offset;
+        } else {
+            this.cursorInvertedOffset = -1;
         }
         if (++this.cursorDrawIndex === 7) this.cursorDrawIndex = 0;
+    }
+
+    invertForCursor(offset, fromPixel) {
+        for (let i = fromPixel; i < this.pixelsPerChar; ++i) {
+            this.fb32[offset + i] ^= 0x00ffffff;
+        }
+        if (this.doubledScanlines && !this.interlacedSyncAndVideo) {
+            for (let i = fromPixel; i < this.pixelsPerChar; ++i) {
+                this.fb32[offset + 1024 + i] ^= 0x00ffffff;
+            }
+        }
+    }
+
+    // The render loop paints a whole 1MHz cell on one 2MHz tick and skips the next, but the ULA
+    // output stage switches at 2MHz: a register write landing on the skipped tick changes the
+    // second half of the cell just painted. See https://github.com/mattgodbolt/jsbeeb/issues/766
+    repaintSecondHalfOfCell() {
+        if (!this.halfClock || !this.oddClock) return;
+        if ((this.dispEnabled & EVERYTHINGENABLED) !== EVERYTHINGENABLED) return;
+        if (this.bitmapX < 0 || this.bitmapX >= 1024 || this.bitmapY >= 625) return;
+        // The same line doubling decision as the render loop, which inlines it for speed.
+        const doubledLines =
+            (this.doubledScanlines && !this.interlacedSyncAndVideo) || this.isEvenRender === this.lastRenderWasEven;
+        const bitmapRow = doubledLines ? this.bitmapY & ~1 : this.bitmapY;
+        const offset = bitmapRow * 1024 + this.bitmapX;
+        const halfCell = this.pixelsPerChar >>> 1;
+        if (this.teletextMode) {
+            this.teletext.emitSecondHalf(this.fb32, offset);
+        } else {
+            this.blitFbSecondHalf(this.cellData, offset);
+        }
+        if (doubledLines) {
+            this.fb32.copyWithin(offset + 1024 + halfCell, offset + halfCell, offset + this.pixelsPerChar);
+        }
+        if (this.cursorInvertedOffset === offset) {
+            this.invertForCursor(offset, halfCell);
+        }
     }
 
     setScreenHwScroll(viaScreenHwScroll) {
@@ -1022,6 +1072,7 @@ export class Video {
                     }
 
                     const offset = bitmapRow * 1024 + this.bitmapX;
+                    this.cellData = dat;
 
                     if ((this.dispEnabled & EVERYTHINGENABLED) === EVERYTHINGENABLED) {
                         // Note this row's logical pixel size for display
@@ -1047,14 +1098,14 @@ export class Video {
                                 this.fb32.fill(OPAQUE_BLACK, offset, offset + this.pixelsPerChar);
                             }
                         } else {
-                            this.blitFb(dat, offset, this.pixelsPerChar, doubledLines);
+                            this.blitFb(dat, offset, this.pixelsPerChar);
                         }
                         if (doubledLines) {
                             this.fb32.copyWithin(offset + 1024, offset, offset + this.pixelsPerChar);
                         }
                     }
                     if (this.cursorDrawIndex) {
-                        this.handleCursor(offset, doubledLines);
+                        this.handleCursor(offset);
                     }
                 }
             }

--- a/tests/unit/test-teletext.js
+++ b/tests/unit/test-teletext.js
@@ -305,6 +305,15 @@ describe("Teletext", () => {
         expect(solidOnly(cellAt(4), White)).toBe(true);
     });
 
+    it("can paint the second half of a cell on its own", () => {
+        const [whole] = renderCells([SolidBlock], LetterA);
+        const buffer = makeFast32(new Uint32Array(PixelsPerCell)).fill(0x0badf00d);
+        teletext.emitSecondHalf(buffer, 0);
+
+        expect(Array.from(buffer.subarray(0, PixelsPerCell / 2))).toEqual(Array(PixelsPerCell / 2).fill(0x0badf00d));
+        expect(Array.from(buffer.subarray(PixelsPerCell / 2))).toEqual(Array.from(whole.subarray(PixelsPerCell / 2)));
+    });
+
     // Codes 0, 16 and 27 are reserved, 10 and 11 drive a boxing output the BBC has nothing wired to,
     // and 14 and 15 select an alternate character set the chip does not carry. Pages rely on this:
     // the Ceefax engineering page reveals its concealed text by rewriting code 24 as code 16.

--- a/tests/unit/test-video.js
+++ b/tests/unit/test-video.js
@@ -549,9 +549,7 @@ describe("Video", () => {
         });
     });
 
-    // In a 1MHz mode the render loop paints a whole 16 texel cell on one 2MHz tick and skips the
-    // next, but the ULA's output stage still switches at 2MHz: a register write landing on the
-    // skipped tick changes the second half of the cell that has just been painted.
+    // See Video.repaintSecondHalfOfCell.
     describe("ULA writes half way through a 1MHz cell", () => {
         const Mode4 = 0x88;
         const Mode4Teletext = 0x8a;

--- a/tests/unit/test-video.js
+++ b/tests/unit/test-video.js
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, vi, afterEach } from "vitest";
-import { Video, HDISPENABLE, VDISPENABLE, USERDISPENABLE, EVERYTHINGENABLED } from "../../src/video.js";
+import { Video, HDISPENABLE, VDISPENABLE, USERDISPENABLE, EVERYTHINGENABLED, OPAQUE_BLACK } from "../../src/video.js";
 import * as utils from "../../src/utils.js";
 import { texelsPerPixel } from "../../src/video-filters/pixel-grid.js";
 import { decodeLineGrid } from "../line-grid.js";
@@ -53,6 +53,7 @@ describe("Video", () => {
             fetchData: vi.fn(),
             advance: vi.fn(),
             emit: vi.fn(),
+            emitSecondHalf: vi.fn(),
         };
 
         // Replace the teletext instance
@@ -545,6 +546,122 @@ describe("Video", () => {
 
             expect(mockTeletext.emit).not.toHaveBeenCalled();
             expect(mockFb32[TEST_FB_OFFSET]).toBe(0xff000000);
+        });
+    });
+
+    // In a 1MHz mode the render loop paints a whole 16 texel cell on one 2MHz tick and skips the
+    // next, but the ULA's output stage still switches at 2MHz: a register write landing on the
+    // skipped tick changes the second half of the cell that has just been painted.
+    describe("ULA writes half way through a 1MHz cell", () => {
+        const Mode4 = 0x88;
+        const Mode4Teletext = 0x8a;
+        const Mode0 = 0x9c;
+        const Red = 0xffff0000;
+        const Green = 0xff00ff00;
+        const AllPixelsSet = 0xff;
+        const CellWidth = 16;
+        const HalfCell = 8;
+        const inverted = (colour) => (colour ^ 0x00ffffff) >>> 0;
+        let offset;
+
+        // Leaves the beam at the start of a cell with the body about to run on the next tick.
+        beforeEach(() => {
+            video.dispEnabled = EVERYTHINGENABLED;
+            video.regs[7] = 30; // keep vsync, and the flyback it brings, away from the cell under test
+            video.horizCounter = 10;
+            video.bitmapX = 92;
+            video.bitmapY = 100;
+            video.oddClock = false;
+            mockCpu.videoRead.mockReturnValue(AllPixelsSet);
+            video.ulaPal.fill(Red);
+            offset = 100 * 1024 + 100;
+        });
+
+        const cell = () => Array.from(mockFb32.subarray(offset, offset + CellWidth));
+        const firstHalf = () => cell().slice(0, HalfCell);
+        const secondHalf = () => cell().slice(HalfCell);
+
+        it("repaints the second half as teletext when the teletext bit is set", () => {
+            video.ula.write(0, Mode4);
+            video.polltime(1);
+            expect(cell()).toEqual(Array(CellWidth).fill(Red));
+
+            video.ula.write(0, Mode4Teletext);
+
+            expect(mockTeletext.emitSecondHalf).toHaveBeenCalledWith(expect.any(Uint32Array), offset);
+        });
+
+        it("repaints the second half as bitmap when the teletext bit is cleared", () => {
+            video.ula.write(0, Mode4Teletext);
+            video.polltime(1);
+            expect(mockTeletext.emit).toHaveBeenCalledWith(expect.any(Uint32Array), offset);
+            expect(cell()).toEqual(Array(CellWidth).fill(OPAQUE_BLACK));
+
+            video.ula.write(0, Mode4);
+
+            expect(firstHalf()).toEqual(Array(HalfCell).fill(OPAQUE_BLACK));
+            expect(secondHalf()).toEqual(Array(HalfCell).fill(Red));
+        });
+
+        it("applies a palette write to the second half only", () => {
+            video.ula.write(0, Mode4);
+            video.polltime(1);
+
+            video.ula.write(1, 0xf0 | (7 ^ 2)); // a set pixel in a two colour mode is logical colour 15
+            expect(video.ulaPal[15]).toBe(Green);
+
+            expect(firstHalf()).toEqual(Array(HalfCell).fill(Red));
+            expect(secondHalf()).toEqual(Array(HalfCell).fill(Green));
+        });
+
+        it("leaves the cell alone when the write lands at the start of the next cell", () => {
+            video.ula.write(0, Mode4);
+            video.polltime(2);
+            const before = cell();
+
+            video.ula.write(0, Mode4Teletext);
+
+            expect(cell()).toEqual(before);
+            expect(mockTeletext.emitSecondHalf).not.toHaveBeenCalled();
+        });
+
+        it("leaves a 2MHz mode alone, where every tick already paints", () => {
+            video.ula.write(0, Mode0);
+            video.polltime(1);
+            const before = Array.from(mockFb32.subarray(offset, offset + CellWidth));
+
+            video.ula.write(1, 0xf0 | (7 ^ 2));
+
+            expect(Array.from(mockFb32.subarray(offset, offset + CellWidth))).toEqual(before);
+        });
+
+        it("repaints the doubled scanline too", () => {
+            video.doubledScanlines = true;
+            video.interlacedSyncAndVideo = false;
+            video.ula.write(0, Mode4);
+            video.polltime(1);
+            expect(Array.from(mockFb32.subarray(offset + 1024, offset + 1024 + CellWidth))).toEqual(
+                Array(CellWidth).fill(Red),
+            );
+
+            video.ula.write(1, 0xf0 | (7 ^ 2));
+
+            expect(Array.from(mockFb32.subarray(offset + 1024 + HalfCell, offset + 1024 + CellWidth))).toEqual(
+                Array(HalfCell).fill(Green),
+            );
+        });
+
+        it("keeps the cursor inverted over the repainted half", () => {
+            video.ula.write(0, Mode4 | 0x60); // cursor on both halves of the master cursor table
+            video.cursorOnThisFrame = true;
+            video.cursorDrawIndex = 3;
+            video.polltime(1);
+            expect(cell()).toEqual(Array(CellWidth).fill(inverted(Red)));
+
+            video.ula.write(1, 0xf0 | (7 ^ 2));
+
+            expect(firstHalf()).toEqual(Array(HalfCell).fill(inverted(Red)));
+            expect(secondHalf()).toEqual(Array(HalfCell).fill(inverted(Green)));
         });
     });
 

--- a/tests/unit/test-video.js
+++ b/tests/unit/test-video.js
@@ -623,6 +623,16 @@ describe("Video", () => {
             expect(mockTeletext.emitSecondHalf).not.toHaveBeenCalled();
         });
 
+        it("leaves the frame alone while the beam is above it", () => {
+            video.ula.write(0, Mode4);
+            video.polltime(1);
+            video.bitmapY = -1;
+
+            video.ula.write(0, Mode4Teletext);
+
+            expect(mockTeletext.emitSecondHalf).not.toHaveBeenCalled();
+        });
+
         it("leaves a 2MHz mode alone, where every tick already paints", () => {
             video.ula.write(0, Mode0);
             video.polltime(1);


### PR DESCRIPTION
## What

In a 1MHz mode (MODE 4 to 7) the render loop paints a whole 16 texel cell on one 2MHz tick and skips the next. A Video ULA register write landing on the skipped tick therefore only took effect from the next cell. The real ULA switches source, mode and palette at 2MHz whatever the character clock, so a write half way through a cell changes the second half of that cell.

Every ULA write now calls `Video.repaintSecondHalfOfCell()`. It does nothing unless we are in a 1MHz mode and the write landed on the skipped tick; then it repaints texels 8 to 15 of the cell just painted from the new state: teletext glyph, bitmap byte, the doubled scanline, and the cursor XOR if the cursor was drawn over that cell. Palette and NULA writes are covered by the same path, since it sits where the state changes rather than where we paint.

## Evidence

A test program in MODE 4 flipping the teletext select bit every 11 cycles, six times per scanline: the signal is boxes 5.5 cells wide. Hooking the write and paint paths before the fix:

```
writes: dx=88 texels (5.50 cells), every time
painted: b19 T5 b6 T5 b6 T5 b10
```

Every mid-cell write was deferred to the cell boundary. After the fix the boxes are 88 texels each. Full write-up in #766.

## Performance

The render loop is unchanged apart from keeping the fetched byte; the cost lands in the cold write path. The first cut regressed MODE 7 by 10% from an extracted method that stopped V8 inlining the loop, and a `fromPixel` parameter on `emit` cost 3% on its own, so both became separate `*SecondHalf` methods. Video only microbenchmark, before vs after, ms/frame: MODE 7 0.945 vs 0.945, MODE 0 1.95 vs 1.96, MODE 4 1.26 vs 1.28. Within noise.

## Tests

Unit tests for: teletext on mid cell, teletext off mid cell, palette write mid cell, a write on the next cell's tick (no repaint), a 2MHz mode (no repaint), doubled scanlines, and the cursor. The teletext hardware reference images T1 to T7 are unchanged.

Closes #766. The test page for the disc is #878.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
