### PR TITLE
fix: advance the emulator on a timer instead of requestAnimationFrame

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -553,6 +553,7 @@ function swapCanvas(newFilterClass) {
 const canvas = createCanvasForFilter(displayModeFilter);
 displayModeFilter = canvas.filterClass;
 
+let paintMsThisTick = 0;
 video = new Video(
     model.isMaster,
     canvas.fb32,
@@ -560,7 +561,9 @@ video = new Video(
         frames++;
         if (frames < frameSkip) return;
         frames = 0;
+        const start = performance.now();
         canvas.paint(minx, miny, maxx, maxy, { frameCount: this.frameCount, lineGrid: this.lineGrid });
+        paintMsThisTick += performance.now() - start;
     },
     { isAtom: model.isAtom },
 );
@@ -2294,26 +2297,28 @@ const RewindCaptureCycles = (RewindCaptureInterval * clocksPerSecond) / 50;
 // throughout execute(), so only the idle time starves the audio queue.
 const TickLogIntervalMs = 1000;
 const SlowTickLogMs = 30;
-const tickLog = { start: 0, ticks: 0, maxIdle: 0, maxExecute: 0, maxSnapshot: 0 };
+const tickLog = { start: 0, ticks: 0, maxIdle: 0, maxExecute: 0, maxPaint: 0, maxSnapshot: 0 };
 
-function logTick(now, idleMs, executeMs, snapshotMs) {
+function logTick(now, idleMs, executeMs, paintMs, snapshotMs) {
     const log = tickLog;
     if (log.start === 0) log.start = now;
     log.ticks++;
     log.maxIdle = Math.max(log.maxIdle, idleMs);
     log.maxExecute = Math.max(log.maxExecute, executeMs);
+    log.maxPaint = Math.max(log.maxPaint, paintMs);
     log.maxSnapshot = Math.max(log.maxSnapshot, snapshotMs);
     if (now - log.start < TickLogIntervalMs) return;
     const audio = audioHandler.takeEventCounts();
     if (log.maxIdle > SlowTickLogMs || log.maxExecute > SlowTickLogMs || audio.underrun || audio.dropped) {
         console.log(
             `${(now / 1000).toFixed(0)}s: ${log.ticks} ticks, idle max ${log.maxIdle.toFixed(0)}ms, ` +
-                `execute max ${log.maxExecute.toFixed(0)}ms, snapshot ${log.maxSnapshot.toFixed(1)}ms; ` +
+                `execute max ${log.maxExecute.toFixed(0)}ms (paint ${log.maxPaint.toFixed(0)}ms), ` +
+                `snapshot ${log.maxSnapshot.toFixed(1)}ms; ` +
                 `audio underruns ${audio.underrun}, dropped ${audio.dropped} buffers`,
         );
     }
     log.start = now;
-    log.ticks = log.maxIdle = log.maxExecute = log.maxSnapshot = 0;
+    log.ticks = log.maxIdle = log.maxExecute = log.maxPaint = log.maxSnapshot = 0;
 }
 
 rewindUI = new RewindUI({
@@ -2411,7 +2416,8 @@ function tick() {
                 rewindUI.updateButtonState();
                 snapshotMs = performance.now() - end;
             }
-            if (audioStatsNode) logTick(now, speedy ? 0 : now - lastEnd, end - now, snapshotMs);
+            if (audioStatsNode) logTick(now, speedy ? 0 : now - lastEnd, end - now, paintMsThisTick, snapshotMs);
+            paintMsThisTick = 0;
         } catch (e) {
             running = false;
             utils.noteEvent("exception", "thrown", e.stack);

--- a/src/main.js
+++ b/src/main.js
@@ -2250,6 +2250,7 @@ function profileVideo(arg) {
 }
 
 let last = 0;
+let lastEnd = 0;
 
 function VirtualSpeedUpdater() {
     this.cycles = 0;
@@ -2287,30 +2288,32 @@ let rewindCycleCounter = 0;
 const RewindCaptureInterval = 50; // emulated frames, ~1 second
 const RewindCaptureCycles = (RewindCaptureInterval * clocksPerSecond) / 50;
 
-// Under ?audioDebug, one console line per second in which a tick ran late
-// or the audio queue underran or dropped, so a click can be matched to a cause.
+// Under ?audioDebug, one console line per second in which the emulator sat
+// idle between ticks or a tick ran long, or the audio queue underran or
+// dropped, so a click can be matched to a cause. The sound chip posts samples
+// throughout execute(), so only the idle time starves the audio queue.
 const TickLogIntervalMs = 1000;
 const SlowTickLogMs = 30;
-const tickLog = { start: 0, ticks: 0, maxGap: 0, maxExecute: 0, maxSnapshot: 0 };
+const tickLog = { start: 0, ticks: 0, maxIdle: 0, maxExecute: 0, maxSnapshot: 0 };
 
-function logTick(now, gapMs, executeMs, snapshotMs) {
+function logTick(now, idleMs, executeMs, snapshotMs) {
     const log = tickLog;
     if (log.start === 0) log.start = now;
     log.ticks++;
-    log.maxGap = Math.max(log.maxGap, gapMs);
+    log.maxIdle = Math.max(log.maxIdle, idleMs);
     log.maxExecute = Math.max(log.maxExecute, executeMs);
     log.maxSnapshot = Math.max(log.maxSnapshot, snapshotMs);
     if (now - log.start < TickLogIntervalMs) return;
     const audio = audioHandler.takeEventCounts();
-    if (log.maxGap > SlowTickLogMs || log.maxExecute > SlowTickLogMs || audio.underrun || audio.dropped) {
+    if (log.maxIdle > SlowTickLogMs || log.maxExecute > SlowTickLogMs || audio.underrun || audio.dropped) {
         console.log(
-            `${(now / 1000).toFixed(0)}s: ${log.ticks} ticks, gap max ${log.maxGap.toFixed(0)}ms, ` +
+            `${(now / 1000).toFixed(0)}s: ${log.ticks} ticks, idle max ${log.maxIdle.toFixed(0)}ms, ` +
                 `execute max ${log.maxExecute.toFixed(0)}ms, snapshot ${log.maxSnapshot.toFixed(1)}ms; ` +
                 `audio underruns ${audio.underrun}, dropped ${audio.dropped} buffers`,
         );
     }
     log.start = now;
-    log.ticks = log.maxGap = log.maxExecute = log.maxSnapshot = 0;
+    log.ticks = log.maxIdle = log.maxExecute = log.maxSnapshot = 0;
 }
 
 rewindUI = new RewindUI({
@@ -2408,7 +2411,7 @@ function tick() {
                 rewindUI.updateButtonState();
                 snapshotMs = performance.now() - end;
             }
-            if (audioStatsNode) logTick(now, speedy ? 0 : now - last, end - now, snapshotMs);
+            if (audioStatsNode) logTick(now, speedy ? 0 : now - lastEnd, end - now, snapshotMs);
         } catch (e) {
             running = false;
             utils.noteEvent("exception", "thrown", e.stack);
@@ -2420,6 +2423,7 @@ function tick() {
         }
     }
     last = now;
+    lastEnd = performance.now();
 }
 
 function run() {

--- a/src/main.js
+++ b/src/main.js
@@ -2335,6 +2335,7 @@ function logTick(now, idleMs, executeMs, paintMs, snapshotMs) {
     const audio = audioHandler.takeEventCounts();
     const present = presentMsMax;
     presentMsMax = 0;
+    const queueMin = Number.isFinite(audio.queueMinMs) ? `${audio.queueMinMs.toFixed(1)}ms` : "(no stats)";
     if (
         log.maxIdle > SlowTickLogMs ||
         log.maxExecute > SlowTickLogMs ||
@@ -2346,7 +2347,7 @@ function logTick(now, idleMs, executeMs, paintMs, snapshotMs) {
             `${(now / 1000).toFixed(0)}s: ${log.ticks} ticks, idle max ${log.maxIdle.toFixed(0)}ms, ` +
                 `execute max ${log.maxExecute.toFixed(0)}ms (paint ${log.maxPaint.toFixed(1)}ms), ` +
                 `present max ${present.toFixed(0)}ms, snapshot ${log.maxSnapshot.toFixed(1)}ms; ` +
-                `audio queue min ${audio.queueMinMs.toFixed(1)}ms, underruns ${audio.underrun}, ` +
+                `audio queue min ${queueMin}, underruns ${audio.underrun}, ` +
                 `dropped ${audio.dropped} buffers`,
         );
     }

--- a/src/main.js
+++ b/src/main.js
@@ -2349,15 +2349,20 @@ for (const item of document.querySelectorAll(".drive-tracks")) {
 // chip's samples (issue #885). Video paints on emulated flyback whenever the
 // tick lands, and the desynchronised canvas is scanned out from there.
 const TickMs = 10;
-let tickHandle = null;
+let tickToken = null;
 
+// A user-blocking task runs ahead of rendering and ordinary timers, so a stuck
+// compositor does not hold the tick off too.
 function scheduleTick(delayMs) {
-    if (tickHandle !== null) window.clearTimeout(tickHandle);
-    tickHandle = window.setTimeout(tick, delayMs);
+    const token = (tickToken = {});
+    const fire = () => {
+        if (tickToken === token) tick();
+    };
+    if (window.scheduler?.postTask) window.scheduler.postTask(fire, { delay: delayMs, priority: "user-blocking" });
+    else window.setTimeout(fire, delayMs);
 }
 
 function tick() {
-    tickHandle = null;
     if (!running) {
         last = 0;
         return;

--- a/src/main.js
+++ b/src/main.js
@@ -2346,7 +2346,8 @@ function logTick(now, idleMs, executeMs, paintMs, snapshotMs) {
             `${(now / 1000).toFixed(0)}s: ${log.ticks} ticks, idle max ${log.maxIdle.toFixed(0)}ms, ` +
                 `execute max ${log.maxExecute.toFixed(0)}ms (paint ${log.maxPaint.toFixed(1)}ms), ` +
                 `present max ${present.toFixed(0)}ms, snapshot ${log.maxSnapshot.toFixed(1)}ms; ` +
-                `audio underruns ${audio.underrun}, dropped ${audio.dropped} buffers`,
+                `audio queue min ${audio.queueMinMs.toFixed(1)}ms, underruns ${audio.underrun}, ` +
+                `dropped ${audio.dropped} buffers`,
         );
     }
     log.start = now;

--- a/src/main.js
+++ b/src/main.js
@@ -553,17 +553,40 @@ function swapCanvas(newFilterClass) {
 const canvas = createCanvasForFilter(displayModeFilter);
 displayModeFilter = canvas.filterClass;
 
+// The emulator paints into its own framebuffer; flyback copies the finished
+// frame into the canvas and an animation frame presents it, so a stalled
+// display holds up the picture and not the emulation (issue #885).
+const videoFb32 = new Uint32Array(canvas.fb32.length);
+const pendingFrame = { minx: 0, miny: 0, maxx: 0, maxy: 0, frameCount: 0, lineGrid: new Uint8Array(0) };
+let presentScheduled = false;
 let paintMsThisTick = 0;
+let presentMsMax = 0;
+
+function present() {
+    presentScheduled = false;
+    const start = performance.now();
+    canvas.paint(pendingFrame.minx, pendingFrame.miny, pendingFrame.maxx, pendingFrame.maxy, pendingFrame);
+    presentMsMax = Math.max(presentMsMax, performance.now() - start);
+}
+
 video = new Video(
     model.isMaster,
-    canvas.fb32,
+    videoFb32,
     function paint(minx, miny, maxx, maxy) {
         frames++;
         if (frames < frameSkip) return;
         frames = 0;
         const start = performance.now();
-        canvas.paint(minx, miny, maxx, maxy, { frameCount: this.frameCount, lineGrid: this.lineGrid });
+        canvas.fb32.set(videoFb32.subarray(miny * 1024, maxy * 1024), miny * 1024);
+        if (pendingFrame.lineGrid.length !== this.lineGrid.length)
+            pendingFrame.lineGrid = new Uint8Array(this.lineGrid.length);
+        pendingFrame.lineGrid.set(this.lineGrid);
+        Object.assign(pendingFrame, { minx, miny, maxx, maxy, frameCount: this.frameCount });
         paintMsThisTick += performance.now() - start;
+        if (!presentScheduled) {
+            presentScheduled = true;
+            window.requestAnimationFrame(present);
+        }
     },
     { isAtom: model.isAtom },
 );
@@ -2298,6 +2321,7 @@ const RewindCaptureCycles = (RewindCaptureInterval * clocksPerSecond) / 50;
 const TickLogIntervalMs = 1000;
 const SlowTickLogMs = 30;
 const tickLog = { start: 0, ticks: 0, maxIdle: 0, maxExecute: 0, maxPaint: 0, maxSnapshot: 0 };
+const SlowPresentLogMs = 30;
 
 function logTick(now, idleMs, executeMs, paintMs, snapshotMs) {
     const log = tickLog;
@@ -2309,11 +2333,19 @@ function logTick(now, idleMs, executeMs, paintMs, snapshotMs) {
     log.maxSnapshot = Math.max(log.maxSnapshot, snapshotMs);
     if (now - log.start < TickLogIntervalMs) return;
     const audio = audioHandler.takeEventCounts();
-    if (log.maxIdle > SlowTickLogMs || log.maxExecute > SlowTickLogMs || audio.underrun || audio.dropped) {
+    const present = presentMsMax;
+    presentMsMax = 0;
+    if (
+        log.maxIdle > SlowTickLogMs ||
+        log.maxExecute > SlowTickLogMs ||
+        present > SlowPresentLogMs ||
+        audio.underrun ||
+        audio.dropped
+    ) {
         console.log(
             `${(now / 1000).toFixed(0)}s: ${log.ticks} ticks, idle max ${log.maxIdle.toFixed(0)}ms, ` +
-                `execute max ${log.maxExecute.toFixed(0)}ms (paint ${log.maxPaint.toFixed(0)}ms), ` +
-                `snapshot ${log.maxSnapshot.toFixed(1)}ms; ` +
+                `execute max ${log.maxExecute.toFixed(0)}ms (paint ${log.maxPaint.toFixed(1)}ms), ` +
+                `present max ${present.toFixed(0)}ms, snapshot ${log.maxSnapshot.toFixed(1)}ms; ` +
                 `audio underruns ${audio.underrun}, dropped ${audio.dropped} buffers`,
         );
     }

--- a/src/main.js
+++ b/src/main.js
@@ -373,7 +373,7 @@ sbBind(document.querySelector(".sidebar.bottom"), parsedQuery.sbBottom, function
 if (cpuMultiplier !== 1) console.log(`CPU multiplier set to ${cpuMultiplier}`);
 const cpuSpeed = model.cyclesPerSecond;
 const clocksPerSecond = (cpuMultiplier * cpuSpeed) | 0;
-const MaxCyclesPerFrame = clocksPerSecond / 10;
+const MaxCyclesPerTick = clocksPerSecond / 10;
 
 let tryGl = true;
 if (parsedQuery.glEnabled !== undefined) {
@@ -2283,33 +2283,34 @@ function VirtualSpeedUpdater() {
 const virtualSpeedUpdater = new VirtualSpeedUpdater();
 
 const rewindBuffer = new RewindBuffer(30);
-let rewindFrameCounter = 0;
-const RewindCaptureInterval = 50; // ~1 second at 50fps
+let rewindCycleCounter = 0;
+const RewindCaptureInterval = 50; // emulated frames, ~1 second
+const RewindCaptureCycles = (RewindCaptureInterval * clocksPerSecond) / 50;
 
-// Under ?audioDebug, one console line per second in which a frame ran late
+// Under ?audioDebug, one console line per second in which a tick ran late
 // or the audio queue underran or dropped, so a click can be matched to a cause.
-const FrameLogIntervalMs = 1000;
-const SlowFrameLogMs = 30;
-const frameLog = { start: 0, frames: 0, maxGap: 0, maxExecute: 0, maxSnapshot: 0 };
+const TickLogIntervalMs = 1000;
+const SlowTickLogMs = 30;
+const tickLog = { start: 0, ticks: 0, maxGap: 0, maxExecute: 0, maxSnapshot: 0 };
 
-function logFrame(now, gapMs, executeMs, snapshotMs) {
-    const log = frameLog;
+function logTick(now, gapMs, executeMs, snapshotMs) {
+    const log = tickLog;
     if (log.start === 0) log.start = now;
-    log.frames++;
+    log.ticks++;
     log.maxGap = Math.max(log.maxGap, gapMs);
     log.maxExecute = Math.max(log.maxExecute, executeMs);
     log.maxSnapshot = Math.max(log.maxSnapshot, snapshotMs);
-    if (now - log.start < FrameLogIntervalMs) return;
+    if (now - log.start < TickLogIntervalMs) return;
     const audio = audioHandler.takeEventCounts();
-    if (log.maxGap > SlowFrameLogMs || log.maxExecute > SlowFrameLogMs || audio.underrun || audio.dropped) {
+    if (log.maxGap > SlowTickLogMs || log.maxExecute > SlowTickLogMs || audio.underrun || audio.dropped) {
         console.log(
-            `${(now / 1000).toFixed(0)}s: ${log.frames} frames, gap max ${log.maxGap.toFixed(0)}ms, ` +
+            `${(now / 1000).toFixed(0)}s: ${log.ticks} ticks, gap max ${log.maxGap.toFixed(0)}ms, ` +
                 `execute max ${log.maxExecute.toFixed(0)}ms, snapshot ${log.maxSnapshot.toFixed(1)}ms; ` +
                 `audio underruns ${audio.underrun}, dropped ${audio.dropped} buffers`,
         );
     }
     log.start = now;
-    log.frames = log.maxGap = log.maxExecute = log.maxSnapshot = 0;
+    log.ticks = log.maxGap = log.maxExecute = log.maxSnapshot = 0;
 }
 
 rewindUI = new RewindUI({
@@ -2343,21 +2344,28 @@ for (const item of document.querySelectorAll(".drive-tracks")) {
     if (drive) showDriveTracks(driveIndex);
 }
 
-function draw(now) {
+// The emulator advances on a timer rather than requestAnimationFrame: a stall
+// in display presentation withholds animation frames, and with them the sound
+// chip's samples (issue #885). Video paints on emulated flyback whenever the
+// tick lands, and the desynchronised canvas is scanned out from there.
+const TickMs = 10;
+let tickHandle = null;
+
+function scheduleTick(delayMs) {
+    if (tickHandle !== null) window.clearTimeout(tickHandle);
+    tickHandle = window.setTimeout(tick, delayMs);
+}
+
+function tick() {
+    tickHandle = null;
     if (!running) {
         last = 0;
         return;
     }
-    // If we got here via setTimeout, we don't get passed the time.
-    if (now === undefined) {
-        now = window.performance.now();
-    }
+    const now = performance.now();
 
     const motorOn = processor.acia.motorOn;
-    const discOn = processor.fdc.motorOn[0] || processor.fdc.motorOn[1];
     const speedy = fastAsPossible || (fastTape && motorOn);
-    const useTimeout = speedy || motorOn || discOn;
-    const timeout = speedy ? 0 : 1000.0 / 50;
 
     // In speedy mode, we still run all the state machines accurately
     // but we paint less often because painting is the most expensive
@@ -2366,14 +2374,7 @@ function draw(now) {
     // modes, i.e. MODE 7, still look ok.
     video.frameSkipCount = speedy ? 9 : 0;
 
-    // We use setTimeout instead of requestAnimationFrame in two cases:
-    // a) We're trying to run as fast as possible.
-    // b) Tape is playing, normal speed but backgrounded tab should run.
-    if (useTimeout) {
-        window.setTimeout(draw, timeout);
-    } else {
-        window.requestAnimationFrame(draw);
-    }
+    scheduleTick(speedy ? 0 : TickMs);
 
     audioHandler.soundChip.catchUp();
     gamepad.update(processor.sysvia);
@@ -2381,10 +2382,9 @@ function draw(now) {
     if (last !== 0) {
         let cycles;
         if (!speedy) {
-            // Now and last are DOMHighResTimeStamp, just a double.
             const sinceLast = now - last;
             cycles = (sinceLast * clocksPerSecond) / 1000;
-            cycles = Math.min(cycles, MaxCyclesPerFrame);
+            cycles = Math.min(cycles, MaxCyclesPerTick);
         } else {
             cycles = clocksPerSecond / 50;
         }
@@ -2395,15 +2395,15 @@ function draw(now) {
             }
             const end = performance.now();
             virtualSpeedUpdater.update(cycles, end - now, speedy);
-            // Capture rewind snapshot periodically
             let snapshotMs = 0;
-            if (++rewindFrameCounter >= RewindCaptureInterval) {
-                rewindFrameCounter = 0;
+            rewindCycleCounter += cycles;
+            if (rewindCycleCounter >= RewindCaptureCycles) {
+                rewindCycleCounter = 0;
                 rewindBuffer.push(processor.snapshotState());
                 rewindUI.updateButtonState();
                 snapshotMs = performance.now() - end;
             }
-            if (audioStatsNode) logFrame(now, speedy ? 0 : now - last, end - now, snapshotMs);
+            if (audioStatsNode) logTick(now, speedy ? 0 : now - last, end - now, snapshotMs);
         } catch (e) {
             running = false;
             utils.noteEvent("exception", "thrown", e.stack);
@@ -2418,7 +2418,7 @@ function draw(now) {
 }
 
 function run() {
-    window.requestAnimationFrame(draw);
+    scheduleTick(0);
 }
 
 let wasPreviouslyRunning = false;

--- a/src/web/audio-handler.js
+++ b/src/web/audio-handler.js
@@ -31,7 +31,7 @@ export class AudioHandler {
         this.noAudio = false;
         toggle(this.warningNode, false);
         this.stats = {};
-        this.eventCounts = { underrun: 0, dropped: 0 };
+        this.eventCounts = { underrun: 0, dropped: 0, queueMinMs: Infinity };
         if (statsNode) {
             this._initStats(statsNode).catch((error) => {
                 console.error("Unable to initialise audio stats", error);
@@ -141,6 +141,7 @@ export class AudioHandler {
                 this._onAudioEvent(now, event.data);
                 return;
             }
+            this.eventCounts.queueMinMs = Math.min(this.eventCounts.queueMinMs, event.data.queueMinMs);
             for (const stat of Object.keys(event.data)) {
                 if (this.stats[stat]) this.stats[stat].append(now, event.data[stat]);
             }
@@ -158,7 +159,7 @@ export class AudioHandler {
 
     takeEventCounts() {
         const counts = this.eventCounts;
-        this.eventCounts = { underrun: 0, dropped: 0 };
+        this.eventCounts = { underrun: 0, dropped: 0, queueMinMs: Infinity };
         return counts;
     }
 

--- a/src/web/audio-renderer.js
+++ b/src/web/audio-renderer.js
@@ -32,6 +32,7 @@ class SoundChipProcessor extends AudioWorkletProcessor {
         this.targetLatencyMs = options?.processorOptions?.targetLatencyMs ?? DefaultTargetLatencyMs;
         this.startQueueSizeSamples = samplesFor(this.targetLatencyMs);
         this.smoothedOccupancyError = 0;
+        this.minOccupancySamples = Infinity;
         this.running = false;
         this.maxQueueSizeSamples = samplesFor(MaxQueuedMs);
         this.port.onmessage = (event) => {
@@ -51,8 +52,10 @@ class SoundChipProcessor extends AudioWorkletProcessor {
             underruns: this.underruns,
             queueSize: this.queue.length,
             queueAge: this._queueAge(),
+            queueMinMs: (1000 * this.minOccupancySamples) / this.inputSampleRate,
             sampleRatio: sampleRatio,
         });
+        this.minOccupancySamples = Infinity;
     }
 
     _queueAge() {
@@ -164,6 +167,7 @@ class SoundChipProcessor extends AudioWorkletProcessor {
             channel[i] = source[loc] * (1 - alpha) + source[loc + 1] * alpha;
         }
         this._phase = end - numInputSamples;
+        this.minOccupancySamples = Math.min(this.minOccupancySamples, this._occupancySamples());
         this.stats(sampleRatio);
         return true;
     }


### PR DESCRIPTION
Implements #885: the emulator no longer depends on the display to make progress. Stacked on #886 for the log lines and the age-cap fix; the commits after those are this PR.

## What changed

- **Emulation runs on a 10 ms tick, not `requestAnimationFrame`.** `draw()` becomes `tick()`, scheduled with `scheduler.postTask` at `user-blocking` priority where available (Chrome), else `setTimeout`. Each tick emulates the wall time elapsed since the last, capped at 100 ms as before; fast-as-possible uses a 0 ms delay as before. The rAF/timeout split is gone.
- **The video is presented from an animation frame, not painted on flyback.** The emulator writes to its own framebuffer; flyback copies the finished rows into the canvas (about a millisecond) and requests an animation frame, which does the GL upload and draw. A stalled display now delays the picture only; the paint used to block inside `execute()` for up to 39 ms on a stalled display, during which the sound chip produced nothing.
- Rewind captures every second of emulated time rather than every 50 ticks.
- The `?audioDebug` line now reports the idle time between ticks (the only stretch that starves the worklet, since the chip posts samples throughout `execute()`), the flyback copy cost, and the rAF-side present time.

## Measured on the machine that clicked

On `main`, an otherwise idle machine at the prompt underran roughly every 10 s, each time behind a 50-80 ms display presentation stall (Chrome trace in #885). On this branch, at the default 20 ms target:

- The 80 ms holes are gone: `idle max` between ticks stays under ~25 ms.
- No audible clicks on a held `SOUND` tone over a minute, including across Break.
- Remaining logged underruns come with `idle max 16-23ms`, just over the 20 ms queue's ~15 ms low point; the restart trim they cause (8-16 buffers) was not audible.
- Reboot and Elite boot still stutter briefly while the JIT warms: the emulator runs slower than real time for a second, which no scheduling fixes.

## What to feel for

1. `SOUND 1,-15,200,200` at the prompt with `?audioDebug`, default latency. Quiet seconds should log nothing; the odd `underruns 1` line with `idle max` around 20 ms is expected and should be inaudible.
2. Input latency and smoothness: something reflex-driven, MODE 7 scrolling, a bitmap mode. Presenting from rAF puts the picture on the same 60 Hz cadence the old loop had; it should feel like `main`, not worse.
3. Fast-forward and tape, with and without fast tape.
4. Pause/resume (the paused screen should still repaint after a state load), rewind, tab switch and back.
5. Idle CPU at the prompt: 100 wakeups a second instead of 60.
