### PR TITLE
test: stop the Music 5000 toast leaking timers into later test files

### DIFF
--- a/tests/unit/test-audio-handler.js
+++ b/tests/unit/test-audio-handler.js
@@ -1,6 +1,8 @@
 // @vitest-environment jsdom
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+import * as bootstrap from "bootstrap";
+
 import { AudioHandler } from "../../src/web/audio-handler.js";
 
 const SuspendedText = "Your browser has suspended audio";
@@ -127,7 +129,21 @@ describe("AudioHandler", () => {
         };
 
         beforeEach(() => vi.spyOn(console, "error").mockImplementation(() => {}));
-        afterEach(() => vi.restoreAllMocks());
+
+        // A toast left mid-show leaks timers past this file's jsdom window:
+        // bootstrap fakes transitionend with an uncancellable short timer,
+        // which in turn arms the five second autohide. Let the transition
+        // finish while this window is still current, then dispose to cancel
+        // the autohide; either timer firing later crashes the run from
+        // whichever test file is running at the time.
+        afterEach(async () => {
+            vi.restoreAllMocks();
+            await vi.waitFor(() => {
+                for (const el of document.querySelectorAll(".toast"))
+                    expect(el.classList.contains("showing")).toBe(false);
+            });
+            for (const el of document.querySelectorAll(".toast")) bootstrap.Toast.getInstance(el)?.dispose();
+        });
 
         it("says there will be no sound in the banner, and leaves it up", async () => {
             stubAudio({ addModule: rejectModule("audio-renderer") });


### PR DESCRIPTION
Found while committing a docs tweak to #879: the pre-commit `vitest related` run failed about two times in three with an unhandled `TypeError: parameter 1 is not of type 'Event'` from bootstrap, attributed to `test-audio-handler.js`, with all tests passing.

The mechanism: the "toasts about the Music 5000" test creates a real bootstrap toast on the real clock. Bootstrap fakes `transitionend` with a short anonymous `setTimeout` (uncancellable), and that in turn arms the toast's five second autohide. Both can outlive the file's jsdom window; when one fires, bootstrap constructs an `Event` from whatever realm is current (a later test file's window, or Node's own `Event`), and `dispatchEvent` on the old-realm element rejects it. Whether it strikes depends on where the file lands in the run and how long the run lasts, hence flaky: reliably clean standalone, ~2/3 failing under `vitest related --no-file-parallelism` with `soundchip.js` staged.

The fix, in the describe block that makes the toast: wait for the show transition to finish while the file's window is still current (so bootstrap's timer fires in the right realm), then `dispose()` the toast to cancel the autohide. Verified with eight consecutive clean runs of the previously-failing command; `test-toast.js` already protects itself the same way via fake timers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019CJ9csHch7kjzF3DKzR5DP