### PR TITLE
refactor: move the load-failure and notice reporting out of main.js

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -31,6 +31,7 @@ import { toHfe } from "./disc-hfe.js";
 import { Keyboard } from "./keyboard.js";
 import { GamepadSource } from "./gamepad-source.js";
 import { toast } from "./web/toast.js";
+import { errorText, reportIgnoredFiles, reportLoadFailure, showNotice, unzipAndReport } from "./web/reporting.js";
 import { MicrophoneInput } from "./microphone-input.js";
 import { SpeechOutput } from "./speech-output.js";
 import { Printer } from "./printer.js";
@@ -437,31 +438,6 @@ function showError(context, error) {
     errorDialog.querySelector(".context").textContent = context;
     errorDialog.querySelector(".error").textContent = error;
     errorDialogModal.show();
-}
-
-const errorText = (error) => error?.message ?? `${error}`;
-
-function reportLoadFailure(description, error) {
-    console.error(`Error loading ${description}:`, error);
-    toast(`Could not load ${description}: ${errorText(error)}`, { title: "Loading" });
-}
-
-function reportIgnoredFiles(name, ignored) {
-    if (!ignored.length) return;
-    toast(`Loaded ${name}. The archive also holds ${ignored.join(", ")}, and only one file is loaded from it.`, {
-        title: "Archive",
-    });
-}
-
-async function unzipAndReport(data) {
-    const unzipped = await utils.unzipDiscImage(data);
-    reportIgnoredFiles(unzipped.name, unzipped.ignored);
-    return unzipped;
-}
-
-function showNotice(event) {
-    const { message, title, quietKey } = event.detail;
-    toast(message, { title, quietKey });
 }
 
 if (keyMappingWarnings.length) {

--- a/src/web/reporting.js
+++ b/src/web/reporting.js
@@ -1,0 +1,28 @@
+import * as utils from "../utils.js";
+import { toast } from "./toast.js";
+
+export const errorText = (error) => error?.message ?? `${error}`;
+
+export function reportLoadFailure(description, error) {
+    console.error(`Error loading ${description}:`, error);
+    toast(`Could not load ${description}: ${errorText(error)}`, { title: "Loading" });
+}
+
+export function reportIgnoredFiles(name, ignored) {
+    if (!ignored.length) return;
+    toast(`Loaded ${name}. The archive also holds ${ignored.join(", ")}, and only one file is loaded from it.`, {
+        title: "Archive",
+    });
+}
+
+export async function unzipAndReport(data) {
+    const unzipped = await utils.unzipDiscImage(data);
+    reportIgnoredFiles(unzipped.name, unzipped.ignored);
+    return unzipped;
+}
+
+/** Handles a component's "notice" event by toasting it. */
+export function showNotice(event) {
+    const { message, title, quietKey } = event.detail;
+    toast(message, { title, quietKey });
+}

--- a/tests/unit/test-reporting.js
+++ b/tests/unit/test-reporting.js
@@ -1,0 +1,95 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import * as fs from "fs";
+import { dirname, join } from "path";
+import { fileURLToPath } from "url";
+
+import {
+    errorText,
+    reportIgnoredFiles,
+    reportLoadFailure,
+    showNotice,
+    unzipAndReport,
+} from "../../src/web/reporting.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const readZip = (name) => new Uint8Array(fs.readFileSync(join(__dirname, "zip", name)));
+
+describe("reporting", () => {
+    beforeEach(() => {
+        vi.useFakeTimers();
+        vi.spyOn(console, "error").mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+        vi.runAllTimers();
+        vi.useRealTimers();
+        vi.restoreAllMocks();
+        document.body.innerHTML = "";
+        window.localStorage.clear();
+    });
+
+    const toasts = () =>
+        [...document.querySelectorAll(".toast")].map((el) => el.textContent.replace(/\s+/g, " ").trim());
+
+    describe("errorText", () => {
+        it("uses an error's message", () => {
+            expect(errorText(new Error("Bad disc"))).toBe("Bad disc");
+        });
+
+        it("stringifies anything else that was thrown", () => {
+            expect(errorText("plain string")).toBe("plain string");
+            expect(errorText(42)).toBe("42");
+            expect(errorText(undefined)).toBe("undefined");
+        });
+    });
+
+    describe("reportLoadFailure", () => {
+        it("toasts what could not be loaded and why", () => {
+            reportLoadFailure("disc elite.ssd", new Error("404"));
+            expect(toasts()).toEqual([expect.stringContaining("Could not load disc elite.ssd: 404")]);
+        });
+
+        it("keeps the full error on the console", () => {
+            const error = new Error("404");
+            reportLoadFailure("disc elite.ssd", error);
+            expect(console.error).toHaveBeenCalledWith("Error loading disc elite.ssd:", error);
+        });
+    });
+
+    describe("reportIgnoredFiles", () => {
+        it("says nothing when the archive held only the one file", () => {
+            reportIgnoredFiles("game.ssd", []);
+            expect(toasts()).toEqual([]);
+        });
+
+        it("names the files that were passed over", () => {
+            reportIgnoredFiles("side1.ssd", ["side2.ssd", "notes.txt"]);
+            expect(toasts()).toEqual([
+                expect.stringContaining("Loaded side1.ssd. The archive also holds side2.ssd, notes.txt"),
+            ]);
+        });
+    });
+
+    describe("unzipAndReport", () => {
+        it("returns the unzipped image and reports the members it passed over", async () => {
+            const unzipped = await unzipAndReport(readZip("test-two-sides.zip"));
+            expect(unzipped.name).toBe("side1.ssd");
+            expect(unzipped.ignored).toEqual(["side2.ssd"]);
+            expect(toasts()).toEqual([expect.stringContaining("side2.ssd")]);
+        });
+
+        it("is quiet about an archive with nothing else loadable in it", async () => {
+            const unzipped = await unzipAndReport(readZip("test-mixed.zip"));
+            expect(unzipped.name).toBe("test.ssd");
+            expect(toasts()).toEqual([]);
+        });
+    });
+
+    describe("showNotice", () => {
+        it("toasts a component's notice event", () => {
+            showNotice(new CustomEvent("notice", { detail: { message: "Tape motor on", title: "Tape" } }));
+            expect(toasts()).toEqual([expect.stringContaining("Tape motor on")]);
+        });
+    });
+});


### PR DESCRIPTION
First extraction for #638.

**Moved verbatim** to `src/web/reporting.js`: `errorText`, `reportLoadFailure`, `reportIgnoredFiles`, `unzipAndReport`, `showNotice`.

**Changed**: nothing but the import in `main.js`.

**Tests**: `tests/unit/test-reporting.js`, against the toasts the functions raise and the zip fixtures.

**Checked**: unit suite; the browser smoke test from #935, all checks green. Independent of the other Phase 1 PRs; where they touch the same import block in `main.js` I will merge `main` in as each lands.
