### PR TITLE
fix: fade the sound out on an audio underrun and back in on restart

### DIFF
--- a/src/web/audio-renderer.js
+++ b/src/web/audio-renderer.js
@@ -18,6 +18,12 @@ const OccupancySmoothingTau = 0.5;
 const ProportionalGain = 0.2;
 const MaxAdjust = InputSampleRate * 0.0005;
 
+// An underrun holds the last sample and fades it out; the restart fades the
+// new audio in. Long enough to take the click out of the step, short enough
+// to hide inside the gap.
+const FadeSeconds = 0.001;
+const GainStep = 1 / (sampleRate * FadeSeconds);
+
 class SoundChipProcessor extends AudioWorkletProcessor {
     constructor(options) {
         super(options);
@@ -26,6 +32,7 @@ class SoundChipProcessor extends AudioWorkletProcessor {
         this._lastSample = 0;
         this._lastFilteredOutput = 0;
         this._phase = 0;
+        this._gain = 0;
         this._source = new Float32Array(0);
         this.queue = [];
         this._queueSizeSamples = 0;
@@ -143,7 +150,6 @@ class SoundChipProcessor extends AudioWorkletProcessor {
     process(inputs, outputs) {
         this.cleanQueue();
         if (!this.running && this._queueSizeSamples >= this.startQueueSizeSamples) this._restart();
-        if (this.queue.length === 0) return true;
 
         // I looked into using https://www.npmjs.com/package/@alexanderolsen/libsamplerate-js or similar (the full API),
         // but we fiddle the sample rate here to catch up with the target latency, which is harder to do with that API.
@@ -168,12 +174,15 @@ class SoundChipProcessor extends AudioWorkletProcessor {
             source[i] = prevSample;
         }
         this._lastFilteredOutput = prevSample;
+        let gain = this._gain;
         for (let i = 0; i < channel.length; i++) {
             const pos = this._phase + i * sampleRatio;
             const loc = Math.floor(pos);
             const alpha = pos - loc;
-            channel[i] = source[loc] * (1 - alpha) + source[loc + 1] * alpha;
+            gain = this.running ? Math.min(1, gain + GainStep) : Math.max(0, gain - GainStep);
+            channel[i] = (source[loc] * (1 - alpha) + source[loc + 1] * alpha) * gain;
         }
+        this._gain = gain;
         this._phase = end - numInputSamples;
         this.minOccupancySamples = Math.min(this.minOccupancySamples, this._occupancySamples());
         this.stats(sampleRatio);

--- a/src/web/audio-renderer.js
+++ b/src/web/audio-renderer.js
@@ -169,9 +169,13 @@ class SoundChipProcessor extends AudioWorkletProcessor {
         const source = this._source;
         source[0] = this._lastFilteredOutput;
         let prevSample = this._lastFilteredOutput;
+        // The input position from which the queue was dry, so the fade starts
+        // there rather than at the top of the quantum.
+        let dryFrom = this.running ? Infinity : 0;
         for (let i = 1; i <= numInputSamples; ++i) {
             prevSample += filterAlpha * (this.nextSample() - prevSample);
             source[i] = prevSample;
+            if (!this.running && dryFrom === Infinity) dryFrom = i;
         }
         this._lastFilteredOutput = prevSample;
         let gain = this._gain;
@@ -179,7 +183,7 @@ class SoundChipProcessor extends AudioWorkletProcessor {
             const pos = this._phase + i * sampleRatio;
             const loc = Math.floor(pos);
             const alpha = pos - loc;
-            gain = this.running ? Math.min(1, gain + GainStep) : Math.max(0, gain - GainStep);
+            gain = pos < dryFrom ? Math.min(1, gain + GainStep) : Math.max(0, gain - GainStep);
             channel[i] = (source[loc] * (1 - alpha) + source[loc + 1] * alpha) * gain;
         }
         this._gain = gain;

--- a/tests/unit/test-audio-renderer.js
+++ b/tests/unit/test-audio-renderer.js
@@ -299,6 +299,20 @@ describe("SoundChipProcessor underrun fade", () => {
         expect(played[played.length - 1]).toBe(0);
     });
 
+    it("should hold full gain up to the sample the queue ran dry at", () => {
+        const proc = new SoundChipProcessor();
+        settled(proc);
+        // Leave the queue with about half a quantum's worth so it runs dry mid-quantum.
+        const perQuantum = Math.floor((OutputQuantum * proc.inputSampleRate) / 48000);
+        while (proc._occupancySamples() > perQuantum / 2) quantum(proc);
+        const before = proc._occupancySamples();
+        const out = quantum(proc);
+        expect(proc.running).toBe(false);
+        const dryAtOutput = Math.floor(before / (proc.inputSampleRate / 48000));
+        for (let i = 0; i < dryAtOutput - 1; ++i) expect(out[i]).toBeCloseTo(level, 3);
+        expect(out[out.length - 1]).toBeLessThan(level);
+    });
+
     it("should fade back in on restart", () => {
         const proc = new SoundChipProcessor();
         settled(proc);

--- a/tests/unit/test-audio-renderer.js
+++ b/tests/unit/test-audio-renderer.js
@@ -107,7 +107,7 @@ describe("SoundChipProcessor rate control", () => {
     it("should speed up when the queue is over target and slow down when under", () => {
         const over = new SoundChipProcessor();
         over.running = true;
-        for (let i = 0; i < Math.ceil((2 * over.startQueueSizeSamples) / 512); ++i)
+        for (let i = 0; i < Math.ceil((4 * over.startQueueSizeSamples) / 512); ++i)
             over.onBuffer(Date.now(), new Float32Array(512));
         const outputs = [[new Float32Array(OutputQuantum)]];
         for (let i = 0; i < 20; ++i) over.process([], outputs);
@@ -262,5 +262,64 @@ describe("SoundChipProcessor target latency option", () => {
         expect(proc.startQueueSizeSamples).toBeLessThanOrEqual(proc.maxQueueSizeSamples / 2);
         proc.setTargetLatency("abc");
         expect(proc.targetLatencyMs).toBe(new SoundChipProcessor().targetLatencyMs);
+    });
+});
+
+describe("SoundChipProcessor underrun fade", () => {
+    const FadeSamples = 48000 * 0.001;
+    const level = 0.5;
+    const fill = (proc, samples) => {
+        for (let i = 0; i < Math.ceil(samples / 512); ++i) proc.onBuffer(Date.now(), new Float32Array(512).fill(level));
+    };
+    const quantum = (proc) => {
+        const outputs = [[new Float32Array(OutputQuantum)]];
+        proc.process([], outputs);
+        return outputs[0][0];
+    };
+    const maxStep = (samples) => {
+        let worst = 0;
+        for (let i = 1; i < samples.length; ++i) worst = Math.max(worst, Math.abs(samples[i] - samples[i - 1]));
+        return worst;
+    };
+    // Two targets' worth queued, played until settled at the fill level.
+    const settled = (proc) => {
+        fill(proc, 2 * proc.startQueueSizeSamples);
+        let out;
+        for (let i = 0; i < 4; ++i) out = quantum(proc);
+        expect(out[out.length - 1]).toBeCloseTo(level, 3);
+    };
+
+    it("should fade out on underrun instead of stepping to silence", () => {
+        const proc = new SoundChipProcessor();
+        settled(proc);
+        const played = [];
+        for (let i = 0; i < 40; ++i) played.push(...quantum(proc));
+        expect(proc.underruns).toBe(1);
+        expect(maxStep(played)).toBeLessThanOrEqual(level / FadeSamples + 1e-6);
+        expect(played[played.length - 1]).toBe(0);
+    });
+
+    it("should fade back in on restart", () => {
+        const proc = new SoundChipProcessor();
+        settled(proc);
+        for (let i = 0; i < 40; ++i) quantum(proc);
+        expect(proc.running).toBe(false);
+        fill(proc, proc.startQueueSizeSamples);
+        const first = quantum(proc);
+        expect(proc.running).toBe(true);
+        expect(Math.abs(first[0])).toBeLessThanOrEqual(level / FadeSamples + 1e-6);
+        expect(maxStep(first)).toBeLessThanOrEqual(level / FadeSamples + 1e-6);
+        expect(first[first.length - 1]).toBeCloseTo(level, 1);
+    });
+
+    it("should keep posting stats while the queue is empty", () => {
+        const proc = new SoundChipProcessor();
+        settled(proc);
+        for (let i = 0; i < 40; ++i) quantum(proc);
+        expect(proc.queue.length).toBe(0);
+        const posted = vi.spyOn(proc.port, "postMessage");
+        proc.nextStats = 0;
+        quantum(proc);
+        expect(posted).toHaveBeenCalledWith(expect.objectContaining({ queueSize: 0 }));
     });
 });


### PR DESCRIPTION
Tidies the worklet's empty-queue path (part of #865). A gap of a few hundred samples is audible with or without a click at its edges, so this does not make underruns sound acceptable; #894 is the change that would.

## What changed

- The worklet no longer returns early on an empty queue. That path output zeros, did not count the underrun and skipped `stats()`, so an underrun that ran the queue dry mid-quantum held the last sample for the rest of that quantum and then stepped to zero at the next one, and the `?audioDebug` chart froze while the queue stayed empty. The empty queue now goes through the same path as running dry: the last sample is held, and `stats()` keeps posting.
- A 1 ms linear gain ramp fades the held sample to silence after an underrun, and fades the new audio in on restart. The step is gone; the gap is still a gap.

Unit tests cover the fade-out (no sample-to-sample step larger than the ramp allows, ending at exactly zero), the fade-in, and stats posting while empty.

## What to listen for

Underruns are rare on `main` now, so provoke them: `?audioDebug&audioLatencyMs=5` gives a queue too shallow to survive anything, and a held `SOUND 1,-15,200,200` will underrun every few seconds (red spikes on the chart).

1. Each underrun should now be a short gap in the tone with no click at either edge, where before it was a gap with a tick at the start.
2. Sampled speech and music should be unchanged when the queue is not underrunning (the gain sits at exactly 1 the rest of the time).
3. The queue chart should keep moving through a dropout instead of freezing.

Related: #865 (remaining item now tracked by #894), #892 for the Music 5000 part.
