### PR TITLE
fix: initialise Google Drive on the first click that needs it, not at boot

### DIFF
--- a/index.html
+++ b/index.html
@@ -83,7 +83,7 @@
                     From examples or local</a
                   >
                 </li>
-                <li class="if-drive-available">
+                <li>
                   <a href="#google-drive" class="dropdown-item" id="open-drive-link">From Google Drive</a>
                 </li>
                 <hr />

--- a/src/google-drive.js
+++ b/src/google-drive.js
@@ -23,7 +23,17 @@ export class GoogleDriveLoader {
         this.driveClient = undefined;
     }
 
-    async initialise() {
+    initialise() {
+        if (!this._initialising) {
+            this._initialising = this._initialise().catch((error) => {
+                this._initialising = undefined;
+                throw error;
+            });
+        }
+        return this._initialising;
+    }
+
+    async _initialise() {
         console.log("Creating GAPI");
         await this._loadScript("https://apis.google.com/js/api.js");
         console.log("Got GAPI, creating token client");

--- a/src/main.js
+++ b/src/main.js
@@ -1725,22 +1725,16 @@ async function gdLoad(cat, layout) {
     }
 }
 
-for (const el of document.querySelectorAll(".if-drive-available")) el.style.display = "none";
-// Loading the Google client holds the main thread for ~100ms; keep that clear of boot.
-const GoogleDriveInitDelayMs = 3000;
-async function showGoogleDriveWhenAvailable() {
-    try {
-        const available = await googleDrive.initialise();
-        if (available) {
-            for (const el of document.querySelectorAll(".if-drive-available")) el.style.display = "";
-            await gdAuth(true);
-        }
-    } catch (error) {
-        console.log(`Google Drive is unavailable: ${errorText(error)}`);
-    }
-}
 const googleDriveModal = new bootstrap.Modal(googleDriveEl);
+// Loading the Google client holds the main thread for ~100ms, so it waits for
+// someone to ask for Drive.
 document.getElementById("open-drive-link").addEventListener("click", async function () {
+    try {
+        await googleDrive.initialise();
+    } catch (error) {
+        toast(`Google Drive is unavailable: ${errorText(error)}`, { title: "Google Drive" });
+        return false;
+    }
     const authed = await gdAuth(false);
     if (authed) {
         googleDriveModal.show();
@@ -2208,7 +2202,6 @@ const startPromise = (async () => {
         }
 
         go();
-        window.setTimeout(showGoogleDriveWhenAvailable, GoogleDriveInitDelayMs);
     } catch (error) {
         console.error("Error initialising emulator:", error);
         showError("initialising", error);

--- a/src/main.js
+++ b/src/main.js
@@ -1725,7 +1725,9 @@ async function gdLoad(cat, layout) {
 }
 
 for (const el of document.querySelectorAll(".if-drive-available")) el.style.display = "none";
-(async () => {
+// Loading the Google client holds the main thread for ~100ms; keep that clear of boot.
+const GoogleDriveInitDelayMs = 3000;
+async function showGoogleDriveWhenAvailable() {
     try {
         const available = await googleDrive.initialise();
         if (available) {
@@ -1735,7 +1737,7 @@ for (const el of document.querySelectorAll(".if-drive-available")) el.style.disp
     } catch (error) {
         console.log(`Google Drive is unavailable: ${errorText(error)}`);
     }
-})();
+}
 const googleDriveModal = new bootstrap.Modal(googleDriveEl);
 document.getElementById("open-drive-link").addEventListener("click", async function () {
     const authed = await gdAuth(false);
@@ -2205,6 +2207,7 @@ const startPromise = (async () => {
         }
 
         go();
+        window.setTimeout(showGoogleDriveWhenAvailable, GoogleDriveInitDelayMs);
     } catch (error) {
         console.error("Error initialising emulator:", error);
         showError("initialising", error);

--- a/tests/unit/test-google-drive.js
+++ b/tests/unit/test-google-drive.js
@@ -21,4 +21,31 @@ describe("GoogleDriveLoader", () => {
         expect(script.src).toContain("apis.google.com");
         await expect(initialising).rejects.toThrow(/apis\.google\.com/);
     });
+
+    it("shares one initialisation between concurrent callers", async () => {
+        const loader = new GoogleDriveLoader();
+
+        const first = loader.initialise();
+        const second = loader.initialise();
+        expect(second).toBe(first);
+        expect(document.querySelectorAll("script")).toHaveLength(1);
+
+        document.querySelector("script").dispatchEvent(new Event("error"));
+        await expect(first).rejects.toThrow();
+        await expect(second).rejects.toThrow();
+    });
+
+    it("tries again after a failed initialisation", async () => {
+        const loader = new GoogleDriveLoader();
+
+        const failed = loader.initialise();
+        document.querySelector("script").dispatchEvent(new Event("error"));
+        await expect(failed).rejects.toThrow();
+
+        const retried = loader.initialise();
+        expect(retried).not.toBe(failed);
+        expect(document.querySelectorAll("script")).toHaveLength(2);
+        document.querySelectorAll("script")[1].dispatchEvent(new Event("error"));
+        await expect(retried).rejects.toThrow();
+    });
 });


### PR DESCRIPTION
Fixes #888. Loading Google's client scripts and running `gapi.client.init` with the Drive discovery document held the main thread for ~100ms during every boot (the `idle max 100-130ms` line that came with a boot-time stutter), for a feature most sessions never use.

## What changed

- Nothing Google-related happens at boot. The "From Google Drive" menu item is always shown.
- Clicking it runs `googleDrive.initialise()` (memoised, so repeated clicks and the `gd:` disc-URL path share one load, and a failure clears the memo so a later click can retry), then the existing sign-in flow (silent first, then prompting) and the modal. If the scripts are blocked (an extension, offline) the click says so in a toast.
- The Drive save form is only reachable from that modal, so it is always initialised by the time it runs.

An earlier version of this PR delayed the initialisation by 3s; that only moved the stall, as reviewed.

## What to check

- With `?audioDebug`, the boot second should show a small `idle max` (single digits here) and no "Creating GAPI" in the console.
- "From Google Drive" opens the modal after a short wait the first time, lists files, loads one; creating a disc from the modal still works.
- A `disc=gd:...` URL still loads.
