### PR TITLE
refactor: move the Google Drive picker out of main.js

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -1,4 +1,3 @@
-import * as bootstrap from "bootstrap";
 import { version } from "../package.json";
 
 import "bootswatch/dist/darkly/bootstrap.min.css";
@@ -13,7 +12,6 @@ import { LoadSD } from "./mmc.js";
 import { Cmos, localStoragePersistence } from "./cmos.js";
 import { GamePad } from "./gamepads.js";
 import * as disc from "./fdc.js";
-import { GoogleDriveLoader } from "./google-drive.js";
 import * as tokeniser from "./basic-tokenise.js";
 import * as canvasLib from "./canvas.js";
 import { Config } from "./config.js";
@@ -31,6 +29,7 @@ import { BuiltInImages, MediaLoader } from "./web/media-loader.js";
 import { AutobootTicks } from "./web/archive-list.js";
 import { SthPicker } from "./web/sth-picker.js";
 import { HfePicker } from "./web/hfe-picker.js";
+import { GoogleDrivePicker } from "./web/google-drive-picker.js";
 import { Drives } from "./web/drives.js";
 import { UrlState } from "./web/url-state.js";
 import { Modals } from "./web/modals.js";
@@ -677,12 +676,13 @@ const media = new MediaLoader({
         sth: (name) => sthPicker.discs.fetch(name),
         tapeSth: (name) => sthPicker.tapes.fetch(name),
         hfe: (path) => hfePicker.archive.fetch(path),
-        drive: (cat, layout) => gdLoad(cat, layout),
+        drive: (cat, layout) => drivePicker.load(cat, layout),
     },
 });
 const autobootTicks = new AutobootTicks({ urlState });
 const sthPicker = new SthPicker({ media, drives, modals, urlState, processor, autoboot });
 const hfePicker = new HfePicker({ media, drives, modals, urlState, processor, autoboot });
+const drivePicker = new GoogleDrivePicker({ media, drives, modals, processor });
 
 processor.teletextAdaptor?.addEventListener("notice", showNotice);
 processor.acia.addEventListener("notice", showNotice);
@@ -1006,154 +1006,6 @@ async function reloadSnapshotMedia(savedMedia) {
         }
     }
 }
-
-const googleDriveAuth = document.getElementById("google-drive-auth");
-
-const googleDrive = new GoogleDriveLoader();
-const googleDriveEl = document.getElementById("google-drive");
-
-async function gdAuth(imm) {
-    try {
-        return await googleDrive.authorize(imm);
-    } catch (err) {
-        console.log("Error handling google auth: " + err);
-        googleDriveEl.querySelector(".loading").textContent =
-            "There was an error accessing your Google Drive account: " + err;
-    }
-}
-
-let googleDriveLoadingResolve, googleDriveLoadingReject;
-document.querySelector("#google-drive-auth form").addEventListener("submit", async function (e) {
-    googleDriveAuth.style.display = "none";
-    e.preventDefault();
-    const authed = await gdAuth(false);
-    if (authed) googleDriveLoadingResolve();
-    else googleDriveLoadingReject(new Error("Unable to authorize Google Drive"));
-});
-
-async function gdLoad(cat, layout) {
-    modals.popupLoading("Loading '" + cat.name + "' from Google Drive");
-    try {
-        const available = await googleDrive.initialise();
-        console.log("Google Drive available =", available);
-        if (!available) throw new Error("Google Drive is not available");
-
-        const authed = await gdAuth(true);
-        console.log("Google Drive authed=", authed);
-
-        if (!authed) {
-            await new Promise(function (resolve, reject) {
-                googleDriveLoadingResolve = resolve;
-                googleDriveLoadingReject = reject;
-                googleDriveAuth.style.display = "";
-            });
-        }
-
-        const ssd = await googleDrive.load(processor.fdc, cat.id, layout);
-        console.log("Google Drive loading finished");
-        modals.loadingFinished();
-        if (!ssd.savesChanges) {
-            toast(`${cat.name} is read only on Google Drive, so changes to it are not written back.`, {
-                title: "Google Drive",
-                quietKey: "quietDriveReadOnly",
-            });
-        }
-        return ssd;
-    } catch (error) {
-        console.error("Google Drive loading error:", error);
-        modals.loadingFinished(`Unable to load ${cat.name} from Google Drive: ${errorText(error)}`);
-    }
-}
-
-const googleDriveModal = new bootstrap.Modal(googleDriveEl);
-// Loading the Google client holds the main thread for ~100ms, so it waits for
-// someone to ask for Drive.
-document.getElementById("open-drive-link").addEventListener("click", async function () {
-    try {
-        await googleDrive.initialise();
-    } catch (error) {
-        toast(`Google Drive is unavailable: ${errorText(error)}`, { title: "Google Drive" });
-        return false;
-    }
-    const authed = await gdAuth(false);
-    if (authed) {
-        googleDriveModal.show();
-    }
-    return false;
-});
-googleDriveEl.addEventListener("show.bs.modal", async function () {
-    const gdLoading = googleDriveEl.querySelector(".loading");
-    gdLoading.textContent = "Loading...";
-    gdLoading.style.display = "";
-    for (const el of googleDriveEl.querySelectorAll("li:not(.template)")) el.remove();
-    let cat;
-    try {
-        cat = await googleDrive.listFiles();
-    } catch (error) {
-        console.error("Error listing Google Drive files:", error);
-        gdLoading.textContent = `Unable to list your Google Drive files: ${errorText(error)}`;
-        return;
-    }
-    const dbList = googleDriveEl.querySelector(".list");
-    gdLoading.style.display = "none";
-    const template = dbList.querySelector(".template");
-    for (const item of cat) {
-        const row = template.cloneNode(true);
-        row.classList.remove("template");
-        dbList.appendChild(row);
-        row.querySelector(".name").textContent = item.name;
-        row.addEventListener("click", async function () {
-            utils.noteEvent("google-drive", "click", item.name);
-            media.setDisc1Image(`gd:${item.id}/${item.name}`);
-            googleDriveModal.hide();
-            const ssd = await gdLoad(item, drives.layoutForDrive(0));
-            if (ssd) drives.putDiscIn(0, ssd);
-        });
-    }
-});
-document.querySelector("#google-drive form").addEventListener("submit", async function (e) {
-    e.preventDefault();
-    let name = document.querySelector("#google-drive .disc-name").value;
-    if (!name) return;
-
-    modals.popupLoading("Connecting to Google Drive");
-    googleDriveModal.hide();
-    modals.popupLoading("Creating '" + name + "' on Google Drive");
-
-    let data;
-    if (document.querySelector("#google-drive .create-from-existing").checked) {
-        const discType = disc.guessDiscTypeFromName(name);
-        try {
-            data = discType.saver(processor.fdc.drives[0].disc);
-        } catch (e) {
-            modals.loadingFinished(`Unable to create ${name} on Google Drive: ${errorText(e)}`);
-            return;
-        }
-        name = utils.replaceOrAddExtension(name, discType.extension);
-        console.log(`Saving existing disc: ${name}`);
-    } else {
-        // TODO support HFE, I guess?
-        const discType = disc.guessDiscTypeFromName(name);
-        if (!discType.byteSize) {
-            throw new Error(`Cannot create blank disc of type ${discType.extension} - unknown size`);
-        }
-        data = new Uint8Array(discType.byteSize);
-        if (discType.supportsCatalogue) {
-            discType.setDiscName(data, name);
-        }
-        console.log(`Creating blank: ${name}`);
-    }
-
-    try {
-        const result = await googleDrive.create(processor.fdc, name, data);
-        media.setDisc1Image("gd:" + result.fileId + "/" + name);
-        drives.putDiscIn(0, result.disc);
-        modals.loadingFinished();
-    } catch (error) {
-        console.error(`Error creating Google Drive disc: ${error}`, error);
-        modals.loadingFinished(`Unable to create ${name} on Google Drive: ${errorText(error)}`);
-    }
-});
 
 document.getElementById("download-filestore-link").addEventListener("click", function () {
     downloadDriveData(processor.filestore.scsi, "scsi", ".dat");

--- a/src/web/google-drive-picker.js
+++ b/src/web/google-drive-picker.js
@@ -1,0 +1,172 @@
+import * as utils from "../utils.js";
+import * as bootstrap from "bootstrap";
+import * as disc from "../fdc.js";
+import { GoogleDriveLoader } from "../google-drive.js";
+import { toast } from "./toast.js";
+import { errorText } from "./reporting.js";
+
+/**
+ * The Google Drive picker: signing in, listing the user's discs, loading one
+ * and creating a new one, blank or from what is in drive 0.
+ */
+export class GoogleDrivePicker {
+    constructor({ media, drives, modals, processor, loader = new GoogleDriveLoader() }) {
+        this.media = media;
+        this.drives = drives;
+        this.modals = modals;
+        this.processor = processor;
+        this.googleDrive = loader;
+
+        this.authEl = document.getElementById("google-drive-auth");
+        this.el = document.getElementById("google-drive");
+        this.modal = new bootstrap.Modal(this.el);
+        this.authResolve = null;
+        this.authReject = null;
+
+        document.querySelector("#google-drive-auth form").addEventListener("submit", async (e) => {
+            this.authEl.style.display = "none";
+            e.preventDefault();
+            const authed = await this.auth(false);
+            if (authed) this.authResolve();
+            else this.authReject(new Error("Unable to authorize Google Drive"));
+        });
+
+        // Loading the Google client holds the main thread for ~100ms, so it waits for
+        // someone to ask for Drive.
+        document.getElementById("open-drive-link").addEventListener("click", async () => {
+            try {
+                await this.googleDrive.initialise();
+            } catch (error) {
+                toast(`Google Drive is unavailable: ${errorText(error)}`, { title: "Google Drive" });
+                return false;
+            }
+            const authed = await this.auth(false);
+            if (authed) {
+                this.modal.show();
+            }
+            return false;
+        });
+
+        this.el.addEventListener("show.bs.modal", () => this.showList());
+        document.querySelector("#google-drive form").addEventListener("submit", (e) => this.create(e));
+    }
+
+    async auth(imm) {
+        try {
+            return await this.googleDrive.authorize(imm);
+        } catch (err) {
+            console.log("Error handling google auth: " + err);
+            this.el.querySelector(".loading").textContent =
+                "There was an error accessing your Google Drive account: " + err;
+        }
+    }
+
+    async load(cat, layout) {
+        this.modals.popupLoading("Loading '" + cat.name + "' from Google Drive");
+        try {
+            const available = await this.googleDrive.initialise();
+            console.log("Google Drive available =", available);
+            if (!available) throw new Error("Google Drive is not available");
+
+            const authed = await this.auth(true);
+            console.log("Google Drive authed=", authed);
+
+            if (!authed) {
+                await new Promise((resolve, reject) => {
+                    this.authResolve = resolve;
+                    this.authReject = reject;
+                    this.authEl.style.display = "";
+                });
+            }
+
+            const ssd = await this.googleDrive.load(this.processor.fdc, cat.id, layout);
+            console.log("Google Drive loading finished");
+            this.modals.loadingFinished();
+            if (!ssd.savesChanges) {
+                toast(`${cat.name} is read only on Google Drive, so changes to it are not written back.`, {
+                    title: "Google Drive",
+                    quietKey: "quietDriveReadOnly",
+                });
+            }
+            return ssd;
+        } catch (error) {
+            console.error("Google Drive loading error:", error);
+            this.modals.loadingFinished(`Unable to load ${cat.name} from Google Drive: ${errorText(error)}`);
+        }
+    }
+
+    async showList() {
+        const gdLoading = this.el.querySelector(".loading");
+        gdLoading.textContent = "Loading...";
+        gdLoading.style.display = "";
+        for (const el of this.el.querySelectorAll("li:not(.template)")) el.remove();
+        let cat;
+        try {
+            cat = await this.googleDrive.listFiles();
+        } catch (error) {
+            console.error("Error listing Google Drive files:", error);
+            gdLoading.textContent = `Unable to list your Google Drive files: ${errorText(error)}`;
+            return;
+        }
+        const dbList = this.el.querySelector(".list");
+        gdLoading.style.display = "none";
+        const template = dbList.querySelector(".template");
+        for (const item of cat) {
+            const row = template.cloneNode(true);
+            row.classList.remove("template");
+            dbList.appendChild(row);
+            row.querySelector(".name").textContent = item.name;
+            row.addEventListener("click", async () => {
+                utils.noteEvent("google-drive", "click", item.name);
+                this.media.setDisc1Image(`gd:${item.id}/${item.name}`);
+                this.modal.hide();
+                const ssd = await this.load(item, this.drives.layoutForDrive(0));
+                if (ssd) this.drives.putDiscIn(0, ssd);
+            });
+        }
+    }
+
+    async create(e) {
+        e.preventDefault();
+        let name = document.querySelector("#google-drive .disc-name").value;
+        if (!name) return;
+
+        this.modals.popupLoading("Connecting to Google Drive");
+        this.modal.hide();
+        this.modals.popupLoading("Creating '" + name + "' on Google Drive");
+
+        let data;
+        if (document.querySelector("#google-drive .create-from-existing").checked) {
+            const discType = disc.guessDiscTypeFromName(name);
+            try {
+                data = discType.saver(this.processor.fdc.drives[0].disc);
+            } catch (e) {
+                this.modals.loadingFinished(`Unable to create ${name} on Google Drive: ${errorText(e)}`);
+                return;
+            }
+            name = utils.replaceOrAddExtension(name, discType.extension);
+            console.log(`Saving existing disc: ${name}`);
+        } else {
+            // TODO support HFE, I guess?
+            const discType = disc.guessDiscTypeFromName(name);
+            if (!discType.byteSize) {
+                throw new Error(`Cannot create blank disc of type ${discType.extension} - unknown size`);
+            }
+            data = new Uint8Array(discType.byteSize);
+            if (discType.supportsCatalogue) {
+                discType.setDiscName(data, name);
+            }
+            console.log(`Creating blank: ${name}`);
+        }
+
+        try {
+            const result = await this.googleDrive.create(this.processor.fdc, name, data);
+            this.media.setDisc1Image("gd:" + result.fileId + "/" + name);
+            this.drives.putDiscIn(0, result.disc);
+            this.modals.loadingFinished();
+        } catch (error) {
+            console.error(`Error creating Google Drive disc: ${error}`, error);
+            this.modals.loadingFinished(`Unable to create ${name} on Google Drive: ${errorText(error)}`);
+        }
+    }
+}

--- a/tests/unit/test-google-drive-picker.js
+++ b/tests/unit/test-google-drive-picker.js
@@ -1,0 +1,153 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { GoogleDrivePicker } from "../../src/web/google-drive-picker.js";
+
+const Markup = `
+<a id="open-drive-link"></a>
+<div id="google-drive-auth" style="display: none"><form></form></div>
+<div id="google-drive" class="modal"><div class="modal-dialog"><div class="modal-content"><div class="modal-body">
+  <span class="loading"></span>
+  <ul class="list"><li class="template"><span class="name"></span></li></ul>
+  <form><input class="disc-name" value="" /><input type="checkbox" class="create-from-existing" /></form>
+</div></div></div></div>`;
+
+describe("GoogleDrivePicker", () => {
+    let deps;
+    let loader;
+
+    beforeEach(() => {
+        document.body.innerHTML = Markup;
+        loader = {
+            initialise: vi.fn().mockResolvedValue(true),
+            authorize: vi.fn().mockResolvedValue(true),
+            load: vi.fn(),
+            listFiles: vi.fn().mockResolvedValue([]),
+            create: vi.fn(),
+        };
+        deps = {
+            media: { setDisc1Image: vi.fn() },
+            drives: { layoutForDrive: () => "auto", putDiscIn: vi.fn() },
+            modals: { popupLoading: vi.fn(), loadingFinished: vi.fn() },
+            processor: { fdc: { drives: [{ disc: null }, {}] } },
+            loader,
+        };
+        vi.spyOn(console, "log").mockImplementation(() => {});
+        vi.spyOn(console, "error").mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+        document.body.innerHTML = "";
+        window.localStorage.clear();
+    });
+
+    const make = () => new GoogleDrivePicker(deps);
+    const toasts = () =>
+        [...document.querySelectorAll(".toast")].map((el) => el.textContent.replace(/\s+/g, " ").trim());
+
+    describe("load", () => {
+        it("loads a file once signed in, through the loading dialog", async () => {
+            const ssd = { savesChanges: true };
+            loader.load.mockResolvedValue(ssd);
+            const got = await make().load({ id: "abc", name: "mine.ssd" }, "auto");
+            expect(loader.load).toHaveBeenCalledWith(deps.processor.fdc, "abc", "auto");
+            expect(deps.modals.popupLoading).toHaveBeenCalledWith("Loading 'mine.ssd' from Google Drive");
+            expect(deps.modals.loadingFinished).toHaveBeenCalledWith();
+            expect(got).toBe(ssd);
+            expect(toasts()).toEqual([]);
+        });
+
+        it("says when the loaded disc will not take changes", async () => {
+            loader.load.mockResolvedValue({ savesChanges: false });
+            await make().load({ id: "abc", name: "mine.ssd" }, "auto");
+            expect(toasts()).toEqual([expect.stringContaining("mine.ssd is read only on Google Drive")]);
+        });
+
+        it("reports Drive being unavailable through the loading dialog", async () => {
+            loader.initialise.mockResolvedValue(false);
+            const got = await make().load({ id: "abc", name: "mine.ssd" }, "auto");
+            expect(got).toBeUndefined();
+            expect(deps.modals.loadingFinished).toHaveBeenCalledWith(
+                expect.stringContaining("Unable to load mine.ssd from Google Drive"),
+            );
+        });
+
+        it("shows the sign-in and carries on once the form is submitted", async () => {
+            loader.authorize.mockResolvedValueOnce(false).mockResolvedValueOnce(true);
+            loader.load.mockResolvedValue({ savesChanges: true });
+            const picker = make();
+            const loading = picker.load({ id: "abc", name: "mine.ssd" }, "auto");
+            await vi.waitFor(() => expect(document.getElementById("google-drive-auth").style.display).toBe(""));
+            document.querySelector("#google-drive-auth form").dispatchEvent(new Event("submit"));
+            await loading;
+            expect(loader.load).toHaveBeenCalled();
+            expect(document.getElementById("google-drive-auth").style.display).toBe("none");
+        });
+    });
+
+    describe("the file list", () => {
+        it("lists the files and loads the one clicked", async () => {
+            loader.listFiles.mockResolvedValue([{ id: "abc", name: "mine.ssd" }]);
+            const ssd = { savesChanges: true };
+            loader.load.mockResolvedValue(ssd);
+            const picker = make();
+            vi.spyOn(picker.modal, "hide").mockImplementation(() => {});
+            document.getElementById("google-drive").dispatchEvent(new Event("show.bs.modal"));
+            await vi.waitFor(() =>
+                expect(document.querySelectorAll("#google-drive li:not(.template)")).toHaveLength(1),
+            );
+            document.querySelector("#google-drive li:not(.template)").click();
+            await vi.waitFor(() => expect(deps.drives.putDiscIn).toHaveBeenCalledWith(0, ssd));
+            expect(deps.media.setDisc1Image).toHaveBeenCalledWith("gd:abc/mine.ssd");
+        });
+
+        it("says when the list cannot be fetched", async () => {
+            loader.listFiles.mockRejectedValue(new Error("offline"));
+            make();
+            document.getElementById("google-drive").dispatchEvent(new Event("show.bs.modal"));
+            await vi.waitFor(() =>
+                expect(document.querySelector("#google-drive .loading").textContent).toContain(
+                    "Unable to list your Google Drive files: offline",
+                ),
+            );
+        });
+    });
+
+    describe("creating a disc", () => {
+        const submit = () => document.querySelector("#google-drive form").dispatchEvent(new Event("submit"));
+
+        it("creates a blank disc under the typed name and puts it in drive 0", async () => {
+            loader.create.mockResolvedValue({ fileId: "xyz", disc: { name: "fresh.ssd" } });
+            const picker = make();
+            vi.spyOn(picker.modal, "hide").mockImplementation(() => {});
+            document.querySelector("#google-drive .disc-name").value = "fresh.ssd";
+            submit();
+            await vi.waitFor(() => expect(deps.drives.putDiscIn).toHaveBeenCalled());
+            const [, name, data] = loader.create.mock.calls[0];
+            expect(name).toBe("fresh.ssd");
+            expect(data.length).toBeGreaterThan(0);
+            expect(deps.media.setDisc1Image).toHaveBeenCalledWith("gd:xyz/fresh.ssd");
+        });
+
+        it("reports a drive 0 disc that cannot be saved in the named format", async () => {
+            const picker = make();
+            vi.spyOn(picker.modal, "hide").mockImplementation(() => {});
+            document.querySelector("#google-drive .disc-name").value = "copy.ssd";
+            document.querySelector("#google-drive .create-from-existing").checked = true;
+            submit();
+            await vi.waitFor(() =>
+                expect(deps.modals.loadingFinished).toHaveBeenCalledWith(
+                    expect.stringContaining("Unable to create copy.ssd on Google Drive"),
+                ),
+            );
+            expect(loader.create).not.toHaveBeenCalled();
+        });
+
+        it("does nothing without a name", async () => {
+            make();
+            submit();
+            expect(deps.modals.popupLoading).not.toHaveBeenCalled();
+        });
+    });
+});


### PR DESCRIPTION
PR 8 of the #638 Phase 2 stack, last picker.

**Moved**: `GoogleDrivePicker` in `src/web/google-drive-picker.js` owns the sign-in flow, the file list, loading and the create form. After this, `main.js` does not touch Bootstrap at all.

**Changed**: the `GoogleDriveLoader` is a constructor argument defaulting to the real one, so the flows are testable without the Google client; nothing else.

**Tests**: the load flow including the deferred sign-in (panel shown, form submitted, load resumes), read-only notice, list population and click-through, creating a blank disc, and the failure paths.

**Checked**: unit suite, all ten smoke checks. The real sign-in flow needs a hand check against Google, which I cannot do from here.
