### PR TITLE
fix: apply the board's output filter at the chip rate, before decimation

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,6 +289,9 @@ sudo rpm -i out/dist/jsbeeb-1.0.1.x86_64.rpm
 - (mostly internal use) `logFdcCommands`, `logFdcStateChanges` - turn on logging in the disc controller.
 - `audioDebug` - show the audio lead chart, and log one console line per second in which the emulator tick ran late or the sound stalled or skipped.
 - `audioLatencyMs` - how far the sound runs behind the emulator, in milliseconds (default 20). Raising it lets the sound ride out longer stalls of the emulator, at the cost of lagging the picture by that much.
+- `audiofilterfreq` / `audiofilterq` - the corner frequency in Hz and the Q of the lowpass modelling the board's output
+  filter, applied to the sound chip before it is resampled. The defaults, 7234 and 0.696, are the Beeb's own.
+  `audiofilterfreq=0` turns the filter off.
 - `displayMode=X` - picks the display: `rgb` (the default, a plain monitor), `pal` (a television fed by the Beeb's UHF modulator)
   or `xbr` (an upscaler, see [docs/xbr-display-mode.md](docs/xbr-display-mode.md)).
 

--- a/src/biquad.js
+++ b/src/biquad.js
@@ -1,0 +1,36 @@
+// Coefficients from the RBJ Audio EQ Cookbook: the second-order prototype
+// under a bilinear transform prewarped so the corner lands on `frequency`.
+export class LowPassBiquad {
+    constructor(sampleRate, frequency, q) {
+        const w0 = (2 * Math.PI * frequency) / sampleRate;
+        const alpha = Math.sin(w0) / (2 * q);
+        const cosW0 = Math.cos(w0);
+        const a0 = 1 + alpha;
+        this.b0 = (1 - cosW0) / (2 * a0);
+        this.b1 = (1 - cosW0) / a0;
+        this.a1 = (-2 * cosW0) / a0;
+        this.a2 = (1 - alpha) / a0;
+        this.x1 = 0;
+        this.x2 = 0;
+        this.y1 = 0;
+        this.y2 = 0;
+    }
+
+    process(buffer, offset, length) {
+        const { b0, b1, a1, a2 } = this;
+        let { x1, x2, y1, y2 } = this;
+        for (let i = offset; i < offset + length; ++i) {
+            const x = buffer[i];
+            const y = b0 * x + b1 * x1 + b0 * x2 - a1 * y1 - a2 * y2;
+            x2 = x1;
+            x1 = x;
+            y2 = y1;
+            y1 = y;
+            buffer[i] = y;
+        }
+        this.x1 = x1;
+        this.x2 = x2;
+        this.y1 = y1;
+        this.y2 = y2;
+    }
+}

--- a/src/main.js
+++ b/src/main.js
@@ -175,12 +175,6 @@ const cpuMultiplier = parsedQuery.cpuMultiplier ?? 1;
 let fastAsPossible = false;
 let fastTape = false;
 let noSeek;
-// The board's output filter is an equal-component Sallen-Key (Service Manual
-// section 3.8: 10K and 2n2 twice, gain 1 + 22/39): f0 = 1/(2*pi*RC) = 7234 Hz,
-// Q = 1/(3 - K) = 0.696, below 1/sqrt(2), so no resonant peak. BiquadFilterNode
-// takes lowpass Q in decibels: 20*log10(0.696) = -3.15.
-let audioFilterFreq = 7234;
-let audioFilterQ = -3.15;
 let stationId = 101;
 let econet = null;
 
@@ -209,8 +203,6 @@ if (parsedQuery.embed) {
 fastTape = !!parsedQuery.fasttape;
 noSeek = !!parsedQuery.noseek;
 
-if (parsedQuery.audiofilterfreq !== undefined) audioFilterFreq = parsedQuery.audiofilterfreq;
-if (parsedQuery.audiofilterq !== undefined) audioFilterQ = parsedQuery.audiofilterq;
 if (parsedQuery.stationId !== undefined) stationId = parsedQuery.stationId;
 if (parsedQuery.frameSkip !== undefined) frameSkip = parsedQuery.frameSkip;
 
@@ -613,8 +605,8 @@ const audioStatsNode = parsedQuery.audioDebug ? audioStatsEl : null;
 const audioHandler = new AudioHandler({
     warningNode: document.getElementById("audio-warning"),
     statsNode: audioStatsNode,
-    audioFilterFreq,
-    audioFilterQ,
+    audioFilterFreq: parsedQuery.audiofilterfreq,
+    audioFilterQ: parsedQuery.audiofilterq,
     audioLatencyMs: parsedQuery.audioLatencyMs,
     noSeek,
     cpuSpeed,

--- a/src/web/audio-handler.js
+++ b/src/web/audio-handler.js
@@ -62,7 +62,7 @@ export class AudioHandler {
             this.masterGain.connect(this.audioContext.destination);
             this.ddNoise = noSeek ? new FakeDdNoise() : new DdNoise(this.audioContext, this.masterGain);
             this.relayNoise = new RelayNoise(this.audioContext, this.masterGain);
-            this._setup(audioFilterFreq, audioFilterQ).catch((error) => this._audioUnavailable(error));
+            this._setup({ audioFilterFreq, audioFilterQ }).catch((error) => this._audioUnavailable(error));
         } else {
             if (this.audioContext && !this.audioContext.audioWorklet) {
                 this.audioContext = null;
@@ -127,27 +127,18 @@ export class AudioHandler {
         this.chart.streamTo(statsNode, 100);
     }
 
-    async _setup(audioFilterFreq, audioFilterQ) {
+    async _setup({ audioFilterFreq, audioFilterQ }) {
         await this.audioContext.audioWorklet.addModule(rendererUrl);
-        if (audioFilterFreq !== 0) {
-            const filterNode = this.audioContext.createBiquadFilter();
-            filterNode.type = "lowpass";
-            filterNode.frequency.value = audioFilterFreq;
-            filterNode.Q.value = audioFilterQ;
-            this._audioDestination = filterNode;
-            filterNode.connect(this.audioContext.destination);
-        } else {
-            this._audioDestination = this.audioContext.destination;
-        }
-
         this._jsAudioNode = new AudioWorkletNode(this.audioContext, "sound-chip-processor", {
             processorOptions: {
                 targetLatencyMs: this._targetLatencyMs(),
                 isAtom: this.isAtom,
                 cpuSpeed: this.cpuSpeed,
+                audioFilterFreq,
+                audioFilterQ,
             },
         });
-        this._jsAudioNode.connect(this._audioDestination);
+        this._jsAudioNode.connect(this.audioContext.destination);
         this._jsAudioNode.port.onmessage = (event) => {
             const now = Date.now();
             if (event.data.event) {

--- a/src/web/audio-renderer.js
+++ b/src/web/audio-renderer.js
@@ -60,7 +60,7 @@ class SoundChipProcessor extends AudioWorkletProcessor {
         this.nextStats = 0;
     }
 
-    // Off below 1 Hz; a setting the biquad cannot realise (non-finite, at or
+    // Zero turns it off; a setting the biquad cannot realise (non-finite, at or
     // above Nyquist, non-positive Q) falls back to the board's own values.
     _makeOutputFilter(frequency = OutputFilterHz, q = OutputFilterQ) {
         if (frequency <= 0) return null;

--- a/src/web/audio-renderer.js
+++ b/src/web/audio-renderer.js
@@ -31,14 +31,13 @@ class SoundChipProcessor extends AudioWorkletProcessor {
             isAtom = false,
             cpuSpeed = 1000000,
             targetLatencyMs,
-            audioFilterFreq = OutputFilterHz,
-            audioFilterQ = OutputFilterQ,
+            audioFilterFreq,
+            audioFilterQ,
         } = options?.processorOptions ?? {};
         this.chip = isAtom ? new AtomSoundChip(null, { cpuSpeed }) : new SoundChip(null);
         this.inputSampleRate = this.chip.soundchipFreq;
         this.samplesPerCycle = this.chip.samplesPerCycle;
-        this.outputFilter =
-            audioFilterFreq > 0 ? new LowPassBiquad(this.inputSampleRate, audioFilterFreq, audioFilterQ) : null;
+        this.outputFilter = this._makeOutputFilter(audioFilterFreq, audioFilterQ);
 
         this.events = [];
         this.eventsHead = 0;
@@ -59,6 +58,15 @@ class SoundChipProcessor extends AudioWorkletProcessor {
             else this.onProduced(event.data.upTo, event.data.events);
         };
         this.nextStats = 0;
+    }
+
+    // Off below 1 Hz; a setting the biquad cannot realise (non-finite, at or
+    // above Nyquist, non-positive Q) falls back to the board's own values.
+    _makeOutputFilter(frequency = OutputFilterHz, q = OutputFilterQ) {
+        if (frequency <= 0) return null;
+        const usable = frequency < this.inputSampleRate / 2 && q > 0;
+        if (!usable) return new LowPassBiquad(this.inputSampleRate, OutputFilterHz, OutputFilterQ);
+        return new LowPassBiquad(this.inputSampleRate, frequency, q);
     }
 
     setTargetLatency(ms) {

--- a/src/web/audio-renderer.js
+++ b/src/web/audio-renderer.js
@@ -2,12 +2,12 @@
 import { SoundChip, AtomSoundChip } from "../soundchip.js";
 import { LowPassBiquad } from "../biquad.js";
 
-// The board's output filter, an equal-component Sallen-Key (Service Manual
-// section 3.8: 10K and 2n2 twice, gain K = 1 + 22/39): f0 = 1/(2*pi*RC),
-// Q = 1/(3 - K). Run at the chip rate, ahead of decimation, it is also the
-// anti-alias filter.
-const OutputFilterHz = 1 / (2 * Math.PI * 10e3 * 2.2e-9);
-const OutputFilterQ = 1 / (3 - (1 + 22 / 39));
+// The board's output filter is an equal-component Sallen-Key (Service Manual
+// section 3.8: 10K and 2n2 twice, gain K = 1 + 22/39): f0 = 1/(2*pi*RC) = 7234 Hz,
+// Q = 1/(3 - K) = 0.696, below 1/sqrt(2), so no resonant peak. Run at the chip
+// rate, ahead of decimation, it is also the anti-alias filter.
+const OutputFilterHz = 7234;
+const OutputFilterQ = 0.696;
 
 const DefaultTargetLatencyMs = 1000 * (1 / 50); // One frame
 const MaxTargetLatencyMs = 250;

--- a/src/web/audio-renderer.js
+++ b/src/web/audio-renderer.js
@@ -1,8 +1,13 @@
 /* global sampleRate, currentTime, registerProcessor, AudioWorkletProcessor */
 import { SoundChip, AtomSoundChip } from "../soundchip.js";
+import { LowPassBiquad } from "../biquad.js";
 
-const lowPassFilterFreq = sampleRate / 2;
-const RC = 1 / (2 * Math.PI * lowPassFilterFreq);
+// The board's output filter, an equal-component Sallen-Key (Service Manual
+// section 3.8: 10K and 2n2 twice, gain K = 1 + 22/39): f0 = 1/(2*pi*RC),
+// Q = 1/(3 - K). Run at the chip rate, ahead of decimation, it is also the
+// anti-alias filter.
+const OutputFilterHz = 1 / (2 * Math.PI * 10e3 * 2.2e-9);
+const OutputFilterQ = 1 / (3 - (1 + 22 / 39));
 
 const DefaultTargetLatencyMs = 1000 * (1 / 50); // One frame
 const MaxTargetLatencyMs = 250;
@@ -22,10 +27,18 @@ const isResync = (event) => event.state !== undefined || event.reset !== undefin
 class SoundChipProcessor extends AudioWorkletProcessor {
     constructor(options) {
         super(options);
-        const { isAtom = false, cpuSpeed = 1000000, targetLatencyMs } = options?.processorOptions ?? {};
+        const {
+            isAtom = false,
+            cpuSpeed = 1000000,
+            targetLatencyMs,
+            audioFilterFreq = OutputFilterHz,
+            audioFilterQ = OutputFilterQ,
+        } = options?.processorOptions ?? {};
         this.chip = isAtom ? new AtomSoundChip(null, { cpuSpeed }) : new SoundChip(null);
         this.inputSampleRate = this.chip.soundchipFreq;
         this.samplesPerCycle = this.chip.samplesPerCycle;
+        this.outputFilter =
+            audioFilterFreq > 0 ? new LowPassBiquad(this.inputSampleRate, audioFilterFreq, audioFilterQ) : null;
 
         this.events = [];
         this.eventsHead = 0;
@@ -36,10 +49,9 @@ class SoundChipProcessor extends AudioWorkletProcessor {
         this.skippedMs = 0;
         this.minLeadMs = Infinity;
 
-        this._lastFilteredOutput = 0;
+        this._lastInputSample = 0;
         this._phase = 0;
         this._source = new Float32Array(0);
-        this._rendered = new Float32Array(0);
         this.smoothedLeadError = 0;
         this.setTargetLatency(targetLatencyMs);
         this.port.onmessage = (event) => {
@@ -157,12 +169,11 @@ class SoundChipProcessor extends AudioWorkletProcessor {
         return Math.floor((boundary - this.clock) * this.samplesPerCycle);
     }
 
-    _renderInput(out, length) {
+    _renderInput(out, offset, length) {
         if (this.stalled) {
-            this._stall(out, 0, length);
+            this._stall(out, offset, length);
             return;
         }
-        let offset = 0;
         while (length > 0) {
             const n = Math.min(length, this._samplesUntilNextChange());
             if (n > 0) {
@@ -189,28 +200,17 @@ class SoundChipProcessor extends AudioWorkletProcessor {
         const effectiveSampleRate = this._effectiveSampleRate(channel.length / sampleRate);
         const sampleRatio = effectiveSampleRate / sampleRate;
 
-        const dt = 1 / effectiveSampleRate;
-        const filterAlpha = dt / (RC + dt);
-
         // The fractional read position carries across quanta, so consumption
         // averages exactly sampleRatio and the pitch never steps at a rounding
         // boundary. source[0] is the last input sample of the previous quantum.
         const end = this._phase + channel.length * sampleRatio;
         const numInputSamples = Math.floor(end);
-        if (this._source.length <= numInputSamples) {
-            this._source = new Float32Array(numInputSamples * 2);
-            this._rendered = new Float32Array(numInputSamples * 2);
-        }
+        if (this._source.length <= numInputSamples) this._source = new Float32Array(numInputSamples * 2);
         const source = this._source;
-        const rendered = this._rendered;
-        this._renderInput(rendered, numInputSamples);
-        source[0] = this._lastFilteredOutput;
-        let prevSample = this._lastFilteredOutput;
-        for (let i = 1; i <= numInputSamples; ++i) {
-            prevSample += filterAlpha * (rendered[i - 1] - prevSample);
-            source[i] = prevSample;
-        }
-        this._lastFilteredOutput = prevSample;
+        source[0] = this._lastInputSample;
+        this._renderInput(source, 1, numInputSamples);
+        this.outputFilter?.process(source, 1, numInputSamples);
+        this._lastInputSample = source[numInputSamples];
         for (let i = 0; i < channel.length; i++) {
             const pos = this._phase + i * sampleRatio;
             const loc = Math.floor(pos);

--- a/tests/unit/test-audio-handler.js
+++ b/tests/unit/test-audio-handler.js
@@ -12,7 +12,7 @@ describe("AudioHandler", () => {
     let contexts;
 
     function fakeNode() {
-        return { connect: () => {}, gain: { value: 0 }, frequency: { value: 0 }, Q: { value: 0 }, type: "" };
+        return { connect: () => {}, gain: { value: 0 } };
     }
 
     function fakeContext(hasWorklet, addModule) {
@@ -21,7 +21,6 @@ describe("AudioHandler", () => {
             destination: {},
             audioWorklet: hasWorklet ? { addModule } : undefined,
             createGain: fakeNode,
-            createBiquadFilter: fakeNode,
             resume: async () => {},
         };
     }
@@ -41,7 +40,8 @@ describe("AudioHandler", () => {
         vi.stubGlobal(
             "AudioWorkletNode",
             class {
-                constructor() {
+                constructor(context, name, options) {
+                    this.options = options;
                     this.port = { postMessage: () => {}, onmessage: null };
                 }
                 connect() {}
@@ -52,8 +52,6 @@ describe("AudioHandler", () => {
     function makeHandler(options = {}) {
         return new AudioHandler({
             warningNode: document.getElementById("audio-warning"),
-            audioFilterFreq: 0,
-            audioFilterQ: 0,
             noSeek: true,
             cpuSpeed: 2000000,
             ...options,
@@ -157,6 +155,16 @@ describe("AudioHandler", () => {
                 [{ cycle: 0, enabled: false }],
                 [{ cycle: 0, enabled: true }],
             ]);
+        });
+
+        it("hands the output filter settings to the worklet", async () => {
+            const handler = makeHandler({ audioFilterFreq: 1234, audioFilterQ: 0.5 });
+            await vi.waitFor(() => expect(handler._jsAudioNode).not.toBeNull());
+
+            expect(handler._jsAudioNode.options.processorOptions).toMatchObject({
+                audioFilterFreq: 1234,
+                audioFilterQ: 0.5,
+            });
         });
 
         it("creates no Music 5000 audio context unless one is fitted", () => {

--- a/tests/unit/test-audio-renderer.js
+++ b/tests/unit/test-audio-renderer.js
@@ -35,8 +35,15 @@ const CyclesPerSample = 4; // 2MHz CPU, 500kHz chip
 // SN76489 writes for a 1kHz tone on channel 0 at full volume: 4MHz / (32 * 125).
 const TonePeriod = 125;
 const ToneHz = 4000000 / (32 * TonePeriod);
-const ToneOn = [0x80 | (TonePeriod & 0x0f), TonePeriod >> 4, 0x90];
+const toneWrites = (period) => [0x80 | (period & 0x0f), period >> 4, 0x90];
+const ToneOn = toneWrites(TonePeriod);
 const ToneOff = [0x9f];
+
+// A 1250 Hz tone's 39th harmonic folds about the output rate to a frequency
+// no real harmonic occupies; only a filter ahead of the resampler can touch it.
+const AliasTonePeriod = 100;
+const AliasToneHz = 4000000 / (32 * AliasTonePeriod);
+const FoldedSpurHz = 39 * AliasToneHz - OutputRate;
 
 // Amplitude of the frequency-bin component at freq, via the Goertzel algorithm.
 function goertzelAmplitude(samples, freq, rate) {
@@ -82,13 +89,19 @@ const quantum = (proc) => {
 
 // Producer ticks every tickMs of simulated time, consumer runs 128-frame
 // quanta. Returns the effective rates and output collected after collectAfter.
-function simulate(proc, producer, seconds, { tickMs = 10, collectAfter = 0, ticking = () => true } = {}) {
+// nominalRate pins the resampling ratio, for spectral measurements.
+function simulate(
+    proc,
+    producer,
+    seconds,
+    { tickMs = 10, collectAfter = 0, ticking = () => true, nominalRate = false } = {},
+) {
     const rates = [];
     const output = [];
     const originalRate = proc._effectiveSampleRate.bind(proc);
     let simTime = 0;
     proc._effectiveSampleRate = (dt) => {
-        const rate = originalRate(dt);
+        const rate = nominalRate ? proc.inputSampleRate : originalRate(dt);
         if (simTime >= collectAfter) rates.push(rate);
         return rate;
     };
@@ -114,9 +127,9 @@ function simulate(proc, producer, seconds, { tickMs = 10, collectAfter = 0, tick
 }
 
 // A processor already running with a target's lead, playing the test tone.
-function startedWithTone(proc) {
+function startedWithTone(proc, writes = ToneOn) {
     const producer = makeProducer(proc);
-    producer.poke(...ToneOn);
+    producer.poke(...writes);
     producer.advance(proc.targetLatencyMs);
     producer.flush();
     quantum(proc);
@@ -133,6 +146,18 @@ describe("SoundChipProcessor rendering", () => {
         expect(goertzelAmplitude(output, ToneHz * 1.5, OutputRate)).toBeLessThan(0.02);
     });
 
+    it("should filter the chip at its own rate, ahead of the resampler, unless the filter is off", () => {
+        const foldedSpur = (options) => {
+            const proc = new SoundChipProcessor({ processorOptions: options });
+            const producer = startedWithTone(proc, toneWrites(AliasTonePeriod));
+            const { output } = simulate(proc, producer, 0.5, { collectAfter: 0.1, nominalRate: true });
+            return goertzelAmplitude(output, FoldedSpurHz, OutputRate);
+        };
+        const unfiltered = foldedSpur({ audioFilterFreq: 0 });
+        expect(unfiltered).toBeGreaterThan(0.002);
+        expect(foldedSpur({})).toBeLessThan(unfiltered / 10);
+    });
+
     it("should apply a write at its cycle, part way through a quantum", () => {
         const proc = new SoundChipProcessor();
         const producer = startedWithTone(proc);
@@ -143,7 +168,7 @@ describe("SoundChipProcessor rendering", () => {
         producer.poke(...ToneOff);
         producer.advance(10);
         producer.flush();
-        proc._renderInput(rendered, rendered.length);
+        proc._renderInput(rendered, 0, rendered.length);
         const loud = rendered.subarray(0, 500);
         const quiet = rendered.subarray(520, 1000);
         expect(Math.max(...loud) - Math.min(...loud)).toBeGreaterThan(0.1);

--- a/tests/unit/test-audio-renderer.js
+++ b/tests/unit/test-audio-renderer.js
@@ -158,6 +158,16 @@ describe("SoundChipProcessor rendering", () => {
         expect(foldedSpur({})).toBeLessThan(unfiltered / 10);
     });
 
+    it("should fall back to the board's filter when the settings cannot be realised", () => {
+        for (const options of [{ audioFilterQ: 0 }, { audioFilterQ: NaN }, { audioFilterFreq: 1e6 }]) {
+            const proc = new SoundChipProcessor({ processorOptions: options });
+            const producer = startedWithTone(proc);
+            const { output } = simulate(proc, producer, 0.3, { collectAfter: 0.1 });
+            expect(output.every(Number.isFinite)).toBe(true);
+            expect(goertzelAmplitude(output, ToneHz, OutputRate)).toBeGreaterThan(0.1);
+        }
+    });
+
     it("should apply a write at its cycle, part way through a quantum", () => {
         const proc = new SoundChipProcessor();
         const producer = startedWithTone(proc);

--- a/tests/unit/test-biquad.js
+++ b/tests/unit/test-biquad.js
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest";
+
+import { LowPassBiquad } from "../../src/biquad.js";
+
+const SampleRate = 500000;
+// Chosen so every frequency measured below is a whole number of cycles in
+// the measurement window, making the Goertzel amplitude exact.
+const Corner = SampleRate / 80;
+const Q = 0.696;
+const Window = 128000;
+
+function goertzelAmplitude(samples, freq) {
+    const w = (2 * Math.PI * freq) / SampleRate;
+    const coeff = 2 * Math.cos(w);
+    let s1 = 0;
+    let s2 = 0;
+    for (const sample of samples) {
+        const s0 = sample + coeff * s1 - s2;
+        s2 = s1;
+        s1 = s0;
+    }
+    return (2 * Math.sqrt(s1 * s1 + s2 * s2 - coeff * s1 * s2)) / samples.length;
+}
+
+function sine(freq, length) {
+    const samples = new Float64Array(length);
+    for (let i = 0; i < length; ++i) samples[i] = Math.sin((2 * Math.PI * freq * i) / SampleRate);
+    return samples;
+}
+
+// Gain in dB of a steady sine at freq, measured once the transient has died.
+function gainDb(freq) {
+    const samples = sine(freq, 2 * Window);
+    new LowPassBiquad(SampleRate, Corner, Q).process(samples, 0, samples.length);
+    return 20 * Math.log10(goertzelAmplitude(samples.subarray(Window), freq));
+}
+
+describe("LowPassBiquad", () => {
+    it("should pass frequencies well below the corner unchanged", () => {
+        expect(gainDb(Corner / 16)).toBeCloseTo(0, 1);
+    });
+
+    it("should have a gain of Q at the corner", () => {
+        expect(gainDb(Corner)).toBeCloseTo(20 * Math.log10(Q), 2);
+    });
+
+    it("should roll off at 12 dB per octave above the corner", () => {
+        const octave = gainDb(8 * Corner) - gainDb(4 * Corner);
+        expect(octave).toBeLessThan(-11);
+        expect(octave).toBeGreaterThan(-13.5);
+    });
+
+    it("should leave the untouched parts of the buffer alone", () => {
+        const samples = new Float64Array(10).fill(1);
+        new LowPassBiquad(SampleRate, Corner, Q).process(samples, 3, 4);
+        expect(Array.from(samples.subarray(0, 3))).toEqual([1, 1, 1]);
+        expect(Array.from(samples.subarray(7))).toEqual([1, 1, 1]);
+        expect(samples[3]).not.toBe(1);
+    });
+
+    it("should carry its state across calls, so chunking does not change the output", () => {
+        const whole = sine(Corner, 4096);
+        const chunked = Float64Array.from(whole);
+        new LowPassBiquad(SampleRate, Corner, Q).process(whole, 0, whole.length);
+        const filter = new LowPassBiquad(SampleRate, Corner, Q);
+        for (let offset = 0; offset < chunked.length; offset += 128) filter.process(chunked, offset, 128);
+        expect(Array.from(chunked)).toEqual(Array.from(whole));
+    });
+});


### PR DESCRIPTION
Part of #862: the "much cheaper first step".

## What moved

The board's output filter (7234 Hz, Q 0.696, from #880) was a Web Audio `BiquadFilterNode` connected after the worklet, downstream of the resampler, where it could not touch anything that had already folded. It now runs inside the worklet at the chip's 500 kHz, ahead of the linear-interpolation decimator, as an RBJ cookbook lowpass (`src/biquad.js`). The Web Audio node is removed so the filter is not applied twice. Same response by default; `audiofilterfreq=0` still turns it off.

## The one-pole RC is gone

The RC at `sampleRate / 2` was the only anti-alias filtering before; the issue measured it at about 6 dB. The biquad at the chip rate is 20 to 45 dB down at the frequencies that fold, so the RC no longer contributed anything and would have deviated slightly from the hardware's in-band response. Removing it also removes the second staging buffer in `process()`.

## `audiofilterq` is now a conventional Q

`BiquadFilterNode` takes a lowpass Q in decibels, so the URL parameter was `-3.15` for the hardware's 0.696. With the node gone there is no reason to keep the dB form, so `audiofilterq` is a conventional Q and the default is derived in the worklet from the Sallen-Key components. Both parameters were undocumented; they are now in the README's URL parameter list.

## Measured

One tone channel at full volume, 48 kHz device rate, resampling ratio pinned at nominal: total non-harmonic power relative to harmonic power, and the worst spur in dBc. "Before" is the worklet alone, as the issue measured it; "before + node" adds an emulation of the old post-resampler `BiquadFilterNode` for a whole-chain comparison.

| f0 | before | before + node | after |
| --- | --- | --- | --- |
| 440 Hz | -28.6 / -40.7 | -36.3 / -49.5 | -47.2 / below window leakage |
| 1250 Hz | -23.6 / -32.0 | -30.2 / -40.1 | -43.2 / below window leakage |
| 2500 Hz | -20.5 / -27.1 | -26.8 / -34.3 | -40.9 / -46.5 |
| 6250 Hz | -17.0 / -21.1 | -21.3 / -24.7 | -36.6 / -40.0 |

Whether the polyphase FIR is still worth doing on top of this is left open on #862.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
