### PR TITLE
refactor: move autoboot and BASIC insertion out of main.js

### DIFF
--- a/src/basic-loader.js
+++ b/src/basic-loader.js
@@ -1,0 +1,20 @@
+"use strict";
+
+/**
+ * Pokes a tokenised BASIC program into memory at PAGE, and sets TOP and
+ * VARTOP after it, exactly as if it had just been typed.
+ */
+export function installBasic(tokenised, { readByte, writeByte }) {
+    const page = readByte(0x18) << 8;
+    for (let i = 0; i < tokenised.length; ++i) {
+        writeByte(page + i, tokenised.charCodeAt(i));
+    }
+    // Set VARTOP (0x12/3) and TOP(0x02/3)
+    const end = page + tokenised.length;
+    const endLow = end & 0xff;
+    const endHigh = (end >>> 8) & 0xff;
+    writeByte(0x02, endLow);
+    writeByte(0x03, endHigh);
+    writeByte(0x12, endLow);
+    writeByte(0x13, endHigh);
+}

--- a/src/main.js
+++ b/src/main.js
@@ -11,7 +11,6 @@ import * as utils_atom from "./utils_atom.js";
 import { LoadSD } from "./mmc.js";
 import { Cmos, localStoragePersistence } from "./cmos.js";
 import { GamePad } from "./gamepads.js";
-import * as tokeniser from "./basic-tokenise.js";
 import * as canvasLib from "./canvas.js";
 import { Config } from "./config.js";
 import { DefaultModel, findModel, tubeModelFor } from "./models.js";
@@ -29,6 +28,7 @@ import { SthPicker } from "./web/sth-picker.js";
 import { HfePicker } from "./web/hfe-picker.js";
 import { GoogleDrivePicker } from "./web/google-drive-picker.js";
 import { isSnapshotFile, SnapshotUI } from "./web/snapshot-ui.js";
+import { Autoboot } from "./web/autoboot.js";
 import { Drives } from "./web/drives.js";
 import { UrlState } from "./web/url-state.js";
 import { Modals } from "./web/modals.js";
@@ -60,11 +60,6 @@ let frameSkip = 0;
 let syncLights;
 let running;
 let model;
-
-// Convert text to machine-appropriate key sequences (BBC or Atom)
-function stringToMachineKeys(text) {
-    return model.isAtom ? utils_atom.stringToATOMKeys(text) : utils.stringToBBCKeys(text);
-}
 
 const gamepad = new GamePad();
 if (!window.isSecureContext)
@@ -488,7 +483,7 @@ const pastetext = document.getElementById("paste-text");
 pastetext.closest("form").addEventListener("submit", (event) => event.preventDefault());
 pastetext.addEventListener("paste", function (event) {
     const text = event.clipboardData.getData("text/plain");
-    sendRawKeyboard(stringToMachineKeys(text), true);
+    sendRawKeyboard(autoBoot.stringToMachineKeys(text), true);
 });
 const cubMonitor = document.getElementById("cub-monitor");
 function onCubMouseEvent(evt) {
@@ -658,9 +653,24 @@ const media = new MediaLoader({
         drive: (cat, layout) => drivePicker.load(cat, layout),
     },
 });
+const autoBoot = new Autoboot({ model, processor, sendKeys: sendRawKeyboard });
 const autobootTicks = new AutobootTicks({ urlState });
-const sthPicker = new SthPicker({ media, drives, modals, urlState, processor, autoboot });
-const hfePicker = new HfePicker({ media, drives, modals, urlState, processor, autoboot });
+const sthPicker = new SthPicker({
+    media,
+    drives,
+    modals,
+    urlState,
+    processor,
+    autoboot: (image) => autoBoot.boot(image),
+});
+const hfePicker = new HfePicker({
+    media,
+    drives,
+    modals,
+    urlState,
+    processor,
+    autoboot: (image) => autoBoot.boot(image),
+});
 const drivePicker = new GoogleDrivePicker({ media, drives, modals, processor });
 const snapshots = new SnapshotUI({
     processor,
@@ -908,48 +918,6 @@ function sendRawKeyboard(keysToSend, checkCapsAndShiftLocks) {
     }
 }
 
-function autoboot(image) {
-    const BBC = utils.BBC;
-
-    console.log("Autobooting disc");
-    utils.noteEvent("init", "autoboot", image);
-
-    // Shift-break simulation, hold SHIFT for 1000ms.
-    sendRawKeyboard([BBC.SHIFT, 1000], false);
-}
-
-function autoBootType(keys) {
-    console.log("Auto typing '" + keys + "'");
-    utils.noteEvent("init", "autochain");
-
-    const bbcKeys = stringToMachineKeys(keys);
-    sendRawKeyboard([1000].concat(bbcKeys), false);
-}
-
-function autoChainTape() {
-    console.log("Auto Chaining Tape");
-    utils.noteEvent("init", "autochain");
-
-    const bbcKeys = stringToMachineKeys('*TAPE\nCH.""\n');
-    sendRawKeyboard([1000].concat(bbcKeys), false);
-}
-
-function autoRunTape() {
-    console.log("Auto Running Tape");
-    utils.noteEvent("init", "autorun");
-
-    const bbcKeys = stringToMachineKeys("*TAPE\n*/\n");
-    sendRawKeyboard([1000].concat(bbcKeys), false);
-}
-
-function autoRunBasic() {
-    console.log("Auto Running basic");
-    utils.noteEvent("init", "autorunbasic");
-
-    const bbcKeys = stringToMachineKeys("RUN\n");
-    sendRawKeyboard([1000].concat(bbcKeys), false);
-}
-
 document.getElementById("download-filestore-link").addEventListener("click", function () {
     downloadDriveData(processor.filestore.scsi, "scsi", ".dat");
 });
@@ -1107,39 +1075,12 @@ const startPromise = (async () => {
         startImageLoad(`MMC image ${mmcImage}`, async () => processor.atommc.SetMMCData(await LoadSD(mmcImage)));
     }
 
-    async function insertBasic(getBasicPromise, needsRun) {
-        const prog = await getBasicPromise;
-        const t = await tokeniser.create();
-        const tokenised = await t.tokenise(prog);
-
-        const idleAddr = processor.model.isMaster ? 0xe7e6 : 0xe581;
-        const hook = processor.debugInstruction.add(function (addr) {
-            if (addr !== idleAddr) return;
-            const page = processor.readmem(0x18) << 8;
-            for (let i = 0; i < tokenised.length; ++i) {
-                processor.writemem(page + i, tokenised.charCodeAt(i));
-            }
-            // Set VARTOP (0x12/3) and TOP(0x02/3)
-            const end = page + tokenised.length;
-            const endLow = end & 0xff;
-            const endHigh = (end >>> 8) & 0xff;
-            processor.writemem(0x02, endLow);
-            processor.writemem(0x03, endHigh);
-            processor.writemem(0x12, endLow);
-            processor.writemem(0x13, endHigh);
-            hook.remove();
-            if (needsRun) {
-                autoRunBasic();
-            }
-        });
-    }
-
     if (parsedQuery.loadBasic) {
         const needsRun = needsAutoboot === "run";
         needsAutoboot = "";
 
         await startImageLoad(`BASIC program ${parsedQuery.loadBasic}`, () =>
-            insertBasic(
+            autoBoot.insertBasic(
                 (async () => {
                     const data = await utils.loadData(parsedQuery.loadBasic);
                     return String.fromCharCode.apply(null, data);
@@ -1151,7 +1092,7 @@ const startPromise = (async () => {
 
     if (parsedQuery.embedBasic) {
         await startImageLoad("the BASIC program from the URL", () =>
-            insertBasic(Promise.resolve(parsedQuery.embedBasic), true),
+            autoBoot.insertBasic(Promise.resolve(parsedQuery.embedBasic), true),
         );
     }
 
@@ -1165,16 +1106,16 @@ const startPromise = (async () => {
         switch (needsAutoboot) {
             case "boot":
                 autobootTicks.show(true);
-                autoboot(discImage);
+                autoBoot.boot(discImage);
                 break;
             case "type":
-                autoBootType(autoType);
+                autoBoot.type(autoType);
                 break;
             case "chain":
-                autoChainTape();
+                autoBoot.chainTape();
                 break;
             case "run":
-                autoRunTape();
+                autoBoot.runTape();
                 break;
             default:
                 autobootTicks.show(false);

--- a/src/web/autoboot.js
+++ b/src/web/autoboot.js
@@ -1,0 +1,85 @@
+import * as utils from "../utils.js";
+import * as utils_atom from "../utils_atom.js";
+import * as tokeniser from "../basic-tokenise.js";
+import { installBasic } from "../basic-loader.js";
+
+/** Booting and typing for the machine at startup: shift-break, *TAPE incantations and BASIC programs. */
+export class Autoboot {
+    /** @param {Function} deps.sendKeys sends a raw key sequence once the keyboard exists */
+    constructor({ model, processor, sendKeys }) {
+        this.model = model;
+        this.processor = processor;
+        this.sendKeys = sendKeys;
+    }
+
+    /** Convert text to machine-appropriate key sequences (BBC or Atom) */
+    stringToMachineKeys(text) {
+        return this.model.isAtom ? utils_atom.stringToATOMKeys(text) : utils.stringToBBCKeys(text);
+    }
+
+    boot(image) {
+        const BBC = utils.BBC;
+
+        console.log("Autobooting disc");
+        utils.noteEvent("init", "autoboot", image);
+
+        // Shift-break simulation, hold SHIFT for 1000ms.
+        this.sendKeys([BBC.SHIFT, 1000], false);
+    }
+
+    type(keys) {
+        console.log("Auto typing '" + keys + "'");
+        utils.noteEvent("init", "autochain");
+
+        const bbcKeys = this.stringToMachineKeys(keys);
+        this.sendKeys([1000].concat(bbcKeys), false);
+    }
+
+    chainTape() {
+        console.log("Auto Chaining Tape");
+        utils.noteEvent("init", "autochain");
+
+        const bbcKeys = this.stringToMachineKeys('*TAPE\nCH.""\n');
+        this.sendKeys([1000].concat(bbcKeys), false);
+    }
+
+    runTape() {
+        console.log("Auto Running Tape");
+        utils.noteEvent("init", "autorun");
+
+        const bbcKeys = this.stringToMachineKeys("*TAPE\n*/\n");
+        this.sendKeys([1000].concat(bbcKeys), false);
+    }
+
+    runBasic() {
+        console.log("Auto Running basic");
+        utils.noteEvent("init", "autorunbasic");
+
+        const bbcKeys = this.stringToMachineKeys("RUN\n");
+        this.sendKeys([1000].concat(bbcKeys), false);
+    }
+
+    /**
+     * Tokenises a BASIC program and installs it once the OS reaches its idle
+     * loop, so it lands after the machine has finished starting up.
+     */
+    async insertBasic(getBasicPromise, needsRun) {
+        const prog = await getBasicPromise;
+        const t = await tokeniser.create();
+        const tokenised = await t.tokenise(prog);
+
+        const { processor } = this;
+        const idleAddr = processor.model.isMaster ? 0xe7e6 : 0xe581;
+        const hook = processor.debugInstruction.add((addr) => {
+            if (addr !== idleAddr) return;
+            installBasic(tokenised, {
+                readByte: (a) => processor.readmem(a),
+                writeByte: (a, value) => processor.writemem(a, value),
+            });
+            hook.remove();
+            if (needsRun) {
+                this.runBasic();
+            }
+        });
+    }
+}

--- a/tests/test-machine.js
+++ b/tests/test-machine.js
@@ -1,3 +1,4 @@
+import { installBasic } from "../src/basic-loader.js";
 import * as fdc from "../src/fdc.js";
 import { fake6502 } from "../src/fake6502.js";
 import { findModel } from "../src/models.js";
@@ -250,19 +251,10 @@ export class TestMachine {
     async loadBasic(source) {
         const tokeniser = await Tokeniser.create();
         const tokenised = tokeniser.tokenise(source);
-        // TODO: dedupe from main.js
-        const page = this.readbyte(0x18) << 8;
-        for (let i = 0; i < tokenised.length; ++i) {
-            this.writebyte(page + i, tokenised.charCodeAt(i));
-        }
-        // Set VARTOP (0x12/3) and TOP(0x02/3)
-        const end = page + tokenised.length;
-        const endLow = end & 0xff;
-        const endHigh = (end >>> 8) & 0xff;
-        this.writebyte(0x02, endLow);
-        this.writebyte(0x03, endHigh);
-        this.writebyte(0x12, endLow);
-        this.writebyte(0x13, endHigh);
+        installBasic(tokenised, {
+            readByte: (addr) => this.readbyte(addr),
+            writeByte: (addr, value) => this.writebyte(addr, value),
+        });
     }
 
     /**

--- a/tests/unit/test-autoboot.js
+++ b/tests/unit/test-autoboot.js
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { Autoboot } from "../../src/web/autoboot.js";
 import * as utils from "../../src/utils.js";
@@ -25,6 +25,10 @@ describe("Autoboot", () => {
                 },
             },
         };
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
     });
 
     const make = (isAtom = false) => new Autoboot({ model: { isAtom }, processor, sendKeys });
@@ -56,7 +60,6 @@ describe("Autoboot", () => {
         expect(spelled).toHaveBeenCalledWith('*TAPE\nCH.""\n');
         make().runTape();
         expect(spelled).toHaveBeenCalledWith("*TAPE\n*/\n");
-        vi.restoreAllMocks();
     });
 
     describe("insertBasic", () => {

--- a/tests/unit/test-autoboot.js
+++ b/tests/unit/test-autoboot.js
@@ -1,0 +1,91 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { Autoboot } from "../../src/web/autoboot.js";
+import * as utils from "../../src/utils.js";
+
+describe("Autoboot", () => {
+    let sendKeys;
+    let processor;
+
+    beforeEach(() => {
+        vi.spyOn(console, "log").mockImplementation(() => {});
+        sendKeys = vi.fn();
+        const memory = new Uint8Array(0x10000);
+        memory[0x18] = 0x19;
+        processor = {
+            model: { isMaster: false },
+            memory,
+            readmem: (addr) => memory[addr],
+            writemem: (addr, value) => (memory[addr] = value),
+            debugInstruction: {
+                hook: null,
+                add(fn) {
+                    this.hook = fn;
+                    return { remove: () => (this.hook = null) };
+                },
+            },
+        };
+    });
+
+    const make = (isAtom = false) => new Autoboot({ model: { isAtom }, processor, sendKeys });
+
+    it("boots a disc by holding SHIFT through a break", () => {
+        make().boot("elite.ssd");
+        expect(sendKeys).toHaveBeenCalledWith([utils.BBC.SHIFT, 1000], false);
+    });
+
+    it("types the requested keys after a pause", () => {
+        make().type("*CAT\n");
+        const [keys, checkLocks] = sendKeys.mock.calls[0];
+        expect(keys[0]).toBe(1000);
+        expect(keys.length).toBeGreaterThan(1);
+        expect(checkLocks).toBe(false);
+    });
+
+    it("converts keys for the machine it is booting", () => {
+        make(false).type("A");
+        const bbcKeys = sendKeys.mock.calls[0][0];
+        make(true).type("A");
+        const atomKeys = sendKeys.mock.calls[1][0];
+        expect(bbcKeys).not.toEqual(atomKeys);
+    });
+
+    it("chains and runs tapes with the right incantations", () => {
+        const spelled = vi.spyOn(utils, "stringToBBCKeys");
+        make().chainTape();
+        expect(spelled).toHaveBeenCalledWith('*TAPE\nCH.""\n');
+        make().runTape();
+        expect(spelled).toHaveBeenCalledWith("*TAPE\n*/\n");
+        vi.restoreAllMocks();
+    });
+
+    describe("insertBasic", () => {
+        it("installs the program when the OS goes idle, once, and runs it when asked", async () => {
+            await make().insertBasic(Promise.resolve('10 PRINT "HI"'), true);
+            expect(processor.debugInstruction.hook).toBeTruthy();
+
+            // Not yet: some other instruction.
+            processor.debugInstruction.hook(0x1234);
+            expect(processor.memory[0x1900]).toBe(0);
+            expect(sendKeys).not.toHaveBeenCalled();
+
+            // The B's idle loop address.
+            processor.debugInstruction.hook(0xe581);
+            expect(processor.memory[0x1900]).not.toBe(0);
+            expect(processor.debugInstruction.hook).toBeNull();
+            // RUN typed after a pause.
+            expect(sendKeys).toHaveBeenCalledTimes(1);
+            expect(sendKeys.mock.calls[0][0][0]).toBe(1000);
+        });
+
+        it("hooks the Master's idle loop on a Master", async () => {
+            processor.model.isMaster = true;
+            await make().insertBasic(Promise.resolve("10 END"), false);
+            processor.debugInstruction.hook(0xe581);
+            expect(processor.memory[0x1900]).toBe(0);
+            processor.debugInstruction.hook(0xe7e6);
+            expect(processor.memory[0x1900]).not.toBe(0);
+            expect(sendKeys).not.toHaveBeenCalled();
+        });
+    });
+});

--- a/tests/unit/test-basic-loader.js
+++ b/tests/unit/test-basic-loader.js
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+
+import { installBasic } from "../../src/basic-loader.js";
+
+describe("installBasic", () => {
+    const machine = (page = 0x19) => {
+        const memory = new Uint8Array(0x10000);
+        memory[0x18] = page;
+        return { memory, readByte: (addr) => memory[addr], writeByte: (addr, value) => (memory[addr] = value) };
+    };
+
+    it("pokes the program in at PAGE", () => {
+        const m = machine(0x19);
+        installBasic("\r\x00\x0a\x0dABC", m);
+        expect(m.memory[0x1900]).toBe(0x0d);
+        expect(String.fromCharCode(m.memory[0x1904], m.memory[0x1905], m.memory[0x1906])).toBe("ABC");
+    });
+
+    it("sets TOP and VARTOP to just past the program", () => {
+        const m = machine(0x0e);
+        const program = "x".repeat(0x105);
+        installBasic(program, m);
+        const end = 0x0e00 + 0x105;
+        expect(m.memory[0x02] | (m.memory[0x03] << 8)).toBe(end);
+        expect(m.memory[0x12] | (m.memory[0x13] << 8)).toBe(end);
+    });
+});


### PR DESCRIPTION
PR 10, the last of the #638 Phase 2 stack.

**Moved**: `Autoboot` in `src/web/autoboot.js` owns shift-break, the typed startup incantations (`type`, `chainTape`, `runTape`, `runBasic`), machine-appropriate key conversion and installing a tokenised BASIC program at the OS idle loop. The memory pokes become `installBasic` in `src/basic-loader.js`, which `tests/test-machine.js` now shares instead of its own copy, closing its "dedupe from main.js" TODO.

**Changed from the plan**: the `needsAutoboot` startup switch stays in `main.js` as dispatch, because it also drives the autoboot ticks and moving it would have split one decision across two files.

**Tests**: the key sequences per machine, the idle-loop hook installing once at the right address per model and typing RUN only when asked, and `installBasic`'s PAGE/TOP/VARTOP handling. The integration tests that use `loadBasic` (nops, rmw, via) pass against the shared helper.

**Checked**: unit suite, those three integration files, all ten smoke checks.
