### PR TITLE
refactor: move the Stairway to Hell picker out of main.js

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -11,7 +11,6 @@ import { Cpu6502, AtomCpu6502 } from "./6502.js";
 import * as utils_atom from "./utils_atom.js";
 import { LoadSD } from "./mmc.js";
 import { Cmos, localStoragePersistence } from "./cmos.js";
-import { StairwayToHell } from "./sth.js";
 import { BbcDiscArchive, Provenance, describe as describeHfe, matches, provenancesIn } from "./bbcdiscs.js";
 import { GamePad } from "./gamepads.js";
 import * as disc from "./fdc.js";
@@ -30,6 +29,8 @@ import { Keyboard } from "./keyboard.js";
 import { GamepadSource } from "./gamepad-source.js";
 import { toast } from "./web/toast.js";
 import { BuiltInImages, MediaLoader } from "./web/media-loader.js";
+import { AutobootTicks, clearArchiveList, showArchiveMessage } from "./web/archive-list.js";
+import { SthPicker } from "./web/sth-picker.js";
 import { Drives } from "./web/drives.js";
 import { UrlState } from "./web/url-state.js";
 import { Modals } from "./web/modals.js";
@@ -69,8 +70,6 @@ const dbgr = new Debugger();
 let frames = 0;
 let frameSkip = 0;
 let syncLights;
-let discSth;
-let tapeSth;
 let hfeArchive;
 let running;
 let model;
@@ -676,12 +675,14 @@ const media = new MediaLoader({
     loadSnapshot: (file, buffer) => loadStateFromFile(file, buffer),
     // The archives are created further down; each source resolves when used.
     sources: {
-        sth: (name) => discSth.fetch(name),
-        tapeSth: (name) => tapeSth.fetch(name),
+        sth: (name) => sthPicker.discs.fetch(name),
+        tapeSth: (name) => sthPicker.tapes.fetch(name),
         hfe: (path) => hfeArchive.fetch(path),
         drive: (cat, layout) => gdLoad(cat, layout),
     },
 });
+const autobootTicks = new AutobootTicks({ urlState });
+const sthPicker = new SthPicker({ media, drives, modals, urlState, processor, autoboot });
 
 processor.teletextAdaptor?.addEventListener("notice", showNotice);
 processor.acia.addEventListener("notice", showNotice);
@@ -908,148 +909,7 @@ document.addEventListener("keydown", (evt) => {
 document.addEventListener("keypress", (evt) => keyboard.keyPress(evt));
 document.addEventListener("keyup", (evt) => keyboard.keyUp(evt));
 
-function clearArchiveList(listId) {
-    for (const el of document.querySelectorAll(`#${listId} li:not(.template)`)) el.remove();
-}
-
-function showArchiveMessage(modalId, listId, message) {
-    const loading = document.querySelector(`#${modalId} .loading`);
-    loading.textContent = message;
-    loading.style.display = "";
-    clearArchiveList(listId);
-}
-
-function filterArchiveList(listId, filter) {
-    filter = filter.toLowerCase();
-    for (const el of document.querySelectorAll(`#${listId} li:not(.template)`)) {
-        el.style.display = el.textContent.toLowerCase().includes(filter) ? "" : "none";
-    }
-}
-
-function sthStartLoad() {
-    showArchiveMessage("sth", "sth-list", "Loading catalog from STH archive");
-}
-
-async function discSthClick(item) {
-    utils.noteEvent("sth", "click", item);
-    media.setDisc1Image("sth:" + item);
-    const needsAutoboot = parsedQuery.autoboot !== undefined;
-    if (needsAutoboot) {
-        processor.reset(true);
-    }
-
-    modals.popupLoading("Loading " + item);
-    try {
-        const loaded = await media.loadDiscImage(parsedQuery.disc1, drives.layoutForDrive(0));
-        drives.putDiscIn(0, loaded);
-        modals.loadingFinished();
-
-        if (needsAutoboot) {
-            autoboot(item);
-        }
-    } catch (err) {
-        console.error("Error loading disc image:", err);
-        modals.loadingFinished(`Unable to load ${item} from the STH archive: ${errorText(err)}`);
-    }
-}
-
-async function tapeSthClick(item) {
-    utils.noteEvent("sth", "clickTape", item);
-    media.setTapeImage("sth:" + item);
-
-    modals.popupLoading("Loading " + item);
-    try {
-        const tape = await media.loadTapeImage(parsedQuery.tape);
-        media.setProcessorTape(tape);
-        modals.loadingFinished();
-    } catch (err) {
-        console.error("Error loading tape image:", err);
-        modals.loadingFinished(`Unable to load ${item} from the STH archive: ${errorText(err)}`);
-    }
-}
-
-const $sthModal = new bootstrap.Modal(document.getElementById("sth"));
-document.getElementById("sth").addEventListener("shown.bs.modal", () => {
-    document.getElementById("sth-filter").focus();
-});
-
-function makeOnCat(onClick) {
-    return function (cat) {
-        clearArchiveList("sth-list");
-        const sthList = document.getElementById("sth-list");
-        document.querySelector("#sth .loading").style.display = "none";
-        const template = sthList.querySelector(".template");
-
-        function doSome(all) {
-            const MaxAtATime = 100;
-            const Delay = 30;
-            const batch = all.slice(0, MaxAtATime);
-            const remaining = all.slice(MaxAtATime);
-            const filter = document.getElementById("sth-filter").value;
-            for (const name of batch) {
-                const row = template.cloneNode(true);
-                row.classList.remove("template");
-                sthList.appendChild(row);
-                row.querySelector(".name").textContent = name;
-                row.addEventListener("click", function () {
-                    onClick(name);
-                    $sthModal.hide();
-                });
-                row.style.display = name.toLowerCase().indexOf(filter) >= 0 ? "" : "none";
-            }
-            if (all.length) setTimeout(() => doSome(remaining), Delay);
-        }
-
-        doSome(cat);
-    };
-}
-
-function sthOnError() {
-    showArchiveMessage("sth", "sth-list", "There was an error accessing the STH archive");
-}
-
-discSth = new StairwayToHell(sthStartLoad, makeOnCat(discSthClick), sthOnError, false);
-tapeSth = new StairwayToHell(sthStartLoad, makeOnCat(tapeSthClick), sthOnError, true);
 hfeArchive = new BbcDiscArchive(hfeStartLoad, hfeOnCat, hfeOnError);
-
-// Every archive picker offers the same autoboot choice, and it is one setting,
-// so ticking it in either has to show in both.
-const autobootChecks = document.querySelectorAll("#sth .autoboot, #hfe .autoboot");
-function showAutoboot(checked) {
-    for (const check of autobootChecks) check.checked = checked;
-}
-for (const check of autobootChecks) {
-    check.addEventListener("click", function () {
-        showAutoboot(check.checked);
-        if (check.checked) {
-            parsedQuery.autoboot = "";
-        } else {
-            delete parsedQuery.autoboot;
-        }
-        urlState.updateUrl();
-    });
-}
-
-document.addEventListener("click", function (e) {
-    const target = e.target.closest("a.sth");
-    if (!target) return;
-    const type = target.dataset.id;
-    if (type === "discs") {
-        discSth.populate();
-    } else if (type === "tapes") {
-        tapeSth.populate();
-    } else {
-        console.log("unknown id", type);
-    }
-});
-
-function setSthFilter(filter) {
-    filterArchiveList("sth-list", filter);
-}
-
-const sthFilter = document.getElementById("sth-filter");
-sthFilter.addEventListener("change", () => setSthFilter(sthFilter.value));
-sthFilter.addEventListener("keyup", () => setSthFilter(sthFilter.value));
 
 // Rendering is spread over several turns of the event loop, so a list that has
 // been emptied may still have a chain of appends heading for it. Anything that
@@ -1737,7 +1597,7 @@ const startPromise = (async () => {
 
         switch (needsAutoboot) {
             case "boot":
-                showAutoboot(true);
+                autobootTicks.show(true);
                 autoboot(discImage);
                 break;
             case "type":
@@ -1750,7 +1610,7 @@ const startPromise = (async () => {
                 autoRunTape();
                 break;
             default:
-                showAutoboot(false);
+                autobootTicks.show(false);
                 break;
         }
 
@@ -2188,8 +2048,8 @@ electron({
     modals: {
         show: (modalId, sthType) => {
             if (modalId === "sth" && sthType) {
-                if (sthType === "discs") discSth.populate();
-                else if (sthType === "tapes") tapeSth.populate();
+                if (sthType === "discs") sthPicker.discs.populate();
+                else if (sthType === "tapes") sthPicker.tapes.populate();
             }
             modals.show(modalId);
         },

--- a/src/web/archive-list.js
+++ b/src/web/archive-list.js
@@ -1,0 +1,44 @@
+/** List plumbing every archive picker shares: one modal, one list, one filter box. */
+
+export function clearArchiveList(listId) {
+    for (const el of document.querySelectorAll(`#${listId} li:not(.template)`)) el.remove();
+}
+
+export function showArchiveMessage(modalId, listId, message) {
+    const loading = document.querySelector(`#${modalId} .loading`);
+    loading.textContent = message;
+    loading.style.display = "";
+    clearArchiveList(listId);
+}
+
+export function filterArchiveList(listId, filter) {
+    filter = filter.toLowerCase();
+    for (const el of document.querySelectorAll(`#${listId} li:not(.template)`)) {
+        el.style.display = el.textContent.toLowerCase().includes(filter) ? "" : "none";
+    }
+}
+
+/**
+ * Every archive picker offers the same autoboot choice, and it is one setting,
+ * so ticking it in either has to show in both.
+ */
+export class AutobootTicks {
+    constructor({ urlState }) {
+        this.checks = document.querySelectorAll(".modal .autoboot");
+        for (const check of this.checks) {
+            check.addEventListener("click", () => {
+                this.show(check.checked);
+                if (check.checked) {
+                    urlState.params.autoboot = "";
+                } else {
+                    delete urlState.params.autoboot;
+                }
+                urlState.updateUrl();
+            });
+        }
+    }
+
+    show(checked) {
+        for (const check of this.checks) check.checked = checked;
+    }
+}

--- a/src/web/sth-picker.js
+++ b/src/web/sth-picker.js
@@ -1,0 +1,125 @@
+import * as utils from "../utils.js";
+import * as bootstrap from "bootstrap";
+import { StairwayToHell } from "../sth.js";
+import { errorText } from "./reporting.js";
+import { clearArchiveList, filterArchiveList, showArchiveMessage } from "./archive-list.js";
+
+/**
+ * The Stairway to Hell archive picker: one modal browsing either the disc or
+ * the tape catalogue, filtered as it renders.
+ */
+export class SthPicker {
+    constructor({ media, drives, modals, urlState, processor, autoboot }) {
+        this.media = media;
+        this.drives = drives;
+        this.modals = modals;
+        this.urlState = urlState;
+        this.processor = processor;
+        this.autoboot = autoboot;
+
+        this.modal = new bootstrap.Modal(document.getElementById("sth"));
+        document.getElementById("sth").addEventListener("shown.bs.modal", () => {
+            document.getElementById("sth-filter").focus();
+        });
+
+        const startLoad = () => showArchiveMessage("sth", "sth-list", "Loading catalog from STH archive");
+        const onError = () => showArchiveMessage("sth", "sth-list", "There was an error accessing the STH archive");
+        this.discs = new StairwayToHell(
+            startLoad,
+            (cat) => this.renderCatalogue(cat, (item) => this.pickDisc(item)),
+            onError,
+            false,
+        );
+        this.tapes = new StairwayToHell(
+            startLoad,
+            (cat) => this.renderCatalogue(cat, (item) => this.pickTape(item)),
+            onError,
+            true,
+        );
+
+        document.addEventListener("click", (e) => {
+            const target = e.target.closest("a.sth");
+            if (!target) return;
+            const type = target.dataset.id;
+            if (type === "discs") {
+                this.discs.populate();
+            } else if (type === "tapes") {
+                this.tapes.populate();
+            } else {
+                console.log("unknown id", type);
+            }
+        });
+
+        const sthFilter = document.getElementById("sth-filter");
+        const applyFilter = () => filterArchiveList("sth-list", sthFilter.value);
+        sthFilter.addEventListener("change", applyFilter);
+        sthFilter.addEventListener("keyup", applyFilter);
+    }
+
+    async pickDisc(item) {
+        utils.noteEvent("sth", "click", item);
+        this.media.setDisc1Image("sth:" + item);
+        const needsAutoboot = this.urlState.params.autoboot !== undefined;
+        if (needsAutoboot) {
+            this.processor.reset(true);
+        }
+
+        this.modals.popupLoading("Loading " + item);
+        try {
+            const loaded = await this.media.loadDiscImage(this.urlState.params.disc1, this.drives.layoutForDrive(0));
+            this.drives.putDiscIn(0, loaded);
+            this.modals.loadingFinished();
+
+            if (needsAutoboot) {
+                this.autoboot(item);
+            }
+        } catch (err) {
+            console.error("Error loading disc image:", err);
+            this.modals.loadingFinished(`Unable to load ${item} from the STH archive: ${errorText(err)}`);
+        }
+    }
+
+    async pickTape(item) {
+        utils.noteEvent("sth", "clickTape", item);
+        this.media.setTapeImage("sth:" + item);
+
+        this.modals.popupLoading("Loading " + item);
+        try {
+            const tape = await this.media.loadTapeImage(this.urlState.params.tape);
+            this.media.setProcessorTape(tape);
+            this.modals.loadingFinished();
+        } catch (err) {
+            console.error("Error loading tape image:", err);
+            this.modals.loadingFinished(`Unable to load ${item} from the STH archive: ${errorText(err)}`);
+        }
+    }
+
+    renderCatalogue(cat, onClick) {
+        clearArchiveList("sth-list");
+        const sthList = document.getElementById("sth-list");
+        document.querySelector("#sth .loading").style.display = "none";
+        const template = sthList.querySelector(".template");
+
+        const doSome = (all) => {
+            const MaxAtATime = 100;
+            const Delay = 30;
+            const batch = all.slice(0, MaxAtATime);
+            const remaining = all.slice(MaxAtATime);
+            const filter = document.getElementById("sth-filter").value;
+            for (const name of batch) {
+                const row = template.cloneNode(true);
+                row.classList.remove("template");
+                sthList.appendChild(row);
+                row.querySelector(".name").textContent = name;
+                row.addEventListener("click", () => {
+                    onClick(name);
+                    this.modal.hide();
+                });
+                row.style.display = name.toLowerCase().indexOf(filter) >= 0 ? "" : "none";
+            }
+            if (all.length) setTimeout(() => doSome(remaining), Delay);
+        };
+
+        doSome(cat);
+    }
+}

--- a/tests/unit/test-archive-list.js
+++ b/tests/unit/test-archive-list.js
@@ -1,0 +1,89 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { AutobootTicks, clearArchiveList, filterArchiveList, showArchiveMessage } from "../../src/web/archive-list.js";
+
+const Markup = `
+<div id="sth" class="modal"><span class="loading" style="display: none"></span>
+  <ul id="sth-list"><li class="template"><span class="name"></span></li></ul>
+  <label><input type="checkbox" class="autoboot" /></label>
+</div>
+<div id="hfe" class="modal"><span class="loading"></span>
+  <ul id="hfe-list"><li class="template"><span class="name"></span></li></ul>
+  <label><input type="checkbox" class="autoboot" /></label>
+</div>`;
+
+const addRow = (listId, text) => {
+    const row = document.createElement("li");
+    row.textContent = text;
+    document.getElementById(listId).appendChild(row);
+    return row;
+};
+
+describe("archive lists", () => {
+    beforeEach(() => {
+        document.body.innerHTML = Markup;
+    });
+
+    afterEach(() => {
+        document.body.innerHTML = "";
+    });
+
+    it("clears every row but the template", () => {
+        addRow("sth-list", "Elite");
+        addRow("sth-list", "Chuckie Egg");
+        clearArchiveList("sth-list");
+        expect(document.querySelectorAll("#sth-list li")).toHaveLength(1);
+        expect(document.querySelector("#sth-list .template")).toBeTruthy();
+    });
+
+    it("shows a message and empties the list it talks about", () => {
+        addRow("sth-list", "Elite");
+        showArchiveMessage("sth", "sth-list", "Loading catalog from STH archive");
+        const loading = document.querySelector("#sth .loading");
+        expect(loading.textContent).toBe("Loading catalog from STH archive");
+        expect(loading.style.display).toBe("");
+        expect(document.querySelectorAll("#sth-list li:not(.template)")).toHaveLength(0);
+    });
+
+    it("filters rows by their text, without regard to case", () => {
+        const elite = addRow("sth-list", "Elite");
+        const chuckie = addRow("sth-list", "Chuckie Egg");
+        filterArchiveList("sth-list", "ELITE");
+        expect(elite.style.display).toBe("");
+        expect(chuckie.style.display).toBe("none");
+        filterArchiveList("sth-list", "");
+        expect(chuckie.style.display).toBe("");
+    });
+
+    describe("AutobootTicks", () => {
+        let urlState;
+        const boxes = () => [...document.querySelectorAll(".autoboot")];
+
+        beforeEach(() => {
+            urlState = { params: {}, updateUrl: vi.fn() };
+            new AutobootTicks({ urlState });
+        });
+
+        it("mirrors a tick into every picker and the URL", () => {
+            boxes()[0].click();
+            expect(boxes().map((box) => box.checked)).toEqual([true, true]);
+            expect(urlState.params.autoboot).toBe("");
+            expect(urlState.updateUrl).toHaveBeenCalledTimes(1);
+        });
+
+        it("clears the URL when unticked from the other picker", () => {
+            boxes()[0].click();
+            boxes()[1].click();
+            expect(boxes().map((box) => box.checked)).toEqual([false, false]);
+            expect(urlState.params.autoboot).toBeUndefined();
+        });
+
+        it("can be shown a state without touching the URL", () => {
+            const ticks = new AutobootTicks({ urlState });
+            ticks.show(true);
+            expect(boxes().every((box) => box.checked)).toBe(true);
+            expect(urlState.updateUrl).not.toHaveBeenCalled();
+        });
+    });
+});

--- a/tests/unit/test-sth-picker.js
+++ b/tests/unit/test-sth-picker.js
@@ -1,0 +1,147 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { SthPicker } from "../../src/web/sth-picker.js";
+
+const Markup = `
+<div id="sth" class="modal"><div class="modal-dialog"><div class="modal-content"><div class="modal-body">
+  <span class="loading"></span>
+  <input id="sth-filter" value="" />
+  <ul id="sth-list"><li class="template"><span class="name"></span></li></ul>
+</div></div></div></div>`;
+
+describe("SthPicker", () => {
+    let deps;
+
+    beforeEach(() => {
+        vi.useFakeTimers();
+        document.body.innerHTML = Markup;
+        deps = {
+            media: {
+                setDisc1Image: vi.fn(),
+                setTapeImage: vi.fn(),
+                loadDiscImage: vi.fn(),
+                loadTapeImage: vi.fn(),
+                setProcessorTape: vi.fn(),
+            },
+            drives: { layoutForDrive: () => "auto", putDiscIn: vi.fn() },
+            modals: { popupLoading: vi.fn(), loadingFinished: vi.fn() },
+            urlState: { params: {}, updateUrl: vi.fn() },
+            processor: { reset: vi.fn() },
+            autoboot: vi.fn(),
+        };
+    });
+
+    afterEach(() => {
+        vi.runAllTimers();
+        vi.useRealTimers();
+        vi.restoreAllMocks();
+        document.body.innerHTML = "";
+        window.localStorage.clear();
+    });
+
+    const make = () => new SthPicker(deps);
+    const rows = () => [...document.querySelectorAll("#sth-list li:not(.template)")];
+
+    describe("rendering the catalogue", () => {
+        it("renders a large catalogue a batch at a time", () => {
+            const names = Array.from({ length: 250 }, (_, i) => `GAME${i}.zip`);
+            make().renderCatalogue(names, () => {});
+            expect(rows()).toHaveLength(100);
+            vi.advanceTimersByTime(30);
+            expect(rows()).toHaveLength(200);
+            vi.advanceTimersByTime(30);
+            expect(rows()).toHaveLength(250);
+        });
+
+        it("renders every batch honouring the filter already typed", () => {
+            document.getElementById("sth-filter").value = "elite";
+            const names = ["ELITE.zip", ...Array.from({ length: 150 }, (_, i) => `GAME${i}.zip`)];
+            make().renderCatalogue(names, () => {});
+            vi.runAllTimers();
+            expect(rows()).toHaveLength(151);
+            const shown = rows().filter((row) => row.style.display !== "none");
+            expect(shown.map((row) => row.textContent)).toEqual(["ELITE.zip"]);
+        });
+
+        it("re-filters what is already on screen as the user types", () => {
+            make().renderCatalogue(["ELITE.zip", "CHUCKIE.zip"], () => {});
+            const filter = document.getElementById("sth-filter");
+            filter.value = "chuckie";
+            filter.dispatchEvent(new Event("keyup"));
+            const shown = rows().filter((row) => row.style.display !== "none");
+            expect(shown.map((row) => row.textContent)).toEqual(["CHUCKIE.zip"]);
+        });
+
+        it("hides the loading text once the catalogue is up", () => {
+            document.querySelector("#sth .loading").style.display = "";
+            make().renderCatalogue(["A.zip"], () => {});
+            expect(document.querySelector("#sth .loading").style.display).toBe("none");
+        });
+
+        it("answers a click with the name and puts the modal away", () => {
+            const onClick = vi.fn();
+            const picker = make();
+            const hide = vi.spyOn(picker.modal, "hide").mockImplementation(() => {});
+            picker.renderCatalogue(["ELITE.zip"], onClick);
+            rows()[0].click();
+            expect(onClick).toHaveBeenCalledWith("ELITE.zip");
+            expect(hide).toHaveBeenCalled();
+        });
+    });
+
+    describe("picking a disc", () => {
+        it("names it in the URL, loads it into drive 0 and closes the loading dialog", async () => {
+            const loaded = {};
+            deps.media.setDisc1Image.mockImplementation((name) => (deps.urlState.params.disc1 = name));
+            deps.media.loadDiscImage.mockResolvedValue(loaded);
+            await make().pickDisc("ELITE.zip");
+            expect(deps.media.setDisc1Image).toHaveBeenCalledWith("sth:ELITE.zip");
+            expect(deps.media.loadDiscImage).toHaveBeenCalledWith("sth:ELITE.zip", "auto");
+            expect(deps.drives.putDiscIn).toHaveBeenCalledWith(0, loaded);
+            expect(deps.modals.loadingFinished).toHaveBeenCalledWith();
+            expect(deps.processor.reset).not.toHaveBeenCalled();
+            expect(deps.autoboot).not.toHaveBeenCalled();
+        });
+
+        it("resets and autoboots when the tick is on", async () => {
+            deps.urlState.params.autoboot = "";
+            deps.media.loadDiscImage.mockResolvedValue({});
+            await make().pickDisc("ELITE.zip");
+            expect(deps.processor.reset).toHaveBeenCalledWith(true);
+            expect(deps.autoboot).toHaveBeenCalledWith("ELITE.zip");
+        });
+
+        it("reports a failure through the loading dialog", async () => {
+            vi.spyOn(console, "error").mockImplementation(() => {});
+            deps.media.loadDiscImage.mockRejectedValue(new Error("404"));
+            await make().pickDisc("ELITE.zip");
+            expect(deps.drives.putDiscIn).not.toHaveBeenCalled();
+            expect(deps.modals.loadingFinished).toHaveBeenCalledWith(
+                expect.stringContaining("Unable to load ELITE.zip from the STH archive: 404"),
+            );
+        });
+    });
+
+    describe("picking a tape", () => {
+        it("names it in the URL and routes it to the machine", async () => {
+            const tape = {};
+            deps.media.setTapeImage.mockImplementation((name) => (deps.urlState.params.tape = name));
+            deps.media.loadTapeImage.mockResolvedValue(tape);
+            await make().pickTape("CHUCKIE.zip");
+            expect(deps.media.setTapeImage).toHaveBeenCalledWith("sth:CHUCKIE.zip");
+            expect(deps.media.loadTapeImage).toHaveBeenCalledWith("sth:CHUCKIE.zip");
+            expect(deps.media.setProcessorTape).toHaveBeenCalledWith(tape);
+        });
+
+        it("reports a failure through the loading dialog", async () => {
+            vi.spyOn(console, "error").mockImplementation(() => {});
+            deps.media.loadTapeImage.mockRejectedValue(new Error("410"));
+            await make().pickTape("CHUCKIE.zip");
+            expect(deps.media.setProcessorTape).not.toHaveBeenCalled();
+            expect(deps.modals.loadingFinished).toHaveBeenCalledWith(
+                expect.stringContaining("Unable to load CHUCKIE.zip from the STH archive: 410"),
+            );
+        });
+    });
+});


### PR DESCRIPTION
PR 6 of the #638 Phase 2 stack, first of the three pickers.

**Moved**: `SthPicker` in `src/web/sth-picker.js` owns the modal, the batched catalogue rendering, the filter and the disc and tape click-throughs, all driving the media loader from #949's `sources`. The list plumbing every archive picker shares (`clearArchiveList`, `showArchiveMessage`, `filterArchiveList`) and the autoboot tick that is one setting across pickers move to `src/web/archive-list.js`, where the next two pickers join them.

**Changed**: `discSthClick`/`tapeSthClick`/`makeOnCat` become the methods `pickDisc`, `pickTape` and `renderCatalogue`; behaviour is verbatim.

**Tests**: batched rendering under fake timers, the filter honoured per batch and re-applied on typing, the click-throughs including autoboot and failure reporting, and the autoboot tick mirrored across pickers.

**Checked**: unit suite, all ten smoke checks.
