### PR TITLE
docs: state the real PAL chroma cutoff and fix the FIR generator's units

### DIFF
--- a/docs/pal-comb-filter-research.md
+++ b/docs/pal-comb-filter-research.md
@@ -1,5 +1,7 @@
 # Authentic PAL TV Comb Filter Research
 
+**Status:** this is research into a luma comb as an option, not a description of the shipped shader. The current design (see [pal-simulation-design.md](pal-simulation-design.md)) has no luma comb: chroma is demodulated per line, blended at baseband with the line two texture rows above, remodulated and subtracted from the composite to give luma.
+
 ## Sources
 
 1. **Watkinson "Engineer's Guide to Decoding & Encoding"** (pages 37-39)

--- a/docs/pal-simulation-design.md
+++ b/docs/pal-simulation-design.md
@@ -27,7 +27,7 @@ The shader implements these steps for each pixel:
 
 2. **Demodulate with FIR filter**
    - Multiply composite by sin(ωt) and cos(ωt) to shift chroma to baseband
-   - Apply 21-tap FIR low-pass filter (~2.2 MHz cutoff) horizontally
+   - Apply 21-tap FIR low-pass filter (1.108 MHz design cutoff, -3 dB at about 0.83 MHz) horizontally
    - FIR_GAIN = 2.0 compensates for demodulation amplitude loss (sin²(x) = 0.5)
    - Process current line AND previous line (2H delay) separately
 
@@ -85,8 +85,7 @@ Y = composite_curr - remodulated_chroma;
 
 **Why it failed:**
 
-- 1H spacing = 0.75 cycles = 270° phase shift
-- Mathematical analysis showed U/V mixing:
+- The delay used was one whole 1024-texel texture line, which is 64 µs = 283.75 subcarrier cycles, so the delayed chroma arrived 270° from the direct chroma and the sum mixed U into V and V into U:
   ```
   chroma_band = (U_N + V_{N-1})·sin(ωt) + (V_N + U_{N-1})·cos(ωt)
   ```
@@ -94,7 +93,7 @@ Y = composite_curr - remodulated_chroma;
 - Tried compensating with FIR_GAIN = 4.0 (double amplitude loss) - made it worse
 - Result: Severe checkerboard artifacts, washed out colors
 
-**Lesson:** 1H comb at composite level doesn't work for PAL due to phase relationships. Must demodulate FIRST with correct phase, THEN blend.
+**Lesson:** A 1H comb at composite level does work for PAL; every delay-line PAL set uses one. The glass delay line is 63.943 µs (283.5 cycles), not 64 µs, precisely so the delayed chroma is 180° from the direct chroma. Reproducing that needs a 283.5-cycle delay (about 1023.1 texels), not a whole texture line. Demodulating first and blending at baseband sidesteps the requirement, which is what the shipped design does.
 
 #### 2. 3-Tap Bandpass Comb with Complementary Subtraction
 
@@ -283,8 +282,10 @@ See shader source for actual matrix values.
 
 ### FIR Filter
 
-- **Taps:** 21 (symmetric)
-- **Cutoff frequency:** 2.217 MHz (half subcarrier)
+- **Taps:** 21 (symmetric), Kaiser window with β=5
+- **Cutoff frequency:** 1.108 MHz design cutoff (quarter subcarrier), which for a windowed sinc is the -6 dB point
+- **Measured response:** -1.05 dB at 0.5 MHz, -3 dB at 0.83 MHz, -5.6 dB at 1.108 MHz, -32 dB at 2.2 MHz, -86 dB at 4.43 MHz
+- **Why this narrow:** broadcast PAL chroma extends to ±1.3 MHz at -3 dB, but consumer decoders commonly roll off between 0.5 and 1 MHz; this filter models a domestic set rather than a studio decoder
 - **Sample rate:** 16 MHz
 - **Gain compensation:** FIR_GAIN = 2.0 to compensate for demodulation amplitude loss
 - **Source:** Derived from svofski/CRT project
@@ -320,9 +321,9 @@ See shader source for actual matrix values.
    - Caused by chroma blending with black (correct behavior)
    - May need comparison with real hardware to validate
 
-4. **No gamma correction**
-   - Should ideally use sRGB framebuffer (GL_FRAMEBUFFER_SRGB)
-   - Deferred for future implementation
+### Gamma
+
+No gamma handling is needed, and an sRGB framebuffer would be the wrong direction. PAL encoders work on gamma-corrected R'G'B' and the decoder's R'G'B' output goes to the display as-is, so the whole chain runs on gamma-coded values. With one bit per gun the YUV matrix gives the same result either way, and NULA palette values are already gamma-coded.
 
 ## Integration with jsbeeb
 

--- a/src/video-filters/shaders/pal-composite.frag.glsl
+++ b/src/video-filters/shaders/pal-composite.frag.glsl
@@ -85,7 +85,7 @@ void main() {
     // BEGIN_FIR_COEFFICIENTS
     // This section is replaced by the Vite build to include FIR filter coefficients.
     // Change Cutoff (in comment below) or FIRTAPS value to configure.
-    // Cutoff: 1.108 MHz (quarter subcarrier)
+    // Cutoff: 1.108 MHz (quarter subcarrier; the -6 dB design point, -3 dB at about 0.83 MHz)
     const int FIRTAPS = 21;
     float FIR[FIRTAPS];
     // END_FIR_COEFFICIENTS

--- a/tools/fir-generator.js
+++ b/tools/fir-generator.js
@@ -3,7 +3,7 @@
  *
  * Based on reverse-engineering Rich's original coefficients (generated via ChatGPT):
  * - Uses Kaiser window with β=5
- * - Actual cutoff frequency is 0.5× the specified nominal frequency
+ * - The cutoff is the -6 dB point of the windowed sinc
  * - Normalized coefficients (sum = 1.0)
  * - Sample rate: 16 MHz
  */
@@ -25,7 +25,7 @@ function kaiserWindow(n, M, beta) {
     return Math.cosh(arg) / Math.cosh(beta);
 }
 
-function generateFirLowpass(numTaps, cutoffNormalized, beta) {
+function generateFirLowpass(numTaps, cutoffCyclesPerSample, beta) {
     // Generate FIR lowpass filter using Kaiser windowed sinc
     const center = (numTaps - 1) / 2;
     const coefficients = [];
@@ -33,7 +33,7 @@ function generateFirLowpass(numTaps, cutoffNormalized, beta) {
     for (let n = 0; n < numTaps; n++) {
         // Ideal lowpass filter (sinc function)
         const t = n - center;
-        const h = 2 * cutoffNormalized * sinc(2 * cutoffNormalized * t);
+        const h = 2 * cutoffCyclesPerSample * sinc(2 * cutoffCyclesPerSample * t);
 
         // Apply Kaiser window
         const w = kaiserWindow(n, numTaps, beta);
@@ -49,24 +49,22 @@ function generateFirLowpass(numTaps, cutoffNormalized, beta) {
  * Generate FIR filter coefficients and format as GLSL array initialization.
  *
  * @param {number} numTaps - Number of filter taps (must be odd)
- * @param {number} nominalCutoffMhz - Nominal cutoff frequency in MHz
+ * @param {number} cutoffMhz - Cutoff frequency in MHz
  * @param {string} indent - Indentation string to prepend to each line
  * @returns {string} GLSL array initialization code
  */
-export function generateFirCoefficients(numTaps, nominalCutoffMhz, indent) {
+export function generateFirCoefficients(numTaps, cutoffMhz, indent) {
     // Validate inputs
     if (numTaps <= 0 || numTaps % 2 === 0) {
         throw new Error(`numTaps must be a positive odd number, got ${numTaps}`);
     }
-    if (nominalCutoffMhz <= 0 || nominalCutoffMhz > 8) {
-        throw new Error(`nominalCutoffMhz must be between 0 and 8 MHz (Nyquist), got ${nominalCutoffMhz}`);
+    if (cutoffMhz <= 0 || cutoffMhz > 8) {
+        throw new Error(`cutoffMhz must be between 0 and 8 MHz (Nyquist), got ${cutoffMhz}`);
     }
 
-    // Key discovery: actual cutoff is 0.5× the specified frequency
-    const actualCutoffHz = nominalCutoffMhz * 1e6 * 0.5;
-    const cutoffNormalized = actualCutoffHz / (SAMPLE_RATE_HZ / 2.0);
+    const cutoffCyclesPerSample = (cutoffMhz * 1e6) / SAMPLE_RATE_HZ;
 
-    const coeffs = generateFirLowpass(numTaps, cutoffNormalized, BETA);
+    const coeffs = generateFirLowpass(numTaps, cutoffCyclesPerSample, BETA);
 
     // Format as GLSL array initialization (4 per line)
     const lines = [];


### PR DESCRIPTION
## What was mislabelled

The PAL chroma filter's cutoff was stated three different ways, none of them matching the filter:

| Where | Said | Truth |
| --- | --- | --- |
| `docs/pal-simulation-design.md` (pipeline overview) | ~2.2 MHz | 1.108 MHz design cutoff |
| `docs/pal-simulation-design.md` (FIR Filter section) | 2.217 MHz, half subcarrier | 1.108 MHz, quarter subcarrier |
| `pal-composite.frag.glsl` | 1.108 MHz | correct, but that is the -6 dB point of a windowed sinc, not the -3 dB point |
| `tools/fir-generator.js` | "actual cutoff is 0.5x the nominal" | a units confusion; the nominal figure is the true design cutoff |

Measured response of the shipped 21-tap Kaiser (beta 5) filter: -1.05 dB at 0.5 MHz, -3 dB at 0.83 MHz, -5.6 dB at 1.108 MHz, -32 dB at 2.2 MHz, -86 dB at 4.43 MHz. Broadcast PAL chroma is +/-1.3 MHz at -3 dB; consumer decoders commonly roll off between 0.5 and 1 MHz, so this is a domestic-set choice and the doc now says so.

## Changes

- `tools/fir-generator.js`: the generator normalised the cutoff to Nyquist and then used it in a formula that takes cycles per sample; the two factor-of-two errors cancelled and were papered over with a `0.5x` fudge and a "key discovery" comment. Now computes cycles per sample directly. Output is bit-identical (checked for 21 taps at 1.108 MHz and four other tap/cutoff/indent combinations). Public signature unchanged.
- Shader `// Cutoff:` comment line: still parsed by the Vite plugin; the build log confirms `Generated 21-tap filter @ 1.108 MHz`.
- `docs/pal-simulation-design.md`:
  - FIR Filter section states the design cutoff, the measured response and the rationale.
  - The 1H composite comb "Why it failed" and "Lesson" now give the real reason: the experiment used a whole 1024-texel line (283.75 cycles), whereas a delay-line PAL set's glass line is 63.943 us (283.5 cycles) precisely so the delayed chroma is 180 degrees from the direct chroma. The section is otherwise left as a record of what was tried.
  - The "no gamma correction / use an sRGB framebuffer" outstanding issue is replaced with a short Gamma note: the PAL chain runs on gamma-coded R'G'B' end to end, so no gamma handling is needed and sRGB would be the wrong direction.
- `docs/pal-comb-filter-research.md`: status note at the top saying it is research into an option; the shader has no luma comb (luma is composite minus remodulated chroma).

Untouched on purpose (being rewritten alongside the phase fix): the 2H-delay rationale, the field phase offset, Outstanding Issues 1 and 2, Frame Counter Propagation, and the shader header.

Fixes #902
Refs #904 (the remaining items land with the phase fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
