### PR TITLE
refactor: move the save state UI out of main.js

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -11,7 +11,6 @@ import * as utils_atom from "./utils_atom.js";
 import { LoadSD } from "./mmc.js";
 import { Cmos, localStoragePersistence } from "./cmos.js";
 import { GamePad } from "./gamepads.js";
-import * as disc from "./fdc.js";
 import * as tokeniser from "./basic-tokenise.js";
 import * as canvasLib from "./canvas.js";
 import { Config } from "./config.js";
@@ -21,7 +20,6 @@ import { AudioHandler } from "./web/audio-handler.js";
 import { DefaultAudioOutput, isAudioOutput } from "./audio-output.js";
 import { QuickSettings } from "./web/quick-settings.js";
 import { Econet } from "./econet.js";
-import { DiscLayout } from "./disc.js";
 import { Keyboard } from "./keyboard.js";
 import { GamepadSource } from "./gamepad-source.js";
 import { toast } from "./web/toast.js";
@@ -30,6 +28,7 @@ import { AutobootTicks } from "./web/archive-list.js";
 import { SthPicker } from "./web/sth-picker.js";
 import { HfePicker } from "./web/hfe-picker.js";
 import { GoogleDrivePicker } from "./web/google-drive-picker.js";
+import { isSnapshotFile, SnapshotUI } from "./web/snapshot-ui.js";
 import { Drives } from "./web/drives.js";
 import { UrlState } from "./web/url-state.js";
 import { Modals } from "./web/modals.js";
@@ -40,20 +39,10 @@ import { Printer } from "./printer.js";
 import { MouseJoystickSource } from "./mouse-joystick-source.js";
 import { calculateMouseCoordinates } from "./mouse-coordinates.js";
 import { getFilterForMode } from "./canvas.js";
-import {
-    createSnapshot,
-    restoreSnapshot,
-    snapshotToJSON,
-    snapshotFromJSON,
-    isSameModel,
-    hasCoProcessor,
-} from "./snapshot.js";
-import { isBemSnapshot, parseBemSnapshot } from "./bem-snapshot.js";
-import { isUefSnapshot, parseUefSnapshot } from "./uef-snapshot.js";
 import { RewindBuffer } from "./rewind.js";
 import { RewindUI } from "./rewind-ui.js";
 import { DiscVisualiser } from "./disc-visualiser.js";
-import { downloadBlob, downloadDriveData } from "./dom-utils.js";
+import { downloadDriveData } from "./dom-utils.js";
 import {
     guessModelFromHostname,
     parseMediaParams,
@@ -346,16 +335,6 @@ if (parsedQuery.lowLatency !== undefined) {
 const screenCanvas = document.getElementById("screen");
 
 const modals = new Modals({ isRunning: () => running, stop, go });
-
-async function compressBlob(blob) {
-    const stream = blob.stream().pipeThrough(new CompressionStream("gzip"));
-    return new Response(stream).blob();
-}
-
-async function decompressBlob(blob) {
-    const stream = blob.stream().pipeThrough(new DecompressionStream("gzip"));
-    return new Response(stream).blob();
-}
 
 if (keyMappingWarnings.length) {
     toast(`${keyMappingWarnings.join(" ")} The key names are listed in the README.`, {
@@ -670,7 +649,7 @@ const media = new MediaLoader({
     config,
     modals,
     isSnapshotFile,
-    loadSnapshot: (file, buffer) => loadStateFromFile(file, buffer),
+    loadSnapshot: (file, buffer) => snapshots.loadStateFromFile(file, buffer),
     // The archives are created further down; each source resolves when used.
     sources: {
         sth: (name) => sthPicker.discs.fetch(name),
@@ -683,6 +662,18 @@ const autobootTicks = new AutobootTicks({ urlState });
 const sthPicker = new SthPicker({ media, drives, modals, urlState, processor, autoboot });
 const hfePicker = new HfePicker({ media, drives, modals, urlState, processor, autoboot });
 const drivePicker = new GoogleDrivePicker({ media, drives, modals, processor });
+const snapshots = new SnapshotUI({
+    processor,
+    model,
+    video,
+    media,
+    drives,
+    urlState,
+    modals,
+    isRunning: () => running,
+    stop,
+    go,
+});
 
 processor.teletextAdaptor?.addEventListener("notice", showNotice);
 processor.acia.addEventListener("notice", showNotice);
@@ -959,54 +950,6 @@ function autoRunBasic() {
     sendRawKeyboard([1000].concat(bbcKeys), false);
 }
 
-async function reloadSnapshotMedia(savedMedia) {
-    if (!savedMedia) return;
-    for (let driveIndex = 0; driveIndex < 2; driveIndex++) {
-        const discKey = driveIndex === 0 ? "disc1" : "disc2";
-        const imageDataKey = discKey + "ImageData";
-        const crcKey = discKey + "Crc32";
-
-        // A snapshot from before layout detection has no field, and was contiguous.
-        const layout = savedMedia[discKey + "Layout"] ?? DiscLayout.contiguous;
-
-        let loadedDisc = null;
-        if (savedMedia[discKey]) {
-            // URL-based disc — reload from source
-            loadedDisc = await media.loadDiscImage(savedMedia[discKey], layout);
-        } else if (savedMedia[imageDataKey]) {
-            // Locally-loaded disc — reconstruct from embedded image data
-            const imageData =
-                savedMedia[imageDataKey] instanceof Uint8Array
-                    ? savedMedia[imageDataKey]
-                    : new Uint8Array(Object.values(savedMedia[imageDataKey]));
-            const discName = savedMedia[discKey + "Name"] || "snapshot.ssd";
-            loadedDisc = disc.discFor(processor.fdc, discName, imageData, undefined, layout);
-            // Retain the image bytes so subsequent saves can re-embed them.
-            loadedDisc.setOriginalImage(imageData);
-        }
-        if (!loadedDisc) continue;
-
-        // Verify CRC32 if present
-        if (savedMedia[crcKey] != null && loadedDisc.originalImageCrc32 != null) {
-            if (loadedDisc.originalImageCrc32 !== savedMedia[crcKey]) {
-                toast(
-                    `${loadedDisc.name} has changed since this state was saved. The state has been restored anyway and may not run correctly.`,
-                    { title: "Restoring state" },
-                );
-            }
-        }
-
-        drives.putDiscIn(driveIndex, loadedDisc);
-        // Only update the URL/query for URL-sourced discs. For embedded
-        // (local-file) discs, setting parsedQuery would put a bogus source
-        // in the URL and break subsequent saves/reloads.
-        if (savedMedia[discKey]) {
-            if (driveIndex === 0) media.setDisc1Image(savedMedia[discKey]);
-            else media.setDisc2Image(savedMedia[discKey]);
-        }
-    }
-}
-
 document.getElementById("download-filestore-link").addEventListener("click", function () {
     downloadDriveData(processor.filestore.scsi, "scsi", ".dat");
 });
@@ -1028,100 +971,6 @@ document.getElementById("hard-reset").addEventListener("click", function (event)
 document.getElementById("soft-reset").addEventListener("click", function (event) {
     processor.reset(false);
     event.preventDefault();
-});
-
-document.getElementById("save-state").addEventListener("click", async function (event) {
-    event.preventDefault();
-    const wasRunning = running;
-    if (running) stop(false);
-    try {
-        const media = {};
-        if (parsedQuery.disc1 || parsedQuery.disc) media.disc1 = parsedQuery.disc1 || parsedQuery.disc;
-        if (parsedQuery.disc2) media.disc2 = parsedQuery.disc2;
-
-        // For each drive with a disc loaded, include CRC32 for verification
-        // and embed original image data if no URL source exists (local file).
-        const drives = processor.fdc.drives;
-        for (let driveIndex = 0; driveIndex < 2; driveIndex++) {
-            const driveDisc = drives[driveIndex].disc;
-            if (!driveDisc || driveDisc.originalImageCrc32 == null) continue;
-            const discKey = driveIndex === 0 ? "disc1" : "disc2";
-            const crcKey = discKey + "Crc32";
-            media[crcKey] = driveDisc.originalImageCrc32;
-            // The snapshot's dirty tracks are indexed by physical track, so restoring has to lay
-            // the disc out the way this one was rather than work it out again.
-            media[discKey + "Layout"] = driveDisc.is40Track ? DiscLayout.expanded40 : DiscLayout.contiguous;
-            if (!media[discKey] && driveDisc.originalImageData) {
-                media[discKey + "ImageData"] = driveDisc.originalImageData;
-                media[discKey + "Name"] = driveDisc.name;
-            }
-        }
-
-        const snapshot = createSnapshot(processor, model, Object.keys(media).length > 0 ? media : undefined);
-        const json = snapshotToJSON(snapshot);
-        const blob = await compressBlob(new Blob([json]));
-        const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
-        downloadBlob(blob, `jsbeeb-${model.name}-${timestamp}.json.gz`);
-    } catch (e) {
-        modals.showError("saving state", e);
-    }
-    if (wasRunning) go();
-});
-
-async function loadStateFromFile(file, preReadBuffer) {
-    const wasRunning = running;
-    if (running) stop(false);
-    try {
-        const arrayBuffer = preReadBuffer || (await file.arrayBuffer());
-        let snapshot;
-        if (isBemSnapshot(arrayBuffer)) {
-            snapshot = await parseBemSnapshot(arrayBuffer);
-        } else if (isUefSnapshot(arrayBuffer)) {
-            snapshot = parseUefSnapshot(arrayBuffer);
-        } else {
-            // Detect gzip (magic bytes 0x1f 0x8b) or plain JSON
-            const bytes = new Uint8Array(arrayBuffer);
-            let text;
-            if (bytes[0] === 0x1f && bytes[1] === 0x8b) {
-                const decompressed = await decompressBlob(new Blob([arrayBuffer]));
-                text = await decompressed.text();
-            } else {
-                text = new TextDecoder().decode(arrayBuffer);
-            }
-            snapshot = snapshotFromJSON(text);
-        }
-        if (!isSameModel(snapshot.model, model.name) || hasCoProcessor(snapshot) !== processor.hasTube) {
-            // Model or co-processor mismatch: stash state and reload with a matching machine
-            sessionStorage.setItem("jsbeeb-pending-state", snapshotToJSON(snapshot));
-            window.location.href = urlState.urlWith({ model: snapshot.model, coProcessor: hasCoProcessor(snapshot) });
-            return;
-        }
-        // Order matters: reload disc media first so the base disc is in the
-        // drive before restoreSnapshot applies dirty track overlays on top.
-        await reloadSnapshotMedia(snapshot.media);
-        restoreSnapshot(processor, model, snapshot);
-        // Force a repaint so the display updates even while paused
-        video.paint();
-    } catch (e) {
-        modals.showError("loading state", e);
-    }
-    if (wasRunning) go();
-}
-
-function isSnapshotFile(filename, arrayBuffer) {
-    const lower = filename.toLowerCase();
-    if (lower.endsWith(".snp") || lower.endsWith(".json") || lower.endsWith(".json.gz") || lower.endsWith(".gz"))
-        return true;
-    // .uef can be either a BeebEm save state or a regular tape image - check content
-    if (lower.endsWith(".uef") && arrayBuffer) return isUefSnapshot(arrayBuffer);
-    return false;
-}
-
-document.getElementById("load-state").addEventListener("change", async function (event) {
-    const file = event.target.files[0];
-    if (!file) return;
-    event.target.value = "";
-    await loadStateFromFile(file);
 });
 
 for (const link of document.querySelectorAll("#tape-menu a")) {
@@ -1336,21 +1185,8 @@ const startPromise = (async () => {
             dbgr.setPatch(parsedQuery.patch);
         }
 
-        // Restore pending state from a cross-model load (sessionStorage)
-        const pendingState = sessionStorage.getItem("jsbeeb-pending-state");
-        if (pendingState) {
-            sessionStorage.removeItem("jsbeeb-pending-state");
-            try {
-                const snapshot = snapshotFromJSON(pendingState);
-                // Order matters: reload disc media first so the base disc is in the
-                // drive before restoreSnapshot applies dirty track overlays on top.
-                await reloadSnapshotMedia(snapshot.media);
-                restoreSnapshot(processor, model, snapshot);
-                processor.execute(40000);
-            } catch (e) {
-                modals.showError("restoring saved state", e);
-            }
-        }
+        // Restore the state a cross-model reload stashed, if there is one.
+        await snapshots.restorePendingState();
 
         go();
     } catch (error) {
@@ -1772,7 +1608,7 @@ electron({
             modals.show(modalId);
         },
     },
-    loadStateFile: loadStateFromFile,
+    loadStateFile: snapshots.loadStateFromFile.bind(snapshots),
     actions: {
         "soft-reset": () => processor.reset(false),
         "hard-reset": hardReset,

--- a/src/web/snapshot-ui.js
+++ b/src/web/snapshot-ui.js
@@ -15,6 +15,9 @@ import { isUefSnapshot, parseUefSnapshot } from "../uef-snapshot.js";
 
 const PendingStateKey = "jsbeeb-pending-state";
 
+/** Enough for the restored OS to settle before the user sees the screen. */
+const PostRestoreCycles = 40000;
+
 async function compressBlob(blob) {
     const stream = blob.stream().pipeThrough(new CompressionStream("gzip"));
     return new Response(stream).blob();
@@ -153,7 +156,7 @@ export class SnapshotUI {
         sessionStorage.removeItem(PendingStateKey);
         try {
             await this.restore(snapshotFromJSON(pendingState));
-            this.processor.execute(40000);
+            this.processor.execute(PostRestoreCycles);
         } catch (e) {
             this.modals.showError("restoring saved state", e);
         }

--- a/src/web/snapshot-ui.js
+++ b/src/web/snapshot-ui.js
@@ -1,0 +1,216 @@
+import * as disc from "../fdc.js";
+import { DiscLayout } from "../disc.js";
+import { downloadBlob } from "../dom-utils.js";
+import { toast } from "./toast.js";
+import {
+    createSnapshot,
+    restoreSnapshot,
+    snapshotToJSON,
+    snapshotFromJSON,
+    isSameModel,
+    hasCoProcessor,
+} from "../snapshot.js";
+import { isBemSnapshot, parseBemSnapshot } from "../bem-snapshot.js";
+import { isUefSnapshot, parseUefSnapshot } from "../uef-snapshot.js";
+
+const PendingStateKey = "jsbeeb-pending-state";
+
+async function compressBlob(blob) {
+    const stream = blob.stream().pipeThrough(new CompressionStream("gzip"));
+    return new Response(stream).blob();
+}
+
+async function decompressBlob(blob) {
+    const stream = blob.stream().pipeThrough(new DecompressionStream("gzip"));
+    return new Response(stream).blob();
+}
+
+export function isSnapshotFile(filename, arrayBuffer) {
+    const lower = filename.toLowerCase();
+    if (lower.endsWith(".snp") || lower.endsWith(".json") || lower.endsWith(".json.gz") || lower.endsWith(".gz"))
+        return true;
+    // .uef can be either a BeebEm save state or a regular tape image - check content
+    if (lower.endsWith(".uef") && arrayBuffer) return isUefSnapshot(arrayBuffer);
+    return false;
+}
+
+/** The saved snapshot in whichever of the formats we read the buffer holds. */
+export async function readSnapshot(arrayBuffer) {
+    if (isBemSnapshot(arrayBuffer)) return await parseBemSnapshot(arrayBuffer);
+    if (isUefSnapshot(arrayBuffer)) return parseUefSnapshot(arrayBuffer);
+    // Detect gzip (magic bytes 0x1f 0x8b) or plain JSON
+    const bytes = new Uint8Array(arrayBuffer);
+    let text;
+    if (bytes[0] === 0x1f && bytes[1] === 0x8b) {
+        const decompressed = await decompressBlob(new Blob([arrayBuffer]));
+        text = await decompressed.text();
+    } else {
+        text = new TextDecoder().decode(arrayBuffer);
+    }
+    return snapshotFromJSON(text);
+}
+
+/**
+ * What a snapshot needs to put the same discs back: their URL references
+ * where they have one, the image bytes where they do not, and CRCs for
+ * saying when a source has changed underneath a state.
+ */
+export function snapshotMedia(fdcDrives, params) {
+    const manifest = {};
+    if (params.disc1 || params.disc) manifest.disc1 = params.disc1 || params.disc;
+    if (params.disc2) manifest.disc2 = params.disc2;
+
+    // For each drive with a disc loaded, include CRC32 for verification
+    // and embed original image data if no URL source exists (local file).
+    for (let driveIndex = 0; driveIndex < 2; driveIndex++) {
+        const driveDisc = fdcDrives[driveIndex].disc;
+        if (!driveDisc || driveDisc.originalImageCrc32 == null) continue;
+        const discKey = driveIndex === 0 ? "disc1" : "disc2";
+        const crcKey = discKey + "Crc32";
+        manifest[crcKey] = driveDisc.originalImageCrc32;
+        // The snapshot's dirty tracks are indexed by physical track, so restoring has to lay
+        // the disc out the way this one was rather than work it out again.
+        manifest[discKey + "Layout"] = driveDisc.is40Track ? DiscLayout.expanded40 : DiscLayout.contiguous;
+        if (!manifest[discKey] && driveDisc.originalImageData) {
+            manifest[discKey + "ImageData"] = driveDisc.originalImageData;
+            manifest[discKey + "Name"] = driveDisc.name;
+        }
+    }
+    return Object.keys(manifest).length > 0 ? manifest : undefined;
+}
+
+/** Saving and restoring states: the menu item, the file input and the reload across a model change. */
+export class SnapshotUI {
+    constructor({ processor, model, video, media, drives, urlState, modals, isRunning, stop, go }) {
+        this.processor = processor;
+        this.model = model;
+        this.video = video;
+        this.media = media;
+        this.drives = drives;
+        this.urlState = urlState;
+        this.modals = modals;
+        this.isRunning = isRunning;
+        this.stop = stop;
+        this.go = go;
+
+        document.getElementById("save-state").addEventListener("click", async (event) => {
+            event.preventDefault();
+            await this.saveState();
+        });
+
+        document.getElementById("load-state").addEventListener("change", async (event) => {
+            const file = event.target.files[0];
+            if (!file) return;
+            event.target.value = "";
+            await this.loadStateFromFile(file);
+        });
+    }
+
+    async saveState() {
+        const wasRunning = this.isRunning();
+        if (wasRunning) this.stop(false);
+        try {
+            const manifest = snapshotMedia(this.processor.fdc.drives, this.urlState.params);
+            const snapshot = createSnapshot(this.processor, this.model, manifest);
+            const json = snapshotToJSON(snapshot);
+            const blob = await compressBlob(new Blob([json]));
+            const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
+            downloadBlob(blob, `jsbeeb-${this.model.name}-${timestamp}.json.gz`);
+        } catch (e) {
+            this.modals.showError("saving state", e);
+        }
+        if (wasRunning) this.go();
+    }
+
+    async loadStateFromFile(file, preReadBuffer) {
+        const wasRunning = this.isRunning();
+        if (wasRunning) this.stop(false);
+        try {
+            const arrayBuffer = preReadBuffer || (await file.arrayBuffer());
+            const snapshot = await readSnapshot(arrayBuffer);
+            if (!isSameModel(snapshot.model, this.model.name) || hasCoProcessor(snapshot) !== this.processor.hasTube) {
+                // Model or co-processor mismatch: stash state and reload with a matching machine
+                sessionStorage.setItem(PendingStateKey, snapshotToJSON(snapshot));
+                window.location.href = this.urlState.urlWith({
+                    model: snapshot.model,
+                    coProcessor: hasCoProcessor(snapshot),
+                });
+                return;
+            }
+            await this.restore(snapshot);
+            // Force a repaint so the display updates even while paused
+            this.video.paint();
+        } catch (e) {
+            this.modals.showError("loading state", e);
+        }
+        if (wasRunning) this.go();
+    }
+
+    /** Picks up the state a cross-model reload stashed, once the matching machine is up. */
+    async restorePendingState() {
+        const pendingState = sessionStorage.getItem(PendingStateKey);
+        if (!pendingState) return;
+        sessionStorage.removeItem(PendingStateKey);
+        try {
+            await this.restore(snapshotFromJSON(pendingState));
+            this.processor.execute(40000);
+        } catch (e) {
+            this.modals.showError("restoring saved state", e);
+        }
+    }
+
+    async restore(snapshot) {
+        // Order matters: reload disc media first so the base disc is in the
+        // drive before restoreSnapshot applies dirty track overlays on top.
+        await this.reloadSnapshotMedia(snapshot.media);
+        restoreSnapshot(this.processor, this.model, snapshot);
+    }
+
+    async reloadSnapshotMedia(savedMedia) {
+        if (!savedMedia) return;
+        for (let driveIndex = 0; driveIndex < 2; driveIndex++) {
+            const discKey = driveIndex === 0 ? "disc1" : "disc2";
+            const imageDataKey = discKey + "ImageData";
+            const crcKey = discKey + "Crc32";
+
+            // A snapshot from before layout detection has no field, and was contiguous.
+            const layout = savedMedia[discKey + "Layout"] ?? DiscLayout.contiguous;
+
+            let loadedDisc = null;
+            if (savedMedia[discKey]) {
+                // URL-based disc — reload from source
+                loadedDisc = await this.media.loadDiscImage(savedMedia[discKey], layout);
+            } else if (savedMedia[imageDataKey]) {
+                // Locally-loaded disc — reconstruct from embedded image data
+                const imageData =
+                    savedMedia[imageDataKey] instanceof Uint8Array
+                        ? savedMedia[imageDataKey]
+                        : new Uint8Array(Object.values(savedMedia[imageDataKey]));
+                const discName = savedMedia[discKey + "Name"] || "snapshot.ssd";
+                loadedDisc = disc.discFor(this.processor.fdc, discName, imageData, undefined, layout);
+                // Retain the image bytes so subsequent saves can re-embed them.
+                loadedDisc.setOriginalImage(imageData);
+            }
+            if (!loadedDisc) continue;
+
+            // Verify CRC32 if present
+            if (savedMedia[crcKey] != null && loadedDisc.originalImageCrc32 != null) {
+                if (loadedDisc.originalImageCrc32 !== savedMedia[crcKey]) {
+                    toast(
+                        `${loadedDisc.name} has changed since this state was saved. The state has been restored anyway and may not run correctly.`,
+                        { title: "Restoring state" },
+                    );
+                }
+            }
+
+            this.drives.putDiscIn(driveIndex, loadedDisc);
+            // Only update the URL/query for URL-sourced discs. For embedded
+            // (local-file) discs, setting parsedQuery would put a bogus source
+            // in the URL and break subsequent saves/reloads.
+            if (savedMedia[discKey]) {
+                if (driveIndex === 0) this.media.setDisc1Image(savedMedia[discKey]);
+                else this.media.setDisc2Image(savedMedia[discKey]);
+            }
+        }
+    }
+}

--- a/tests/unit/test-snapshot-ui.js
+++ b/tests/unit/test-snapshot-ui.js
@@ -1,0 +1,187 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { SnapshotUI, isSnapshotFile, snapshotMedia } from "../../src/web/snapshot-ui.js";
+import { DiscLayout } from "../../src/disc.js";
+
+const Markup = `<a id="save-state"></a><input type="file" id="load-state" />`;
+
+/** A catalogued single-density image, the smallest thing discFor accepts. */
+function ssdImage(sectors = 800) {
+    const data = new Uint8Array(80 * 10 * 256);
+    data[0x106] = (sectors >>> 8) & 3;
+    data[0x107] = sectors & 0xff;
+    return data;
+}
+
+describe("snapshot media manifest", () => {
+    const urlDisc = { originalImageCrc32: 0x1234, is40Track: false, originalImageData: null };
+    const localDisc = {
+        originalImageCrc32: 0x5678,
+        is40Track: true,
+        originalImageData: new Uint8Array([1, 2]),
+        name: "mine.ssd",
+    };
+
+    it("is nothing when no drive holds anything worth recording", () => {
+        expect(snapshotMedia([{ disc: null }, { disc: null }], {})).toBeUndefined();
+    });
+
+    it("names a URL-sourced disc and carries its CRC and layout", () => {
+        const manifest = snapshotMedia([{ disc: urlDisc }, { disc: null }], { disc1: "sth:ELITE.zip" });
+        expect(manifest).toEqual({
+            disc1: "sth:ELITE.zip",
+            disc1Crc32: 0x1234,
+            disc1Layout: DiscLayout.contiguous,
+        });
+    });
+
+    it("takes the bare disc parameter when disc1 is not set", () => {
+        const manifest = snapshotMedia([{ disc: null }, { disc: null }], { disc: "elite.ssd" });
+        expect(manifest.disc1).toBe("elite.ssd");
+    });
+
+    it("embeds the bytes of a local disc, with its name and 40 track layout", () => {
+        const manifest = snapshotMedia([{ disc: localDisc }, { disc: null }], {});
+        expect(manifest.disc1).toBeUndefined();
+        expect(manifest.disc1ImageData).toBe(localDisc.originalImageData);
+        expect(manifest.disc1Name).toBe("mine.ssd");
+        expect(manifest.disc1Layout).toBe(DiscLayout.expanded40);
+    });
+
+    it("records drive 1 under its own keys", () => {
+        const manifest = snapshotMedia([{ disc: null }, { disc: urlDisc }], { disc2: "b.ssd" });
+        expect(manifest.disc2).toBe("b.ssd");
+        expect(manifest.disc2Crc32).toBe(0x1234);
+    });
+});
+
+describe("isSnapshotFile", () => {
+    it("knows the state file extensions", () => {
+        expect(isSnapshotFile("state.snp")).toBe(true);
+        expect(isSnapshotFile("state.json")).toBe(true);
+        expect(isSnapshotFile("state.json.gz")).toBe(true);
+        expect(isSnapshotFile("elite.ssd")).toBe(false);
+    });
+
+    it("treats a uef that is not a BeebEm state as a tape", () => {
+        expect(isSnapshotFile("tape.uef", new Uint8Array([1, 2, 3]).buffer)).toBe(false);
+    });
+});
+
+describe("SnapshotUI", () => {
+    let deps;
+
+    beforeEach(() => {
+        document.body.innerHTML = Markup;
+        deps = {
+            processor: { fdc: { drives: [{ disc: null }, { disc: null }] }, hasTube: false, execute: vi.fn() },
+            model: { name: "B-DFS1.2" },
+            video: { paint: vi.fn() },
+            media: { loadDiscImage: vi.fn(), setDisc1Image: vi.fn(), setDisc2Image: vi.fn() },
+            drives: { putDiscIn: vi.fn() },
+            urlState: { params: {}, urlWith: vi.fn() },
+            modals: { showError: vi.fn() },
+            isRunning: () => true,
+            stop: vi.fn(),
+            go: vi.fn(),
+        };
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+        document.body.innerHTML = "";
+        window.localStorage.clear();
+        window.sessionStorage.clear();
+    });
+
+    const make = () => new SnapshotUI(deps);
+    const toasts = () =>
+        [...document.querySelectorAll(".toast")].map((el) => el.textContent.replace(/\s+/g, " ").trim());
+
+    describe("loading a state", () => {
+        it("stops the emulator, reports a file it cannot read, and runs on", async () => {
+            await make().loadStateFromFile(null, new Uint8Array([0x00, 0x01, 0x02]).buffer);
+            expect(deps.stop).toHaveBeenCalledWith(false);
+            expect(deps.modals.showError).toHaveBeenCalledWith("loading state", expect.anything());
+            expect(deps.go).toHaveBeenCalledTimes(1);
+        });
+
+        it("leaves a stopped emulator stopped afterwards", async () => {
+            deps.isRunning = () => false;
+            await make().loadStateFromFile(null, new Uint8Array([0]).buffer);
+            expect(deps.stop).not.toHaveBeenCalled();
+            expect(deps.go).not.toHaveBeenCalled();
+        });
+    });
+
+    describe("reloading a snapshot's media", () => {
+        it("does nothing for a snapshot with none", async () => {
+            await make().reloadSnapshotMedia(undefined);
+            expect(deps.drives.putDiscIn).not.toHaveBeenCalled();
+        });
+
+        it("reloads a URL-sourced disc from its source and names it in the URL", async () => {
+            const loaded = { name: "ELITE.ssd", originalImageCrc32: 0x1234 };
+            deps.media.loadDiscImage.mockResolvedValue(loaded);
+            await make().reloadSnapshotMedia({ disc1: "sth:ELITE.zip", disc1Crc32: 0x1234 });
+            expect(deps.media.loadDiscImage).toHaveBeenCalledWith("sth:ELITE.zip", DiscLayout.contiguous);
+            expect(deps.drives.putDiscIn).toHaveBeenCalledWith(0, loaded);
+            expect(deps.media.setDisc1Image).toHaveBeenCalledWith("sth:ELITE.zip");
+            expect(toasts()).toEqual([]);
+        });
+
+        it("warns when the source has changed under the state", async () => {
+            deps.media.loadDiscImage.mockResolvedValue({ name: "ELITE.ssd", originalImageCrc32: 0x9999 });
+            await make().reloadSnapshotMedia({ disc1: "sth:ELITE.zip", disc1Crc32: 0x1234 });
+            expect(toasts()).toEqual([expect.stringContaining("ELITE.ssd has changed since this state was saved")]);
+            expect(deps.drives.putDiscIn).toHaveBeenCalled();
+        });
+
+        it("rebuilds an embedded local disc and keeps it out of the URL", async () => {
+            const imageData = ssdImage();
+            await make().reloadSnapshotMedia({
+                disc1ImageData: imageData,
+                disc1Name: "mine.ssd",
+                disc1Layout: DiscLayout.contiguous,
+            });
+            const [driveIndex, loadedDisc] = deps.drives.putDiscIn.mock.calls[0];
+            expect(driveIndex).toBe(0);
+            expect(loadedDisc.name).toBe("mine.ssd");
+            expect(loadedDisc.originalImageData).toBeTruthy();
+            expect(deps.media.setDisc1Image).not.toHaveBeenCalled();
+        });
+
+        it("rebuilds image data that was serialised as a plain object", async () => {
+            const imageData = ssdImage();
+            await make().reloadSnapshotMedia({
+                disc1ImageData: Object.fromEntries(imageData.entries()),
+                disc1Name: "mine.ssd",
+            });
+            expect(deps.drives.putDiscIn).toHaveBeenCalled();
+        });
+
+        it("restores drive 1 alongside drive 0", async () => {
+            const loaded = { name: "B.ssd" };
+            deps.media.loadDiscImage.mockResolvedValue(loaded);
+            await make().reloadSnapshotMedia({ disc2: "b.ssd" });
+            expect(deps.drives.putDiscIn).toHaveBeenCalledWith(1, loaded);
+            expect(deps.media.setDisc2Image).toHaveBeenCalledWith("b.ssd");
+        });
+    });
+
+    describe("the pending state", () => {
+        it("is quiet when there is nothing pending", async () => {
+            await make().restorePendingState();
+            expect(deps.modals.showError).not.toHaveBeenCalled();
+            expect(deps.processor.execute).not.toHaveBeenCalled();
+        });
+
+        it("consumes a stashed state even when it cannot be restored", async () => {
+            sessionStorage.setItem("jsbeeb-pending-state", "not json at all");
+            await make().restorePendingState();
+            expect(deps.modals.showError).toHaveBeenCalledWith("restoring saved state", expect.anything());
+            expect(sessionStorage.getItem("jsbeeb-pending-state")).toBeNull();
+        });
+    });
+});


### PR DESCRIPTION
PR 9 of the #638 Phase 2 stack.

**Moved**: `SnapshotUI` in `src/web/snapshot-ui.js` owns the save menu item, the load file input, the restore across a model change (the sessionStorage stash) and `reloadSnapshotMedia`. Two pieces fall out pure: `snapshotMedia`, building the media manifest a save carries, and `readSnapshot`, recognising BeebEm, UEF, gzipped and plain JSON states. `isSnapshotFile` moves here too; the media loader's drop zone takes it as a dependency.

**Tests**: the manifest for URL-sourced, local and empty drives; extension detection; media reloading including the CRC warning, embedded image data (typed and JSON-mangled), and the URL rules; the stop/restore/go bracket around a load; the pending state consumed even when unreadable.

**Checked**: unit suite, all ten smoke checks (the save/load check exercises the whole path end to end through a URL-named disc).
