### PR TITLE
fix: mute the sound when the debugger is entered while the audio is stalled

### DIFF
--- a/src/web/audio-handler.js
+++ b/src/web/audio-handler.js
@@ -54,6 +54,7 @@ export class AudioHandler {
             this.audioContext.onstatechange = () => this.checkStatus();
             const onEvent = (event) => {
                 if (event.progress) this.flushChipEvents();
+                else if (event.enabled !== undefined) this._setEnabled(event.enabled);
                 else this._chipEvents.push(event);
             };
             this.soundChip = this.isAtom
@@ -145,6 +146,7 @@ export class AudioHandler {
             },
         });
         this._jsAudioNode.connect(this.audioContext.destination);
+        if (!this.soundChip.enabled) this._setEnabled(false);
         this._jsAudioNode.port.onmessage = (event) => {
             const now = Date.now();
             if (event.data.event) {
@@ -169,6 +171,12 @@ export class AudioHandler {
 
     _targetLatencyMs() {
         return this.windowFocused ? this.audioLatencyMs : UnfocusedLatencyMs;
+    }
+
+    // Muting is a control, not part of the chip's timeline: it takes effect on
+    // arrival rather than when the worklet's clock reaches it.
+    _setEnabled(enabled) {
+        this._jsAudioNode?.port.postMessage({ command: "setEnabled", enabled });
     }
 
     setAudioOutput(audioOutput) {

--- a/src/web/audio-handler.js
+++ b/src/web/audio-handler.js
@@ -173,8 +173,6 @@ export class AudioHandler {
         return this.windowFocused ? this.audioLatencyMs : UnfocusedLatencyMs;
     }
 
-    // Muting is a control, not part of the chip's timeline: it takes effect on
-    // arrival rather than when the worklet's clock reaches it.
     _setEnabled(enabled) {
         this._jsAudioNode?.port.postMessage({ command: "setEnabled", enabled });
     }

--- a/src/web/audio-renderer.js
+++ b/src/web/audio-renderer.js
@@ -166,9 +166,8 @@ class SoundChipProcessor extends AudioWorkletProcessor {
         this.stalled = false;
     }
 
-    // Holds the producer's current state, so changes it sends still apply:
-    // a stopped producer's mute cannot wait for a lead that never comes.
-    // A resync starts a new timeline and does wait.
+    // Holding the producer's state means following its changes; a resync
+    // starts a new timeline, so it waits for the restart.
     _stall(out, offset, length) {
         if (!this.stalled) {
             this.stalled = true;

--- a/src/web/audio-renderer.js
+++ b/src/web/audio-renderer.js
@@ -61,6 +61,7 @@ class SoundChipProcessor extends AudioWorkletProcessor {
             if (event.data.command === "setTargetLatency") this.setTargetLatency(event.data.targetLatencyMs);
             else if (event.data.command === "setAudioOutput") this.setAudioOutput(event.data.audioOutput);
             else if (event.data.command === "setSpeakerAmount") this.setSpeakerAmount(event.data.speakerAmount);
+            else if (event.data.command === "setEnabled") this.chip.enabled = event.data.enabled;
             else this.onProduced(event.data.upTo, event.data.events);
         };
         this.nextStats = 0;
@@ -166,15 +167,12 @@ class SoundChipProcessor extends AudioWorkletProcessor {
         this.stalled = false;
     }
 
-    // Holding the producer's state means following its changes; a resync
-    // starts a new timeline, so it waits for the restart.
     _stall(out, offset, length) {
         if (!this.stalled) {
             this.stalled = true;
             this.stalls++;
             this._notify("stall", 1);
         }
-        while (this.eventsHead < this.events.length && !isResync(this.events[this.eventsHead])) this._applyHead();
         this.chip.renderAt(this.clock, out, offset, length);
     }
 

--- a/src/web/audio-renderer.js
+++ b/src/web/audio-renderer.js
@@ -166,12 +166,16 @@ class SoundChipProcessor extends AudioWorkletProcessor {
         this.stalled = false;
     }
 
+    // Holds the producer's current state, so changes it sends still apply:
+    // a stopped producer's mute cannot wait for a lead that never comes.
+    // A resync starts a new timeline and does wait.
     _stall(out, offset, length) {
         if (!this.stalled) {
             this.stalled = true;
             this.stalls++;
             this._notify("stall", 1);
         }
+        while (this.eventsHead < this.events.length && !isResync(this.events[this.eventsHead])) this._applyHead();
         this.chip.renderAt(this.clock, out, offset, length);
     }
 

--- a/tests/unit/test-audio-handler.js
+++ b/tests/unit/test-audio-handler.js
@@ -42,7 +42,13 @@ describe("AudioHandler", () => {
             class {
                 constructor(context, name, options) {
                     this.options = options;
-                    this.port = { postMessage: () => {}, onmessage: null };
+                    this.port = {
+                        posted: [],
+                        postMessage(message) {
+                            this.posted.push(message);
+                        },
+                        onmessage: null,
+                    };
                 }
                 connect() {}
             },
@@ -143,7 +149,7 @@ describe("AudioHandler", () => {
             ]);
         });
 
-        it("ships a mute at once, since the stopped emulator will not tick", async () => {
+        it("mutes and unmutes by command, ahead of the chip's timeline, and flushes what the stopped emulator will not", async () => {
             const handler = makeHandler();
             await vi.waitFor(() => expect(handler._jsAudioNode).not.toBeNull());
             const posted = vi.spyOn(handler._jsAudioNode.port, "postMessage");
@@ -151,10 +157,20 @@ describe("AudioHandler", () => {
             handler.mute();
             handler.unmute();
 
-            expect(posted.mock.calls.map((call) => call[0].events)).toEqual([
-                [{ cycle: 0, enabled: false }],
-                [{ cycle: 0, enabled: true }],
+            expect(posted.mock.calls.map((call) => call[0])).toEqual([
+                { command: "setEnabled", enabled: false },
+                { upTo: 0, events: [] },
+                { command: "setEnabled", enabled: true },
+                { upTo: 0, events: [] },
             ]);
+        });
+
+        it("tells a worklet built after a mute that it starts muted", async () => {
+            const handler = makeHandler();
+            handler.mute();
+            await vi.waitFor(() => expect(handler._jsAudioNode).not.toBeNull());
+
+            expect(handler._jsAudioNode.port.posted).toContainEqual({ command: "setEnabled", enabled: false });
         });
 
         it("hands the output filter settings to the worklet", async () => {

--- a/tests/unit/test-audio-renderer.js
+++ b/tests/unit/test-audio-renderer.js
@@ -268,23 +268,25 @@ describe("SoundChipProcessor rendering", () => {
         expect(proc.skippedMs).toBeCloseTo(100 - proc.targetLatencyMs, 0);
     });
 
-    it("should go silent when the producer mutes as it stops", () => {
+    const mute = (proc) => proc.port.onmessage({ data: { command: "setEnabled", enabled: false } });
+
+    it("should go silent when muted as the producer stops", () => {
         const proc = new SoundChipProcessor(BoardOutput);
         const producer = startedWithTone(proc);
-        producer.chip.mute();
+        mute(proc);
         producer.flush();
         const { output } = simulate(proc, producer, 0.5, { collectAfter: 0.25, ticking: () => false });
         expect(goertzelAmplitude(output, ToneHz, OutputRate)).toBeLessThan(1e-3);
         expect(Math.max(...output.map(Math.abs))).toBeLessThan(1e-3);
     });
 
-    it("should go silent when muted while already stalled, without waiting for a lead it will never get", () => {
+    it("should go silent when muted while stalled, without waiting for a lead it will never get", () => {
         const proc = new SoundChipProcessor(BoardOutput);
         const producer = startedWithTone(proc);
         simulate(proc, producer, 0.2, { ticking: () => false });
         expect(proc.stalled).toBe(true);
         producer.advance(1);
-        producer.chip.mute();
+        mute(proc);
         producer.flush();
         const { output } = simulate(proc, producer, 0.5, { collectAfter: 0.25, ticking: () => false });
         expect(Math.max(...output.map(Math.abs))).toBeLessThan(1e-3);

--- a/tests/unit/test-audio-renderer.js
+++ b/tests/unit/test-audio-renderer.js
@@ -268,6 +268,28 @@ describe("SoundChipProcessor rendering", () => {
         expect(proc.skippedMs).toBeCloseTo(100 - proc.targetLatencyMs, 0);
     });
 
+    it("should go silent when the producer mutes as it stops", () => {
+        const proc = new SoundChipProcessor(BoardOutput);
+        const producer = startedWithTone(proc);
+        producer.chip.mute();
+        producer.flush();
+        const { output } = simulate(proc, producer, 0.5, { collectAfter: 0.25, ticking: () => false });
+        expect(goertzelAmplitude(output, ToneHz, OutputRate)).toBeLessThan(1e-3);
+        expect(Math.max(...output.map(Math.abs))).toBeLessThan(1e-3);
+    });
+
+    it("should go silent when muted while already stalled, without waiting for a lead it will never get", () => {
+        const proc = new SoundChipProcessor(BoardOutput);
+        const producer = startedWithTone(proc);
+        simulate(proc, producer, 0.2, { ticking: () => false });
+        expect(proc.stalled).toBe(true);
+        producer.advance(1);
+        producer.chip.mute();
+        producer.flush();
+        const { output } = simulate(proc, producer, 0.5, { collectAfter: 0.25, ticking: () => false });
+        expect(Math.max(...output.map(Math.abs))).toBeLessThan(1e-3);
+    });
+
     it("should carry on with the tone, not silence, while stalled", () => {
         const proc = new SoundChipProcessor(BoardOutput);
         startedWithTone(proc);


### PR DESCRIPTION
Entering the debugger (Ctrl+Home, the pause button) sometimes left the last note droning, with `soundChip.enabled` already false: the mute had been sent but never applied.

The worklet stalls when it catches up with the producer's position (a slow frame, a GC pause) and deliberately holds its current sound rather than going silent, leaving the stall only when the producer is a full lead ahead again. A mute sent as a timeline event while stalled therefore waited for a restart that a stopped emulator can never trigger. Intermittent because it needs a stall at the moment of stopping; easier to hit in a busy game.

Muting is a control, not chip state at a cycle, so it now travels the way `setTargetLatency` and `setAudioOutput` do: the handler turns the chip's `enabled` event into a `setEnabled` command that the worklet applies on arrival, ahead of whatever is queued on the timeline (a worklet built after a mute is told it starts muted). The timeline and the stall keep exactly their #897 behaviour: hold state, apply nothing until the restart, resyncs start a new timeline. Tests: a mute as the producer stops, a mute sent to an already stalled worklet, and the handler's command ordering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
