### PR TITLE
refactor: name the messages and events between the emulator and the sound worklet

### DIFF
--- a/src/soundchip.js
+++ b/src/soundchip.js
@@ -122,8 +122,7 @@ export class SoundChip {
         else if (event.sine !== undefined) {
             if (event.sine) this.toneGenerator.tone(event.sine);
             else this.toneGenerator.mute();
-        } else if (event.enabled !== undefined) this.enabled = event.enabled;
-        else if (event.state !== undefined) this.restoreState(event.state);
+        } else if (event.state !== undefined) this.restoreState(event.state);
         else if (event.reset !== undefined) this.reset(event.reset);
     }
 
@@ -412,7 +411,6 @@ export class SoundChip {
 
     enable(e) {
         this.enabled = e;
-        this._emit({ enabled: e });
     }
 
     mute() {

--- a/src/soundchip.js
+++ b/src/soundchip.js
@@ -101,29 +101,34 @@ export class SoundChip {
             mute: () => {
                 this.catchUp();
                 this.sineOn = false;
-                this._emit({ sine: 0 });
+                this._emit("sine", 0);
             },
             tone: (freq) => {
                 this.catchUp();
                 this.sineOn = true;
                 this.sineStep = (freq / sampleRate) * this.sineTable.length;
-                this._emit({ sine: freq });
+                this._emit("sine", freq);
             },
+        };
+
+        this.eventHandlers = {
+            progress: () => {},
+            poke: (value) => this.poke(value),
+            sine: (freq) => (freq ? this.toneGenerator.tone(freq) : this.toneGenerator.mute()),
+            state: (state) => this.restoreState(state),
+            reset: (hard) => this.reset(hard),
         };
     }
 
-    _emit(event) {
-        if (this._onEvent) this._onEvent({ cycle: this.scheduler.epoch, ...event });
+    _emit(kind, value) {
+        if (this._onEvent) this._onEvent({ cycle: this.scheduler.epoch, kind, value });
     }
 
     /** Applies an event from another chip's onEvent, at the cycle this chip is rendering. */
     applyEvent(event) {
-        if (event.poke !== undefined) this.poke(event.poke);
-        else if (event.sine !== undefined) {
-            if (event.sine) this.toneGenerator.tone(event.sine);
-            else this.toneGenerator.mute();
-        } else if (event.state !== undefined) this.restoreState(event.state);
-        else if (event.reset !== undefined) this.reset(event.reset);
+        const handler = this.eventHandlers[event.kind];
+        if (!handler) throw new Error(`Unknown sound event ${event.kind}`);
+        handler(event.value, event);
     }
 
     /** Renders `length` samples of output from `cycle`, for a chip that is driven by events. */
@@ -213,7 +218,7 @@ export class SoundChip {
         this.volume[2] = volumeTable[v2];
         this.volume[3] = volumeTable[v3];
         this.noisePoked();
-        this._emit({ state: this.snapshotState() });
+        this._emit("state", this.snapshotState());
     }
 
     generate(out, offset, length) {
@@ -254,7 +259,7 @@ export class SoundChip {
         });
         if (this._onEvent) {
             this.progressTask = this.scheduler.newTask(() => {
-                this._emit({ progress: true });
+                this._emit("progress", true);
                 this.progressTask.schedule(EventProgressCycles);
             });
             this.progressTask.schedule(EventProgressCycles);
@@ -311,7 +316,7 @@ export class SoundChip {
 
     poke(value) {
         this.catchUp();
-        this._emit({ poke: value });
+        this._emit("poke", value);
 
         let command;
         if (value & 0x80) {
@@ -393,12 +398,12 @@ export class SoundChip {
         this.dcPrevIn = state.dcPrevIn ?? 0;
         this.dcPrevOut = state.dcPrevOut ?? 0;
         this.progressTask?.ensureScheduled(true, EventProgressCycles);
-        this._emit({ state: this.snapshotState() });
+        this._emit("state", this.snapshotState());
     }
 
     reset(hard) {
         if (!hard) return;
-        this._emit({ reset: true });
+        this._emit("reset", true);
         for (let i = 0; i < 4; ++i) {
             this.counter[i] = 0;
             this.registers[i] = 0;
@@ -455,6 +460,11 @@ export class AtomSoundChip extends SoundChip {
         this._speakerPrevIn = 0;
         this._speakerPrevOut = 0;
         this._speakerCycleOffset = 0;
+
+        Object.assign(this.eventHandlers, {
+            bit: (bit, { cycle }) => this.bitChange.push({ bit, cycles: cycle }),
+            speakerReset: () => this.speakerReset(),
+        });
     }
 
     reset(hard) {
@@ -468,19 +478,13 @@ export class AtomSoundChip extends SoundChip {
         this._speakerCycleOffset = 0;
     }
 
-    applyEvent(event) {
-        if (event.bit !== undefined) this.bitChange.push({ bit: event.bit, cycles: event.cycle });
-        else if (event.speakerReset !== undefined) this.speakerReset();
-        else super.applyEvent(event);
-    }
-
     renderAt(cycle, out, offset, length) {
         this._speakerCycleOffset = 0;
         super.renderAt(cycle, out, offset, length);
     }
 
     speakerReset() {
-        this._emit({ speakerReset: true });
+        this._emit("speakerReset", true);
         this.bitChange = [];
         this.currentSpeakerBit = 0.0;
         this._speakerPrevIn = 0;
@@ -519,7 +523,7 @@ export class AtomSoundChip extends SoundChip {
     updateSpeaker(value, microCycle, seconds) {
         const cycles = microCycle + seconds / this.secondsPerCycle;
         const bit = value ? 1.0 : 0.0;
-        if (this._onEvent) this._onEvent({ cycle: cycles, bit });
+        if (this._onEvent) this._onEvent({ cycle: cycles, kind: "bit", value: bit });
         else this.bitChange.push({ bit, cycles });
     }
 }

--- a/src/web/audio-handler.js
+++ b/src/web/audio-handler.js
@@ -216,7 +216,11 @@ export class AudioHandler {
     // emulator has got, so the worklet knows its lead even when nothing changed.
     flushChipEvents() {
         if (!this._jsAudioNode) return;
-        this._jsAudioNode.port.postMessage({ upTo: this.soundChip.scheduler.epoch, events: this._chipEvents });
+        this._jsAudioNode.port.postMessage({
+            command: "produced",
+            upTo: this.soundChip.scheduler.epoch,
+            events: this._chipEvents,
+        });
         this._chipEvents = [];
     }
 

--- a/src/web/audio-handler.js
+++ b/src/web/audio-handler.js
@@ -53,7 +53,7 @@ export class AudioHandler {
         if (this.audioContext && this.audioContext.audioWorklet) {
             this.audioContext.onstatechange = () => this.checkStatus();
             const onEvent = (event) => {
-                if (event.progress) this.flushChipEvents();
+                if (event.kind === "progress") this.flushChipEvents();
                 else this._chipEvents.push(event);
             };
             this.soundChip = this.isAtom

--- a/src/web/audio-handler.js
+++ b/src/web/audio-handler.js
@@ -54,7 +54,6 @@ export class AudioHandler {
             this.audioContext.onstatechange = () => this.checkStatus();
             const onEvent = (event) => {
                 if (event.progress) this.flushChipEvents();
-                else if (event.enabled !== undefined) this._setEnabled(event.enabled);
                 else this._chipEvents.push(event);
             };
             this.soundChip = this.isAtom
@@ -251,15 +250,17 @@ export class AudioHandler {
         await this.relayNoise.initialise();
     }
 
-    // The emulator is stopping, so no tick will ship the change; send it now.
+    // The emulator is stopping, so no tick will ship its last writes; send them now.
     mute() {
         this.soundChip.mute();
+        this._setEnabled(false);
         this.flushChipEvents();
         if (this.masterGain) this.masterGain.gain.value = 0;
     }
 
     unmute() {
         this.soundChip.unmute();
+        this._setEnabled(true);
         this.flushChipEvents();
         if (this.masterGain) this.masterGain.gain.value = 1;
     }

--- a/src/web/audio-renderer.js
+++ b/src/web/audio-renderer.js
@@ -19,7 +19,8 @@ const LeadSmoothingTau = 0.5;
 const ProportionalGain = 0.2;
 const MaxAdjustFraction = 0.0005;
 
-const isResync = (event) => event.state !== undefined || event.reset !== undefined;
+const ResyncKinds = new Set(["state", "reset"]);
+const isResync = (event) => ResyncKinds.has(event.kind);
 
 // Renders the chip from its timestamped state changes, so a producer that
 // falls behind leaves the chip sounding its current state (a stall) rather
@@ -57,30 +58,21 @@ class SoundChipProcessor extends AudioWorkletProcessor {
         this._phase = 0;
         this.smoothedLeadError = 0;
         this.setTargetLatency(targetLatencyMs);
+        this.commands = {
+            produced: (m) => this.onProduced(m.upTo, m.events),
+            setEnabled: (m) => (this.chip.enabled = m.enabled),
+            setTargetLatency: (m) => this.setTargetLatency(m.targetLatencyMs),
+            setAudioOutput: (m) => this.setAudioOutput(m.audioOutput),
+            setSpeakerAmount: (m) => this.setSpeakerAmount(m.speakerAmount),
+        };
         this.port.onmessage = (event) => this.onMessage(event.data);
         this.nextStats = 0;
     }
 
     onMessage(message) {
-        switch (message.command) {
-            case "produced":
-                this.onProduced(message.upTo, message.events);
-                break;
-            case "setEnabled":
-                this.chip.enabled = message.enabled;
-                break;
-            case "setTargetLatency":
-                this.setTargetLatency(message.targetLatencyMs);
-                break;
-            case "setAudioOutput":
-                this.setAudioOutput(message.audioOutput);
-                break;
-            case "setSpeakerAmount":
-                this.setSpeakerAmount(message.speakerAmount);
-                break;
-            default:
-                throw new Error(`Unknown sound command ${message.command}`);
-        }
+        const command = this.commands[message.command];
+        if (!command) throw new Error(`Unknown sound command ${message.command}`);
+        command(message);
     }
 
     setAudioOutput(audioOutput) {

--- a/src/web/audio-renderer.js
+++ b/src/web/audio-renderer.js
@@ -57,14 +57,30 @@ class SoundChipProcessor extends AudioWorkletProcessor {
         this._phase = 0;
         this.smoothedLeadError = 0;
         this.setTargetLatency(targetLatencyMs);
-        this.port.onmessage = (event) => {
-            if (event.data.command === "setTargetLatency") this.setTargetLatency(event.data.targetLatencyMs);
-            else if (event.data.command === "setAudioOutput") this.setAudioOutput(event.data.audioOutput);
-            else if (event.data.command === "setSpeakerAmount") this.setSpeakerAmount(event.data.speakerAmount);
-            else if (event.data.command === "setEnabled") this.chip.enabled = event.data.enabled;
-            else this.onProduced(event.data.upTo, event.data.events);
-        };
+        this.port.onmessage = (event) => this.onMessage(event.data);
         this.nextStats = 0;
+    }
+
+    onMessage(message) {
+        switch (message.command) {
+            case "produced":
+                this.onProduced(message.upTo, message.events);
+                break;
+            case "setEnabled":
+                this.chip.enabled = message.enabled;
+                break;
+            case "setTargetLatency":
+                this.setTargetLatency(message.targetLatencyMs);
+                break;
+            case "setAudioOutput":
+                this.setAudioOutput(message.audioOutput);
+                break;
+            case "setSpeakerAmount":
+                this.setSpeakerAmount(message.speakerAmount);
+                break;
+            default:
+                throw new Error(`Unknown sound command ${message.command}`);
+        }
     }
 
     setAudioOutput(audioOutput) {

--- a/tests/unit/test-audio-handler.js
+++ b/tests/unit/test-audio-handler.js
@@ -129,7 +129,7 @@ describe("AudioHandler", () => {
             handler.flushChipEvents();
 
             expect(posted.mock.calls.map((call) => call[0])).toEqual([
-                { command: "produced", upTo: 5000, events: [{ cycle: 5000, poke: 0x8d }] },
+                { command: "produced", upTo: 5000, events: [{ cycle: 5000, kind: "poke", value: 0x8d }] },
                 { command: "produced", upTo: 5000, events: [] },
             ]);
         });
@@ -145,7 +145,7 @@ describe("AudioHandler", () => {
             scheduler.polltime(4000);
 
             expect(posted.mock.calls.map((call) => call[0])).toEqual([
-                { command: "produced", upTo: 4000, events: [{ cycle: 0, poke: 0x8d }] },
+                { command: "produced", upTo: 4000, events: [{ cycle: 0, kind: "poke", value: 0x8d }] },
             ]);
         });
 

--- a/tests/unit/test-audio-handler.js
+++ b/tests/unit/test-audio-handler.js
@@ -129,8 +129,8 @@ describe("AudioHandler", () => {
             handler.flushChipEvents();
 
             expect(posted.mock.calls.map((call) => call[0])).toEqual([
-                { upTo: 5000, events: [{ cycle: 5000, poke: 0x8d }] },
-                { upTo: 5000, events: [] },
+                { command: "produced", upTo: 5000, events: [{ cycle: 5000, poke: 0x8d }] },
+                { command: "produced", upTo: 5000, events: [] },
             ]);
         });
 
@@ -145,7 +145,7 @@ describe("AudioHandler", () => {
             scheduler.polltime(4000);
 
             expect(posted.mock.calls.map((call) => call[0])).toEqual([
-                { upTo: 4000, events: [{ cycle: 0, poke: 0x8d }] },
+                { command: "produced", upTo: 4000, events: [{ cycle: 0, poke: 0x8d }] },
             ]);
         });
 
@@ -159,9 +159,9 @@ describe("AudioHandler", () => {
 
             expect(posted.mock.calls.map((call) => call[0])).toEqual([
                 { command: "setEnabled", enabled: false },
-                { upTo: 0, events: [] },
+                { command: "produced", upTo: 0, events: [] },
                 { command: "setEnabled", enabled: true },
-                { upTo: 0, events: [] },
+                { command: "produced", upTo: 0, events: [] },
             ]);
         });
 

--- a/tests/unit/test-audio-renderer.js
+++ b/tests/unit/test-audio-renderer.js
@@ -199,7 +199,7 @@ describe("SoundChipProcessor rendering", () => {
 
         const proc = new SoundChipProcessor({ processorOptions: { audioOutput: "off" } });
         const producer = startedWithTone(proc, writes);
-        proc.port.onmessage({ data: { command: "setAudioOutput", audioOutput: "board" } });
+        proc.onMessage({ command: "setAudioOutput", audioOutput: "board" });
         const { output } = simulate(proc, producer, 0.5, { collectAfter: 0.1, nominalRate: true });
         expect(goertzelAmplitude(output, harmonic, OutputRate)).toBeLessThan(off / 4);
     });
@@ -207,13 +207,13 @@ describe("SoundChipProcessor rendering", () => {
     it("should only rebuild the chain for an amount that matters", () => {
         const proc = new SoundChipProcessor({ processorOptions: { audioOutput: "board" } });
         const before = proc.outputFilters;
-        proc.port.onmessage({ data: { command: "setSpeakerAmount", speakerAmount: 0.5 } });
+        proc.onMessage({ command: "setSpeakerAmount", speakerAmount: 0.5 });
         expect(proc.outputFilters).toBe(before);
-        proc.port.onmessage({ data: { command: "setAudioOutput", audioOutput: "speaker" } });
+        proc.onMessage({ command: "setAudioOutput", audioOutput: "speaker" });
         const speaker = proc.outputFilters;
-        proc.port.onmessage({ data: { command: "setSpeakerAmount", speakerAmount: 0.5 } });
+        proc.onMessage({ command: "setSpeakerAmount", speakerAmount: 0.5 });
         expect(proc.outputFilters).toBe(speaker);
-        proc.port.onmessage({ data: { command: "setSpeakerAmount", speakerAmount: 0.25 } });
+        proc.onMessage({ command: "setSpeakerAmount", speakerAmount: 0.25 });
         expect(proc.outputFilters).not.toBe(speaker);
     });
 
@@ -268,7 +268,12 @@ describe("SoundChipProcessor rendering", () => {
         expect(proc.skippedMs).toBeCloseTo(100 - proc.targetLatencyMs, 0);
     });
 
-    const mute = (proc) => proc.port.onmessage({ data: { command: "setEnabled", enabled: false } });
+    const mute = (proc) => proc.onMessage({ command: "setEnabled", enabled: false });
+
+    it("should reject a message it does not know", () => {
+        const proc = new SoundChipProcessor(BoardOutput);
+        expect(() => proc.onMessage({ upTo: 0, events: [] })).toThrow(/Unknown sound command/);
+    });
 
     it("should go silent when muted as the producer stops", () => {
         const proc = new SoundChipProcessor(BoardOutput);

--- a/tests/unit/test-soundchip.js
+++ b/tests/unit/test-soundchip.js
@@ -434,8 +434,8 @@ describe("SoundChip events", () => {
         scheduler.polltime(10);
         chip.poke(0x07);
         expect(events).toEqual([
-            { cycle: 1234, poke: 0x8d },
-            { cycle: 1244, poke: 0x07 },
+            { cycle: 1234, kind: "poke", value: 0x8d },
+            { cycle: 1244, kind: "poke", value: 0x07 },
         ]);
     });
 
@@ -447,14 +447,9 @@ describe("SoundChip events", () => {
         chip.reset(false);
         chip.reset(true);
         chip.restoreState(chip.snapshotState());
-        expect(events.map((event) => Object.keys(event).find((key) => key !== "cycle"))).toEqual([
-            "sine",
-            "sine",
-            "reset",
-            "state",
-        ]);
-        expect(events[0].sine).toBe(1200);
-        expect(events[1].sine).toBe(0);
+        expect(events.map((event) => event.kind)).toEqual(["sine", "sine", "reset", "state"]);
+        expect(events[0].value).toBe(1200);
+        expect(events[1].value).toBe(0);
         expect(chip.enabled).toBe(false);
     });
 
@@ -462,14 +457,14 @@ describe("SoundChip events", () => {
         const { chip, scheduler, events } = makeEventChip();
         scheduler.polltime(10000);
         expect(events).toEqual([
-            { cycle: 4000, progress: true },
-            { cycle: 8000, progress: true },
+            { cycle: 4000, kind: "progress", value: true },
+            { cycle: 8000, kind: "progress", value: true },
         ]);
         scheduler.restoreState({ epoch: 20000 });
         chip.restoreState(chip.snapshotState());
         events.length = 0;
         scheduler.polltime(4000);
-        expect(events).toEqual([{ cycle: 24000, progress: true }]);
+        expect(events).toEqual([{ cycle: 24000, kind: "progress", value: true }]);
     });
 
     it("should not render when it has an event sink", () => {
@@ -508,7 +503,7 @@ describe("SoundChip events", () => {
         const chip = new AtomSoundChip(() => {}, { onEvent: (event) => events.push(event) });
         chip.setScheduler(scheduler);
         chip.updateSpeaker(true, 10, 0.5);
-        expect(events).toEqual([{ cycle: 10 + 0.5 * 1000000, bit: 1 }]);
+        expect(events).toEqual([{ cycle: 10 + 0.5 * 1000000, kind: "bit", value: 1 }]);
         expect(chip.bitChange).toEqual([]);
 
         const { chip: renderer } = makeAtomSoundChip();

--- a/tests/unit/test-soundchip.js
+++ b/tests/unit/test-soundchip.js
@@ -439,7 +439,7 @@ describe("SoundChip events", () => {
         ]);
     });
 
-    it("should report tape tones, muting, resets and restores as events", () => {
+    it("should report tape tones, resets and restores as events, but not muting, which is not chip state", () => {
         const { chip, events } = makeEventChip();
         chip.toneGenerator.tone(1200);
         chip.toneGenerator.mute();
@@ -450,13 +450,12 @@ describe("SoundChip events", () => {
         expect(events.map((event) => Object.keys(event).find((key) => key !== "cycle"))).toEqual([
             "sine",
             "sine",
-            "enabled",
             "reset",
             "state",
         ]);
         expect(events[0].sine).toBe(1200);
         expect(events[1].sine).toBe(0);
-        expect(events[2].enabled).toBe(false);
+        expect(chip.enabled).toBe(false);
     });
 
     it("should report progress every few emulated milliseconds, and keep doing so after a restore", () => {


### PR DESCRIPTION
Tidies the seam between the emulator and the sound worklet that #932 left half done, in three steps.

**Mute is a command.** `AudioHandler.mute()` and `unmute()` post `setEnabled` themselves, alongside `setTargetLatency`, `setAudioOutput` and `setSpeakerAmount`, rather than the chip emitting an event that the handler intercepted on the way out. The chip's `enable()` only sets its own flag and `applyEvent` no longer knows about it.

**Every message on the port is named.** The batch of chip events was whatever message had no `command`; it is now `produced`. The worklet dispatches from a table keyed on the command and throws on one it does not know. One port for data and control, so a mute posted after the last flush lands after it.

**Events carry their kind.** They were `{cycle, <kind>: value}`, the kind being whichever key happened to be present, so every consumer probed for each possible key in turn (`event.poke !== undefined`, then `event.sine`, and so on). They are now `{cycle, kind, value}`. The chip applies them through a handler table (the Atom chip adds its `bit` and `speakerReset` handlers to it instead of overriding `applyEvent`), `isResync` is a set membership, and an unknown kind throws. No behaviour change; the tests that built events by hand now spell the kind.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
