### PR TITLE
feat: put the sound output, speaker amount and display mode on the top bar

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,14 +291,16 @@ sudo rpm -i out/dist/jsbeeb-1.0.1.x86_64.rpm
 - `audioLatencyMs` - how far the sound runs behind the emulator, in milliseconds (default 20). Raising it lets the sound ride out longer stalls of the emulator, at the cost of lagging the picture by that much.
 - `audioOutput` - what the sound chip is heard through: `speaker` (the default: the board's output stage and the
   internal speaker and case, fitted to recordings of a Master 128), `board` (the board's output stage alone, as at
-  its line-level socket) or `off` (the chip resampled and nothing else). The configuration dialog has the same
-  choice, and remembers it. See [docs/audio-path.md](docs/audio-path.md) for the path, the Master's circuit and
-  what a real machine measures.
+  its line-level socket) or `off` (the chip resampled and nothing else). The top bar has the same choice, and
+  remembers it. See [docs/audio-path.md](docs/audio-path.md) for the path, the Master's circuit and what a real
+  machine measures.
+- `speakerAmount` - how much of the speaker's character to apply, from 0 (the same as `board`) to 1 (as measured,
+  the default). The slider next to the sound output on the top bar sets it live, and remembers it.
 - `audiofilterfreq` / `audiofilterq` - the corner frequency in Hz and the Q of the lowpass modelling the board's output
   filter, applied to the sound chip before it is resampled. The defaults, 7234 and 0.696, are the Beeb's own.
   `audiofilterfreq=0` turns the whole output path off.
 - `displayMode=X` - picks the display: `rgb` (the default, a plain monitor), `pal` (a television fed by the Beeb's UHF modulator)
-  or `xbr` (an upscaler, see [docs/xbr-display-mode.md](docs/xbr-display-mode.md)).
+  or `xbr` (an upscaler, see [docs/xbr-display-mode.md](docs/xbr-display-mode.md)). The top bar has the same choice, and remembers it.
 
 ### Atom-specific parameters
 

--- a/docs/audio-path.md
+++ b/docs/audio-path.md
@@ -26,6 +26,8 @@ The outputs, chosen in the configuration dialog or with `audioOutput=` in the UR
   unity, which leaves it about 10 dB quieter than the board output at 1 kHz. Replayed headlessly
   and compared with the four microphone takes, it is within 3 dB at every step from 173 Hz to
   7.8 kHz except the three interference dips on which the takes disagree among themselves.
+  `speakerAmount` (the slider beside the output on the top bar) scales the fit toward flat, 1
+  being as measured and 0 the board output alone.
 - **off**: the resampled chip output alone.
 
 ## The Master 128 output stage

--- a/index.html
+++ b/index.html
@@ -226,6 +226,32 @@
             Edit BBC BASIC interactively with Owlet at
             <a href="https://bbcmic.ro/" target="_blank">bbcmic.ro</a>!
           </span>
+          <form class="d-flex align-items-center me-3" id="quick-settings">
+            <span class="me-1" aria-hidden="true">&#x1f50a;</span>
+            <select id="audio-output" class="form-select form-select-sm w-auto" aria-label="Sound output">
+              <option value="speaker">Speaker</option>
+              <option value="board">Line out</option>
+              <option value="off">Unfiltered</option>
+            </select>
+            <input
+              id="speaker-amount"
+              type="range"
+              class="form-range ms-2"
+              style="width: 5rem"
+              min="0"
+              max="1"
+              step="0.05"
+              value="1"
+              title="How much of the speaker's character to apply"
+              aria-label="Speaker amount"
+            />
+            <span class="ms-3 me-1" aria-hidden="true">&#x1f4fa;</span>
+            <select id="display-mode" class="form-select form-select-sm w-auto" aria-label="Display mode">
+              <option value="rgb">RGB Monitor</option>
+              <option value="pal">PAL TV</option>
+              <option value="xbr">Smoothed (xBR)</option>
+            </select>
+          </form>
           <form class="form-inline">
             <button
               id="debug-play"
@@ -1056,39 +1082,6 @@
                     <input class="form-check-input" type="checkbox" id="hasEconet" name="hasEconet" />
                     <label class="form-check-label" for="hasEconet">Econet with file server</label>
                   </div>
-                </div>
-              </div>
-            </div>
-
-            <div id="audioOutputSettings" style="margin-top: 15px">
-              <div class="row align-items-center">
-                <div class="col-sm-6">
-                  <label for="audioOutputDropdown" class="col-form-label">Sound output:</label>
-                </div>
-                <div class="col-sm-6 dropdown">
-                  <button
-                    type="button"
-                    class="btn btn-secondary dropdown-toggle"
-                    data-bs-toggle="dropdown"
-                    id="audioOutputDropdown"
-                  >
-                    <span class="audio-output-text">Internal speaker</span>
-                  </button>
-                  <ul
-                    class="dropdown-menu dropdown-menu-dark audio-output-menu"
-                    role="menu"
-                    aria-labelledby="audioOutputDropdown"
-                  >
-                    <li>
-                      <a href="#" class="dropdown-item audio-output-option" data-output="speaker">Internal speaker</a>
-                    </li>
-                    <li>
-                      <a href="#" class="dropdown-item audio-output-option" data-output="board">Line out</a>
-                    </li>
-                    <li>
-                      <a href="#" class="dropdown-item audio-output-option" data-output="off">Unfiltered</a>
-                    </li>
-                  </ul>
                 </div>
               </div>
             </div>

--- a/src/config.js
+++ b/src/config.js
@@ -145,16 +145,6 @@ export class Config extends EventTarget {
             });
         }
 
-        for (const option of document.querySelectorAll(".audio-output-option")) {
-            option.addEventListener("click", (e) => {
-                e.preventDefault();
-                const audioOutput = e.currentTarget.dataset.output;
-                this.changed.audioOutput = audioOutput;
-                this.setAudioOutput(audioOutput);
-                this.onChange({ audioOutput });
-            });
-        }
-
         for (const option of document.querySelectorAll(".display-mode-option")) {
             option.addEventListener("click", (e) => {
                 e.preventDefault();
@@ -191,10 +181,6 @@ export class Config extends EventTarget {
         }
     }
 
-    setAudioOutput(audioOutput) {
-        const option = document.querySelector(`.audio-output-option[data-output="${audioOutput}"]`);
-        for (const el of document.querySelectorAll(".audio-output-text")) el.textContent = option.textContent;
-    }
     setMicrophoneChannel(channel) {
         const text = channel !== undefined ? `Channel ${channel}` : "Disabled";
         for (const el of document.querySelectorAll(".mic-channel-text")) el.textContent = text;

--- a/src/main.js
+++ b/src/main.js
@@ -24,6 +24,7 @@ import { DefaultModel, findModel, tubeModelFor } from "./models.js";
 import { initialise as electron } from "./app/electron.js";
 import { AudioHandler } from "./web/audio-handler.js";
 import { DefaultAudioOutput, isAudioOutput } from "./audio-output.js";
+import { QuickSettings } from "./web/quick-settings.js";
 import { Econet } from "./econet.js";
 import { DiscLayout, toSsdOrDsd } from "./disc.js";
 import { toHfe } from "./disc-hfe.js";
@@ -251,19 +252,10 @@ setSpeechOutput(!!parsedQuery.speechOutput);
 
 const config = new Config(
     function onChange(changed) {
-        if (changed.audioOutput) audioHandler.setAudioOutput(changed.audioOutput);
-        if (changed.displayMode) {
-            // swapCanvas settles displayModeFilter on whatever was really
-            // built, so take the picture from that rather than the request.
-            swapCanvas(getFilterForMode(changed.displayMode));
-            setCrtPic(displayModeFilter);
-            // Trigger window resize to recalculate layout with new dimensions
-            window.dispatchEvent(new Event("resize"));
-        }
+        if (changed.displayMode) applyDisplayMode(changed.displayMode);
     },
     function onClose(changed) {
         parsedQuery = Object.assign(parsedQuery, changed);
-        if (changed.audioOutput) window.localStorage.audioOutput = changed.audioOutput;
         if (changed.keyLayout) {
             window.localStorage.keyLayout = changed.keyLayout;
             emulationConfig.keyLayout = changed.keyLayout;
@@ -319,11 +311,24 @@ config.setCheckboxes({
     mouseJoystickEnabled: !!parsedQuery.mouseJoystickEnabled,
     speechOutput: speechOutput.enabled,
 });
-let displayMode = parsedQuery.displayMode || "rgb";
+const displayMode = parsedQuery.displayMode || window.localStorage.displayMode || "rgb";
 config.setDisplayMode(displayMode);
 const audioOutput =
     [parsedQuery.audioOutput, window.localStorage.audioOutput].find(isAudioOutput) ?? DefaultAudioOutput;
-config.setAudioOutput(audioOutput);
+const speakerAmount =
+    [parsedQuery.speakerAmount, parseFloat(window.localStorage.speakerAmount)].find(Number.isFinite) ?? 1;
+
+function applyDisplayMode(mode) {
+    // swapCanvas settles displayModeFilter on whatever was really
+    // built, so take the picture from that rather than the request.
+    swapCanvas(getFilterForMode(mode));
+    setCrtPic(displayModeFilter);
+    // Trigger window resize to recalculate layout with new dimensions
+    window.dispatchEvent(new Event("resize"));
+    config.setDisplayMode(mode);
+    quickSettings?.showDisplayMode(mode);
+    window.localStorage.displayMode = mode;
+}
 
 model = config.model;
 
@@ -543,7 +548,7 @@ function createCanvasForFilter(filterClass) {
     return newCanvas;
 }
 
-let displayModeFilter = canvasLib.getFilterForMode(parsedQuery.displayMode || "rgb");
+let displayModeFilter = canvasLib.getFilterForMode(displayMode);
 function swapCanvas(newFilterClass) {
     // Everything but the filter is the same whatever the mode: the framebuffer
     // texture, the vertex buffers and fb32 all carry over untouched.
@@ -627,7 +632,7 @@ const audioHandler = new AudioHandler({
     audioOutput,
     audioFilterFreq: parsedQuery.audiofilterfreq,
     audioFilterQ: parsedQuery.audiofilterq,
-    speakerAmount: parsedQuery.speakerAmount,
+    speakerAmount,
     audioLatencyMs: parsedQuery.audioLatencyMs,
     noSeek,
     cpuSpeed,
@@ -638,6 +643,10 @@ const audioHandler = new AudioHandler({
 // start playing without user interaction, so we need to delay a
 // little to get a reliable indication.
 window.setTimeout(() => audioHandler.checkStatus(), 1000);
+const quickSettings = new QuickSettings(
+    { audioHandler, onDisplayMode: applyDisplayMode, storage: window.localStorage },
+    { audioOutput, speakerAmount, displayMode },
+);
 
 for (const el of document.querySelectorAll(".initially-hidden")) el.classList.remove("initially-hidden");
 

--- a/src/web/audio-handler.js
+++ b/src/web/audio-handler.js
@@ -175,6 +175,10 @@ export class AudioHandler {
         this._jsAudioNode?.port.postMessage({ command: "setAudioOutput", audioOutput });
     }
 
+    setSpeakerAmount(speakerAmount) {
+        this._jsAudioNode?.port.postMessage({ command: "setSpeakerAmount", speakerAmount });
+    }
+
     // Returns how far ahead of the sound the picture should now run, in ms.
     setWindowFocused(focused) {
         this.windowFocused = focused;

--- a/src/web/audio-renderer.js
+++ b/src/web/audio-renderer.js
@@ -54,6 +54,7 @@ class SoundChipProcessor extends AudioWorkletProcessor {
         this.port.onmessage = (event) => {
             if (event.data.command === "setTargetLatency") this.setTargetLatency(event.data.targetLatencyMs);
             else if (event.data.command === "setAudioOutput") this.setAudioOutput(event.data.audioOutput);
+            else if (event.data.command === "setSpeakerAmount") this.setSpeakerAmount(event.data.speakerAmount);
             else this.onProduced(event.data.upTo, event.data.events);
         };
         this.nextStats = 0;
@@ -62,6 +63,11 @@ class SoundChipProcessor extends AudioWorkletProcessor {
     setAudioOutput(audioOutput) {
         this.audioOutput = audioOutput;
         this.outputFilters = outputStages(this.inputSampleRate, audioOutput, this.boardFilter);
+    }
+
+    setSpeakerAmount(speakerAmount) {
+        this.boardFilter.speakerAmount = speakerAmount;
+        this.setAudioOutput(this.audioOutput);
     }
 
     setTargetLatency(ms) {

--- a/src/web/quick-settings.js
+++ b/src/web/quick-settings.js
@@ -1,0 +1,34 @@
+import { AudioOutputs } from "../audio-output.js";
+
+/** The sound output, speaker amount and display mode controls on the top bar. */
+export class QuickSettings {
+    constructor({ audioHandler, onDisplayMode, storage }, { audioOutput, speakerAmount, displayMode }) {
+        this.output = document.getElementById("audio-output");
+        this.amount = document.getElementById("speaker-amount");
+        this.display = document.getElementById("display-mode");
+        if (!this.output || !this.amount || !this.display) return;
+
+        this.output.value = audioOutput;
+        this.amount.value = speakerAmount;
+        this.display.value = displayMode;
+        this._showAmountFor(audioOutput);
+
+        this.output.addEventListener("change", () => {
+            const value = this.output.value;
+            audioHandler.setAudioOutput(value);
+            storage.audioOutput = value;
+            this._showAmountFor(value);
+        });
+        this.amount.addEventListener("input", () => audioHandler.setSpeakerAmount(parseFloat(this.amount.value)));
+        this.amount.addEventListener("change", () => (storage.speakerAmount = this.amount.value));
+        this.display.addEventListener("change", () => onDisplayMode(this.display.value));
+    }
+
+    _showAmountFor(audioOutput) {
+        this.amount.disabled = audioOutput !== AudioOutputs.speaker;
+    }
+
+    showDisplayMode(mode) {
+        if (this.display) this.display.value = mode;
+    }
+}

--- a/tests/unit/test-quick-settings.js
+++ b/tests/unit/test-quick-settings.js
@@ -1,0 +1,78 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { QuickSettings } from "../../src/web/quick-settings.js";
+
+const Markup = `
+<select id="audio-output"><option value="speaker">S</option><option value="board">B</option><option value="off">O</option></select>
+<input id="speaker-amount" type="range" min="0" max="1" step="0.05" value="1" />
+<select id="display-mode"><option value="rgb">R</option><option value="pal">P</option><option value="xbr">X</option></select>`;
+
+describe("QuickSettings", () => {
+    let audioHandler;
+    let onDisplayMode;
+    let storage;
+
+    beforeEach(() => {
+        document.body.innerHTML = Markup;
+        audioHandler = { setAudioOutput: vi.fn(), setSpeakerAmount: vi.fn() };
+        onDisplayMode = vi.fn();
+        storage = {};
+    });
+
+    afterEach(() => {
+        document.body.innerHTML = "";
+    });
+
+    const make = (initial = { audioOutput: "speaker", speakerAmount: 1, displayMode: "rgb" }) =>
+        new QuickSettings({ audioHandler, onDisplayMode, storage }, initial);
+
+    const change = (id, value) => {
+        const el = document.getElementById(id);
+        el.value = value;
+        el.dispatchEvent(new Event("change"));
+    };
+
+    it("shows the initial settings and only enables the amount for the speaker", () => {
+        make({ audioOutput: "board", speakerAmount: 0.4, displayMode: "pal" });
+        expect(document.getElementById("audio-output").value).toBe("board");
+        expect(document.getElementById("speaker-amount").value).toBe("0.4");
+        expect(document.getElementById("speaker-amount").disabled).toBe(true);
+        expect(document.getElementById("display-mode").value).toBe("pal");
+    });
+
+    it("applies and remembers a new sound output", () => {
+        make();
+        change("audio-output", "off");
+        expect(audioHandler.setAudioOutput).toHaveBeenCalledWith("off");
+        expect(storage.audioOutput).toBe("off");
+        expect(document.getElementById("speaker-amount").disabled).toBe(true);
+        change("audio-output", "speaker");
+        expect(document.getElementById("speaker-amount").disabled).toBe(false);
+    });
+
+    it("applies the amount as it moves and remembers it when released", () => {
+        make();
+        const amount = document.getElementById("speaker-amount");
+        amount.value = "0.5";
+        amount.dispatchEvent(new Event("input"));
+        expect(audioHandler.setSpeakerAmount).toHaveBeenCalledWith(0.5);
+        expect(storage.speakerAmount).toBeUndefined();
+        amount.dispatchEvent(new Event("change"));
+        expect(storage.speakerAmount).toBe("0.5");
+    });
+
+    it("hands the display mode to its callback and follows changes made elsewhere", () => {
+        const settings = make();
+        change("display-mode", "xbr");
+        expect(onDisplayMode).toHaveBeenCalledWith("xbr");
+        settings.showDisplayMode("pal");
+        expect(document.getElementById("display-mode").value).toBe("pal");
+    });
+
+    it("does nothing on a page without the controls", () => {
+        document.body.innerHTML = "";
+        const settings = make();
+        expect(() => settings.showDisplayMode("pal")).not.toThrow();
+    });
+});


### PR DESCRIPTION
Stacked on #923. Puts the settings people will actually want to flip on the top bar, next to play and pause, where they can be changed while the emulator keeps running (the configuration dialog stops it while open):

- **Sound output** (Speaker / Line out / Unfiltered) and the **speaker amount** slider (0 is the board output, 1 the speaker as measured), both live and remembered. The sound output leaves the configuration dialog.
- **Display mode** (RGB Monitor / PAL TV / Smoothed), live, in step with the dialog's own dropdown, and now remembered between visits like the sound settings.

`src/web/quick-settings.js` owns the three controls and does nothing on a page without them (the desktop app strips the bar). Checked in headless Chrome: URL parameters land in the controls, changes apply and persist, the dialog's text follows, no console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
