### PR TITLE
refactor: move the HFE archive picker out of main.js

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -11,7 +11,6 @@ import { Cpu6502, AtomCpu6502 } from "./6502.js";
 import * as utils_atom from "./utils_atom.js";
 import { LoadSD } from "./mmc.js";
 import { Cmos, localStoragePersistence } from "./cmos.js";
-import { BbcDiscArchive, Provenance, describe as describeHfe, matches, provenancesIn } from "./bbcdiscs.js";
 import { GamePad } from "./gamepads.js";
 import * as disc from "./fdc.js";
 import { GoogleDriveLoader } from "./google-drive.js";
@@ -29,8 +28,9 @@ import { Keyboard } from "./keyboard.js";
 import { GamepadSource } from "./gamepad-source.js";
 import { toast } from "./web/toast.js";
 import { BuiltInImages, MediaLoader } from "./web/media-loader.js";
-import { AutobootTicks, clearArchiveList, showArchiveMessage } from "./web/archive-list.js";
+import { AutobootTicks } from "./web/archive-list.js";
 import { SthPicker } from "./web/sth-picker.js";
+import { HfePicker } from "./web/hfe-picker.js";
 import { Drives } from "./web/drives.js";
 import { UrlState } from "./web/url-state.js";
 import { Modals } from "./web/modals.js";
@@ -70,7 +70,6 @@ const dbgr = new Debugger();
 let frames = 0;
 let frameSkip = 0;
 let syncLights;
-let hfeArchive;
 let running;
 let model;
 
@@ -677,12 +676,13 @@ const media = new MediaLoader({
     sources: {
         sth: (name) => sthPicker.discs.fetch(name),
         tapeSth: (name) => sthPicker.tapes.fetch(name),
-        hfe: (path) => hfeArchive.fetch(path),
+        hfe: (path) => hfePicker.archive.fetch(path),
         drive: (cat, layout) => gdLoad(cat, layout),
     },
 });
 const autobootTicks = new AutobootTicks({ urlState });
 const sthPicker = new SthPicker({ media, drives, modals, urlState, processor, autoboot });
+const hfePicker = new HfePicker({ media, drives, modals, urlState, processor, autoboot });
 
 processor.teletextAdaptor?.addEventListener("notice", showNotice);
 processor.acia.addEventListener("notice", showNotice);
@@ -908,140 +908,6 @@ document.addEventListener("keydown", (evt) => {
 });
 document.addEventListener("keypress", (evt) => keyboard.keyPress(evt));
 document.addEventListener("keyup", (evt) => keyboard.keyUp(evt));
-
-hfeArchive = new BbcDiscArchive(hfeStartLoad, hfeOnCat, hfeOnError);
-
-// Rendering is spread over several turns of the event loop, so a list that has
-// been emptied may still have a chain of appends heading for it. Anything that
-// clears the list takes a new ticket; a chain whose ticket is stale gives up.
-let hfeRender = 0;
-
-function hfeStartLoad() {
-    hfeRender++;
-    showArchiveMessage("hfe", "hfe-list", "Loading catalogue from HFE archive");
-}
-
-function hfeOnError() {
-    hfeRender++;
-    showArchiveMessage("hfe", "hfe-list", "There was an error accessing the HFE archive");
-}
-
-async function hfeClick(file) {
-    utils.noteEvent("hfe", "click", file.path);
-    media.setDisc1Image("hfe:" + file.path);
-    const needsAutoboot = parsedQuery.autoboot !== undefined;
-    if (needsAutoboot) processor.reset(true);
-
-    const name = describeHfe(file).title;
-    modals.popupLoading("Loading " + name);
-    try {
-        const loaded = await media.loadDiscImage(parsedQuery.disc1, drives.layoutForDrive(0));
-        drives.putDiscIn(0, loaded);
-        modals.loadingFinished();
-        if (needsAutoboot) autoboot(name);
-    } catch (err) {
-        console.error("Error loading disc image:", err);
-        modals.loadingFinished(`Unable to load ${name} from the HFE archive: ${errorText(err)}`);
-    }
-}
-
-function hfeOnCat(catalogue) {
-    const ticket = ++hfeRender;
-    clearArchiveList("hfe-list");
-    const list = document.getElementById("hfe-list");
-    document.querySelector("#hfe .loading").style.display = "none";
-    const template = list.querySelector(".template");
-    showProvenanceChoices(catalogue, onHfeFilter);
-
-    const addSome = (remaining) => {
-        if (ticket !== hfeRender) return;
-        const MaxAtATime = 100;
-        const Delay = 30;
-        // Read per batch: both can be changed while this is still going.
-        const filter = document.getElementById("hfe-filter").value.toLowerCase();
-        const shown = shownProvenances();
-        for (const file of remaining.slice(0, MaxAtATime)) {
-            const { title, publisher, detail } = describeHfe(file);
-            const row = template.cloneNode(true);
-            row.classList.remove("template");
-            row.querySelector(".name").textContent = title;
-            row.querySelector(".publisher").textContent = publisher;
-            row.querySelector(".detail").textContent = detail;
-            row.querySelector(".provenance").textContent =
-                file.provenance === Provenance.Reconstructed ? "reconstructed" : "";
-            if (file.notes) row.title = file.notes;
-            // The row is an anchor, and letting it navigate to "#" would push a
-            // history entry of its own on top of the one updateUrl pushes.
-            row.addEventListener("click", (event) => {
-                event.preventDefault();
-                hfeClick(file);
-                $hfeModal.hide();
-            });
-            row.hfeFile = file;
-            list.appendChild(row);
-            showHfeRow(row, file, filter, shown);
-        }
-        if (remaining.length > MaxAtATime) setTimeout(() => addSome(remaining.slice(MaxAtATime)), Delay);
-    };
-    addSome(catalogue);
-}
-
-const $hfeModal = new bootstrap.Modal(document.getElementById("hfe"));
-document.getElementById("hfe").addEventListener("shown.bs.modal", () => {
-    document.getElementById("hfe-filter").focus();
-});
-document.getElementById("hfe").addEventListener("show.bs.modal", () => hfeArchive.populate());
-
-const hfeFilter = document.getElementById("hfe-filter");
-const hfeProvenance = document.getElementById("hfe-provenance");
-
-const HfeProvenanceLabels = {
-    [Provenance.Captured]: ["Captured", "Direct from disc"],
-    [Provenance.Reconstructed]: ["Reconstructed", "Rebuilt from a sector dump"],
-};
-
-/** Which provenances the picker is showing, or null when it is not offering the choice. */
-const shownProvenances = () => {
-    const boxes = [...hfeProvenance.querySelectorAll("input")];
-    return boxes.length ? new Set(boxes.filter((box) => box.checked).map((box) => box.value)) : null;
-};
-
-// Offer one tick per provenance the archive actually holds, rather than naming
-// them here: a source added later should appear without this having to change.
-function showProvenanceChoices(catalogue, onChange) {
-    const present = provenancesIn(catalogue);
-    // Nothing to choose between: no ticks, and shownProvenances says "all".
-    if (present.length < 2) {
-        hfeProvenance.replaceChildren();
-        return;
-    }
-    const wasShown = shownProvenances();
-    hfeProvenance.replaceChildren(
-        ...present.map((provenance) => {
-            const [text, why] = HfeProvenanceLabels[provenance] ?? [provenance, ""];
-            const label = document.createElement("label");
-            label.title = why;
-            const box = document.createElement("input");
-            box.type = "checkbox";
-            box.value = provenance;
-            box.checked = !wasShown || wasShown.has(provenance);
-            box.addEventListener("change", onChange);
-            label.append(box, text);
-            return label;
-        }),
-    );
-}
-
-const showHfeRow = (row, file, filter, shown) => (row.style.display = matches(file, filter, shown) ? "" : "none");
-
-const onHfeFilter = () => {
-    const filter = hfeFilter.value.toLowerCase();
-    const shown = shownProvenances();
-    for (const row of document.querySelectorAll("#hfe-list li:not(.template)"))
-        showHfeRow(row, row.hfeFile, filter, shown);
-};
-hfeFilter.addEventListener("change", onHfeFilter);
-hfeFilter.addEventListener("keyup", onHfeFilter);
 
 function sendRawKeyboard(keysToSend, checkCapsAndShiftLocks) {
     if (keyboard) {

--- a/src/web/hfe-picker.js
+++ b/src/web/hfe-picker.js
@@ -1,0 +1,156 @@
+import * as utils from "../utils.js";
+import * as bootstrap from "bootstrap";
+import { BbcDiscArchive, Provenance, describe as describeHfe, matches, provenancesIn } from "../bbcdiscs.js";
+import { errorText } from "./reporting.js";
+import { clearArchiveList, showArchiveMessage } from "./archive-list.js";
+
+const HfeProvenanceLabels = {
+    [Provenance.Captured]: ["Captured", "Direct from disc"],
+    [Provenance.Reconstructed]: ["Reconstructed", "Rebuilt from a sector dump"],
+};
+
+const showHfeRow = (row, file, filter, shown) => (row.style.display = matches(file, filter, shown) ? "" : "none");
+
+/**
+ * The HFE archive picker: the catalogue with its filter and provenance
+ * choices, rendered a batch at a time under a ticket so a list that has been
+ * emptied is not appended to by a stale chain.
+ */
+export class HfePicker {
+    constructor({ media, drives, modals, urlState, processor, autoboot }) {
+        this.media = media;
+        this.drives = drives;
+        this.modals = modals;
+        this.urlState = urlState;
+        this.processor = processor;
+        this.autoboot = autoboot;
+
+        // Rendering is spread over several turns of the event loop, so a list that has
+        // been emptied may still have a chain of appends heading for it. Anything that
+        // clears the list takes a new ticket; a chain whose ticket is stale gives up.
+        this.renderTicket = 0;
+
+        this.archive = new BbcDiscArchive(
+            () => {
+                this.renderTicket++;
+                showArchiveMessage("hfe", "hfe-list", "Loading catalogue from HFE archive");
+            },
+            (catalogue) => this.renderCatalogue(catalogue),
+            () => {
+                this.renderTicket++;
+                showArchiveMessage("hfe", "hfe-list", "There was an error accessing the HFE archive");
+            },
+        );
+
+        this.modal = new bootstrap.Modal(document.getElementById("hfe"));
+        document.getElementById("hfe").addEventListener("shown.bs.modal", () => {
+            document.getElementById("hfe-filter").focus();
+        });
+        document.getElementById("hfe").addEventListener("show.bs.modal", () => this.archive.populate());
+
+        this.filter = document.getElementById("hfe-filter");
+        this.provenance = document.getElementById("hfe-provenance");
+        const onFilter = () => this.applyFilter();
+        this.filter.addEventListener("change", onFilter);
+        this.filter.addEventListener("keyup", onFilter);
+    }
+
+    async pick(file) {
+        utils.noteEvent("hfe", "click", file.path);
+        this.media.setDisc1Image("hfe:" + file.path);
+        const needsAutoboot = this.urlState.params.autoboot !== undefined;
+        if (needsAutoboot) this.processor.reset(true);
+
+        const name = describeHfe(file).title;
+        this.modals.popupLoading("Loading " + name);
+        try {
+            const loaded = await this.media.loadDiscImage(this.urlState.params.disc1, this.drives.layoutForDrive(0));
+            this.drives.putDiscIn(0, loaded);
+            this.modals.loadingFinished();
+            if (needsAutoboot) this.autoboot(name);
+        } catch (err) {
+            console.error("Error loading disc image:", err);
+            this.modals.loadingFinished(`Unable to load ${name} from the HFE archive: ${errorText(err)}`);
+        }
+    }
+
+    renderCatalogue(catalogue) {
+        const ticket = ++this.renderTicket;
+        clearArchiveList("hfe-list");
+        const list = document.getElementById("hfe-list");
+        document.querySelector("#hfe .loading").style.display = "none";
+        const template = list.querySelector(".template");
+        this.showProvenanceChoices(catalogue);
+
+        const addSome = (remaining) => {
+            if (ticket !== this.renderTicket) return;
+            const MaxAtATime = 100;
+            const Delay = 30;
+            // Read per batch: both can be changed while this is still going.
+            const filter = this.filter.value.toLowerCase();
+            const shown = this.shownProvenances();
+            for (const file of remaining.slice(0, MaxAtATime)) {
+                const { title, publisher, detail } = describeHfe(file);
+                const row = template.cloneNode(true);
+                row.classList.remove("template");
+                row.querySelector(".name").textContent = title;
+                row.querySelector(".publisher").textContent = publisher;
+                row.querySelector(".detail").textContent = detail;
+                row.querySelector(".provenance").textContent =
+                    file.provenance === Provenance.Reconstructed ? "reconstructed" : "";
+                if (file.notes) row.title = file.notes;
+                // The row is an anchor, and letting it navigate to "#" would push a
+                // history entry of its own on top of the one updateUrl pushes.
+                row.addEventListener("click", (event) => {
+                    event.preventDefault();
+                    this.pick(file);
+                    this.modal.hide();
+                });
+                row.hfeFile = file;
+                list.appendChild(row);
+                showHfeRow(row, file, filter, shown);
+            }
+            if (remaining.length > MaxAtATime) setTimeout(() => addSome(remaining.slice(MaxAtATime)), Delay);
+        };
+        addSome(catalogue);
+    }
+
+    /** Which provenances the picker is showing, or null when it is not offering the choice. */
+    shownProvenances() {
+        const boxes = [...this.provenance.querySelectorAll("input")];
+        return boxes.length ? new Set(boxes.filter((box) => box.checked).map((box) => box.value)) : null;
+    }
+
+    // Offer one tick per provenance the archive actually holds, rather than naming
+    // them here: a source added later should appear without this having to change.
+    showProvenanceChoices(catalogue) {
+        const present = provenancesIn(catalogue);
+        // Nothing to choose between: no ticks, and shownProvenances says "all".
+        if (present.length < 2) {
+            this.provenance.replaceChildren();
+            return;
+        }
+        const wasShown = this.shownProvenances();
+        this.provenance.replaceChildren(
+            ...present.map((provenance) => {
+                const [text, why] = HfeProvenanceLabels[provenance] ?? [provenance, ""];
+                const label = document.createElement("label");
+                label.title = why;
+                const box = document.createElement("input");
+                box.type = "checkbox";
+                box.value = provenance;
+                box.checked = !wasShown || wasShown.has(provenance);
+                box.addEventListener("change", () => this.applyFilter());
+                label.append(box, text);
+                return label;
+            }),
+        );
+    }
+
+    applyFilter() {
+        const filter = this.filter.value.toLowerCase();
+        const shown = this.shownProvenances();
+        for (const row of document.querySelectorAll("#hfe-list li:not(.template)"))
+            showHfeRow(row, row.hfeFile, filter, shown);
+    }
+}

--- a/tests/unit/test-hfe-picker.js
+++ b/tests/unit/test-hfe-picker.js
@@ -129,8 +129,8 @@ describe("HfePicker", () => {
 
     describe("picking a disc", () => {
         it("does not let the row's anchor navigate", () => {
-            deps.media.loadDiscImage.mockResolvedValue({});
             const picker = make();
+            vi.spyOn(picker, "pick").mockResolvedValue();
             vi.spyOn(picker.modal, "hide").mockImplementation(() => {});
             picker.renderCatalogue([entry("A.hfe", "Elite")]);
             const click = new MouseEvent("click", { bubbles: true, cancelable: true });

--- a/tests/unit/test-hfe-picker.js
+++ b/tests/unit/test-hfe-picker.js
@@ -1,0 +1,170 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { HfePicker } from "../../src/web/hfe-picker.js";
+import { Provenance } from "../../src/bbcdiscs.js";
+
+const Markup = `
+<div id="hfe" class="modal"><div class="modal-dialog"><div class="modal-content"><div class="modal-body">
+  <span class="loading"></span>
+  <input id="hfe-filter" value="" />
+  <div id="hfe-provenance"></div>
+  <ul id="hfe-list"><li class="template"><a href="#">
+    <span class="name"></span><span class="publisher"></span><span class="detail"></span><span class="provenance"></span>
+  </a></li></ul>
+</div></div></div></div>`;
+
+const entry = (path, title, provenance = Provenance.Captured, extra = {}) => ({
+    path,
+    title,
+    publisher: "Acornsoft",
+    disc: "D1S1",
+    tracks: [80],
+    provenance,
+    ...extra,
+});
+
+describe("HfePicker", () => {
+    let deps;
+
+    beforeEach(() => {
+        vi.useFakeTimers();
+        document.body.innerHTML = Markup;
+        deps = {
+            media: { setDisc1Image: vi.fn(), loadDiscImage: vi.fn() },
+            drives: { layoutForDrive: () => "auto", putDiscIn: vi.fn() },
+            modals: { popupLoading: vi.fn(), loadingFinished: vi.fn() },
+            urlState: { params: {}, updateUrl: vi.fn() },
+            processor: { reset: vi.fn() },
+            autoboot: vi.fn(),
+        };
+    });
+
+    afterEach(() => {
+        vi.runAllTimers();
+        vi.useRealTimers();
+        vi.restoreAllMocks();
+        document.body.innerHTML = "";
+        window.localStorage.clear();
+    });
+
+    const make = () => new HfePicker(deps);
+    const rows = () => [...document.querySelectorAll("#hfe-list li:not(.template)")];
+    const shownRows = () => rows().filter((row) => row.style.display !== "none");
+
+    describe("rendering the catalogue", () => {
+        it("renders a large catalogue a batch at a time", () => {
+            const picker = make();
+            picker.renderCatalogue(Array.from({ length: 150 }, (_, i) => entry(`G${i}.hfe`, `Game ${i}`)));
+            expect(rows()).toHaveLength(100);
+            vi.advanceTimersByTime(30);
+            expect(rows()).toHaveLength(150);
+        });
+
+        it("gives up a stale render when the list is cleared under it", () => {
+            const picker = make();
+            picker.renderCatalogue(Array.from({ length: 150 }, (_, i) => entry(`G${i}.hfe`, `Game ${i}`)));
+            expect(rows()).toHaveLength(100);
+            picker.renderCatalogue([entry("ONLY.hfe", "Only")]);
+            vi.runAllTimers();
+            // The first chain's second batch must not append to the new list.
+            expect(rows()).toHaveLength(1);
+            expect(rows()[0].querySelector(".name").textContent).toBe("Only");
+        });
+
+        it("marks reconstructed discs and carries notes as a tooltip", () => {
+            make().renderCatalogue([
+                entry("A.hfe", "Captured One"),
+                entry("B.hfe", "Rebuilt One", Provenance.Reconstructed, { notes: "from a sector dump" }),
+            ]);
+            const [captured, rebuilt] = rows();
+            expect(captured.querySelector(".provenance").textContent).toBe("");
+            expect(rebuilt.querySelector(".provenance").textContent).toBe("reconstructed");
+            expect(rebuilt.title).toBe("from a sector dump");
+        });
+    });
+
+    describe("provenance choices", () => {
+        const boxes = () => [...document.querySelectorAll("#hfe-provenance input")];
+
+        it("offers no choice when the archive holds only one provenance", () => {
+            make().renderCatalogue([entry("A.hfe", "A"), entry("B.hfe", "B")]);
+            expect(boxes()).toHaveLength(0);
+        });
+
+        it("offers one tick per provenance present, all on to begin with", () => {
+            make().renderCatalogue([entry("A.hfe", "A"), entry("B.hfe", "B", Provenance.Reconstructed)]);
+            expect(boxes().map((box) => box.value)).toEqual([Provenance.Captured, Provenance.Reconstructed]);
+            expect(boxes().every((box) => box.checked)).toBe(true);
+        });
+
+        it("hides rows whose provenance is unticked", () => {
+            make().renderCatalogue([entry("A.hfe", "A"), entry("B.hfe", "B", Provenance.Reconstructed)]);
+            const reconstructed = boxes().find((box) => box.value === Provenance.Reconstructed);
+            reconstructed.checked = false;
+            reconstructed.dispatchEvent(new Event("change"));
+            expect(shownRows().map((row) => row.querySelector(".name").textContent)).toEqual(["A"]);
+        });
+
+        it("keeps the user's ticks across a re-render", () => {
+            const picker = make();
+            const catalogue = [entry("A.hfe", "A"), entry("B.hfe", "B", Provenance.Reconstructed)];
+            picker.renderCatalogue(catalogue);
+            const reconstructed = boxes().find((box) => box.value === Provenance.Reconstructed);
+            reconstructed.checked = false;
+            picker.renderCatalogue(catalogue);
+            expect(boxes().find((box) => box.value === Provenance.Reconstructed).checked).toBe(false);
+        });
+    });
+
+    describe("the filter box", () => {
+        it("re-filters what is on screen as the user types", () => {
+            make().renderCatalogue([entry("A.hfe", "Elite"), entry("B.hfe", "Chuckie Egg")]);
+            const filter = document.getElementById("hfe-filter");
+            filter.value = "chuckie";
+            filter.dispatchEvent(new Event("keyup"));
+            expect(shownRows().map((row) => row.querySelector(".name").textContent)).toEqual(["Chuckie Egg"]);
+        });
+    });
+
+    describe("picking a disc", () => {
+        it("does not let the row's anchor navigate", () => {
+            deps.media.loadDiscImage.mockResolvedValue({});
+            const picker = make();
+            vi.spyOn(picker.modal, "hide").mockImplementation(() => {});
+            picker.renderCatalogue([entry("A.hfe", "Elite")]);
+            const click = new MouseEvent("click", { bubbles: true, cancelable: true });
+            rows()[0].dispatchEvent(click);
+            expect(click.defaultPrevented).toBe(true);
+        });
+
+        it("names it in the URL, loads it and closes the loading dialog", async () => {
+            const loaded = {};
+            deps.media.setDisc1Image.mockImplementation((name) => (deps.urlState.params.disc1 = name));
+            deps.media.loadDiscImage.mockResolvedValue(loaded);
+            await make().pick(entry("Games/ELITE.hfe", "Elite"));
+            expect(deps.media.setDisc1Image).toHaveBeenCalledWith("hfe:Games/ELITE.hfe");
+            expect(deps.media.loadDiscImage).toHaveBeenCalledWith("hfe:Games/ELITE.hfe", "auto");
+            expect(deps.drives.putDiscIn).toHaveBeenCalledWith(0, loaded);
+            expect(deps.modals.loadingFinished).toHaveBeenCalledWith();
+        });
+
+        it("resets and autoboots by title when the tick is on", async () => {
+            deps.urlState.params.autoboot = "";
+            deps.media.loadDiscImage.mockResolvedValue({});
+            await make().pick(entry("A.hfe", "Elite"));
+            expect(deps.processor.reset).toHaveBeenCalledWith(true);
+            expect(deps.autoboot).toHaveBeenCalledWith("Elite");
+        });
+
+        it("reports a failure through the loading dialog", async () => {
+            vi.spyOn(console, "error").mockImplementation(() => {});
+            deps.media.loadDiscImage.mockRejectedValue(new Error("404"));
+            await make().pick(entry("A.hfe", "Elite"));
+            expect(deps.drives.putDiscIn).not.toHaveBeenCalled();
+            expect(deps.modals.loadingFinished).toHaveBeenCalledWith(
+                expect.stringContaining("Unable to load Elite from the HFE archive: 404"),
+            );
+        });
+    });
+});


### PR DESCRIPTION
PR 7 of the #638 Phase 2 stack, second picker.

**Moved**: `HfePicker` in `src/web/hfe-picker.js` owns the archive object, the ticketed batch rendering, the provenance ticks and the filter. Behaviour verbatim; the module-level helpers become methods.

**Tests**: the render ticket (a stale chain gives up when the list is cleared under it), per-batch filter reads, provenance ticks only offered when the archive holds more than one, ticks kept across a re-render, and the click-throughs. #824 keeps these ideas, which is why they get the coverage.

**Checked**: unit suite, all ten smoke checks.
