### PR TITLE
feat: synthesise the sound chip in the audio worklet from timestamped register writes

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,8 +287,8 @@ sudo rpm -i out/dist/jsbeeb-1.0.1.x86_64.rpm
   Doesn't support the sth: pseudo URL unlike `disc` and `tape`, but if given a ZIP file will attempt to use the `.rom`
   file assumed to be within.
 - (mostly internal use) `logFdcCommands`, `logFdcStateChanges` - turn on logging in the disc controller.
-- `audioDebug` - show the audio queue chart, and log one console line per second in which the emulator tick ran late or the audio queue underran or dropped.
-- `audioLatencyMs` - target audio buffer depth in milliseconds (default 20). Raising it can stop clicks on a machine that drops frames, at the cost of the sound lagging the picture by that much.
+- `audioDebug` - show the audio lead chart, and log one console line per second in which the emulator tick ran late or the sound stalled or skipped.
+- `audioLatencyMs` - how far the sound runs behind the emulator, in milliseconds (default 20). Raising it lets the sound ride out longer stalls of the emulator, at the cost of lagging the picture by that much.
 
 ### Atom-specific parameters
 

--- a/src/main.js
+++ b/src/main.js
@@ -2338,21 +2338,20 @@ function logAudioDebugTick(now, cycles, idleMs, executeMs, paintMs, snapshotMs) 
     const audio = audioHandler.takeEventCounts();
     const present = presentMsMax;
     presentMsMax = 0;
-    const queueMin = Number.isFinite(audio.queueMinMs) ? `${audio.queueMinMs.toFixed(1)}ms` : "(no stats)";
+    const leadMin = Number.isFinite(audio.leadMinMs) ? `${audio.leadMinMs.toFixed(1)}ms` : "(no stats)";
     if (
         log.maxIdle > AudioDebugSlowTickMs ||
         log.maxExecute > AudioDebugSlowTickMs ||
         present > AudioDebugSlowPresentMs ||
-        audio.underrun ||
-        audio.drop
+        audio.stall ||
+        audio.skip
     ) {
         console.log(
             `${(now / 1000).toFixed(0)}s: ${log.ticks} ticks emulating ${((1000 * log.cycles) / clocksPerSecond).toFixed(0)}ms, ` +
                 `idle max ${log.maxIdle.toFixed(0)}ms, ` +
                 `execute max ${log.maxExecute.toFixed(0)}ms (paint ${log.maxPaint.toFixed(1)}ms), ` +
                 `present max ${present.toFixed(0)}ms, snapshot ${log.maxSnapshot.toFixed(1)}ms; ` +
-                `audio queue min ${queueMin}, underruns ${audio.underrun}, ` +
-                `dropped ${audio.drop} buffers`,
+                `audio lead min ${leadMin}, stalls ${audio.stall}, skipped ${audio.skip.toFixed(0)}ms`,
         );
     }
     log.start = now;
@@ -2425,7 +2424,6 @@ function tick() {
 
     scheduleTick(speedy ? 0 : TickMs);
 
-    audioHandler.soundChip.catchUp();
     gamepad.update(processor.sysvia);
     syncLights();
     if (last !== 0) {
@@ -2442,6 +2440,7 @@ function tick() {
             if (!processor.execute(cycles)) {
                 stop(true);
             }
+            audioHandler.flushChipEvents();
             const end = performance.now();
             virtualSpeedUpdater.update(cycles, end - now, speedy);
             let snapshotMs = 0;
@@ -2483,8 +2482,8 @@ function setEmulationLead(leadMs) {
     const aheadMs = leadMs - emulationLeadMs;
     emulationLeadMs = leadMs;
     if (aheadMs > 0) {
-        audioHandler.soundChip.catchUp();
         if (!processor.execute((aheadMs * clocksPerSecond) / 1000)) stop(true);
+        audioHandler.flushChipEvents();
     } else {
         last -= aheadMs;
     }

--- a/src/soundchip.js
+++ b/src/soundchip.js
@@ -12,6 +12,10 @@ export const SoundBufferSamples = 512;
 // mean level, which a zero-mean output would silence (see issue #863).
 const DcRestoreCornerHz = 1 / (2 * Math.PI * 10e3 * 4.7e-6);
 
+// A chip with an event sink reports progress this often, so its events can
+// stream through a long execute() rather than all arriving at its end.
+const EventProgressCycles = 4000;
+
 const volumeTable = new Float32Array(16);
 (() => {
     let f = 1.0;
@@ -249,6 +253,13 @@ export class SoundChip {
         this.activeTask = this.scheduler.newTask(() => {
             if (this.active) this.poke(this.slowDataBus);
         });
+        if (this._onEvent) {
+            this.progressTask = this.scheduler.newTask(() => {
+                this._emit({ progress: true });
+                this.progressTask.schedule(EventProgressCycles);
+            });
+            this.progressTask.schedule(EventProgressCycles);
+        }
     }
 
     render(out, offset, length) {
@@ -382,6 +393,7 @@ export class SoundChip {
         // Older snapshots predate the DC blocker
         this.dcPrevIn = state.dcPrevIn ?? 0;
         this.dcPrevOut = state.dcPrevOut ?? 0;
+        this.progressTask?.ensureScheduled(true, EventProgressCycles);
         this._emit({ state: this.snapshotState() });
     }
 

--- a/src/soundchip.js
+++ b/src/soundchip.js
@@ -35,9 +35,15 @@ export class SoundChip {
      * @param {function(Float32Array): void} onBuffer called with each full
      *     SoundBufferSamples-sized buffer of output. Receives the same buffer
      *     every call, overwritten afterwards: copy the contents if they are kept.
+     * @param {object} [options]
+     * @param {function(object): void} [options.onEvent] called with each
+     *     change to the chip's state, stamped with the cycle it takes effect at.
+     *     A chip with an event sink does not render; something else renders
+     *     from the events (see audio-renderer.js).
      */
-    constructor(onBuffer) {
+    constructor(onBuffer, { onEvent = null } = {}) {
         this._onBuffer = onBuffer;
+        this._onEvent = onEvent;
         // 4MHz input signal. Internal divide-by-8
         this.soundchipFreq = 4000000.0 / 8;
         const sampleRate = this.soundchipFreq;
@@ -91,13 +97,36 @@ export class SoundChip {
             mute: () => {
                 this.catchUp();
                 this.sineOn = false;
+                this._emit({ sine: 0 });
             },
             tone: (freq) => {
                 this.catchUp();
                 this.sineOn = true;
                 this.sineStep = (freq / sampleRate) * this.sineTable.length;
+                this._emit({ sine: freq });
             },
         };
+    }
+
+    _emit(event) {
+        if (this._onEvent) this._onEvent({ cycle: this.scheduler.epoch, ...event });
+    }
+
+    /** Applies an event from another chip's onEvent, at the cycle this chip is rendering. */
+    applyEvent(event) {
+        if (event.poke !== undefined) this.poke(event.poke);
+        else if (event.sine !== undefined) {
+            if (event.sine) this.toneGenerator.tone(event.sine);
+            else this.toneGenerator.mute();
+        } else if (event.enabled !== undefined) this.enabled = event.enabled;
+        else if (event.state !== undefined) this.restoreState(event.state);
+        else if (event.reset !== undefined) this.reset(event.reset);
+    }
+
+    /** Renders `length` samples of output from `cycle`, for a chip that is driven by events. */
+    renderAt(cycle, out, offset, length) {
+        this.scheduler.epoch = this.lastRunEpoch = cycle;
+        this.generate(out, offset, length);
     }
 
     sineChannel(channel, out, offset, length) {
@@ -181,6 +210,7 @@ export class SoundChip {
         this.volume[2] = volumeTable[v2];
         this.volume[3] = volumeTable[v3];
         this.noisePoked();
+        this._emit({ state: this.snapshotState() });
     }
 
     generate(out, offset, length) {
@@ -239,6 +269,7 @@ export class SoundChip {
     }
 
     advance(cycles) {
+        if (this._onEvent) return;
         const num = cycles * this.samplesPerCycle + this.residual;
         let rounded = num | 0;
         this.residual = num - rounded;
@@ -270,6 +301,7 @@ export class SoundChip {
 
     poke(value) {
         this.catchUp();
+        this._emit({ poke: value });
 
         let command;
         if (value & 0x80) {
@@ -350,9 +382,11 @@ export class SoundChip {
         // Older snapshots predate the DC blocker
         this.dcPrevIn = state.dcPrevIn ?? 0;
         this.dcPrevOut = state.dcPrevOut ?? 0;
+        this._emit({ state: this.snapshotState() });
     }
 
     reset(hard) {
+        this._emit({ reset: hard });
         if (!hard) return;
         for (let i = 0; i < 4; ++i) {
             this.counter[i] = 0;
@@ -366,14 +400,15 @@ export class SoundChip {
 
     enable(e) {
         this.enabled = e;
+        this._emit({ enabled: e });
     }
 
     mute() {
-        this.enabled = false;
+        this.enable(false);
     }
 
     unmute() {
-        this.enabled = true;
+        this.enable(true);
     }
 }
 
@@ -383,8 +418,8 @@ export class SoundChip {
  * channel with DC-blocking filter.
  */
 export class AtomSoundChip extends SoundChip {
-    constructor(onBuffer, { cpuSpeed = 1000000 } = {}) {
-        super(onBuffer);
+    constructor(onBuffer, { cpuSpeed = 1000000, onEvent = null } = {}) {
+        super(onBuffer, { onEvent });
         this.samplesPerCycle = this.soundchipFreq / cpuSpeed;
         this.secondsPerCycle = 1 / cpuSpeed;
 
@@ -423,7 +458,19 @@ export class AtomSoundChip extends SoundChip {
         this._speakerCycleOffset = 0;
     }
 
+    applyEvent(event) {
+        if (event.bit !== undefined) this.bitChange.push({ bit: event.bit, cycles: event.cycle });
+        else if (event.speakerReset !== undefined) this.speakerReset();
+        else super.applyEvent(event);
+    }
+
+    renderAt(cycle, out, offset, length) {
+        this._speakerCycleOffset = 0;
+        super.renderAt(cycle, out, offset, length);
+    }
+
     speakerReset() {
+        this._emit({ speakerReset: true });
         this.bitChange = [];
         this.currentSpeakerBit = 0.0;
         this._speakerPrevIn = 0;
@@ -461,7 +508,9 @@ export class AtomSoundChip extends SoundChip {
 
     updateSpeaker(value, microCycle, seconds) {
         const cycles = microCycle + seconds / this.secondsPerCycle;
-        this.bitChange.push({ bit: value ? 1.0 : 0.0, cycles });
+        const bit = value ? 1.0 : 0.0;
+        if (this._onEvent) this._onEvent({ cycle: cycles, bit });
+        else this.bitChange.push({ bit, cycles });
     }
 }
 

--- a/src/soundchip.js
+++ b/src/soundchip.js
@@ -398,8 +398,8 @@ export class SoundChip {
     }
 
     reset(hard) {
-        this._emit({ reset: hard });
         if (!hard) return;
+        this._emit({ reset: true });
         for (let i = 0; i < 4; ++i) {
             this.counter[i] = 0;
             this.registers[i] = 0;

--- a/src/web/audio-handler.js
+++ b/src/web/audio-handler.js
@@ -6,10 +6,8 @@ import { createAudioContext } from "../audio-utils.js";
 import { toggle, fadeIn, fadeOut } from "../dom-utils.js";
 import { toast } from "./toast.js";
 
-// The renderer imports the sound chip, so it is bundled as a worker; a plain
-// URL copies a worklet verbatim, which is fine for one with no imports and is
-// what keeps vite happy when jsbeeb is embedded in other projects
-// (https://github.com/vitejs/vite/discussions/6459).
+// The renderer imports the sound chip, so it must be bundled; a plain URL
+// copies a worklet verbatim (https://github.com/vitejs/vite/discussions/6459).
 import rendererUrl from "./audio-renderer.js?worker&url";
 const music5000WorkletUrl = new URL("../music5000-worklet.js", import.meta.url).href;
 

--- a/src/web/audio-handler.js
+++ b/src/web/audio-handler.js
@@ -53,7 +53,10 @@ export class AudioHandler {
         this._jsAudioNode = null;
         if (this.audioContext && this.audioContext.audioWorklet) {
             this.audioContext.onstatechange = () => this.checkStatus();
-            const onEvent = (event) => this._chipEvents.push(event);
+            const onEvent = (event) => {
+                if (event.progress) this.flushChipEvents();
+                else this._chipEvents.push(event);
+            };
             this.soundChip = this.isAtom
                 ? new AtomSoundChip(null, { cpuSpeed: this.cpuSpeed, onEvent })
                 : new SoundChip(null, { onEvent });

--- a/src/web/audio-handler.js
+++ b/src/web/audio-handler.js
@@ -240,13 +240,16 @@ export class AudioHandler {
         await this.relayNoise.initialise();
     }
 
+    // The emulator is stopping, so no tick will ship the change; send it now.
     mute() {
         this.soundChip.mute();
+        this.flushChipEvents();
         if (this.masterGain) this.masterGain.gain.value = 0;
     }
 
     unmute() {
         this.soundChip.unmute();
+        this.flushChipEvents();
         if (this.masterGain) this.masterGain.gain.value = 1;
     }
 }

--- a/src/web/audio-handler.js
+++ b/src/web/audio-handler.js
@@ -6,13 +6,15 @@ import { createAudioContext } from "../audio-utils.js";
 import { toggle, fadeIn, fadeOut } from "../dom-utils.js";
 import { toast } from "./toast.js";
 
-// Using this approach means when jsbeeb is embedded in other projects, vite doesn't have a fit.
-// See https://github.com/vitejs/vite/discussions/6459
-const rendererUrl = new URL("./audio-renderer.js", import.meta.url).href;
+// The renderer imports the sound chip, so it is bundled as a worker; a plain
+// URL copies a worklet verbatim, which is fine for one with no imports and is
+// what keeps vite happy when jsbeeb is embedded in other projects
+// (https://github.com/vitejs/vite/discussions/6459).
+import rendererUrl from "./audio-renderer.js?worker&url";
 const music5000WorkletUrl = new URL("../music5000-worklet.js", import.meta.url).href;
 
-// Drops plot as buffers dropped, on the queueSize scale; underruns as a fixed spike.
-const UnderrunSpikeHeight = 20;
+// Skips plot as the milliseconds skipped, on the lead scale; stalls as a fixed spike.
+const StallSpikeHeight = 20;
 
 // Nobody is watching an unfocused window, so its sound can run far behind
 // the picture, deep enough to ride out the browser starving the tab.
@@ -38,7 +40,8 @@ export class AudioHandler {
         this.noAudio = false;
         toggle(this.warningNode, false);
         this.stats = {};
-        this.eventCounts = { underrun: 0, drop: 0, queueMinMs: Infinity };
+        this.eventCounts = { stall: 0, skip: 0, leadMinMs: Infinity };
+        this._chipEvents = [];
         if (statsNode) {
             this._initStats(statsNode).catch((error) => {
                 console.error("Unable to initialise audio stats", error);
@@ -50,10 +53,10 @@ export class AudioHandler {
         this._jsAudioNode = null;
         if (this.audioContext && this.audioContext.audioWorklet) {
             this.audioContext.onstatechange = () => this.checkStatus();
-            const onBuffer = (buffer, time) => this._onBuffer(buffer, time);
+            const onEvent = (event) => this._chipEvents.push(event);
             this.soundChip = this.isAtom
-                ? new AtomSoundChip(onBuffer, { cpuSpeed: this.cpuSpeed })
-                : new SoundChip(onBuffer);
+                ? new AtomSoundChip(null, { cpuSpeed: this.cpuSpeed, onEvent })
+                : new SoundChip(null, { onEvent });
             // Master gain node for all sample-based audio (disc, relay, etc.).
             this.masterGain = this.audioContext.createGain();
             this.masterGain.connect(this.audioContext.destination);
@@ -118,10 +121,9 @@ export class AudioHandler {
                 return { min: 0, max: range.max };
             },
         });
-        this._addStat("queueSize", { strokeStyle: "rgb(51,126,108)" });
-        this._addStat("queueAge", { strokeStyle: "rgb(162,119,22)" });
-        this._addStat("underrun", { strokeStyle: "rgb(220,50,50)", lineWidth: 2 });
-        this._addStat("drop", { strokeStyle: "rgb(120,80,200)", lineWidth: 2 });
+        this._addStat("leadMs", { strokeStyle: "rgb(51,126,108)" });
+        this._addStat("stall", { strokeStyle: "rgb(220,50,50)", lineWidth: 2 });
+        this._addStat("skip", { strokeStyle: "rgb(120,80,200)", lineWidth: 2 });
         this.chart.streamTo(statsNode, 100);
     }
 
@@ -139,7 +141,11 @@ export class AudioHandler {
         }
 
         this._jsAudioNode = new AudioWorkletNode(this.audioContext, "sound-chip-processor", {
-            processorOptions: { targetLatencyMs: this._targetLatencyMs() },
+            processorOptions: {
+                targetLatencyMs: this._targetLatencyMs(),
+                isAtom: this.isAtom,
+                cpuSpeed: this.cpuSpeed,
+            },
         });
         this._jsAudioNode.connect(this._audioDestination);
         this._jsAudioNode.port.onmessage = (event) => {
@@ -148,7 +154,7 @@ export class AudioHandler {
                 this._onAudioEvent(now, event.data);
                 return;
             }
-            this.eventCounts.queueMinMs = Math.min(this.eventCounts.queueMinMs, event.data.queueMinMs);
+            this.eventCounts.leadMinMs = Math.min(this.eventCounts.leadMinMs, event.data.leadMinMs);
             for (const stat of Object.keys(event.data)) {
                 if (this.stats[stat]) this.stats[stat].append(now, event.data[stat]);
             }
@@ -160,7 +166,7 @@ export class AudioHandler {
         const series = this.stats[event];
         if (!series) return;
         series.append(now - 1, 0);
-        series.append(now, event === "underrun" ? UnderrunSpikeHeight : count);
+        series.append(now, event === "stall" ? StallSpikeHeight : count);
         series.append(now + 1, 0);
     }
 
@@ -178,7 +184,7 @@ export class AudioHandler {
 
     takeEventCounts() {
         const counts = this.eventCounts;
-        this.eventCounts = { underrun: 0, drop: 0, queueMinMs: Infinity };
+        this.eventCounts = { stall: 0, skip: 0, leadMinMs: Infinity };
         return counts;
     }
 
@@ -196,11 +202,12 @@ export class AudioHandler {
         this.chart.addTimeSeries(timeSeries, info);
     }
 
-    _onBuffer(buffer) {
-        // No transfer list, deliberately: the chip reuses this buffer, and
-        // transferring would detach it and trip crbug.com/537801199. The clone
-        // costs little (512 floats per 1.024ms of chip output, ~2MB/s).
-        if (this._jsAudioNode) this._jsAudioNode.port.postMessage({ time: Date.now(), buffer });
+    // Ships the chip's state changes since the last call, and how far the
+    // emulator has got, so the worklet knows its lead even when nothing changed.
+    flushChipEvents() {
+        if (!this._jsAudioNode) return;
+        this._jsAudioNode.port.postMessage({ upTo: this.soundChip.scheduler.epoch, events: this._chipEvents });
+        this._chipEvents = [];
     }
 
     // Recent browsers, particularly Safari and Chrome, require a user interaction in order to enable sound playback.

--- a/src/web/audio-renderer.js
+++ b/src/web/audio-renderer.js
@@ -16,11 +16,9 @@ const MaxAdjustFraction = 0.0005;
 
 const isResync = (event) => event.state !== undefined || event.reset !== undefined;
 
-// The chip renders from a stream of timestamped state changes rather than
-// from samples, so when the producer falls behind the chip carries on in its
-// current state (a stall) instead of going silent. Once the producer is back
-// far enough ahead, the stalled time is skipped by applying the missed
-// changes at once.
+// Renders the chip from its timestamped state changes, so a producer that
+// falls behind leaves the chip sounding its current state (a stall) rather
+// than silent; the missed time is skipped once the producer is ahead again.
 class SoundChipProcessor extends AudioWorkletProcessor {
     constructor(options) {
         super(options);
@@ -133,10 +131,11 @@ class SoundChipProcessor extends AudioWorkletProcessor {
 
     _restart() {
         const skipTo = this.upTo - this.targetLeadCycles;
-        const skipped = Math.max(0, this._ms(skipTo - this.clock));
-        if (skipTo > this.clock) this._skipTo(skipTo);
+        if (skipTo > this.clock) {
+            this._notify("skip", this._ms(skipTo - this.clock));
+            this._skipTo(skipTo);
+        }
         this.stalled = false;
-        this._notify("skip", skipped);
     }
 
     _stall(out, offset, length) {

--- a/src/web/audio-renderer.js
+++ b/src/web/audio-renderer.js
@@ -1,53 +1,93 @@
 /* global sampleRate, currentTime, registerProcessor, AudioWorkletProcessor */
+import { SoundChip, AtomSoundChip } from "../soundchip.js";
 
 const lowPassFilterFreq = sampleRate / 2;
 const RC = 1 / (2 * Math.PI * lowPassFilterFreq);
 
-const InputSampleRate = 4000000.0 / 8;
-const MaxQueuedMs = 500;
 const DefaultTargetLatencyMs = 1000 * (1 / 50); // One frame
-// Leaves room above the target for the producer's catch-up bursts.
-const MaxTargetLatencyMs = MaxQueuedMs / 2;
+const MaxTargetLatencyMs = 250;
 
-const samplesFor = (ms) => (InputSampleRate * ms) / 1000;
-
-// Smoothing rejects the producer's per-frame bursts; proportional only, as
-// occupancy already integrates rate error; 0.05% authority covers clock skew
+// Smoothing rejects the producer's per-tick bursts; proportional only, as
+// lead already integrates rate error; 0.05% authority covers clock skew
 // without audibly bending pitch.
-const OccupancySmoothingTau = 0.5;
+const LeadSmoothingTau = 0.5;
 const ProportionalGain = 0.2;
-const MaxAdjust = InputSampleRate * 0.0005;
+const MaxAdjustFraction = 0.0005;
 
-// An underrun holds the last sample and fades it out; the restart fades the
-// new audio in. Long enough to take the click out of the step, short enough
-// to hide inside the gap.
-const FadeSeconds = 0.001;
-const GainStep = 1 / (sampleRate * FadeSeconds);
+const isResync = (event) => event.state !== undefined || event.reset !== undefined;
 
+// The chip renders from a stream of timestamped state changes rather than
+// from samples, so when the producer falls behind the chip carries on in its
+// current state (a stall) instead of going silent. Once the producer is back
+// far enough ahead, the stalled time is skipped by applying the missed
+// changes at once.
 class SoundChipProcessor extends AudioWorkletProcessor {
     constructor(options) {
         super(options);
+        const { isAtom = false, cpuSpeed = 1000000, targetLatencyMs } = options?.processorOptions ?? {};
+        this.chip = isAtom ? new AtomSoundChip(null, { cpuSpeed }) : new SoundChip(null);
+        this.inputSampleRate = this.chip.soundchipFreq;
+        this.samplesPerCycle = this.chip.samplesPerCycle;
 
-        this.inputSampleRate = InputSampleRate;
-        this._lastSample = 0;
+        this.events = [];
+        this.eventsHead = 0;
+        this.clock = 0;
+        this.upTo = 0;
+        this.stalled = true;
+        this.stalls = 0;
+        this.skippedMs = 0;
+        this.minLeadMs = Infinity;
+
         this._lastFilteredOutput = 0;
         this._phase = 0;
-        this._gain = 0;
         this._source = new Float32Array(0);
-        this.queue = [];
-        this._queueSizeSamples = 0;
-        this.dropped = 0;
-        this.underruns = 0;
-        this.setTargetLatency(options?.processorOptions?.targetLatencyMs);
-        this.minOccupancySamples = Infinity;
-        this.running = false;
-        this.maxQueueSizeSamples = samplesFor(MaxQueuedMs);
+        this._rendered = new Float32Array(0);
+        this.smoothedLeadError = 0;
+        this.setTargetLatency(targetLatencyMs);
         this.port.onmessage = (event) => {
             if (event.data.command === "setTargetLatency") this.setTargetLatency(event.data.targetLatencyMs);
-            // TODO: even better than this, send over register settings/catch up and run the audio work _here_
-            else this.onBuffer(event.data.time, event.data.buffer);
+            else this.onProduced(event.data.upTo, event.data.events);
         };
         this.nextStats = 0;
+    }
+
+    setTargetLatency(ms) {
+        const valid = Number.isFinite(ms) && ms > 0;
+        this.targetLatencyMs = valid ? Math.min(ms, MaxTargetLatencyMs) : DefaultTargetLatencyMs;
+        this.targetLeadCycles = this._cycles(this.targetLatencyMs);
+        this.smoothedLeadError = 0;
+    }
+
+    _cycles(ms) {
+        return ((ms / 1000) * this.inputSampleRate) / this.samplesPerCycle;
+    }
+
+    _ms(cycles) {
+        return (1000 * cycles * this.samplesPerCycle) / this.inputSampleRate;
+    }
+
+    leadMs() {
+        return this._ms(this.upTo - this.clock);
+    }
+
+    // A resync (restore or reset) starts a new timeline; anything queued
+    // before it belongs to the old one.
+    onProduced(upTo, events) {
+        let from = 0;
+        for (let i = events.length - 1; i >= 0; --i) {
+            if (isResync(events[i])) {
+                from = i;
+                this.events = [];
+                this.eventsHead = 0;
+                break;
+            }
+        }
+        if (this.eventsHead > 0) {
+            this.events = this.events.slice(this.eventsHead);
+            this.eventsHead = 0;
+        }
+        for (let i = from; i < events.length; ++i) this.events.push(events[i]);
+        this.upTo = upTo;
     }
 
     stats(sampleRatio) {
@@ -56,103 +96,95 @@ class SoundChipProcessor extends AudioWorkletProcessor {
         this.port.postMessage({
             sampleRate: sampleRate,
             inputSampleRate: this.inputSampleRate,
-            dropped: this.dropped,
-            underruns: this.underruns,
-            queueSize: this.queue.length,
-            queueAge: this._queueAge(),
-            queueMinMs: (1000 * this.minOccupancySamples) / this.inputSampleRate,
+            stalls: this.stalls,
+            skippedMs: this.skippedMs,
+            leadMs: this.leadMs(),
+            leadMinMs: this.minLeadMs,
+            queuedEvents: this.events.length - this.eventsHead,
             sampleRatio: sampleRatio,
         });
-        this.minOccupancySamples = Infinity;
-    }
-
-    _queueAge() {
-        if (this.queue.length === 0) return 0;
-        const timeInBufferMs = 1000 * (this.queue[0].offset / this.inputSampleRate) + this.queue[0].time;
-        return Date.now() - timeInBufferMs;
-    }
-
-    _occupancySamples() {
-        return this._queueSizeSamples - (this.queue.length ? this.queue[0].offset : 0);
-    }
-
-    _effectiveSampleRate(dtSeconds) {
-        const error = this._occupancySamples() - this.startQueueSizeSamples;
-        const alpha = Math.min(1, dtSeconds / OccupancySmoothingTau);
-        this.smoothedOccupancyError += alpha * (error - this.smoothedOccupancyError);
-        const adjustment = ProportionalGain * this.smoothedOccupancyError;
-        return this.inputSampleRate + Math.min(MaxAdjust, Math.max(-MaxAdjust, adjustment));
-    }
-
-    onBuffer(time, buffer) {
-        this.queue.push({ offset: 0, time, buffer });
-        this._queueSizeSamples += buffer.length;
-        this.cleanQueue();
-    }
-
-    _shift() {
-        const dropped = this.queue.shift();
-        this._queueSizeSamples -= dropped.buffer.length;
-    }
-
-    _drop(count) {
-        for (let i = 0; i < count; ++i) this._shift();
-        this.dropped += count;
-        this._notify("drop", count);
-    }
-
-    cleanQueue() {
-        let dropped = 0;
-        for (let size = this._queueSizeSamples; size > this.maxQueueSizeSamples; ++dropped)
-            size -= this.queue[dropped].buffer.length;
-        if (dropped) this._drop(dropped);
-    }
-
-    // The queue refills after an underrun in one catch-up burst, which has all
-    // arrived by the next quantum; the excess is trimmed here, where the output
-    // is already discontinuous.
-    _restart() {
-        let dropped = 0;
-        for (let occupancy = this._occupancySamples(); dropped < this.queue.length - 1; ++dropped) {
-            const head = this.queue[dropped];
-            const without = occupancy - (head.buffer.length - head.offset);
-            if (without < this.startQueueSizeSamples) break;
-            occupancy = without;
-        }
-        if (dropped) this._drop(dropped);
-        this.running = true;
+        this.minLeadMs = Infinity;
     }
 
     _notify(event, count) {
         this.port.postMessage({ event, count });
     }
 
-    setTargetLatency(ms) {
-        const valid = Number.isFinite(ms) && ms > 0;
-        this.targetLatencyMs = valid ? Math.min(ms, MaxTargetLatencyMs) : DefaultTargetLatencyMs;
-        this.startQueueSizeSamples = samplesFor(this.targetLatencyMs);
-        this.smoothedOccupancyError = 0;
+    _effectiveSampleRate(dtSeconds) {
+        const error = this.upTo - this.clock - this.targetLeadCycles;
+        const alpha = Math.min(1, dtSeconds / LeadSmoothingTau);
+        this.smoothedLeadError += alpha * (error - this.smoothedLeadError);
+        const adjustment = ProportionalGain * this.smoothedLeadError * this.samplesPerCycle;
+        const maxAdjust = this.inputSampleRate * MaxAdjustFraction;
+        return this.inputSampleRate + Math.min(maxAdjust, Math.max(-maxAdjust, adjustment));
     }
 
-    nextSample() {
-        if (this.running && this.queue.length) {
-            const queueElement = this.queue[0];
-            this._lastSample = queueElement.buffer[queueElement.offset];
-            if (++queueElement.offset === queueElement.buffer.length) this._shift();
-        } else if (this.running) {
-            this.running = false;
-            this.underruns++;
-            this._notify("underrun", 1);
+    _applyHead() {
+        this.chip.applyEvent(this.events[this.eventsHead++]);
+    }
+
+    // Applies every queued change up to `cycle` at once and moves the clock
+    // there, so the sound continues from the producer's state without a gap.
+    _skipTo(cycle) {
+        while (this.eventsHead < this.events.length && this.events[this.eventsHead].cycle <= cycle) this._applyHead();
+        this.skippedMs += this._ms(cycle - this.clock);
+        this.clock = cycle;
+    }
+
+    _restart() {
+        const skipTo = this.upTo - this.targetLeadCycles;
+        const skipped = Math.max(0, this._ms(skipTo - this.clock));
+        if (skipTo > this.clock) this._skipTo(skipTo);
+        this.stalled = false;
+        this._notify("skip", skipped);
+    }
+
+    _stall(out, offset, length) {
+        if (!this.stalled) {
+            this.stalled = true;
+            this.stalls++;
+            this._notify("stall", 1);
         }
-        return this._lastSample;
+        this.chip.renderAt(this.clock, out, offset, length);
+    }
+
+    // Renders `length` input samples, applying each change when the clock
+    // reaches it. Past `upTo` the chip's state is held and the clock waits,
+    // until the producer is a full target ahead again (see _restart).
+    _renderInput(out, length) {
+        if (this.stalled) {
+            this._stall(out, 0, length);
+            return;
+        }
+        let offset = 0;
+        while (length > 0) {
+            const head = this.events[this.eventsHead];
+            if (head !== undefined && isResync(head)) {
+                this.clock = head.cycle;
+                this._applyHead();
+                continue;
+            }
+            const boundary = Math.min(head === undefined ? Infinity : head.cycle, this.upTo);
+            const untilBoundary = Math.floor((boundary - this.clock) * this.samplesPerCycle);
+            if (untilBoundary <= 0) {
+                if (head !== undefined && head.cycle <= this.upTo) {
+                    this._applyHead();
+                    continue;
+                }
+                this._stall(out, offset, length);
+                return;
+            }
+            const n = Math.min(length, untilBoundary);
+            this.chip.renderAt(this.clock, out, offset, n);
+            this.clock += n / this.samplesPerCycle;
+            offset += n;
+            length -= n;
+        }
     }
 
     process(inputs, outputs) {
-        this.cleanQueue();
-        if (!this.running && this._queueSizeSamples >= this.startQueueSizeSamples) this._restart();
+        if (this.stalled && this.upTo - this.clock >= this.targetLeadCycles) this._restart();
 
-        // I looked into using https://www.npmjs.com/package/@alexanderolsen/libsamplerate-js or similar (the full API),
-        // but we fiddle the sample rate here to catch up with the target latency, which is harder to do with that API.
         const channel = outputs[0][0];
         const effectiveSampleRate = this._effectiveSampleRate(channel.length / sampleRate);
         const sampleRatio = effectiveSampleRate / sampleRate;
@@ -165,30 +197,28 @@ class SoundChipProcessor extends AudioWorkletProcessor {
         // boundary. source[0] is the last input sample of the previous quantum.
         const end = this._phase + channel.length * sampleRatio;
         const numInputSamples = Math.floor(end);
-        if (this._source.length <= numInputSamples) this._source = new Float32Array(numInputSamples * 2);
+        if (this._source.length <= numInputSamples) {
+            this._source = new Float32Array(numInputSamples * 2);
+            this._rendered = new Float32Array(numInputSamples * 2);
+        }
         const source = this._source;
+        const rendered = this._rendered;
+        this._renderInput(rendered, numInputSamples);
         source[0] = this._lastFilteredOutput;
         let prevSample = this._lastFilteredOutput;
-        // The input position from which the queue was dry, so the fade starts
-        // there rather than at the top of the quantum.
-        let dryFrom = this.running ? Infinity : 0;
         for (let i = 1; i <= numInputSamples; ++i) {
-            prevSample += filterAlpha * (this.nextSample() - prevSample);
+            prevSample += filterAlpha * (rendered[i - 1] - prevSample);
             source[i] = prevSample;
-            if (!this.running && dryFrom === Infinity) dryFrom = i;
         }
         this._lastFilteredOutput = prevSample;
-        let gain = this._gain;
         for (let i = 0; i < channel.length; i++) {
             const pos = this._phase + i * sampleRatio;
             const loc = Math.floor(pos);
             const alpha = pos - loc;
-            gain = pos < dryFrom ? Math.min(1, gain + GainStep) : Math.max(0, gain - GainStep);
-            channel[i] = (source[loc] * (1 - alpha) + source[loc + 1] * alpha) * gain;
+            channel[i] = source[loc] * (1 - alpha) + source[loc + 1] * alpha;
         }
-        this._gain = gain;
         this._phase = end - numInputSamples;
-        this.minOccupancySamples = Math.min(this.minOccupancySamples, this._occupancySamples());
+        this.minLeadMs = Math.min(this.minLeadMs, this.leadMs());
         this.stats(sampleRatio);
         return true;
     }

--- a/tests/unit/test-audio-handler.js
+++ b/tests/unit/test-audio-handler.js
@@ -111,6 +111,22 @@ describe("AudioHandler", () => {
             expect(warning().textContent).toContain(SuspendedText);
         });
 
+        it("ships the chip's writes with the emulator's position on flush", async () => {
+            const handler = makeHandler();
+            await vi.waitFor(() => expect(handler._jsAudioNode).not.toBeNull());
+            const posted = vi.spyOn(handler._jsAudioNode.port, "postMessage");
+
+            handler.soundChip.scheduler.epoch = 5000;
+            handler.soundChip.poke(0x8d);
+            handler.flushChipEvents();
+            handler.flushChipEvents();
+
+            expect(posted.mock.calls.map((call) => call[0])).toEqual([
+                { upTo: 5000, events: [{ cycle: 5000, poke: 0x8d }] },
+                { upTo: 5000, events: [] },
+            ]);
+        });
+
         it("fades the warning out once the audio is running again", () => {
             const handler = makeHandler();
 

--- a/tests/unit/test-audio-handler.js
+++ b/tests/unit/test-audio-handler.js
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import * as bootstrap from "bootstrap";
 
+import { Scheduler } from "../../src/scheduler.js";
 import { AudioHandler } from "../../src/web/audio-handler.js";
 
 const SuspendedText = "Your browser has suspended audio";
@@ -124,6 +125,21 @@ describe("AudioHandler", () => {
             expect(posted.mock.calls.map((call) => call[0])).toEqual([
                 { upTo: 5000, events: [{ cycle: 5000, poke: 0x8d }] },
                 { upTo: 5000, events: [] },
+            ]);
+        });
+
+        it("ships events as the emulation progresses, not only at the end of a tick", async () => {
+            const handler = makeHandler();
+            await vi.waitFor(() => expect(handler._jsAudioNode).not.toBeNull());
+            const scheduler = new Scheduler();
+            handler.soundChip.setScheduler(scheduler);
+            const posted = vi.spyOn(handler._jsAudioNode.port, "postMessage");
+
+            handler.soundChip.poke(0x8d);
+            scheduler.polltime(4000);
+
+            expect(posted.mock.calls.map((call) => call[0])).toEqual([
+                { upTo: 4000, events: [{ cycle: 0, poke: 0x8d }] },
             ]);
         });
 

--- a/tests/unit/test-audio-handler.js
+++ b/tests/unit/test-audio-handler.js
@@ -157,6 +157,7 @@ describe("AudioHandler", () => {
                 [{ cycle: 0, enabled: false }],
                 [{ cycle: 0, enabled: true }],
             ]);
+        });
 
         it("creates no Music 5000 audio context unless one is fitted", () => {
             makeHandler();

--- a/tests/unit/test-audio-handler.js
+++ b/tests/unit/test-audio-handler.js
@@ -127,6 +127,20 @@ describe("AudioHandler", () => {
             ]);
         });
 
+        it("ships a mute at once, since the stopped emulator will not tick", async () => {
+            const handler = makeHandler();
+            await vi.waitFor(() => expect(handler._jsAudioNode).not.toBeNull());
+            const posted = vi.spyOn(handler._jsAudioNode.port, "postMessage");
+
+            handler.mute();
+            handler.unmute();
+
+            expect(posted.mock.calls.map((call) => call[0].events)).toEqual([
+                [{ cycle: 0, enabled: false }],
+                [{ cycle: 0, enabled: true }],
+            ]);
+        });
+
         it("fades the warning out once the audio is running again", () => {
             const handler = makeHandler();
 

--- a/tests/unit/test-audio-renderer.js
+++ b/tests/unit/test-audio-renderer.js
@@ -1,5 +1,7 @@
 import { describe, it, expect, beforeAll, afterAll, vi } from "vitest";
 
+import { SoundChip } from "../../src/soundchip.js";
+
 // audio-renderer.js reads AudioWorklet globals at import time, so stub them
 // before dynamically importing it.
 let SoundChipProcessor;
@@ -26,6 +28,15 @@ afterAll(() => {
 });
 
 const OutputQuantum = 128;
+const OutputRate = 48000;
+const CyclesPerMs = 2000;
+const CyclesPerSample = 4; // 2MHz CPU, 500kHz chip
+
+// SN76489 writes for a 1kHz tone on channel 0 at full volume: 4MHz / (32 * 125).
+const TonePeriod = 125;
+const ToneHz = 4000000 / (32 * TonePeriod);
+const ToneOn = [0x80 | (TonePeriod & 0x0f), TonePeriod >> 4, 0x90];
+const ToneOff = [0x9f];
 
 // Amplitude of the frequency-bin component at freq, via the Goertzel algorithm.
 function goertzelAmplitude(samples, freq, rate) {
@@ -41,10 +52,39 @@ function goertzelAmplitude(samples, freq, rate) {
     return (2 * Math.sqrt(s1 * s1 + s2 * s2 - coeff * s1 * s2)) / samples.length;
 }
 
-// Producer delivers a frame's worth of 512-sample buffers per burst, consumer
-// runs 128-frame quanta. Returns the rates computed after collectAfter seconds.
-function simulate(proc, seconds, { frameRateHz = 60, collectAfter = 0 } = {}) {
+// Stands in for the main thread: a chip that emits events, an epoch that
+// advances with emulated time, and a flush that ships both to the worklet.
+function makeProducer(proc) {
+    const events = [];
+    const chip = new SoundChip(null, { onEvent: (event) => events.push(event) });
+    return {
+        chip,
+        get epoch() {
+            return chip.scheduler.epoch;
+        },
+        poke(...values) {
+            for (const value of values) chip.poke(value);
+        },
+        advance(ms) {
+            chip.scheduler.epoch += ms * CyclesPerMs;
+        },
+        flush() {
+            proc.onProduced(chip.scheduler.epoch, events.splice(0));
+        },
+    };
+}
+
+const quantum = (proc) => {
+    const outputs = [[new Float32Array(OutputQuantum)]];
+    proc.process([], outputs);
+    return outputs[0][0];
+};
+
+// Producer ticks every tickMs of simulated time, consumer runs 128-frame
+// quanta. Returns the effective rates and output collected after collectAfter.
+function simulate(proc, producer, seconds, { tickMs = 10, collectAfter = 0, ticking = () => true } = {}) {
     const rates = [];
+    const output = [];
     const originalRate = proc._effectiveSampleRate.bind(proc);
     let simTime = 0;
     proc._effectiveSampleRate = (dt) => {
@@ -52,201 +92,192 @@ function simulate(proc, seconds, { frameRateHz = 60, collectAfter = 0 } = {}) {
         if (simTime >= collectAfter) rates.push(rate);
         return rate;
     };
-
     try {
-        const dtOut = OutputQuantum / globalThis.sampleRate;
-        const outputs = [[new Float32Array(OutputQuantum)]];
-        let nextBurst = 0;
-        let pendingSamples = 0;
+        const dtOut = OutputQuantum / OutputRate;
+        let nextTick = 0;
         while (simTime < seconds) {
-            if (simTime >= nextBurst) {
-                pendingSamples += proc.inputSampleRate / frameRateHz;
-                while (pendingSamples >= 512) {
-                    proc.onBuffer(Date.now(), new Float32Array(512));
-                    pendingSamples -= 512;
+            if (simTime >= nextTick) {
+                if (ticking(simTime)) {
+                    producer.advance(tickMs);
+                    producer.flush();
                 }
-                nextBurst += 1 / frameRateHz;
+                nextTick += tickMs / 1000;
             }
-            proc.process([], outputs);
+            const out = quantum(proc);
+            if (simTime >= collectAfter) output.push(...out);
             simTime += dtOut;
         }
     } finally {
         proc._effectiveSampleRate = originalRate;
     }
-    return rates;
+    return { rates, output };
 }
 
-describe("SoundChipProcessor rate control", () => {
-    it("should not modulate the playback rate with the producer's frame-rate sawtooth", () => {
-        // Judge the 60 Hz component specifically: the total swing also carries the
-        // startup glide as the loop settles.
+// A processor already running with a target's lead, playing the test tone.
+function startedWithTone(proc) {
+    const producer = makeProducer(proc);
+    producer.poke(...ToneOn);
+    producer.advance(proc.targetLatencyMs);
+    producer.flush();
+    quantum(proc);
+    expect(proc.stalled).toBe(false);
+    return producer;
+}
+
+describe("SoundChipProcessor rendering", () => {
+    it("should render the chip's tone from its register writes", () => {
         const proc = new SoundChipProcessor();
-        // Start on target (half a burst below the threshold) so the loop is
-        // live rather than pinned at its clamp for the whole window.
-        for (let i = 0; i < Math.round(proc.startQueueSizeSamples / 2 / 512); ++i)
-            proc.onBuffer(Date.now(), new Float32Array(512));
-        proc.running = true;
-        const rates = simulate(proc, 6, { frameRateHz: 60, collectAfter: 3 });
-        const controlRate = globalThis.sampleRate / OutputQuantum;
-        expect(rates.length).toBeGreaterThan(1000);
-        // Remove the mean and trim to whole 60 Hz cycles (25 samples at the
-        // 375 Hz control rate), or the ~500 kHz DC term leaks into the bin.
-        const samplesPerFourCycles = 25;
-        const trimmed = rates.slice(0, Math.floor(rates.length / samplesPerFourCycles) * samplesPerFourCycles);
-        const mean = trimmed.reduce((a, b) => a + b, 0) / trimmed.length;
-        const frameRateWobble = goertzelAmplitude(
-            trimmed.map((r) => r - mean),
-            60,
-            controlRate,
-        );
-        expect(frameRateWobble).toBeLessThan(50);
-        const peakToPeak = Math.max(...rates) - Math.min(...rates);
-        expect(peakToPeak).toBeLessThan(400);
+        const producer = startedWithTone(proc);
+        const { output } = simulate(proc, producer, 0.5, { collectAfter: 0.1 });
+        expect(goertzelAmplitude(output, ToneHz, OutputRate)).toBeGreaterThan(0.1);
+        expect(goertzelAmplitude(output, ToneHz * 1.5, OutputRate)).toBeLessThan(0.02);
     });
 
-    it("should speed up when the queue is over target and slow down when under", () => {
+    it("should apply a write at its cycle, part way through a quantum", () => {
+        const proc = new SoundChipProcessor();
+        const producer = startedWithTone(proc);
+        const rendered = new Float32Array(1000);
+        // The tone goes quiet at a cycle in the middle of the samples rendered.
+        const offCycle = proc.clock + 500 * CyclesPerSample;
+        producer.chip.scheduler.epoch = offCycle;
+        producer.poke(...ToneOff);
+        producer.advance(10);
+        producer.flush();
+        proc._renderInput(rendered, rendered.length);
+        const loud = rendered.subarray(0, 500);
+        const quiet = rendered.subarray(520, 1000);
+        expect(Math.max(...loud) - Math.min(...loud)).toBeGreaterThan(0.1);
+        expect(Math.max(...quiet) - Math.min(...quiet)).toBeLessThan(0.01);
+    });
+
+    it("should keep sounding the current state when the producer stalls, then skip the stalled time", () => {
+        const proc = new SoundChipProcessor();
+        const producer = startedWithTone(proc);
+        // The producer stops for 100ms of the consumer's time, then resumes at
+        // real-time rate: the lead drains, time stands still, and once the
+        // producer is a target ahead again nothing needs skipping.
+        simulate(proc, producer, 0.3, { ticking: (t) => !(t > 0.1 && t < 0.2) });
+        expect(proc.stalls).toBe(1);
+        expect(proc.stalled).toBe(false);
+        expect(proc.skippedMs).toBeLessThan(1);
+    });
+
+    it("should skip the missed time when the producer catches up in one burst", () => {
+        const proc = new SoundChipProcessor();
+        const producer = startedWithTone(proc);
+        for (let i = 0; i < 200; ++i) quantum(proc);
+        expect(proc.stalled).toBe(true);
+        producer.advance(100);
+        producer.flush();
+        quantum(proc);
+        expect(proc.stalled).toBe(false);
+        expect(proc.skippedMs).toBeCloseTo(100 - proc.targetLatencyMs, 0);
+    });
+
+    it("should carry on with the tone, not silence, while stalled", () => {
+        const proc = new SoundChipProcessor();
+        startedWithTone(proc);
+        // No more production: the lead drains, then the chip is held.
+        const output = [];
+        for (let i = 0; i < 200; ++i) output.push(...quantum(proc));
+        expect(proc.stalled).toBe(true);
+        const held = output.slice(output.length - 2000);
+        expect(goertzelAmplitude(held, ToneHz, OutputRate)).toBeGreaterThan(0.1);
+    });
+
+    it("should be in the producer's state after skipping, having applied the writes it skipped", () => {
+        const proc = new SoundChipProcessor();
+        const producer = startedWithTone(proc);
+        for (let i = 0; i < 200; ++i) quantum(proc);
+        expect(proc.stalled).toBe(true);
+        producer.advance(50);
+        producer.poke(...ToneOff);
+        producer.advance(50);
+        producer.flush();
+        quantum(proc);
+        expect(proc.stalled).toBe(false);
+        expect(proc.leadMs()).toBeLessThanOrEqual(proc.targetLatencyMs);
+        expect(proc.leadMs()).toBeGreaterThan(proc.targetLatencyMs - 3);
+        const output = [];
+        for (let i = 0; i < 40; ++i) output.push(...quantum(proc));
+        expect(goertzelAmplitude(output.slice(1000), ToneHz, OutputRate)).toBeLessThan(0.01);
+    });
+
+    it("should jump to a restored state's timeline and discard what came before it", () => {
+        const proc = new SoundChipProcessor();
+        const producer = startedWithTone(proc);
+        const state = producer.chip.snapshotState();
+        producer.poke(...ToneOff);
+        // A rewind: the epoch goes backwards and the chip is restored.
+        producer.chip.scheduler.epoch = 1000;
+        producer.chip.restoreState(state);
+        producer.advance(proc.targetLatencyMs);
+        producer.flush();
+        quantum(proc);
+        expect(proc.clock).toBeGreaterThanOrEqual(1000);
+        expect(proc.clock).toBeLessThan(1000 + proc.targetLatencyMs * CyclesPerMs);
+        const output = [];
+        for (let i = 0; i < 10; ++i) output.push(...quantum(proc));
+        expect(goertzelAmplitude(output, ToneHz, OutputRate)).toBeGreaterThan(0.1);
+    });
+});
+
+describe("SoundChipProcessor rate control", () => {
+    it("should not modulate the playback rate at the producer's tick rate", () => {
+        const proc = new SoundChipProcessor();
+        const producer = startedWithTone(proc);
+        const { rates } = simulate(proc, producer, 3, { collectAfter: 2 });
+        const mean = rates.reduce((a, b) => a + b, 0) / rates.length;
+        const wobble = goertzelAmplitude(
+            rates.map((r) => r - mean),
+            100,
+            OutputRate / OutputQuantum,
+        );
+        expect(wobble).toBeLessThan(50);
+        expect(Math.max(...rates) - Math.min(...rates)).toBeLessThan(400);
+        expect(proc.stalls).toBe(0);
+    });
+
+    it("should speed up when the lead is over target and slow down when under", () => {
         const over = new SoundChipProcessor();
-        over.running = true;
-        for (let i = 0; i < Math.ceil((4 * over.startQueueSizeSamples) / 512); ++i)
-            over.onBuffer(Date.now(), new Float32Array(512));
-        const outputs = [[new Float32Array(OutputQuantum)]];
-        for (let i = 0; i < 20; ++i) over.process([], outputs);
+        const overProducer = startedWithTone(over);
+        overProducer.advance(3 * over.targetLatencyMs);
+        overProducer.flush();
+        for (let i = 0; i < 20; ++i) quantum(over);
         expect(over._effectiveSampleRate(0)).toBeGreaterThan(over.inputSampleRate);
 
         const under = new SoundChipProcessor();
-        for (let i = 0; i < Math.ceil(under.startQueueSizeSamples / 2 / 512); ++i)
-            under.onBuffer(Date.now(), new Float32Array(512));
-        under.running = true;
-        for (let i = 0; i < 20; ++i) under.process([], outputs);
+        startedWithTone(under);
+        for (let i = 0; i < 3; ++i) quantum(under);
         expect(under._effectiveSampleRate(0)).toBeLessThan(under.inputSampleRate);
     });
 
-    it("should never bend pitch audibly, however far the queue is from target", () => {
-        const outputs = [[new Float32Array(OutputQuantum)]];
+    it("should never bend pitch audibly, however far the lead is from target", () => {
         const over = new SoundChipProcessor();
-        over.running = true;
-        for (let i = 0; i < Math.ceil((5 * over.startQueueSizeSamples) / 512); ++i)
-            over.onBuffer(Date.now(), new Float32Array(512));
-        for (let i = 0; i < 400; ++i) over.process([], outputs);
+        const producer = startedWithTone(over);
+        producer.advance(20 * over.targetLatencyMs);
+        producer.flush();
+        for (let i = 0; i < 400; ++i) quantum(over);
         expect(over._effectiveSampleRate(0)).toBeLessThanOrEqual(over.inputSampleRate + over.inputSampleRate * 0.0005);
 
         const under = new SoundChipProcessor();
-        under.onBuffer(Date.now(), new Float32Array(512));
-        under.running = true;
-        for (let i = 0; i < 400; ++i) under.process([], outputs);
+        startedWithTone(under);
+        for (let i = 0; i < 400; ++i) quantum(under);
         expect(under._effectiveSampleRate(0)).toBeGreaterThanOrEqual(
             under.inputSampleRate - under.inputSampleRate * 0.0005,
         );
     });
 
-    it("should consume exactly the resampling ratio, never rounding it per quantum", () => {
-        // Rounding the per-quantum consumption quantises the pitch in steps of
-        // one part in ~1300 (1.3 cents), audible once the rate stops jittering.
+    it("should converge the lead to the target without stalling", () => {
         const proc = new SoundChipProcessor();
-        proc.running = true;
-        for (let i = 0; i < 60; ++i) proc.onBuffer(Date.now(), new Float32Array(512));
-        const outputs = [[new Float32Array(OutputQuantum)]];
-        const before = proc._occupancySamples();
-        let expected = 0;
-        const originalRate = proc._effectiveSampleRate.bind(proc);
-        proc._effectiveSampleRate = (dt) => {
-            const rate = originalRate(dt);
-            expected += (OutputQuantum * rate) / globalThis.sampleRate;
-            return rate;
-        };
-        for (let i = 0; i < 20; ++i) proc.process([], outputs);
-        expect(proc.underruns).toBe(0);
-        expect(Math.abs(before - proc._occupancySamples() - expected)).toBeLessThan(1);
-    });
-
-    it("should converge the queue occupancy to the target", () => {
-        const proc = new SoundChipProcessor();
-        proc.running = true;
-        for (let i = 0; i < Math.ceil(proc.startQueueSizeSamples / 512); ++i)
-            proc.onBuffer(Date.now(), new Float32Array(512));
-        simulate(proc, 20, { frameRateHz: 60 });
-        // Instantaneous occupancy rides the burst sawtooth (a whole frame's
-        // samples, ~8300 peak to peak), so judge the smoothed error instead.
-        expect(Math.abs(proc.smoothedOccupancyError)).toBeLessThan(proc.startQueueSizeSamples * 0.1);
-        expect(proc.underruns).toBe(0);
-        expect(proc.dropped).toBe(0);
+        const producer = startedWithTone(proc);
+        simulate(proc, producer, 20);
+        expect(Math.abs(proc.smoothedLeadError)).toBeLessThan(proc.targetLeadCycles * 0.1);
+        expect(proc.stalls).toBe(0);
     });
 });
 
-describe("SoundChipProcessor queue trimming", () => {
-    const outputs = [[new Float32Array(OutputQuantum)]];
-    const fill = (proc, samples) => {
-        for (let i = 0; i < Math.ceil(samples / 512); ++i) proc.onBuffer(Date.now(), new Float32Array(512));
-    };
-    const runDry = (proc) => {
-        while (proc.running) proc.process([], outputs);
-    };
-
-    it("should not drop from a running queue that sits above target", () => {
-        const proc = new SoundChipProcessor();
-        proc.running = true;
-        fill(proc, 3 * proc.startQueueSizeSamples);
-        for (let i = 0; i < 20; ++i) proc.process([], outputs);
-        expect(proc.dropped).toBe(0);
-    });
-
-    it("should trim a catch-up burst to the target when restarting after an underrun", () => {
-        const proc = new SoundChipProcessor();
-        fill(proc, proc.startQueueSizeSamples);
-        proc.process([], outputs);
-        expect(proc.running).toBe(true);
-        runDry(proc);
-        expect(proc.underruns).toBe(1);
-        expect(proc.dropped).toBe(0);
-
-        const target = proc.startQueueSizeSamples;
-        fill(proc, 4 * target);
-        proc.process([], outputs);
-        expect(proc.running).toBe(true);
-        const filled = Math.ceil((4 * target) / 512);
-        const fewestHoldingTarget = Math.ceil(target / 512);
-        expect(proc.dropped).toBe(filled - fewestHoldingTarget);
-    });
-
-    it("should only drop from a queue beyond the hard maximum", () => {
-        const proc = new SoundChipProcessor();
-        fill(proc, proc.maxQueueSizeSamples + 4 * 512);
-        expect(proc.dropped).toBeGreaterThan(0);
-        expect(proc._queueSizeSamples).toBeLessThanOrEqual(proc.maxQueueSizeSamples);
-        expect(proc._queueSizeSamples).toBeGreaterThan(proc.maxQueueSizeSamples - 512);
-    });
-});
-
-describe("SoundChipProcessor target latency changes", () => {
-    const outputs = [[new Float32Array(OutputQuantum)]];
-    const fill = (proc, samples) => {
-        for (let i = 0; i < Math.ceil(samples / 512); ++i) proc.onBuffer(Date.now(), new Float32Array(512));
-    };
-
-    it("should keep playing through a change of target, leaving the queue to the producer", () => {
-        const proc = new SoundChipProcessor();
-        const oldTarget = proc.startQueueSizeSamples;
-        fill(proc, oldTarget);
-        proc.process([], outputs);
-        expect(proc.running).toBe(true);
-
-        proc.setTargetLatency(10 * proc.targetLatencyMs);
-        expect(proc.startQueueSizeSamples).toBe(10 * oldTarget);
-        proc.process([], outputs);
-        expect(proc.running).toBe(true);
-        expect(proc.dropped).toBe(0);
-
-        fill(proc, 10 * oldTarget);
-        proc.setTargetLatency();
-        expect(proc.startQueueSizeSamples).toBe(oldTarget);
-        proc.process([], outputs);
-        expect(proc.running).toBe(true);
-        expect(proc.dropped).toBe(0);
-        expect(proc.underruns).toBe(0);
-    });
-});
-
-describe("SoundChipProcessor target latency option", () => {
+describe("SoundChipProcessor target latency", () => {
     it("should fall back to the default for a missing, zero or non-numeric target", () => {
         const fallback = new SoundChipProcessor().targetLatencyMs;
         for (const targetLatencyMs of [undefined, 0, -5, NaN, Infinity, "abc"]) {
@@ -256,84 +287,19 @@ describe("SoundChipProcessor target latency option", () => {
         expect(new SoundChipProcessor({ processorOptions: { targetLatencyMs: 35 } }).targetLatencyMs).toBe(35);
     });
 
-    it("should cap the target so a catch-up burst still fits under the hard maximum", () => {
+    it("should cap the target and keep playing through a change of it", () => {
         const proc = new SoundChipProcessor();
+        const producer = startedWithTone(proc);
         proc.setTargetLatency(100000);
-        expect(proc.startQueueSizeSamples).toBeLessThanOrEqual(proc.maxQueueSizeSamples / 2);
-        proc.setTargetLatency("abc");
-        expect(proc.targetLatencyMs).toBe(new SoundChipProcessor().targetLatencyMs);
-    });
-});
-
-describe("SoundChipProcessor underrun fade", () => {
-    const FadeSamples = 48000 * 0.001;
-    const level = 0.5;
-    const fill = (proc, samples) => {
-        for (let i = 0; i < Math.ceil(samples / 512); ++i) proc.onBuffer(Date.now(), new Float32Array(512).fill(level));
-    };
-    const quantum = (proc) => {
-        const outputs = [[new Float32Array(OutputQuantum)]];
-        proc.process([], outputs);
-        return outputs[0][0];
-    };
-    const maxStep = (samples) => {
-        let worst = 0;
-        for (let i = 1; i < samples.length; ++i) worst = Math.max(worst, Math.abs(samples[i] - samples[i - 1]));
-        return worst;
-    };
-    // Two targets' worth queued, played until settled at the fill level.
-    const settled = (proc) => {
-        fill(proc, 2 * proc.startQueueSizeSamples);
-        let out;
-        for (let i = 0; i < 4; ++i) out = quantum(proc);
-        expect(out[out.length - 1]).toBeCloseTo(level, 3);
-    };
-
-    it("should fade out on underrun instead of stepping to silence", () => {
-        const proc = new SoundChipProcessor();
-        settled(proc);
-        const played = [];
-        for (let i = 0; i < 40; ++i) played.push(...quantum(proc));
-        expect(proc.underruns).toBe(1);
-        expect(maxStep(played)).toBeLessThanOrEqual(level / FadeSamples + 1e-6);
-        expect(played[played.length - 1]).toBe(0);
-    });
-
-    it("should hold full gain up to the sample the queue ran dry at", () => {
-        const proc = new SoundChipProcessor();
-        settled(proc);
-        // Leave the queue with about half a quantum's worth so it runs dry mid-quantum.
-        const perQuantum = Math.floor((OutputQuantum * proc.inputSampleRate) / 48000);
-        while (proc._occupancySamples() > perQuantum / 2) quantum(proc);
-        const before = proc._occupancySamples();
-        const out = quantum(proc);
-        expect(proc.running).toBe(false);
-        const dryAtOutput = Math.floor(before / (proc.inputSampleRate / 48000));
-        for (let i = 0; i < dryAtOutput - 1; ++i) expect(out[i]).toBeCloseTo(level, 3);
-        expect(out[out.length - 1]).toBeLessThan(level);
-    });
-
-    it("should fade back in on restart", () => {
-        const proc = new SoundChipProcessor();
-        settled(proc);
-        for (let i = 0; i < 40; ++i) quantum(proc);
-        expect(proc.running).toBe(false);
-        fill(proc, proc.startQueueSizeSamples);
-        const first = quantum(proc);
-        expect(proc.running).toBe(true);
-        expect(Math.abs(first[0])).toBeLessThanOrEqual(level / FadeSamples + 1e-6);
-        expect(maxStep(first)).toBeLessThanOrEqual(level / FadeSamples + 1e-6);
-        expect(first[first.length - 1]).toBeCloseTo(level, 1);
-    });
-
-    it("should keep posting stats while the queue is empty", () => {
-        const proc = new SoundChipProcessor();
-        settled(proc);
-        for (let i = 0; i < 40; ++i) quantum(proc);
-        expect(proc.queue.length).toBe(0);
-        const posted = vi.spyOn(proc.port, "postMessage");
-        proc.nextStats = 0;
+        expect(proc.targetLatencyMs).toBeLessThanOrEqual(250);
+        proc.setTargetLatency(2 * proc.targetLatencyMs);
         quantum(proc);
-        expect(posted).toHaveBeenCalledWith(expect.objectContaining({ queueSize: 0 }));
+        expect(proc.stalled).toBe(false);
+        producer.advance(100);
+        producer.flush();
+        proc.setTargetLatency();
+        quantum(proc);
+        expect(proc.stalled).toBe(false);
+        expect(proc.skippedMs).toBe(0);
     });
 });

--- a/tests/unit/test-soundchip.js
+++ b/tests/unit/test-soundchip.js
@@ -417,3 +417,88 @@ describe("AtomSoundChip", () => {
         expect(chip.bitChange).toHaveLength(0);
     });
 });
+
+describe("SoundChip events", () => {
+    function makeEventChip() {
+        const events = [];
+        const scheduler = new Scheduler();
+        const chip = new SoundChip(() => {}, { onEvent: (event) => events.push(event) });
+        chip.setScheduler(scheduler);
+        return { chip, scheduler, events };
+    }
+
+    it("should stamp each write with the cycle it takes effect at", () => {
+        const { chip, scheduler, events } = makeEventChip();
+        scheduler.polltime(1234);
+        chip.poke(0x8d);
+        scheduler.polltime(10);
+        chip.poke(0x07);
+        expect(events).toEqual([
+            { cycle: 1234, poke: 0x8d },
+            { cycle: 1244, poke: 0x07 },
+        ]);
+    });
+
+    it("should report tape tones, muting, resets and restores as events", () => {
+        const { chip, events } = makeEventChip();
+        chip.toneGenerator.tone(1200);
+        chip.toneGenerator.mute();
+        chip.mute();
+        chip.reset(true);
+        chip.restoreState(chip.snapshotState());
+        expect(events.map((event) => Object.keys(event).find((key) => key !== "cycle"))).toEqual([
+            "sine",
+            "sine",
+            "enabled",
+            "reset",
+            "state",
+        ]);
+        expect(events[0].sine).toBe(1200);
+        expect(events[1].sine).toBe(0);
+        expect(events[2].enabled).toBe(false);
+    });
+
+    it("should not render when it has an event sink", () => {
+        const buffers = [];
+        const scheduler = new Scheduler();
+        const chip = new SoundChip((buffer) => buffers.push(buffer), { onEvent: () => {} });
+        chip.setScheduler(scheduler);
+        scheduler.polltime(2000000);
+        chip.catchUp();
+        expect(buffers).toEqual([]);
+    });
+
+    it("should render the same output from the events as the chip they came from", () => {
+        const { chip: source, scheduler, events } = makeEventChip();
+        const { chip: renderer } = makeSoundChip();
+        source.poke(0x8d);
+        source.poke(0x07);
+        source.poke(0x90);
+        scheduler.polltime(4000);
+        source.poke(0x9f);
+        for (const event of events) renderer.applyEvent(event);
+        const out = new Float32Array(2000);
+        renderer.renderAt(0, out, 0, out.length);
+        // With the tone latched then silenced, applying every event at once leaves silence.
+        expect(Math.max(...out) - Math.min(...out)).toBeLessThan(1e-3);
+
+        const { chip: playing } = makeSoundChip();
+        for (const event of events.slice(0, 3)) playing.applyEvent(event);
+        playing.renderAt(0, out, 0, out.length);
+        expect(goertzelAmplitude(out, 1000, 500000)).toBeGreaterThan(0.05);
+    });
+
+    it("should carry Atom speaker bits as events with their exact cycle", () => {
+        const events = [];
+        const scheduler = new Scheduler();
+        const chip = new AtomSoundChip(() => {}, { onEvent: (event) => events.push(event) });
+        chip.setScheduler(scheduler);
+        chip.updateSpeaker(true, 10, 0.5);
+        expect(events).toEqual([{ cycle: 10 + 0.5 * 1000000, bit: 1 }]);
+        expect(chip.bitChange).toEqual([]);
+
+        const { chip: renderer } = makeAtomSoundChip();
+        renderer.applyEvent(events[0]);
+        expect(renderer.bitChange).toEqual([{ bit: 1, cycles: 10 + 0.5 * 1000000 }]);
+    });
+});

--- a/tests/unit/test-soundchip.js
+++ b/tests/unit/test-soundchip.js
@@ -444,6 +444,7 @@ describe("SoundChip events", () => {
         chip.toneGenerator.tone(1200);
         chip.toneGenerator.mute();
         chip.mute();
+        chip.reset(false);
         chip.reset(true);
         chip.restoreState(chip.snapshotState());
         expect(events.map((event) => Object.keys(event).find((key) => key !== "cycle"))).toEqual([

--- a/tests/unit/test-soundchip.js
+++ b/tests/unit/test-soundchip.js
@@ -458,6 +458,20 @@ describe("SoundChip events", () => {
         expect(events[2].enabled).toBe(false);
     });
 
+    it("should report progress every few emulated milliseconds, and keep doing so after a restore", () => {
+        const { chip, scheduler, events } = makeEventChip();
+        scheduler.polltime(10000);
+        expect(events).toEqual([
+            { cycle: 4000, progress: true },
+            { cycle: 8000, progress: true },
+        ]);
+        scheduler.restoreState({ epoch: 20000 });
+        chip.restoreState(chip.snapshotState());
+        events.length = 0;
+        scheduler.polltime(4000);
+        expect(events).toEqual([{ cycle: 24000, progress: true }]);
+    });
+
     it("should not render when it has an event sink", () => {
         const buffers = [];
         const scheduler = new Scheduler();


### PR DESCRIPTION
Implements #894. The browser's sound is now synthesised inside the audio worklet from the chip's register writes, so a stall on the main thread stretches the sound instead of cutting it.

## What changed

- **The chip emits events instead of samples when it has an event sink.** `SoundChip` takes an `onEvent` option; every state change (register write, tape tone on/off, mute/unmute, reset, restore, and the Atom's speaker bits) is reported stamped with the scheduler cycle it takes effect at, and a chip with a sink does not render. The main-thread chip keeps everything else it had (snapshots, `debugPokeAll`, the headless harness's `InstrumentedSoundChip`, the tests), so nothing outside the browser changes.
- **The handler ships events once per tick** (`flushChipEvents`, called from the tick after `execute()` and after a blur run-ahead), together with the emulator's current epoch, so the worklet always knows how far ahead the producer is even when nothing changed. That replaces ~1000 sample buffers a second with ~100 small messages.
- **The worklet owns a second `SoundChip`** (imported; the renderer is now bundled as a worker via `?worker&url` because a plain asset URL copies a worklet verbatim) and renders from the events, applying each when its clock reaches the event's cycle, at sample (2 µs) granularity, exactly as the main-thread chip used to. Resampling and the 0.05% rate control are unchanged apart from watching *lead* (how far the emulator is ahead of the worklet's clock) rather than queued samples.
- **Stalls and skips replace underruns and drops.** When the worklet's clock reaches the producer's position it holds the chip's state and its clock: a held tone keeps sounding, a note lasts longer, sampled speech sits on its inaudible carrier. When the producer is a full target ahead again the missed writes are applied in one go and the clock jumps, so the sound continues from the emulator's current state with no gap and no waveform tear. A restore or reset is a resync: the worklet jumps to the new timeline and discards anything queued from the old one, which is what rewind and save-state loading need.
- `?audioDebug` now charts lead and shows stalls (red) and skips (purple, height = ms skipped); the console line reads `audio lead min Nms, stalls N, skipped Nms`. `audioLatencyMs` now means target lead. #889's blur/focus depth change works unchanged (the run-ahead just moves the emulator's position).

Tests: the worklet is driven with the real `SoundChip` by a simulated producer and checked with Goertzel: the tone renders at the right frequency, a write lands at its cycle mid-quantum, the tone carries on through a stall, a burst catch-up skips the right amount, a producer pause that resumes at real time needs no skip, a rewind resyncs, rate control converges and stays within authority. Chip tests cover the events and that rendering from them matches the source chip; the handler test covers the flush. Verified headless in dev and in the production build (`vite preview`), including a blur/focus cycle.

## What to listen for

1. `SOUND 1,-15,200,200` with `?audioDebug`. Previously an underrun was a gap; now a stall should be inaudible on a held tone (the tone continues) and the line shows `stalls N, skipped 0ms` for brief ones. Provoke long ones with `audioLatencyMs=5`: a stall then shows as `skipped Nms`, which on a held tone is still nothing to hear.
2. Music (a demo with a tune): a long stall should now sound like the current note hanging for a moment and the tune then jumping on, never a click or a gap.
3. **Sampled speech and the PCM tricks (Speech!, Spyhunter, Repton, Chris's demos)**: these are where the timing of writes matters most. They should sound exactly as before in normal running; a stall becomes a short dropout to the carrier rather than a gap. This is the case I can least verify without ears.
4. Tape loading tones (the sine channel), and the Atom if you have one to hand: both now travel as events.
5. Save state, load state, rewind, hard and soft reset: the sound should follow the machine without a burst of stale audio.
6. Alt-tab away and back (#889 behaviour should be unchanged), pause and resume.

Closes #894. The Music 5000 (#892) still uses the sample path.
