### PR TITLE
fix: only create the Music 5000 audio context when one is fitted

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -604,6 +604,7 @@ const audioHandler = new AudioHandler({
     noSeek,
     cpuSpeed,
     isAtom: model.isAtom,
+    hasMusic5000: config.hasMusic5000,
 });
 // Firefox will report that audio is suspended even when it will
 // start playing without user interaction, so we need to delay a

--- a/src/web/audio-handler.js
+++ b/src/web/audio-handler.js
@@ -88,8 +88,8 @@ export class AudioHandler {
 
     // The Music 5000 gets its own context, running at the board's own sample rate.
     _createMusic5000() {
+        if (!this.audioContext?.audioWorklet) return new FakeMusic5000();
         const context = createAudioContext({ sampleRate: 46875 });
-        if (!context?.audioWorklet) return new FakeMusic5000();
         this.audioContextM5000 = context;
         context.onstatechange = () => this.checkStatus();
         context.audioWorklet

--- a/src/web/audio-handler.js
+++ b/src/web/audio-handler.js
@@ -29,6 +29,7 @@ export class AudioHandler {
         noSeek,
         cpuSpeed,
         isAtom,
+        hasMusic5000,
     } = {}) {
         this.cpuSpeed = cpuSpeed;
         this.isAtom = isAtom;
@@ -80,31 +81,31 @@ export class AudioHandler {
 
         this.warningNode.addEventListener("mousedown", () => this.tryResume());
 
-        // Initialise Music 5000 audio context
-        this.audioContextM5000 = createAudioContext({ sampleRate: 46875 });
+        this.audioContextM5000 = null;
+        this._music5000workletnode = null;
+        this.music5000 = hasMusic5000 ? this._createMusic5000() : new FakeMusic5000();
+    }
 
-        if (this.audioContextM5000 && this.audioContextM5000.audioWorklet) {
-            this.audioContextM5000.onstatechange = () => this.checkStatus();
-            this.music5000 = new Music5000((buffer) => this._onBufferMusic5000(buffer));
-
-            this.audioContextM5000.audioWorklet
-                .addModule(music5000WorkletUrl)
-                .then(() => {
-                    this._music5000workletnode = new AudioWorkletNode(this.audioContextM5000, "music5000", {
-                        outputChannelCount: [2],
-                    });
-                    this._music5000workletnode.connect(this.audioContextM5000.destination);
-                })
-                .catch((error) => {
-                    console.error("Unable to initialise Music 5000 audio", error);
-                    toast(
-                        `The Music 5000 will be silent: its audio could not be started (${error?.message ?? error}). Reloading the page may help.`,
-                        { title: "Music 5000", quietKey: "quietMusic5000Audio" },
-                    );
-                });
-        } else {
-            this.music5000 = new FakeMusic5000();
-        }
+    // The Music 5000 gets its own context, running at the board's own sample rate.
+    _createMusic5000() {
+        const context = createAudioContext({ sampleRate: 46875 });
+        if (!context?.audioWorklet) return new FakeMusic5000();
+        this.audioContextM5000 = context;
+        context.onstatechange = () => this.checkStatus();
+        context.audioWorklet
+            .addModule(music5000WorkletUrl)
+            .then(() => {
+                this._music5000workletnode = new AudioWorkletNode(context, "music5000", { outputChannelCount: [2] });
+                this._music5000workletnode.connect(context.destination);
+            })
+            .catch((error) => {
+                console.error("Unable to initialise Music 5000 audio", error);
+                toast(
+                    `The Music 5000 will be silent: its audio could not be started (${error?.message ?? error}). Reloading the page may help.`,
+                    { title: "Music 5000", quietKey: "quietMusic5000Audio" },
+                );
+            });
+        return new Music5000((buffer) => this._onBufferMusic5000(buffer));
     }
 
     // Lazily load smoothie and set up the audio stats chart.

--- a/tests/unit/test-audio-handler.js
+++ b/tests/unit/test-audio-handler.js
@@ -29,8 +29,9 @@ describe("AudioHandler", () => {
         vi.stubGlobal(
             "AudioContext",
             class {
-                constructor() {
+                constructor(options) {
                     const context = fakeContext(hasWorklet, addModule);
+                    context.options = options;
                     contexts.push(context);
                     return context;
                 }
@@ -47,13 +48,14 @@ describe("AudioHandler", () => {
         );
     }
 
-    function makeHandler() {
+    function makeHandler(options = {}) {
         return new AudioHandler({
             warningNode: document.getElementById("audio-warning"),
             audioFilterFreq: 0,
             audioFilterQ: 0,
             noSeek: true,
             cpuSpeed: 2000000,
+            ...options,
         });
     }
 
@@ -111,6 +113,19 @@ describe("AudioHandler", () => {
             expect(warning().textContent).toContain(SuspendedText);
         });
 
+        it("creates no Music 5000 audio context unless one is fitted", () => {
+            makeHandler();
+
+            expect(contexts).toHaveLength(1);
+        });
+
+        it("creates a Music 5000 audio context at the board's sample rate when one is fitted", () => {
+            makeHandler({ hasMusic5000: true });
+
+            expect(contexts).toHaveLength(2);
+            expect(contexts[1].options).toEqual({ sampleRate: 46875 });
+        });
+
         it("fades the warning out once the audio is running again", () => {
             const handler = makeHandler();
 
@@ -160,7 +175,7 @@ describe("AudioHandler", () => {
         it("toasts about the Music 5000 and leaves the banner down", async () => {
             stubAudio({ addModule: rejectModule("music5000") });
 
-            makeHandler();
+            makeHandler({ hasMusic5000: true });
 
             await vi.waitFor(() => expect(document.querySelector(".toast .message")).not.toBeNull());
             expect(document.querySelector(".toast .message").textContent).toContain("Music 5000 will be silent");


### PR DESCRIPTION
Part of #892 (the cheap part only).

## What changed

`AudioHandler` used to open a second `AudioContext` at 46875 Hz, load the Music 5000 worklet and connect its node on every page load, whether or not a Music 5000 was configured. It now takes a `hasMusic5000` option (passed from `main.js` from the config) and only does that work when it is set. Without it, no second context exists and the CPU gets the `FakeMusic5000` exactly as before.

The Music 5000 setting already needs a restart, so the handler is always built with the right answer; nothing has to be created mid-session.

When a Music 5000 is fitted, behaviour is unchanged: same context and sample rate, same worklet, same `tryResume` / `checkStatus` handling of the second context, and the same toast if the worklet fails to load.

## What to check

- Enable the Music 5000 in the config (or use `?model=BMusic5000`), restart, and confirm the demos still play.
- With it disabled, there should be no `audioContextM5000` at all; the rest of the audio path is untouched.

## Not in this PR

The worklet's queue management (start threshold, underrun detection, the ring wrap that relies on 256 and 128 dividing 65536, per-message allocation) remains as described in #892.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
