### PR TITLE
fix: write the sound output, speaker amount and display mode into the URL wherever they are picked

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -323,11 +323,17 @@ const speakerAmount =
 config.setAudioOutput(audioOutput);
 config.setSpeakerAmount(speakerAmount);
 
+// A slider fires for every pixel of a drag, and each URL update is a history entry.
+const UrlSettleMs = 300;
+const updateUrlOnceSettled = utils.debounce(updateUrl, UrlSettleMs);
+
 function applyAudioOutput(output) {
     audioHandler.setAudioOutput(output);
     config.setAudioOutput(output);
     quickSettings?.showAudioOutput(output);
     window.localStorage.audioOutput = output;
+    parsedQuery.audioOutput = output;
+    updateUrl();
 }
 
 function applySpeakerAmount(amount) {
@@ -335,6 +341,8 @@ function applySpeakerAmount(amount) {
     config.setSpeakerAmount(amount);
     quickSettings?.showSpeakerAmount(amount);
     window.localStorage.speakerAmount = amount;
+    parsedQuery.speakerAmount = amount;
+    updateUrlOnceSettled();
 }
 
 function applyDisplayMode(mode) {
@@ -347,6 +355,8 @@ function applyDisplayMode(mode) {
     config.setDisplayMode(mode);
     quickSettings?.showDisplayMode(mode);
     window.localStorage.displayMode = mode;
+    parsedQuery.displayMode = mode;
+    updateUrl();
 }
 
 model = config.model;


### PR DESCRIPTION
Fixes #942.

The three `apply*` functions in `main.js` are the one place a sound output, speaker amount or display mode is applied, whether it came from the top bar or the Settings dialog. They now write the setting into the URL parameters and update the URL, so both routes agree. Before this, the bar never touched the URL, and the dialog's speaker amount slider did not record its change either, so `speakerAmount` never reached the URL by any route.

The slider fires on every pixel of a drag and every URL update is a history entry, so its updates are debounced (300 ms after the last movement); the two button groups update at once.

**Checked** in headless Chrome with a script that picks each setting on the bar, then in the dialog, and reads `location.href` after each: the URL carries `audioOutput`, `speakerAmount` and `displayMode` from both routes. The smoke test from #935 passes on this branch; once both have landed its bar check should assert the URL as well, which I will add.
