### PR TITLE
feat: let a MachineSession snapshot and restore itself

### DIFF
--- a/src/machine-session.js
+++ b/src/machine-session.js
@@ -41,9 +41,9 @@ export class MachineSession {
         this.modelName = modelName;
         this._opts = opts;
 
-        // Raw RGBA framebuffer — the Video chip renders into _fb32 (cleared each frame).
+        // Raw RGBA framebuffer. The Video chip renders into _fb32 (cleared each frame).
         // _completeFb8 is a snapshot taken at paint time (the equivalent of the browser canvas)
-        // and is what screenshot() reads from — always a complete frame, never mid-render.
+        // and is what screenshot() reads from, always a complete frame, never mid-render.
         this._fb8 = new Uint8Array(FB_WIDTH * FB_HEIGHT * 4);
         this._fb32 = new Uint32Array(this._fb8.buffer);
         this._completeFb8 = new Uint8Array(FB_WIDTH * FB_HEIGHT * 4);
@@ -84,16 +84,16 @@ export class MachineSession {
             hasTeletextAdaptor: opts.hasTeletextAdaptor,
         });
 
-        // Accumulated VDU text output — drained by callers
+        // Accumulated VDU text output, drained by callers
         this._pendingOutput = [];
         this._flushCapture = () => {};
 
-        // Breakpoint management — persistent hooks that survive across run calls
+        // Breakpoint management, with persistent hooks that survive across run calls
         this._breakpoints = new Map(); // id → { hook, type, address, hit }
         this._nextBreakpointId = 1;
     }
 
-    /** Load ROMs and hardware — call once before anything else */
+    /** Load ROMs and hardware; call once before anything else */
     async initialise() {
         setNodeBasePath(_jsbeebRoot);
         await this._machine.initialise();
@@ -117,12 +117,12 @@ export class MachineSession {
      *
      * WRCHV discovery: RAM at the OS write-character vector (0x20E on BBC,
      * 0x208 on Atom) initialises to 0x0000 before the OS runs.  We read
-     * directly from cpu.ramRomOs (two array lookups — no
-     * readmem() dispatch overhead) on every instruction, waiting for the
-     * value to change from its initial 0xFFFF.  Once the OS installs a real
-     * handler we use that address for the lifetime of the session.  Programs
-     * that later install a custom VDU driver are handled seamlessly because
-     * we always re-read from the live memory.
+     * directly from cpu.ramRomOs (two array lookups, no readmem() dispatch
+     * overhead) on every instruction, waiting for the value to change from
+     * its initial 0xFFFF.  Once the OS installs a real handler we use that
+     * address for the lifetime of the session.  Programs that later install
+     * a custom VDU driver are handled seamlessly because we always re-read
+     * from the live memory.
      *
      * Text elements: { x, y, text, foreground, background, mode }
      * Screenshots (via the real Video chip) are the right tool for anything
@@ -130,7 +130,7 @@ export class MachineSession {
      */
     _installCaptureHook() {
         const cpu = this._machine.processor;
-        const ram = cpu.ramRomOs; // direct Uint8Array — no dispatch overhead
+        const ram = cpu.ramRomOs; // direct Uint8Array, no dispatch overhead
         // WRCHV vector: BBC at $020E, Atom at $0208.
         const wrchvAddr = this._isAtom ? 0x208 : 0x20e;
         const initialWrchv = ram[wrchvAddr] | (ram[wrchvAddr + 1] << 8); // 0xFFFF pre-boot
@@ -264,7 +264,7 @@ export class MachineSession {
         }
 
         cpu.debugInstruction.add((addr) => {
-            // Two direct array reads — no function-call dispatch overhead.
+            // Two direct array reads, no function-call dispatch overhead.
             // Once the OS sets WRCHV (it changes from 0xFFFF), we start
             // capturing.  Programs that install a custom VDU driver mid-run
             // are handled transparently because we re-read on every call.
@@ -525,7 +525,7 @@ export class MachineSession {
      *
      * @param {Object} [opts]
      * @param {boolean} [opts.clear=true] - If true (default), clear the buffer
-     *   after returning it.  Pass false to peek without consuming — the same
+     *   after returning it.  Pass false to peek without consuming; the same
      *   elements will be returned again on the next call.
      *
      * Each element: { x, y, text, foreground, background, mode }
@@ -576,14 +576,14 @@ export class MachineSession {
     /**
      * Capture the current screen as a PNG.
      * Returns a Buffer containing a 1024×625 PNG (the full emulated display,
-     * including borders — matches what the browser renders).
+     * including borders, matching what the browser renders).
      *
      * The active display area is roughly:
      *   x: leftBorder .. 1024-rightBorder
      *   y: topBorder  .. 625-bottomBorder
      */
     async screenshot() {
-        // Read from _completeFb8 — the last fully-painted frame snapshotted in paint_ext.
+        // Read from _completeFb8, the last fully-painted frame snapshotted in paint_ext.
         // _fb8/_fb32 is the live render buffer (cleared and partially refilled each frame).
         return sharp(Buffer.from(this._completeFb8.buffer), {
             raw: { width: FB_WIDTH, height: FB_HEIGHT, channels: 4 },

--- a/src/machine-session.js
+++ b/src/machine-session.js
@@ -156,6 +156,26 @@ export class MachineSession {
         // that hasn't been terminated by a control character.
         this._flushCapture = flush;
 
+        // Expose the decoder's cursor so snapshot()/restore() can rewind it along
+        // with the machine; without it, text captured after a restore carries the
+        // coordinates and colours the abandoned run had reached.
+        this._snapshotCapture = () => ({
+            attributes: { ...attributes },
+            currentText,
+            params: [...params],
+            nextN,
+        });
+        this._restoreCapture = (state) => {
+            Object.assign(attributes, state.attributes);
+            currentText = state.currentText;
+            params = [...state.params];
+            nextN = state.nextN;
+            // vduProc is a closure and does not survive into the snapshot, so one
+            // taken between a VDU command and its last parameter resumes with
+            // nextN still swallowing them: the sequence is dropped, not printed.
+            vduProc = null;
+        };
+
         const isAtom = this._isAtom;
 
         function onChar(c) {
@@ -278,6 +298,43 @@ export class MachineSession {
     reset(hard = true) {
         this._machine.processor.reset(hard);
         this._pendingOutput = [];
+    }
+
+    /**
+     * Capture the whole session — machine state and captured text alike — as an
+     * opaque object for restore().  Booting is the expensive part of a session,
+     * so snapshotting a booted machine and restoring it between runs is much
+     * cheaper than building a new session for each one.
+     *
+     * Taking a snapshot does not disturb the running machine.
+     *
+     * @param {Object} [opts]
+     * @param {boolean} [opts.includeRoms=true] - carry the ROM contents too.
+     *   Only safe to omit when restoring into a session built from the same
+     *   model, which is then left with whatever ROMs it already had.
+     */
+    snapshot({ includeRoms = true } = {}) {
+        return {
+            machine: this._machine.snapshot({ includeRoms }),
+            pendingOutput: this._pendingOutput.map((element) => ({ ...element })),
+            capture: this._snapshotCapture(),
+        };
+    }
+
+    /**
+     * Put back a state from snapshot().  The machine, and the text captured but
+     * not yet drained, return to exactly what they were; `elapsedCycles` rewinds
+     * with the machine.
+     *
+     * Breakpoints are the session's rather than the machine's and are left
+     * alone, hit flags included.  `frameCount` also keeps counting, so that it
+     * stays a monotonic record of what the session has painted — the same way it
+     * survives a hard reset.
+     */
+    restore(state) {
+        this._machine.restore(state.machine);
+        this._pendingOutput = state.pendingOutput.map((element) => ({ ...element }));
+        this._restoreCapture(state.capture);
     }
 
     /** Tokenise BBC BASIC source and write it into PAGE */

--- a/src/machine-session.js
+++ b/src/machine-session.js
@@ -156,9 +156,9 @@ export class MachineSession {
         // that hasn't been terminated by a control character.
         this._flushCapture = flush;
 
-        // Expose the decoder's cursor so snapshot()/restore() can rewind it along
-        // with the machine; without it, text captured after a restore carries the
-        // coordinates and colours the abandoned run had reached.
+        // Expose the decoder's cursor so snapshot()/restore() can rewind it too:
+        // text captured after a restore would otherwise carry the coordinates
+        // and colours the abandoned run had reached.
         this._snapshotCapture = () => ({
             attributes: { ...attributes },
             currentText,
@@ -170,9 +170,9 @@ export class MachineSession {
             currentText = state.currentText;
             params = [...state.params];
             nextN = state.nextN;
-            // vduProc is a closure and does not survive into the snapshot, so one
-            // taken between a VDU command and its last parameter resumes with
-            // nextN still swallowing them: the sequence is dropped, not printed.
+            // vduProc is a closure and does not survive, so a snapshot taken
+            // mid-sequence resumes with nextN still swallowing the parameters:
+            // the sequence is dropped rather than printed as text.
             vduProc = null;
         };
 
@@ -301,12 +301,8 @@ export class MachineSession {
     }
 
     /**
-     * Capture the whole session — machine state and captured text alike — as an
-     * opaque object for restore().  Booting is the expensive part of a session,
-     * so snapshotting a booted machine and restoring it between runs is much
-     * cheaper than building a new session for each one.
-     *
-     * Taking a snapshot does not disturb the running machine.
+     * Capture machine state and captured text as an opaque object for restore().
+     * Leaves the running session undisturbed.
      *
      * @param {Object} [opts]
      * @param {boolean} [opts.includeRoms=true] - carry the ROM contents too.
@@ -322,14 +318,10 @@ export class MachineSession {
     }
 
     /**
-     * Put back a state from snapshot().  The machine, and the text captured but
-     * not yet drained, return to exactly what they were; `elapsedCycles` rewinds
-     * with the machine.
-     *
-     * Breakpoints are the session's rather than the machine's and are left
-     * alone, hit flags included.  `frameCount` also keeps counting, so that it
-     * stays a monotonic record of what the session has painted — the same way it
-     * survives a hard reset.
+     * Put back a state from snapshot().  `elapsedCycles` rewinds with the
+     * machine; breakpoints belong to the session, not the machine, so they and
+     * their hit flags are left alone, and `frameCount` keeps counting the way it
+     * does across a hard reset.
      */
     restore(state) {
         this._machine.restore(state.machine);

--- a/tests/integration/machine-session.js
+++ b/tests/integration/machine-session.js
@@ -132,3 +132,108 @@ describe("MachineSession frame stepping with interlace off", () => {
         expectCyclesNear(await cyclesOverFrames(session, 5), 5 * CyclesPerNonInterlacedFrame);
     });
 });
+
+describe("MachineSession snapshots", () => {
+    let session;
+
+    beforeAll(async () => {
+        session = await bootedSession();
+        await session.runUntilPrompt(30);
+    }, BootTimeout);
+
+    afterAll(() => session.destroy());
+
+    async function runAndDrain(command) {
+        await session.type(`${command}\r`);
+        return (await session.runUntilPrompt(30)).screenText;
+    }
+
+    it("rewinds memory the machine has written since", async () => {
+        await runAndDrain("A%=42");
+        const state = session.snapshot();
+        await runAndDrain("A%=99");
+
+        expect(await runAndDrain("PRINT A%")).toContain("99");
+        session.restore(state);
+
+        expect(await runAndDrain("PRINT A%")).toContain("42");
+    });
+
+    it("rewinds the cycle count", async () => {
+        const state = session.snapshot();
+        const cyclesAtSnapshot = session.elapsedCycles;
+        await session.runFrames(5);
+        expect(session.elapsedCycles).toBeGreaterThan(cyclesAtSnapshot);
+
+        session.restore(state);
+
+        expect(session.elapsedCycles).toBe(cyclesAtSnapshot);
+    });
+
+    it("keeps counting frames, as a hard reset does", async () => {
+        const state = session.snapshot();
+        await session.runFrames(3);
+        const framesBefore = session.frameCount;
+
+        session.restore(state);
+        await session.runFrames(2);
+
+        expect(session.frameCount).toBe(framesBefore + 2);
+    });
+
+    it("puts back text captured but not yet drained", async () => {
+        await session.type("PRINT 6*7\r");
+        await session.runUntilPrompt(30, { clear: false });
+        const state = session.snapshot();
+
+        expect(session.drainOutput().screenText).toContain("42");
+        expect(session.drainOutput().screenText).not.toContain("42");
+
+        session.restore(state);
+
+        expect(session.drainOutput().screenText).toContain("42");
+    });
+
+    it("rewinds the text cursor along with the machine", async () => {
+        await runAndDrain("CLS");
+        const state = session.snapshot();
+        const rowOfHere = (out) => out.elements.find((element) => element.text.includes("HERE")).y;
+
+        await session.type('PRINT "HERE"\r');
+        const withoutDetour = rowOfHere(await session.runUntilPrompt(30));
+
+        session.restore(state);
+        await runAndDrain("FOR I%=1 TO 5:PRINT:NEXT");
+        session.restore(state);
+        await session.type('PRINT "HERE"\r');
+
+        expect(rowOfHere(await session.runUntilPrompt(30))).toBe(withoutDetour);
+    });
+
+    it("goes on painting after a restore", async () => {
+        const state = session.snapshot();
+        await runAndDrain("MODE 1");
+
+        session.restore(state);
+        await session.runFrames(2);
+
+        expect(await session.screenshot()).toBeInstanceOf(Buffer);
+    });
+
+    it(
+        "restores into a different session of the same model",
+        async () => {
+            await runAndDrain("A%=1234");
+            const state = session.snapshot();
+
+            const other = new MachineSession("B-DFS1.2");
+            await other.initialise();
+            other.restore(state);
+            await other.type("PRINT A%\r");
+
+            expect((await other.runUntilPrompt(30)).screenText).toContain("1234");
+            other.destroy();
+        },
+        BootTimeout,
+    );
+});


### PR DESCRIPTION
`TestMachine` has had whole-machine `snapshot()`/`restore()` all along (CPU, RAM, SWRAM, scheduler, VIAs, video, sound chip, FDC, tube), but `MachineSession` never exposed it. The only way back to a known state was to build a fresh session and boot it again — and booting is the expensive part, so a caller wanting to try several things from one starting point paid for it every time.

This came up from the jsbeeb-mcp side, where an agent naturally wants to boot once, checkpoint, then branch and roll back between experiments.

## Snapshotting the machine alone isn't enough

Two pieces of a session's state live outside the machine:

- **The VDU capture decoder's cursor.** `_installCaptureHook` keeps `attributes` (x, y, colours, mode), the part-built `currentText`, and any in-flight VDU parameters in a closure. Left behind, text captured after a restore carries the coordinates the *abandoned* run had reached.
- **`_pendingOutput`** — text captured but not yet drained. Left behind, a `drainOutput()` after a restore returns the discarded run's output.

Both now rewind with the machine, so a restored session looks exactly as it did. The cursor one is not hypothetical: with the rewind removed, the new cursor test reports row 11 where it should be row 1.

## Deliberate non-goals

- **`frameCount` keeps counting.** It stays a monotonic record of what the session has painted, the same way it already survives a hard reset. `elapsedCycles` *does* rewind, since the scheduler is part of the machine snapshot.
- **Breakpoints are left alone**, hit flags included — they're the session's, not the machine's, and `restoreState` doesn't touch the CPU's debug hooks (they're installed once in the constructor), so they and the capture hook survive a restore intact.
- **`vduProc` doesn't survive**, being a closure. A snapshot taken between a VDU command and its last parameter resumes with `nextN` still swallowing them, so the sequence is dropped rather than printed as text — the narrow, and quieter, of the two failure modes. Documented at the site.

## Tests

Six cases added to `tests/integration/machine-session.js`, covering memory rollback, cycle rewind, frame counting, undrained text, painting after a restore, the cursor rewind, and restoring into a *different* session of the same model.

`Tests 16 passed (16)` for that file; unit suite `1260 passed (1260)`.

The integration suite shows one timeout in `tests/integration/nops.js` on my machine, but that's pre-existing load flakiness rather than anything here — clean `main` fails *worse* (3 failures vs 1) on the same box, and `nops.js` passes alone in 11s against its 30s timeout. It drives `TestMachine` directly and never touches `MachineSession`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LdkPStGXorSvHPgk3b78bf