### PR TITLE
ci: run the browser smoke test as test:smoke, in npm test and in CI

### DIFF
--- a/.github/workflows/test-and-deploy.yml
+++ b/.github/workflows/test-and-deploy.yml
@@ -18,8 +18,9 @@ jobs:
         run: npm install
       - name: checks
         run: npm run ci-checks
-      # Vitest's job summary has a fixed "Vitest Test Report" heading, so each
-      # run gets a heading of its own first to tell the three apart.
+      # Vitest 4's job summary has a fixed "Vitest Test Report" heading, so each
+      # run gets a heading of its own first to tell the three apart. Vitest 5
+      # names them itself; the echoes go when we move to it (#947).
       - name: Unit tests
         run: |
           echo "# Unit tests" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/test-and-deploy.yml
+++ b/.github/workflows/test-and-deploy.yml
@@ -24,6 +24,8 @@ jobs:
         run: npm run test:integration
       - name: Shader tests
         run: npm run test:shader
+      - name: Smoke test
+        run: npm run test:smoke
 
   cpu-test:
     runs-on: ubuntu-24.04

--- a/.github/workflows/test-and-deploy.yml
+++ b/.github/workflows/test-and-deploy.yml
@@ -18,14 +18,24 @@ jobs:
         run: npm install
       - name: checks
         run: npm run ci-checks
+      # Vitest's job summary has a fixed "Vitest Test Report" heading, so each
+      # run gets a heading of its own first to tell the three apart.
       - name: Unit tests
-        run: npm run test:unit
+        run: |
+          echo "# Unit tests" >> "$GITHUB_STEP_SUMMARY"
+          npm run test:unit
       - name: Integration tests
-        run: npm run test:integration
+        run: |
+          echo "# Integration tests" >> "$GITHUB_STEP_SUMMARY"
+          npm run test:integration
       - name: Shader tests
-        run: npm run test:shader
+        run: |
+          echo "# Shader tests" >> "$GITHUB_STEP_SUMMARY"
+          npm run test:shader
       - name: Smoke test
-        run: npm run test:smoke
+        run: |
+          echo "# Smoke test" >> "$GITHUB_STEP_SUMMARY"
+          npm run test:smoke | tee >(sed 's/^/- /' >> "$GITHUB_STEP_SUMMARY")
 
   cpu-test:
     runs-on: ubuntu-24.04

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,9 +14,9 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 - `npm run test:unit` - Run unit tests
 - `npm run test:integration` - Run integration tests
 - `npm run test:cpu` - Run CPU compatibility tests
-- `npm run smoke` - Build, then boot the built page in headless Chrome and check the things unit tests cannot see
-  (construction order, element ids, Bootstrap, the console surface). Run it before opening any PR that touches
-  `main.js`; `node tests/browser/smoke.js --url http://localhost:5173/` runs it against a server that is already up
+- `npm run test:smoke` - Build, then boot the built page in headless Chrome and check the things unit tests cannot
+  see (construction order, element ids, Bootstrap, the console surface). Part of `npm test`, and needs Chrome like the
+  shader tests; `node tests/browser/smoke.js --url http://localhost:5173/` runs it against a server that is already up
 - `npm run ci-checks` - Run linting checks for CI
 - `vitest run tests/unit/test-gzip.js` - Run a single test file
 

--- a/package.json
+++ b/package.json
@@ -115,7 +115,7 @@
     "mirror-bbcdiscs:upload:index": "aws s3 cp .bbcdiscs-mirror/hfe/manifest.json s3://bbc.xania.org/archive/bbcdiscs/hfe/manifest.json --cache-control 'public, max-age=300' && aws s3 cp .bbcdiscs-mirror/manifest.json s3://bbc.xania.org/archive/bbcdiscs/manifest.json --cache-control 'public, max-age=300'",
     "electron": "npm run build && ELECTRON_DISABLE_SANDBOX=1 electron .",
     "electron:build": "electron-builder",
-    "smoke": "npm run build && node tests/browser/smoke.js"
+    "test:smoke": "npm run build && node tests/browser/smoke.js"
   },
   "lint-staged": {
     "*.js": [

--- a/tests/browser/smoke.js
+++ b/tests/browser/smoke.js
@@ -12,6 +12,7 @@ import os from "node:os";
 import path from "node:path";
 
 const Args = parseArgs(process.argv.slice(2));
+const PreviewHost = "127.0.0.1";
 const PreviewPort = 5199;
 const DebugPort = 9229 + Math.floor(Math.random() * 1000);
 const ChromeCandidates = [
@@ -25,6 +26,7 @@ const ScreenBase = 0x7c00;
 const ScreenBytes = 1000;
 const BootTimeoutMs = 30000;
 const StepTimeoutMs = 10000;
+const ServerTimeoutMs = 30000;
 const KeyHoldMs = 120;
 const ConsoleSurface = [
     "processor",
@@ -71,10 +73,13 @@ async function waitUntil(description, probe, timeoutMs) {
 async function startPreview() {
     // vite's own entry point, not npx: a kill has to reach the server itself.
     const vite = path.join(process.cwd(), "node_modules", "vite", "bin", "vite.js");
-    const child = spawn(process.execPath, [vite, "preview", "--port", `${PreviewPort}`, "--strictPort"], {
-        stdio: "ignore",
-    });
-    const url = `http://127.0.0.1:${PreviewPort}/`;
+    // Bound by address, not "localhost": on a runner that resolves to ::1 first.
+    const child = spawn(
+        process.execPath,
+        [vite, "preview", "--host", PreviewHost, "--port", `${PreviewPort}`, "--strictPort"],
+        { stdio: "ignore" },
+    );
+    const url = `http://${PreviewHost}:${PreviewPort}/`;
     await waitUntil(
         "the preview server",
         () =>
@@ -82,7 +87,7 @@ async function startPreview() {
                 (response) => response.ok,
                 () => false,
             ),
-        StepTimeoutMs,
+        ServerTimeoutMs,
     );
     return { url, stop: () => child.kill() };
 }

--- a/tests/browser/smoke.js
+++ b/tests/browser/smoke.js
@@ -2,7 +2,7 @@
 // cannot see: construction order, element ids, Bootstrap, the console surface.
 // Talks to Chrome over the DevTools protocol with Node's own WebSocket.
 //
-//   npm run smoke            build, serve dist/ and run every check
+//   npm run test:smoke       build, serve dist/ and run every check
 //   node tests/browser/smoke.js --url http://localhost:5173/   against a running server
 //   node tests/browser/smoke.js --only modal                    checks whose name matches
 
@@ -14,7 +14,13 @@ import path from "node:path";
 const Args = parseArgs(process.argv.slice(2));
 const PreviewPort = 5199;
 const DebugPort = 9229 + Math.floor(Math.random() * 1000);
-const ChromeCandidates = [process.env.CHROME, "google-chrome", "google-chrome-stable", "chromium", "chromium-browser"];
+const ChromeCandidates = [
+    process.env.CHROME_PATH,
+    "google-chrome",
+    "google-chrome-stable",
+    "chromium",
+    "chromium-browser",
+];
 const ScreenBase = 0x7c00;
 const ScreenBytes = 1000;
 const BootTimeoutMs = 30000;


### PR DESCRIPTION
Follow-up to #935 now it has been through the Phase 1 PRs.

- `npm run smoke` becomes `npm run test:smoke`, so `npm test`'s `test:*` glob includes it, the same footing as `test:shader`, which already needs Chrome. The pre-commit hook runs only related unit tests, so it does not pick this up, as it does not pick up the integration tests.
- The browser override is `CHROME_PATH`, the name `tests/shader/render.js` already uses.
- The build-and-test job runs it after the shader tests; Chrome is already a requirement of that job.

`CLAUDE.md` updated. Ran locally after the rename: all checks green.
