### PR TITLE
fix: cancel the sound chip's DC pedestal as the hardware does

### DIFF
--- a/docs/snapshot-format.md
+++ b/docs/snapshot-format.md
@@ -229,6 +229,8 @@ Contains ~20 scalar fields for SAA5050 rendering state. Glyph table references a
 | `sineOn`          | boolean      | Sine tone generator active                     |
 | `sineStep`        | number       | Sine generator step size                       |
 | `sineTime`        | number       | Sine generator phase                           |
+| `dcPrevIn`        | number       | DC blocker previous input (0 if absent)        |
+| `dcPrevOut`       | number       | DC blocker previous output (0 if absent)       |
 
 ### ACIA (`state.acia`)
 

--- a/src/soundchip.js
+++ b/src/soundchip.js
@@ -194,9 +194,6 @@ export class SoundChip {
                 this.generators[i](i, out, offset, length);
             }
         }
-        // The blocker models circuitry downstream of the chip, so it
-        // processes everything the chip emits, muted (all-zero) output
-        // included.
         const alpha = this.dcAlpha;
         let prevIn = this.dcPrevIn;
         let prevOut = this.dcPrevOut;

--- a/src/soundchip.js
+++ b/src/soundchip.js
@@ -194,14 +194,20 @@ export class SoundChip {
                 this.generators[i](i, out, offset, length);
             }
         }
-        // Runs over muted (all-zero) output too: skipping it would leave
-        // stale filter state to discharge as a spurious transient at unmute.
+        // The blocker models circuitry downstream of the chip, so it
+        // processes everything the chip emits, muted (all-zero) output
+        // included.
+        const alpha = this.dcAlpha;
+        let prevIn = this.dcPrevIn;
+        let prevOut = this.dcPrevOut;
         for (let i = 0; i < length; ++i) {
             const x = out[i + offset];
-            this.dcPrevOut = x - this.dcPrevIn + this.dcAlpha * this.dcPrevOut;
-            this.dcPrevIn = x;
-            out[i + offset] = this.dcPrevOut;
+            prevOut = x - prevIn + alpha * prevOut;
+            prevIn = x;
+            out[i + offset] = prevOut;
         }
+        this.dcPrevIn = prevIn;
+        this.dcPrevOut = prevOut;
     }
 
     catchUp() {

--- a/src/soundchip.js
+++ b/src/soundchip.js
@@ -5,6 +5,13 @@ const speakerVolume = 0.5;
 // Samples per output chunk handed to the onBuffer callback.
 export const SoundBufferSamples = 512;
 
+// The BBC's DC restoration circuit (Service Manual section 3.8: R8 10K, C2
+// 4u7) cancels the SN76489's unipolar pedestal. Modelled as a first-order DC
+// blocker with the same corner, 1/(2*pi*R*C). The generators must stay
+// unipolar: sampled speech is amplitude modulation of a 125 kHz carrier's
+// mean level, which a zero-mean output would silence (see issue #863).
+const DcRestoreCornerHz = 1 / (2 * Math.PI * 10e3 * 4.7e-6);
+
 const volumeTable = new Float32Array(16);
 (() => {
     let f = 1.0;
@@ -71,6 +78,10 @@ export class SoundChip {
         this.residual = 0;
         this.position = 0;
         this.buffer = new Float32Array(SoundBufferSamples);
+
+        this.dcAlpha = 1 - (2 * Math.PI * DcRestoreCornerHz) / sampleRate;
+        this.dcPrevIn = 0;
+        this.dcPrevOut = 0;
 
         this.latchedRegister = 0;
         this.slowDataBus = 0;
@@ -178,9 +189,18 @@ export class SoundChip {
         for (let i = 0; i < length; ++i) {
             out[i + offset] = 0.0;
         }
-        if (!this.enabled) return;
-        for (let i = 0; i < this.generators.length; ++i) {
-            this.generators[i](i, out, offset, length);
+        if (this.enabled) {
+            for (let i = 0; i < this.generators.length; ++i) {
+                this.generators[i](i, out, offset, length);
+            }
+        }
+        // Runs over muted (all-zero) output too, so the pedestal decays away
+        // on mute like the real circuit instead of vanishing in a step.
+        for (let i = 0; i < length; ++i) {
+            const x = out[i + offset];
+            this.dcPrevOut = x - this.dcPrevIn + this.dcAlpha * this.dcPrevOut;
+            this.dcPrevIn = x;
+            out[i + offset] = this.dcPrevOut;
         }
     }
 
@@ -319,9 +339,11 @@ export class SoundChip {
         // Rebind the LFSR function based on noise register
         this.shiftLfsr =
             this.registers[3] & 4 ? this.shiftLfsrWhiteNoise.bind(this) : this.shiftLfsrPeriodicNoise.bind(this);
-        // Reset output buffer
+        // Reset output buffer and DC blocker
         this.position = 0;
         this.buffer.fill(0);
+        this.dcPrevIn = 0;
+        this.dcPrevOut = 0;
     }
 
     reset(hard) {

--- a/src/soundchip.js
+++ b/src/soundchip.js
@@ -194,8 +194,8 @@ export class SoundChip {
                 this.generators[i](i, out, offset, length);
             }
         }
-        // Runs over muted (all-zero) output too, so the pedestal decays away
-        // on mute like the real circuit instead of vanishing in a step.
+        // Runs over muted (all-zero) output too: skipping it would leave
+        // stale filter state to discharge as a spurious transient at unmute.
         for (let i = 0; i < length; ++i) {
             const x = out[i + offset];
             this.dcPrevOut = x - this.dcPrevIn + this.dcAlpha * this.dcPrevOut;

--- a/src/soundchip.js
+++ b/src/soundchip.js
@@ -317,6 +317,8 @@ export class SoundChip {
             sineOn: this.sineOn,
             sineStep: this.sineStep,
             sineTime: this.sineTime,
+            dcPrevIn: this.dcPrevIn,
+            dcPrevOut: this.dcPrevOut,
         };
     }
 
@@ -339,11 +341,12 @@ export class SoundChip {
         // Rebind the LFSR function based on noise register
         this.shiftLfsr =
             this.registers[3] & 4 ? this.shiftLfsrWhiteNoise.bind(this) : this.shiftLfsrPeriodicNoise.bind(this);
-        // Reset output buffer and DC blocker
+        // Reset output buffer
         this.position = 0;
         this.buffer.fill(0);
-        this.dcPrevIn = 0;
-        this.dcPrevOut = 0;
+        // Older snapshots predate the DC blocker
+        this.dcPrevIn = state.dcPrevIn ?? 0;
+        this.dcPrevOut = state.dcPrevOut ?? 0;
     }
 
     reset(hard) {

--- a/tests/unit/test-soundchip.js
+++ b/tests/unit/test-soundchip.js
@@ -223,6 +223,32 @@ describe("SoundChip snapshotState / restoreState", () => {
         expect(chip2.latchedRegister).toBe(0x60);
     });
 
+    it("should snapshot and restore the DC blocker state", () => {
+        const { chip } = makeSoundChip();
+        chip.dcPrevIn = 0.125;
+        chip.dcPrevOut = -0.0625;
+
+        const snapshot = chip.snapshotState();
+        const { chip: chip2 } = makeSoundChip();
+        chip2.restoreState(snapshot);
+
+        expect(chip2.dcPrevIn).toBeCloseTo(0.125);
+        expect(chip2.dcPrevOut).toBeCloseTo(-0.0625);
+    });
+
+    it("should zero the DC blocker for snapshots that predate it", () => {
+        const { chip } = makeSoundChip();
+        const snapshot = chip.snapshotState();
+        delete snapshot.dcPrevIn;
+        delete snapshot.dcPrevOut;
+        chip.dcPrevIn = 0.5;
+        chip.dcPrevOut = 0.5;
+        chip.restoreState(snapshot);
+
+        expect(chip.dcPrevIn).toBe(0);
+        expect(chip.dcPrevOut).toBe(0);
+    });
+
     it("should snapshot and restore sine generator state", () => {
         const { chip } = makeSoundChip();
         chip.sineOn = true;

--- a/tests/unit/test-soundchip.js
+++ b/tests/unit/test-soundchip.js
@@ -55,6 +55,79 @@ describe("SoundChip advance", () => {
     });
 });
 
+// Amplitude of the frequency-bin component at freq, via the Goertzel algorithm.
+function goertzelAmplitude(samples, freq, sampleRate) {
+    const w = (2 * Math.PI * freq) / sampleRate;
+    const coeff = 2 * Math.cos(w);
+    let s1 = 0;
+    let s2 = 0;
+    for (const sample of samples) {
+        const s0 = sample + coeff * s1 - s2;
+        s2 = s1;
+        s1 = s0;
+    }
+    return (2 * Math.sqrt(s1 * s1 + s2 * s2 - coeff * s1 * s2)) / samples.length;
+}
+
+describe("SoundChip DC restoration", () => {
+    // 500 kHz chip rate; the blocker's 47 ms time constant settles well inside half a second.
+    const SettleSamples = 250000;
+
+    function settle(chip, scratch) {
+        for (let done = 0; done < SettleSamples; done += scratch.length) chip.generate(scratch, 0, scratch.length);
+    }
+
+    it("should centre a steady tone around zero instead of riding a pedestal", () => {
+        const { chip } = makeSoundChip();
+        chip.poke(0x80 | 0x00); // channel 0, period low nibble
+        chip.poke(0x20); // period high bits: period 512, a 2048-sample square
+        chip.poke(0x90 | 0x00); // channel 0, full volume
+        const out = new Float32Array(4096); // exactly two square-wave periods
+        settle(chip, out);
+        chip.generate(out, 0, out.length);
+
+        let mean = 0;
+        let min = Infinity;
+        let max = -Infinity;
+        for (const sample of out) {
+            mean += sample;
+            min = Math.min(min, sample);
+            max = Math.max(max, sample);
+        }
+        mean /= out.length;
+        // Unipolar output would have mean vol/2 = 0.125 and min 0.
+        expect(Math.abs(mean)).toBeLessThan(0.01);
+        expect(max).toBeGreaterThan(0.1);
+        expect(min).toBeLessThan(-0.1);
+    });
+
+    it("should preserve volume-register PCM on a period-1 carrier", () => {
+        // Sampled speech sets tone period 1 (a 125 kHz carrier) and writes the
+        // sample data to the volume register: the audio is the carrier's mean
+        // level, vol/2. A zero-mean (bipolar) output would silence it, which
+        // is why the generators stay unipolar (issue #863).
+        const { chip } = makeSoundChip();
+        chip.poke(0x80 | 0x01); // channel 0, period 1
+        chip.poke(0x00);
+        const half = 250; // half a 1 kHz modulation period at 500 kHz
+        const chunk = new Float32Array(half);
+        settle(chip, chunk);
+
+        const modulated = [];
+        const totalHalves = 100; // 50 cycles of 1 kHz, an integral Goertzel bin
+        for (let i = 0; i < totalHalves; ++i) {
+            chip.poke(0x90 | (i % 2 ? 0x08 : 0x00));
+            chip.generate(chunk, 0, half);
+            modulated.push(...chunk);
+        }
+        // Means are vol/2 = 0.125 and 0.0198, so the 1 kHz square modulation
+        // has a fundamental of ((0.125 - 0.0198) / 2) * 4/pi = 0.067.
+        const amplitude = goertzelAmplitude(modulated, 1000, chip.soundchipFreq);
+        expect(amplitude).toBeGreaterThan(0.05);
+        expect(amplitude).toBeLessThan(0.09);
+    });
+});
+
 describe("SoundChip snapshotState / restoreState", () => {
     it("should snapshot and restore tone channel registers", () => {
         const { chip } = makeSoundChip();


### PR DESCRIPTION
Part of #863. **Numerically verified but needs human listening before merge**; instructions below.

## What this does

The SN76489's output is unipolar, so every channel rides a DC pedestal of vol/2. The BBC cancels that on the board with an explicit DC restoration circuit (Service Manual section 3.8: R8 10K, C2 4u7, a ~3.4 Hz corner); this PR models it as a first-order DC blocker on the summed chip output, with the corner derived from those component values. Like the circuit it models, the blocker sits after the chip and filters everything the chip emits; it takes no notice of mute. Its state is machine state (the restore capacitor's charge), so it is carried through snapshots, with a zero fallback for snapshots that predate it.

**The generators deliberately stay unipolar**, contrary to the fix originally proposed in #863: sampled speech sets tone period 1 (a 125 kHz carrier) and writes the sample to the volume register, so the audio *is* the carrier's unipolar mean. Simulation of the proposed bipolar conversion silenced that path by ~99 dB ([details on the issue](https://github.com/mattgodbolt/jsbeeb/issues/863#issuecomment-5403512953)). A new unit test pins the PCM path so a future bipolar refactor cannot silently break it, and another pins the zero-centred steady-tone output.

**Correction to an earlier version of this description**, which claimed pause/stop thumps become a soft decay. Wrong on both ends: pausing never stepped the output in the first place (the worklet freezes on the last sample when its queue empties, and the chip's sample stream resumes bit-for-bit where it left off), and a 3.4 Hz blocker passes fast steps straight through, on the real board just as here, so any step that clicked before still steps identically. What the blocker changes is only what follows a step: a ~47 ms settle back to zero instead of a sustained offset. It cannot introduce a discontinuity anywhere (it is a smooth running-average subtraction; continuous in, continuous out).

## What to listen for

**Must sound identical (the regression risks):**
- **Sampled speech: Spyhunter, Speech!, Repton.** This is the big one. The speech content passes through the blocker untouched in simulation (3.4 Hz corner vs 100 Hz+ content); confirm with ears. Any new muffling, thinning, or level drop here is a bug in this PR.
- **Envelope-shaped music** (anything using `ENVELOPE`). The 100 Hz volume staircase passes a 3.4 Hz restore essentially intact on real hardware too, so it is deliberately untouched. Same character as before expected.
- **Pause, resume, mute, and game sound starting or stopping.** No audible change expected in any transition, per the correction above; a new click here would be a bug.
- **Ordinary tones and noise**: any game music, the boot beep. A square wave through a 47 ms blocker gains a ~8% tilt per half-cycle at the lowest tone frequencies, which is what the hardware does; it should not be audible.

**Should sound better (the point of the change):**
- **Loud multi-channel content** through the default filter should clip less, since the signal no longer sits on a 0.45 pedestal under the filter's resonant peak. (The resonance itself is wrong against the hardware and gets its own follow-up, #880.)

**Against the real Master:** overall tonal balance should be no different from before this PR; the interesting comparison is the speech titles, where jsbeeb and the Master should agree as well as they did last week.

@scarybeasts' sample-playback and novel-audio demos are exactly the kind of material that would catch an error in the "keep it unipolar" reasoning; if any of them sound different from hardware after this, I want to know which.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019CJ9csHch7kjzF3DKzR5DP

