### PR TITLE
fix: say there is nothing to download instead of throwing when drive 0 is empty

### DIFF
--- a/src/web/drives.js
+++ b/src/web/drives.js
@@ -34,7 +34,8 @@ export class Drives {
         }
 
         document.getElementById("download-drive-link").addEventListener("click", () => {
-            const disc = fdc.drives[0].disc;
+            const disc = this.discToDownload();
+            if (!disc) return;
             const save = (options) =>
                 downloadDriveData(toSsdOrDsd(disc, options), disc.name, disc.isDoubleSided ? ".dsd" : ".ssd");
             try {
@@ -47,9 +48,17 @@ export class Drives {
         });
 
         document.getElementById("download-drive-hfe-link").addEventListener("click", () => {
-            const disc = fdc.drives[0].disc;
+            const disc = this.discToDownload();
+            if (!disc) return;
             downloadDriveData(toHfe(disc), disc.name, ".hfe");
         });
+    }
+
+    /** @returns {object|null} the disc in drive 0, saying so when there is nothing to download */
+    discToDownload() {
+        const disc = this.fdc?.drives[0].disc;
+        if (!disc) toast("There is no disc in drive 0 to download.", { title: "Disc" });
+        return disc ?? null;
     }
 
     /** @returns {string} the DiscLayout to load an image for this drive with */

--- a/src/web/drives.js
+++ b/src/web/drives.js
@@ -54,7 +54,7 @@ export class Drives {
         });
     }
 
-    /** @returns {object|null} the disc in drive 0, saying so when there is nothing to download */
+    /** @returns {import("../disc.js").Disc|null} the disc in drive 0, saying so when there is nothing to download */
     discToDownload() {
         const disc = this.fdc?.drives[0].disc;
         if (!disc) toast("There is no disc in drive 0 to download.", { title: "Disc" });

--- a/tests/unit/test-drives.js
+++ b/tests/unit/test-drives.js
@@ -136,6 +136,29 @@ describe("Drives", () => {
         });
     });
 
+    describe("the drive 0 downloads", () => {
+        const download = (id) => document.getElementById(id).click();
+
+        it("say so instead of saving when drive 0 is empty", () => {
+            make();
+            download("download-drive-link");
+            download("download-drive-hfe-link");
+            expect(toasts()).toEqual([
+                expect.stringContaining("no disc in drive 0"),
+                expect.stringContaining("no disc in drive 0"),
+            ]);
+            expect(areYouSure).not.toHaveBeenCalled();
+        });
+
+        it("say so instead of throwing on a machine with no drives", () => {
+            fdc = undefined;
+            make();
+            expect(() => download("download-drive-link")).not.toThrow();
+            expect(() => download("download-drive-hfe-link")).not.toThrow();
+            expect(toasts()).toHaveLength(2);
+        });
+    });
+
     describe("the switches on the menu", () => {
         it("set the drive and show what was picked", () => {
             make();

--- a/tests/unit/test-drives.js
+++ b/tests/unit/test-drives.js
@@ -155,7 +155,10 @@ describe("Drives", () => {
             make();
             expect(() => download("download-drive-link")).not.toThrow();
             expect(() => download("download-drive-hfe-link")).not.toThrow();
-            expect(toasts()).toHaveLength(2);
+            expect(toasts()).toEqual([
+                expect.stringContaining("no disc in drive 0"),
+                expect.stringContaining("no disc in drive 0"),
+            ]);
         });
     });
 


### PR DESCRIPTION
Fixes #945.

Both download handlers go through one `discToDownload()`: it returns the disc in drive 0, or toasts "There is no disc in drive 0 to download." and returns nothing, covering the Atom (no FDC at all) and a BBC whose drive 0 is empty. The menu stays as it is: hiding it for one machine seemed a bigger change than the bug deserved, and the empty-drive case needs the notice anyway.

Tests cover both empty cases for both links; the with-disc path is unchanged and exercised as before.
