### PR TITLE
fix: resample the sound chip through a windowed sinc so nothing above the output rate folds into hearing

### DIFF
--- a/src/resampler.js
+++ b/src/resampler.js
@@ -1,0 +1,88 @@
+function besselI0(x) {
+    let sum = 1;
+    let term = 1;
+    for (let k = 1; k < 50; ++k) {
+        term *= (x / (2 * k)) ** 2;
+        sum += term;
+        if (term < sum * 1e-12) break;
+    }
+    return sum;
+}
+
+/**
+ * Rate conversion by a Kaiser-windowed sinc evaluated only where an output
+ * sample falls, so the cost scales with the output rate, not the input rate.
+ * The kernel is tabulated at `phases` fractional offsets and interpolated
+ * between them. The caller renders each quantum's input into the buffer from
+ * `inputBuffer`, reads its output with `read`, then calls `commit` to carry
+ * the last `taps` input samples over as the next quantum's history.
+ */
+export class PolyphaseResampler {
+    constructor(inputRate, cutoffHz, { taps = 201, phases = 64, beta = 8.5 } = {}) {
+        this.taps = taps;
+        this.phases = phases;
+        this.half = (taps - 1) / 2;
+        this.table = new Float32Array((phases + 1) * taps);
+        const scale = (2 * cutoffHz) / inputRate;
+        const norm = besselI0(beta);
+        for (let p = 0; p <= phases; ++p) {
+            const row = p * taps;
+            let sum = 0;
+            for (let k = 0; k < taps; ++k) {
+                const t = k - this.half - p / phases;
+                const x = Math.PI * scale * t;
+                const sinc = x === 0 ? 1 : Math.sin(x) / x;
+                const u = t / (this.half + 1);
+                const window = u <= -1 || u >= 1 ? 0 : besselI0(beta * Math.sqrt(1 - u * u)) / norm;
+                this.table[row + k] = scale * sinc * window;
+                sum += this.table[row + k];
+            }
+            for (let k = 0; k < taps; ++k) this.table[row + k] /= sum;
+        }
+        this.buffer = new Float32Array(taps);
+        this.newSamples = 0;
+    }
+
+    /** Where to render `count` new input samples; the history precedes it. */
+    inputBuffer(count) {
+        const needed = this.taps + count + 1;
+        if (this.buffer.length < needed) {
+            const grown = new Float32Array(needed * 2);
+            grown.set(this.buffer.subarray(0, this.taps));
+            this.buffer = grown;
+        }
+        this.newSamples = count;
+        return this.buffer.subarray(this.taps, this.taps + count);
+    }
+
+    /**
+     * Fill `out` with samples taken `ratio` input samples apart, the first at
+     * `phase` (0 to 1) past the last sample of the previous quantum. The
+     * output lags the input by `half` samples, which the kernel needs ahead.
+     */
+    read(out, phase, ratio) {
+        const { buffer, table, taps, phases } = this;
+        for (let i = 0; i < out.length; ++i) {
+            const pos = phase + i * ratio;
+            const loc = Math.floor(pos);
+            const fracPhase = (pos - loc) * phases;
+            const p = Math.floor(fracPhase);
+            const mix = fracPhase - p;
+            const rowA = p * taps;
+            const rowB = rowA + taps;
+            let a = 0;
+            let b = 0;
+            for (let k = 0; k < taps; ++k) {
+                const x = buffer[loc + k];
+                a += table[rowA + k] * x;
+                b += table[rowB + k] * x;
+            }
+            out[i] = a + (b - a) * mix;
+        }
+    }
+
+    /** Keep the last `taps` input samples as history for the next quantum. */
+    commit() {
+        this.buffer.copyWithin(0, this.newSamples, this.newSamples + this.taps);
+    }
+}

--- a/src/resampler.js
+++ b/src/resampler.js
@@ -66,7 +66,7 @@ export class PolyphaseResampler {
             const pos = phase + i * ratio;
             const loc = Math.floor(pos);
             const fracPhase = (pos - loc) * phases;
-            const p = Math.floor(fracPhase);
+            const p = Math.min(Math.floor(fracPhase), phases - 1);
             const mix = fracPhase - p;
             const rowA = p * taps;
             const rowB = rowA + taps;

--- a/src/resampler.js
+++ b/src/resampler.js
@@ -13,9 +13,10 @@ function besselI0(x) {
  * Rate conversion by a Kaiser-windowed sinc evaluated only where an output
  * sample falls, so the cost scales with the output rate, not the input rate.
  * The kernel is tabulated at `phases` fractional offsets and interpolated
- * between them. The caller renders each quantum's input into the buffer from
- * `inputBuffer`, reads its output with `read`, then calls `commit` to carry
- * the last `taps` input samples over as the next quantum's history.
+ * between them. Each quantum the caller reserves room for its input, renders
+ * into `buffer` at `inputOffset`, reads the output with `read`, then calls
+ * `commit` to carry the last `taps` input samples over as the next quantum's
+ * history. Nothing is allocated once the buffer has reached its working size.
  */
 export class PolyphaseResampler {
     constructor(inputRate, cutoffHz, { taps = 201, phases = 64, beta = 8.5 } = {}) {
@@ -43,8 +44,8 @@ export class PolyphaseResampler {
         this.newSamples = 0;
     }
 
-    /** Where to render `count` new input samples; the history precedes it. */
-    inputBuffer(count) {
+    /** Make room for `count` new input samples after the history. */
+    reserve(count) {
         const needed = this.taps + count + 1;
         if (this.buffer.length < needed) {
             const grown = new Float32Array(needed * 2);
@@ -52,7 +53,10 @@ export class PolyphaseResampler {
             this.buffer = grown;
         }
         this.newSamples = count;
-        return this.buffer.subarray(this.taps, this.taps + count);
+    }
+
+    get inputOffset() {
+        return this.taps;
     }
 
     /**

--- a/src/web/audio-renderer.js
+++ b/src/web/audio-renderer.js
@@ -1,13 +1,20 @@
 /* global sampleRate, currentTime, registerProcessor, AudioWorkletProcessor */
 import { SoundChip, AtomSoundChip } from "../soundchip.js";
 import { LowPassBiquad } from "../biquad.js";
+import { PolyphaseResampler } from "../resampler.js";
 
 // The board's output filter is an equal-component Sallen-Key (Service Manual
 // section 3.8: 10K and 2n2 twice, gain K = 1 + 22/39): f0 = 1/(2*pi*RC) = 7234 Hz,
 // Q = 1/(3 - K) = 0.696, below 1/sqrt(2), so no resonant peak. Run at the chip
-// rate, ahead of decimation, it is also the anti-alias filter.
+// rate, ahead of the resampler.
 const OutputFilterHz = 7234;
 const OutputFilterQ = 0.696;
+
+// The resampler's sinc is cut off below the output Nyquist so that its
+// transition band has finished before anything folds; sampled sound rides on
+// a 31 kHz or higher carrier that would otherwise land in the audible band.
+const ResamplerCutoffOfOutputRate = 0.4;
+const ResamplerTaps = 201;
 
 const DefaultTargetLatencyMs = 1000 * (1 / 50); // One frame
 const MaxTargetLatencyMs = 250;
@@ -38,6 +45,9 @@ class SoundChipProcessor extends AudioWorkletProcessor {
         this.inputSampleRate = this.chip.soundchipFreq;
         this.samplesPerCycle = this.chip.samplesPerCycle;
         this.outputFilter = this._makeOutputFilter(audioFilterFreq, audioFilterQ);
+        this.resampler = new PolyphaseResampler(this.inputSampleRate, ResamplerCutoffOfOutputRate * sampleRate, {
+            taps: ResamplerTaps,
+        });
 
         this.events = [];
         this.eventsHead = 0;
@@ -48,9 +58,7 @@ class SoundChipProcessor extends AudioWorkletProcessor {
         this.skippedMs = 0;
         this.minLeadMs = Infinity;
 
-        this._lastInputSample = 0;
         this._phase = 0;
-        this._source = new Float32Array(0);
         this.smoothedLeadError = 0;
         this.setTargetLatency(targetLatencyMs);
         this.port.onmessage = (event) => {
@@ -210,21 +218,14 @@ class SoundChipProcessor extends AudioWorkletProcessor {
 
         // The fractional read position carries across quanta, so consumption
         // averages exactly sampleRatio and the pitch never steps at a rounding
-        // boundary. source[0] is the last input sample of the previous quantum.
+        // boundary.
         const end = this._phase + channel.length * sampleRatio;
         const numInputSamples = Math.floor(end);
-        if (this._source.length <= numInputSamples) this._source = new Float32Array(numInputSamples * 2);
-        const source = this._source;
-        source[0] = this._lastInputSample;
-        this._renderInput(source, 1, numInputSamples);
-        this.outputFilter?.process(source, 1, numInputSamples);
-        this._lastInputSample = source[numInputSamples];
-        for (let i = 0; i < channel.length; i++) {
-            const pos = this._phase + i * sampleRatio;
-            const loc = Math.floor(pos);
-            const alpha = pos - loc;
-            channel[i] = source[loc] * (1 - alpha) + source[loc + 1] * alpha;
-        }
+        const source = this.resampler.inputBuffer(numInputSamples);
+        this._renderInput(source, 0, numInputSamples);
+        this.outputFilter?.process(source, 0, numInputSamples);
+        this.resampler.read(channel, this._phase, sampleRatio);
+        this.resampler.commit();
         this._phase = end - numInputSamples;
         this.minLeadMs = Math.min(this.minLeadMs, this.leadMs());
         this.stats(sampleRatio);

--- a/src/web/audio-renderer.js
+++ b/src/web/audio-renderer.js
@@ -221,11 +221,12 @@ class SoundChipProcessor extends AudioWorkletProcessor {
         // boundary.
         const end = this._phase + channel.length * sampleRatio;
         const numInputSamples = Math.floor(end);
-        const source = this.resampler.inputBuffer(numInputSamples);
-        this._renderInput(source, 0, numInputSamples);
-        this.outputFilter?.process(source, 0, numInputSamples);
-        this.resampler.read(channel, this._phase, sampleRatio);
-        this.resampler.commit();
+        const resampler = this.resampler;
+        resampler.reserve(numInputSamples);
+        this._renderInput(resampler.buffer, resampler.inputOffset, numInputSamples);
+        this.outputFilter?.process(resampler.buffer, resampler.inputOffset, numInputSamples);
+        resampler.read(channel, this._phase, sampleRatio);
+        resampler.commit();
         this._phase = end - numInputSamples;
         this.minLeadMs = Math.min(this.minLeadMs, this.leadMs());
         this.stats(sampleRatio);

--- a/tests/unit/test-audio-renderer.js
+++ b/tests/unit/test-audio-renderer.js
@@ -45,6 +45,15 @@ const AliasTonePeriod = 100;
 const AliasToneHz = 4000000 / (32 * AliasTonePeriod);
 const FoldedSpurHz = 39 * AliasToneHz - OutputRate;
 
+// Sample playback parks a channel on an ultrasonic carrier and modulates its
+// volume; period 4 is the usual choice, 31.25 kHz.
+const SampledSoundCarrierPeriod = 4;
+const SampledSoundCarrierHz = 4000000 / (32 * SampledSoundCarrierPeriod);
+
+// 6250 Hz: its third harmonic sits where the board's filter has bitten hard.
+const HighTonePeriod = 20;
+const HighToneHz = 4000000 / (32 * HighTonePeriod);
+
 // Amplitude of the frequency-bin component at freq, via the Goertzel algorithm.
 function goertzelAmplitude(samples, freq, rate) {
     const w = (2 * Math.PI * freq) / rate;
@@ -146,16 +155,33 @@ describe("SoundChipProcessor rendering", () => {
         expect(goertzelAmplitude(output, ToneHz * 1.5, OutputRate)).toBeLessThan(0.02);
     });
 
-    it("should filter the chip at its own rate, ahead of the resampler, unless the filter is off", () => {
-        const foldedSpur = (options) => {
-            const proc = new SoundChipProcessor({ processorOptions: options });
-            const producer = startedWithTone(proc, toneWrites(AliasTonePeriod));
-            const { output } = simulate(proc, producer, 0.5, { collectAfter: 0.1, nominalRate: true });
-            return goertzelAmplitude(output, FoldedSpurHz, OutputRate);
-        };
-        const unfiltered = foldedSpur({ audioFilterFreq: 0 });
-        expect(unfiltered).toBeGreaterThan(0.002);
-        expect(foldedSpur({})).toBeLessThan(unfiltered / 10);
+    const spectralLine = (options, writes, hz) => {
+        const proc = new SoundChipProcessor({ processorOptions: options });
+        const producer = startedWithTone(proc, writes);
+        const { output } = simulate(proc, producer, 0.5, { collectAfter: 0.1, nominalRate: true });
+        return goertzelAmplitude(output, hz, OutputRate);
+    };
+
+    it("should not fold a harmonic from above the output rate into the audible band", () => {
+        const writes = toneWrites(AliasTonePeriod);
+        const fundamental = spectralLine({}, writes, AliasToneHz);
+        expect(fundamental).toBeGreaterThan(0.1);
+        expect(spectralLine({}, writes, FoldedSpurHz)).toBeLessThan(fundamental / 3000);
+        expect(spectralLine({ audioFilterFreq: 0 }, writes, FoldedSpurHz)).toBeLessThan(fundamental / 3000);
+    });
+
+    it("should not fold the carrier of sampled sound into the audible band", () => {
+        const writes = toneWrites(SampledSoundCarrierPeriod);
+        const folded = spectralLine({ audioFilterFreq: 0 }, writes, OutputRate - SampledSoundCarrierHz);
+        expect(folded).toBeLessThan(1e-4);
+    });
+
+    it("should apply the board's filter at the chip rate, ahead of the resampler", () => {
+        const writes = toneWrites(HighTonePeriod);
+        const harmonic = 3 * HighToneHz;
+        const unfiltered = spectralLine({ audioFilterFreq: 0 }, writes, harmonic);
+        expect(unfiltered).toBeGreaterThan(0.01);
+        expect(spectralLine({}, writes, harmonic)).toBeLessThan(unfiltered / 4);
     });
 
     it("should fall back to the board's filter when the settings cannot be realised", () => {

--- a/tests/unit/test-resampler.js
+++ b/tests/unit/test-resampler.js
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vitest";
+
+import { PolyphaseResampler } from "../../src/resampler.js";
+
+const InputRate = 500000;
+const OutputRate = 48000;
+const Ratio = InputRate / OutputRate;
+const Cutoff = 0.4 * OutputRate;
+
+function goertzelAmplitude(samples, freq, rate) {
+    const w = (2 * Math.PI * freq) / rate;
+    const coeff = 2 * Math.cos(w);
+    let s1 = 0;
+    let s2 = 0;
+    for (const x of samples) {
+        const s0 = x + coeff * s1 - s2;
+        s2 = s1;
+        s1 = s0;
+    }
+    return (2 * Math.sqrt(s1 * s1 + s2 * s2 - coeff * s1 * s2)) / samples.length;
+}
+
+// Push `signal` through in quanta of `quantum` output samples, as the worklet does.
+function resampleInQuanta(signal, quantum, options = {}) {
+    const resampler = new PolyphaseResampler(InputRate, Cutoff, options);
+    const out = [];
+    let phase = 0;
+    let consumed = 0;
+    const chunk = new Float32Array(quantum);
+    for (;;) {
+        const end = phase + quantum * Ratio;
+        const count = Math.floor(end);
+        if (consumed + count > signal.length) break;
+        resampler.inputBuffer(count).set(signal.subarray(consumed, consumed + count));
+        consumed += count;
+        resampler.read(chunk, phase, Ratio);
+        resampler.commit();
+        out.push(...chunk);
+        phase = end - count;
+    }
+    return Float32Array.from(out);
+}
+
+const tone = (hz, seconds, amplitude = 1) =>
+    Float32Array.from(
+        { length: seconds * InputRate },
+        (_, i) => amplitude * Math.sin((2 * Math.PI * hz * i) / InputRate),
+    );
+
+describe("PolyphaseResampler", () => {
+    it("should pass DC at unity gain", () => {
+        const out = resampleInQuanta(new Float32Array(InputRate / 10).fill(0.5), 128);
+        const settled = out.subarray(1000);
+        expect(Math.min(...settled)).toBeCloseTo(0.5, 5);
+        expect(Math.max(...settled)).toBeCloseTo(0.5, 5);
+    });
+
+    it("should pass an audible tone with its amplitude intact", () => {
+        const out = resampleInQuanta(tone(1000, 0.2), 128);
+        expect(goertzelAmplitude(out.subarray(2000), 1000, OutputRate)).toBeCloseTo(1, 2);
+    });
+
+    it("should remove what lies above the output rate's Nyquist before it can fold", () => {
+        const carrier = 31250;
+        const out = resampleInQuanta(tone(carrier, 0.2), 128);
+        expect(goertzelAmplitude(out.subarray(2000), OutputRate - carrier, OutputRate)).toBeLessThan(1e-4);
+    });
+
+    it("should give the same output whatever the quantum size", () => {
+        const signal = tone(3000, 0.05, 0.7);
+        const a = resampleInQuanta(signal, 128);
+        const b = resampleInQuanta(signal, 37);
+        const n = Math.min(a.length, b.length);
+        for (let i = 0; i < n; ++i) expect(b[i]).toBeCloseTo(a[i], 4);
+    });
+});

--- a/tests/unit/test-resampler.js
+++ b/tests/unit/test-resampler.js
@@ -31,7 +31,8 @@ function resampleInQuanta(signal, quantum, options = {}) {
         const end = phase + quantum * Ratio;
         const count = Math.floor(end);
         if (consumed + count > signal.length) break;
-        resampler.inputBuffer(count).set(signal.subarray(consumed, consumed + count));
+        resampler.reserve(count);
+        resampler.buffer.set(signal.subarray(consumed, consumed + count), resampler.inputOffset);
         consumed += count;
         resampler.read(chunk, phase, Ratio);
         resampler.commit();


### PR DESCRIPTION
The second step of #862, prompted by a sample-playback player that squeals in jsbeeb and not on hardware.

Sample playback parks a tone channel on an ultrasonic carrier and modulates its volume (period 4, 31.25 kHz, for ReetPetite and tyb-enjoy; 1, 2 and 8 elsewhere). Linear interpolation from 500 kHz to 48 kHz folds that carrier to 16.75 kHz. Measured on ReetPetite, 6 s of the real `SoundChip` output, the music peaking around -40 dBFS:

| front end | 16.75 kHz line | 12 to 24 kHz vs 0.1 to 12 kHz |
|---|---|---|
| one-pole RC then linear interpolation (before #915) | -27 dBFS | -5.5 dB |
| Sallen-Key then linear interpolation (#915) | -48 dBFS | -26 dB |
| Sallen-Key then this resampler | below the -83 dBFS floor | -41 dB |

`src/resampler.js` is a polyphase windowed sinc: a 201-tap Kaiser kernel cut off at 0.4 of the output rate, tabulated at 64 fractional phases and interpolated between them, evaluated only where an output sample falls, with the last 201 input samples carried across quanta. It replaces the linear interpolation in the worklet; the board's filter from #915 stays in front of it. Cost is about 37 ms per second of audio in Node, all on the worklet thread. 101 taps left a trace of the carrier at -76 dBFS with the board filter off, so 201 it is.

Tests: the resampler on its own (unity DC, an audible tone intact, a 31.25 kHz tone gone, output independent of quantum size), and the worklet end to end (a 1250 Hz tone's 39th harmonic and a period-4 carrier both stay out of the audible band with or without the board filter; the board filter still shows at a 6250 Hz tone's third harmonic).

Closes #862

🤖 Generated with [Claude Code](https://claude.com/claude-code)