### PR TITLE
fix: say what was only logged: overruns, bad tapes, drops, read-only Drive discs, no speech, no gamepads

### DIFF
--- a/src/acia.js
+++ b/src/acia.js
@@ -4,8 +4,9 @@
 // https://books.google.com/books?id=wUecAQAAQBAJ&pg=PA431&lpg=PA431&dq=acia+tdre&source=bl&ots=mp-yF-mK-P&sig=e6aXkFRfiIOb57WZmrvdIGsCooI&hl=en&sa=X&ei=0g2fVdDyFIXT-QG8-JD4BA&ved=0CCwQ6AEwAw#v=onepage&q=acia%20tdre&f=false
 // http://www.classiccmp.org/dunfield/r/6850.pdf
 
-export class Acia {
+export class Acia extends EventTarget {
     constructor(cpu, toneGen, scheduler, relayNoise) {
+        super();
         this.cpu = cpu;
         this.toneGen = toneGen;
         this.rs423Handler = null;
@@ -20,6 +21,7 @@ export class Acia {
         this.tapeCarrierCount = 0;
         this.tapeDcdLineLevel = false;
         this.hadDcdHigh = false;
+        this.saidOverrun = false;
         this.serialReceiveRate = 0;
         this.serialReceiveCyclesPerByte = 0;
         this.serialTransmitRate = 0;
@@ -200,14 +202,30 @@ export class Acia {
             // TODO: this doesn't match the datasheet:
             // "The Overrun does not occur in the Status Register until the
             // valid character prior to Overrun has been read."
-            console.log("Serial overrun");
             this.sr |= 0xa0;
+            this.noteOverrun();
         } else {
             // If bit 7 contains parity, mask it off.
             this.dr = byte & (this.cr & 0x10 ? 0xff : 0x7f);
             this.sr |= 0x81;
         }
         this.updateIrq();
+    }
+
+    noteOverrun() {
+        if (this.saidOverrun) return;
+        this.saidOverrun = true;
+        this.dispatchEvent(
+            new CustomEvent("notice", {
+                detail: {
+                    message:
+                        "A serial byte arrived before the previous one was read, so it was lost. " +
+                        "A tape load that stops with Data? is usually this.",
+                    title: "Serial",
+                    quietKey: "quietSerialOverrun",
+                },
+            }),
+        );
     }
 
     snapshotState() {

--- a/src/main.js
+++ b/src/main.js
@@ -89,6 +89,11 @@ function stringToMachineKeys(text) {
 }
 
 const gamepad = new GamePad();
+if (!window.isSecureContext)
+    toast("Gamepads only work over https, so any joystick plugged in here is not seen.", {
+        title: "Gamepads",
+        quietKey: "quietInsecureGamepads",
+    });
 const availableImages = [
     {
         name: "Elite",
@@ -239,7 +244,15 @@ const userPort = {
 // Speech output: initialised from URL param; can be toggled at runtime via the Settings panel.
 // Must be created before Config so the onClose callback and the initial checkbox state can reference it.
 const speechOutput = new SpeechOutput();
-speechOutput.enabled = !!parsedQuery.speechOutput;
+
+function setSpeechOutput(enabled) {
+    speechOutput.enabled = enabled;
+    if (enabled && typeof speechSynthesis === "undefined")
+        toast("This browser has no speech synthesis, so speech output has nothing to speak with.", {
+            title: "Speech",
+        });
+}
+setSpeechOutput(!!parsedQuery.speechOutput);
 
 const config = new Config(
     function onChange(changed) {
@@ -266,9 +279,7 @@ const config = new Config(
                 setupMicrophone();
             }
         }
-        if (changed.speechOutput !== undefined) {
-            speechOutput.enabled = !!changed.speechOutput;
-        }
+        if (changed.speechOutput !== undefined) setSpeechOutput(!!changed.speechOutput);
         if (changed.tubeCpuMultiplier !== undefined) {
             emulationConfig.tubeCpuMultiplier = changed.tubeCpuMultiplier;
             config.setTubeCpuMultiplier(changed.tubeCpuMultiplier);
@@ -719,8 +730,10 @@ pastetext.addEventListener("drop", async function (event) {
         } else if (file.name.toLowerCase().endsWith(".uef")) {
             // Regular UEF tape image (not a BeebEm save state)
             setProcessorTape(await loadTapeFromData(file.name, new Uint8Array(arrayBuffer), model));
+            toast(`Loaded ${file.name} as the tape.`, { title: "Dropped" });
         } else {
             await loadHTMLFile(file);
+            toast(`Loaded ${file.name} into drive 0.`, { title: "Dropped" });
         }
     } catch (error) {
         reportLoadFailure(file.name, error);
@@ -863,6 +876,7 @@ processor = new CpuClass(model, {
 printer.attach(processor.uservia);
 
 processor.teletextAdaptor?.addEventListener("notice", showNotice);
+processor.acia.addEventListener("notice", showNotice);
 
 // Create input sources
 const gamepadSource = new GamepadSource(emulationConfig.getGamepads);
@@ -1707,12 +1721,6 @@ document.querySelector("#google-drive-auth form").addEventListener("submit", asy
 });
 
 async function gdLoad(cat, layout) {
-    // TODO: have a onclose flush event, handle errors
-    /*
-     $(window).bind("beforeunload", function() {
-     return confirm("Do you really want to close?");
-     });
-     */
     popupLoading("Loading '" + cat.name + "' from Google Drive");
     try {
         const available = await googleDrive.initialise();
@@ -1733,6 +1741,12 @@ async function gdLoad(cat, layout) {
         const ssd = await googleDrive.load(processor.fdc, cat.id, layout);
         console.log("Google Drive loading finished");
         loadingFinished();
+        if (!ssd.savesChanges) {
+            toast(`${cat.name} is read only on Google Drive, so changes to it are not written back.`, {
+                title: "Google Drive",
+                quietKey: "quietDriveReadOnly",
+            });
+        }
         return ssd;
     } catch (error) {
         console.error("Google Drive loading error:", error);

--- a/src/tapes.js
+++ b/src/tapes.js
@@ -315,6 +315,5 @@ export async function loadTapeFromData(name, data, model) {
         console.log("Detected a UEF tape");
         return new UefTape(stream, model);
     }
-    console.log("Unknown tape format");
-    return null;
+    throw new Error(`${name} is not a UEF or tapefile tape image`);
 }

--- a/tests/unit/test-acia.js
+++ b/tests/unit/test-acia.js
@@ -68,6 +68,22 @@ describe("Acia", () => {
         });
     });
 
+    describe("receive overrun", () => {
+        it("should raise one notice for a burst of overruns", () => {
+            const acia = createMockAcia();
+            const notices = [];
+            acia.addEventListener("notice", (event) => notices.push(event.detail));
+
+            acia.receive(0x41);
+            expect(notices).toHaveLength(0);
+            acia.receive(0x42);
+            acia.receive(0x43);
+            expect(notices).toHaveLength(1);
+            expect(notices[0].quietKey).toBe("quietSerialOverrun");
+            expect(acia.read(0) & 0x20).toBe(0x20);
+        });
+    });
+
     describe("transmit timing", () => {
         // A 10 bit byte at 75 baud takes 0.1333s: 266666 cycles of the 2MHz clock.
         const ByteCyclesAt75Baud = 266666;

--- a/tests/unit/test-tapes.js
+++ b/tests/unit/test-tapes.js
@@ -93,10 +93,11 @@ describe("tapes", () => {
             expect(tape.poll(mockAcia())).toBe(5 * 2 * 1000 * 1000);
         });
 
-        it("should return null for unknown format", async () => {
+        it("should reject an unknown format, naming the file", async () => {
             const unknown = new Uint8Array([0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b]);
-            const tape = await loadTapeFromData("test.bin", unknown, BbcModel);
-            expect(tape).toBeNull();
+            await expect(loadTapeFromData("test.bin", unknown, BbcModel)).rejects.toThrow(
+                "test.bin is not a UEF or tapefile tape image",
+            );
         });
 
         it("should reject UEF with unsupported major version", async () => {


### PR DESCRIPTION
The last of the #798 audit: everything that was still console-only or silent now reaches the user through the toast.

- A serial overrun (the usual cause of a tape load stopping at `Data?`) raises one notice per session from the ACIA, via the same `notice` event Keyboard and the teletext adaptor use, with a quiet key.
- A file that is not a UEF or tapefile image is a load failure naming the file, through the existing catch and toast path, instead of a null tape that does nothing forever.
- Dropping a file onto the page says what was loaded and whether it went into drive 0 or the tape.
- A Google Drive disc that Drive reports as not editable says so when it is opened, with a quiet key; the first write still gets the #811 notice.
- Ticking speech output in a browser with no speech synthesis says so instead of staying ticked and mute.
- Over an insecure context, where the Gamepad API is absent, a quiet-keyed notice explains why a pad is inert.
- The commented-out jQuery `beforeunload` block in `gdLoad` is deleted.

Closes #798

🤖 Generated with [Claude Code](https://claude.com/claude-code)