### PR TITLE
fix: add pause and resume to the desktop menu and a debugger key legend

### DIFF
--- a/index.html
+++ b/index.html
@@ -449,6 +449,10 @@
           <div><span class="register">S</span>: <span id="cpu6502_s">00</span></div>
           <div><span class="register">PC</span>: <span id="cpu6502_pc">0000</span></div>
         </div>
+        <div id="debug-keys">
+          g run &middot; n step &middot; m step over &middot; o step out &middot; t breakpoint &middot; j/k move
+          &middot; b back &middot; u/i memory &plusmn;8 &middot; U/I memory &plusmn;64
+        </div>
       </div>
       <div id="hardware_debug" class="initially-hidden">
         <div class="via_regs" id="sysvia">
@@ -606,7 +610,32 @@
                   <td><span class="key">Ctrl-Home</span></td>
                   <td><span class="key">Ctrl-Home</span></td>
                 </tr>
+                <tr>
+                  <td>Pause</td>
+                  <td><span class="key">Ctrl-End</span></td>
+                  <td><span class="key">Ctrl-End</span></td>
+                </tr>
+                <tr>
+                  <td>Full speed</td>
+                  <td><span class="key">Ctrl-Insert</span></td>
+                  <td><span class="key">Ctrl-Insert</span></td>
+                </tr>
+                <tr>
+                  <td>Rewind</td>
+                  <td><span class="key">Alt-PageDown</span></td>
+                  <td><span class="key">Alt-PageDown</span></td>
+                </tr>
               </table>
+              <div>
+                While paused, <span class="key">g</span> resumes and <span class="key">n</span> runs one frame. In the
+                debugger, <span class="key">g</span> resumes, <span class="key">n</span> steps one instruction,
+                <span class="key">m</span> steps over a call, <span class="key">o</span> steps out of one,
+                <span class="key">t</span> toggles a breakpoint on the highlighted instruction,
+                <span class="key">j</span> and <span class="key">k</span> move the disassembly,
+                <span class="key">b</span> goes back to where it was, and <span class="key">u</span> and
+                <span class="key">i</span> move the memory view by 8 bytes (<span class="key">U</span> and
+                <span class="key">I</span> by 64).
+              </div>
               <div>
                 Caps lock is unreliable on macOS: browsers never report it being released, so games that use it to move
                 or fire don't work. Any key can be

--- a/src/app/app.js
+++ b/src/app/app.js
@@ -251,6 +251,16 @@ const template = [
             },
             { type: "separator" },
             {
+                label: "Pause and Show Debugger",
+                accelerator: "CmdOrCtrl+Home",
+                click: sendAction("pause"),
+            },
+            {
+                label: "Resume",
+                click: sendAction("resume"),
+            },
+            { type: "separator" },
+            {
                 label: "Soft Reset",
                 click: sendAction("soft-reset"),
             },

--- a/src/jsbeeb.css
+++ b/src/jsbeeb.css
@@ -81,6 +81,12 @@ body {
   width: 90px;
 }
 
+#debug-keys {
+  clear: both;
+  padding-top: 3px;
+  color: #aaaaaa;
+}
+
 #crtc_debug {
   background-color: #333333;
   border: 1px solid #555555;

--- a/src/main.js
+++ b/src/main.js
@@ -790,11 +790,18 @@ let keyboard; // This will be initialised after the processor is created
 
 const debugPause = document.getElementById("debug-pause");
 const debugPlay = document.getElementById("debug-play");
-debugPause.addEventListener("click", () => stop(true));
-debugPlay.addEventListener("click", () => {
+
+function pauseIntoDebugger() {
+    stop(true);
+}
+
+function resumeFromDebugger() {
     dbgr.hide();
     go();
-});
+}
+
+debugPause.addEventListener("click", pauseIntoDebugger);
+debugPlay.addEventListener("click", resumeFromDebugger);
 
 // To lower chance of data loss, only accept drop events in the drop
 // zone in the menu bar.
@@ -2705,6 +2712,8 @@ electron({
         "hard-reset": hardReset,
         "save-state": () => document.getElementById("save-state").click(),
         rewind: () => rewindUI.open(),
+        pause: pauseIntoDebugger,
+        resume: resumeFromDebugger,
     },
 });
 

--- a/src/main.js
+++ b/src/main.js
@@ -797,7 +797,7 @@ function pauseIntoDebugger() {
 
 function resumeFromDebugger() {
     dbgr.hide();
-    go();
+    keyboard.resumeEmulation();
 }
 
 debugPause.addEventListener("click", pauseIntoDebugger);


### PR DESCRIPTION
The desktop app's preload strips the web navbar, and the play and pause buttons live there, so in the app the only way to stop was Ctrl+Home and the only way to resume was to know that `g` does it.

## What changed

- `src/main.js`: the `#debug-pause` / `#debug-play` click handlers are now named functions (`pauseIntoDebugger`, `resumeFromDebugger`) and are exposed as `pause` and `resume` in the Electron `actions` map, so the menu and the buttons share one code path.
- `src/app/app.js`: two new Machine menu items between Rewind and the resets: **Pause and Show Debugger** with `CmdOrCtrl+Home`, and **Resume** with no accelerator (a `G` accelerator would swallow typed `g` in the emulator).
- `index.html`: a one-line key legend at the bottom of the `#debug` panel, visible whenever the debugger is open on the web or in the app, and Help modal rows for Ctrl-End, Ctrl-Insert and Alt-PageDown plus a paragraph describing the debugger keys. Only keys that `src/web/debug.js` and `src/keyboard.js` actually handle are listed.
- `src/jsbeeb.css`: one rule to sit the legend under the floated panels.

## Verification

- `npm run lint`, `npm run format`, `npm run test:unit` and `npm run build` all pass.
- Built the app and ran it headlessly under Xvfb (`ELECTRON_DISABLE_SANDBOX=1`) with a throwaway wrapper (not committed) that inspected `Menu.getApplicationMenu()` and drove the items with `MenuItem.click`: the Machine menu shows both new items with the expected accelerator, Pause shows the debugger with the legend text, and Resume hides it again.
- Checked for double firing on Ctrl+Home: sending Ctrl+Home to the window while running triggers only the renderer's own handler (it calls `preventDefault`, which suppresses the menu accelerator) and no `action` message is sent. While already paused the renderer ignores the key, so the accelerator fires `pause`, which just re-shows the debugger; harmless, and handy after a Ctrl+End pause.

Closes #916

🤖 Generated with [Claude Code](https://claude.com/claude-code)
