### PR TITLE
fix: replace the resonant output filter with the board's actual response

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -174,8 +174,12 @@ const cpuMultiplier = parsedQuery.cpuMultiplier ?? 1;
 let fastAsPossible = false;
 let fastTape = false;
 let noSeek;
-let audioFilterFreq = 7000;
-let audioFilterQ = 5;
+// The board's output filter is an equal-component Sallen-Key (Service Manual
+// section 3.8: 10K and 2n2 twice, gain 1 + 22/39): f0 = 1/(2*pi*RC) = 7234 Hz,
+// Q = 1/(3 - K) = 0.696, below 1/sqrt(2), so no resonant peak. BiquadFilterNode
+// takes lowpass Q in decibels: 20*log10(0.696) = -3.15.
+let audioFilterFreq = 7234;
+let audioFilterQ = -3.15;
 let stationId = 101;
 let econet = null;
 


### PR DESCRIPTION
Closes #863 (jointly with #879, the DC restoration half). **Needs human listening before merge**; instructions below.

## What this does

The default output filter was `frequency 7000, Q 5`. `BiquadFilterNode` takes lowpass Q in **decibels**, so that is a conventional Q of 1.78: a +5.4 dB resonant peak near 6.5 kHz that the real machine does not have. The board's output filter is an equal-component Sallen-Key (Service Manual section 3.8: 10K/2n2 twice, gain 1 + 22/39) giving f0 = 7234 Hz and Q = 0.696, below 1/sqrt(2), so **no peak at all** (analysis in [this comment](https://github.com/mattgodbolt/jsbeeb/issues/863#issuecomment-5304664299) on #863). This PR sets the defaults to the derived hardware values: 7234 Hz and -3.15 dB.

Not modelled: the Sallen-Key's passband gain of 1.56 (a flat level change, absorbed by the volume control) and the later ~420 Hz coupling into the LM386 (which would thin the bass relative to what jsbeeb has always sounded like; a bigger tonal decision than this PR wants to take). The `?audiofilterfreq=` and `?audiofilterq=` query parameters still override, so the old sound is one URL away for comparison: `?audiofilterfreq=7000&audiofilterq=5`.

## What to listen for

This one is **expected to sound different**, unlike #879:

- **Overall brightness character.** The removed peak sat right where the noise channel and high tone harmonics live, so hiss, explosions and percussion should lose a slightly honky ~6.5 kHz emphasis. Music should sound marginally smoother, not duller: content below ~5 kHz is essentially untouched.
- **Against the real Master over composite or line out: this is the change your ears can actually referee.** Play the same game on both and judge which filter default sits closer to the hardware's treble. That comparison is the merge criterion.
- **Sampled speech (Spyhunter, Speech!, Repton)** sits mostly below the affected band but has energy up there; it should sound the same or slightly cleaner, never duller.
- **Loud multi-channel music** should clip less at full volume, since nothing is being amplified +5.4 dB into full scale any more.

If the new default sounds *worse* than the old one against real hardware, that is a finding about the rest of our audio chain, and worth reporting on #863 rather than just closing this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019CJ9csHch7kjzF3DKzR5DP
