### PR TITLE
fix: hide the Fullscreen menu item where the API is missing and report refusals

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -772,10 +772,19 @@ window.addEventListener("blur", function () {
 });
 window.addEventListener("focus", () => setEmulationLead(audioHandler.setWindowFocused(true)));
 
-document.getElementById("fs").addEventListener("click", function (event) {
-    screenCanvas.requestFullscreen();
-    event.preventDefault();
-});
+const fullscreenItem = document.getElementById("fs");
+if (document.fullscreenEnabled) {
+    fullscreenItem.addEventListener("click", async (event) => {
+        event.preventDefault();
+        try {
+            await screenCanvas.requestFullscreen();
+        } catch (error) {
+            toast(`Could not go fullscreen: ${errorText(error)}`, { title: "Fullscreen" });
+        }
+    });
+} else {
+    fullscreenItem.closest("li").hidden = true;
+}
 
 let keyboard; // This will be initialised after the processor is created
 


### PR DESCRIPTION
The Fullscreen item in the More menu now feature-detects the Fullscreen API with `document.fullscreenEnabled`. Where it is absent (iPhone, whichever browser, since they are all WebKit) or disallowed by permissions policy, the menu item is hidden rather than left as a silent no-op.

Where the API is present, `requestFullscreen()` is awaited and a rejection (no user gesture, policy refusal, unsupported element) is reported through the toast instead of being dropped as an unhandled promise rejection.

No user-agent sniffing. A manifest and "add to home screen" hint for iPhone users is a separate mechanism and belongs with the mobile work in #114.

Closes #869

🤖 Generated with [Claude Code](https://claude.com/claude-code)