### PR TITLE
refactor: move the screen layout out of main.js

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -28,6 +28,7 @@ import { GoogleDrivePicker } from "./web/google-drive-picker.js";
 import { isSnapshotFile, SnapshotUI } from "./web/snapshot-ui.js";
 import { Autoboot } from "./web/autoboot.js";
 import { Display } from "./web/display.js";
+import { Layout } from "./web/layout.js";
 import { Drives } from "./web/drives.js";
 import { UrlState } from "./web/url-state.js";
 import { Modals } from "./web/modals.js";
@@ -283,27 +284,6 @@ const emulationConfig = {
     },
 };
 
-function sbBind(div, url, onload) {
-    const img = div.querySelector("img");
-    img.style.display = "none";
-    if (!url) return;
-    img.addEventListener("load", function () {
-        onload(div, img);
-        img.style.display = "";
-    });
-    img.src = url;
-}
-
-sbBind(document.querySelector(".sidebar.left"), parsedQuery.sbLeft, function (div, img) {
-    div.style.left = -img.naturalWidth - 5 + "px";
-});
-sbBind(document.querySelector(".sidebar.right"), parsedQuery.sbRight, function (div, img) {
-    div.style.right = -img.naturalWidth - 5 + "px";
-});
-sbBind(document.querySelector(".sidebar.bottom"), parsedQuery.sbBottom, function (div, img) {
-    div.style.bottom = -img.naturalHeight + "px";
-});
-
 if (cpuMultiplier !== 1) console.log(`CPU multiplier set to ${cpuMultiplier}`);
 const cpuSpeed = model.cyclesPerSecond;
 const clocksPerSecond = (cpuMultiplier * cpuSpeed) | 0;
@@ -411,20 +391,6 @@ window.addEventListener("blur", function () {
     setEmulationLead(audioHandler.setWindowFocused(false));
 });
 window.addEventListener("focus", () => setEmulationLead(audioHandler.setWindowFocused(true)));
-
-const fullscreenItem = document.getElementById("fs");
-if (document.fullscreenEnabled) {
-    fullscreenItem.addEventListener("click", async (event) => {
-        event.preventDefault();
-        try {
-            await screenCanvas.requestFullscreen();
-        } catch (error) {
-            toast(`Could not go fullscreen: ${errorText(error)}`, { title: "Fullscreen" });
-        }
-    });
-} else {
-    fullscreenItem.closest("li").hidden = true;
-}
 
 let keyboard; // This will be initialised after the processor is created
 
@@ -1298,90 +1264,12 @@ function stop(debug) {
     updateDebugButtons();
 }
 
-/** Steps the drawing buffer grows in, as a multiple of the base canvas size. */
-const CanvasScaleStep = 0.25;
-
-(function () {
-    const resizeCubMonitor = document.getElementById("cub-monitor");
-    const resizeCubMonitorPic = document.getElementById("cub-monitor-pic");
-    const borderReservedSize = parsedQuery.embed !== undefined ? 0 : 100;
-    const bottomReservedSize = parsedQuery.embed !== undefined ? 0 : 68;
-
-    function resizeTv() {
-        // Get current display config (may change when display mode switches)
-        const displayConfig = display.filterClass.getDisplayConfig();
-
-        const imageOrigHeight = displayConfig.imageHeight;
-        const imageOrigWidth = displayConfig.imageWidth;
-        const canvasOrigLeft = displayConfig.canvasLeft;
-        const canvasOrigTop = displayConfig.canvasTop;
-        const visibleWidth = displayConfig.visibleWidth;
-        const visibleHeight = displayConfig.visibleHeight;
-
-        const canvasNativeWidth = screenCanvas.getAttribute("width");
-        const canvasNativeHeight = screenCanvas.getAttribute("height");
-        const desiredAspectRatio = imageOrigWidth / imageOrigHeight;
-        const minWidth = imageOrigWidth / 4;
-        const minHeight = imageOrigHeight / 4;
-
-        let navbarHeight = document.getElementById("header-bar")?.offsetHeight || 0;
-        let width = Math.max(minWidth, window.innerWidth - borderReservedSize * 2);
-        let height = Math.max(minHeight, window.innerHeight - navbarHeight - bottomReservedSize);
-        if (width / height <= desiredAspectRatio) {
-            height = width / desiredAspectRatio;
-        } else {
-            width = height * desiredAspectRatio;
-        }
-
-        const containerScale = width / imageOrigWidth;
-        const scaledVisibleWidth = visibleWidth * containerScale;
-        const scaledVisibleHeight = visibleHeight * containerScale;
-
-        const canvasAspect = canvasNativeWidth / canvasNativeHeight;
-        const visibleAspect = scaledVisibleWidth / scaledVisibleHeight;
-
-        let finalCanvasWidth, finalCanvasHeight;
-        if (canvasAspect > visibleAspect) {
-            finalCanvasWidth = scaledVisibleWidth;
-            finalCanvasHeight = scaledVisibleWidth / canvasAspect;
-        } else {
-            finalCanvasHeight = scaledVisibleHeight;
-            finalCanvasWidth = scaledVisibleHeight * canvasAspect;
-        }
-
-        resizeCubMonitor.style.height = height + "px";
-        resizeCubMonitor.style.width = width + "px";
-        resizeCubMonitorPic.style.height = height + "px";
-        resizeCubMonitorPic.style.width = width + "px";
-        // A mode that reconstructs detail wants to draw at the size it will be
-        // seen at, up to the limit it asks for. Drawing more than the display
-        // can show costs fragments and buys nothing, and for an expensive
-        // shader that is the difference between comfortable and not.
-        if (displayConfig.maxCanvasScale) {
-            const wanted = (finalCanvasWidth * (window.devicePixelRatio || 1)) / displayConfig.canvasWidth;
-            // Quantised, because resize fires continuously while a window is
-            // dragged and every distinct value reallocates the drawing buffer.
-            const quantised = Math.round(wanted / CanvasScaleStep) * CanvasScaleStep;
-            const scale = Math.min(displayConfig.maxCanvasScale, Math.max(1, quantised));
-            const backingWidth = Math.round(displayConfig.canvasWidth * scale);
-            if (screenCanvas.width !== backingWidth) {
-                screenCanvas.width = backingWidth;
-                screenCanvas.height = Math.round(displayConfig.canvasHeight * scale);
-                // Resizing threw the drawing buffer away.
-                video.paint();
-            }
-        }
-
-        screenCanvas.style.width = finalCanvasWidth + "px";
-        screenCanvas.style.height = finalCanvasHeight + "px";
-        screenCanvas.style.left = canvasOrigLeft * containerScale + "px";
-        screenCanvas.style.top = canvasOrigTop * containerScale + "px";
-    }
-
-    window.addEventListener("resize", resizeTv);
-    window.setTimeout(resizeTv, 1);
-    window.setTimeout(resizeTv, 500);
-})();
+new Layout({
+    screenCanvas,
+    display,
+    embed: parsedQuery.embed !== undefined,
+    sidebars: { left: parsedQuery.sbLeft, right: parsedQuery.sbRight, bottom: parsedQuery.sbBottom },
+});
 
 if (Object.hasOwn(parsedQuery, "about")) modals.show("info");
 if (Object.hasOwn(parsedQuery, "pp-tos")) modals.show("pp-tos");

--- a/src/web/layout.js
+++ b/src/web/layout.js
@@ -1,0 +1,156 @@
+import { toast } from "./toast.js";
+import { errorText } from "./reporting.js";
+
+/** Steps the drawing buffer grows in, as a multiple of the base canvas size. */
+const CanvasScaleStep = 0.25;
+
+/**
+ * Where everything goes for a given window: the monitor picture, the canvas
+ * within it, and (for a mode with maxCanvasScale) how large a drawing buffer
+ * to ask for. Pure, so the geometry is testable on its own.
+ */
+export function fitMonitor(displayConfig, viewport, canvasNative) {
+    const imageOrigHeight = displayConfig.imageHeight;
+    const imageOrigWidth = displayConfig.imageWidth;
+    const desiredAspectRatio = imageOrigWidth / imageOrigHeight;
+    const minWidth = imageOrigWidth / 4;
+    const minHeight = imageOrigHeight / 4;
+
+    let width = Math.max(minWidth, viewport.innerWidth - viewport.borderReservedSize * 2);
+    let height = Math.max(minHeight, viewport.innerHeight - viewport.navbarHeight - viewport.bottomReservedSize);
+    if (width / height <= desiredAspectRatio) {
+        height = width / desiredAspectRatio;
+    } else {
+        width = height * desiredAspectRatio;
+    }
+
+    const containerScale = width / imageOrigWidth;
+    const scaledVisibleWidth = displayConfig.visibleWidth * containerScale;
+    const scaledVisibleHeight = displayConfig.visibleHeight * containerScale;
+
+    const canvasAspect = canvasNative.width / canvasNative.height;
+    const visibleAspect = scaledVisibleWidth / scaledVisibleHeight;
+
+    let finalCanvasWidth, finalCanvasHeight;
+    if (canvasAspect > visibleAspect) {
+        finalCanvasWidth = scaledVisibleWidth;
+        finalCanvasHeight = scaledVisibleWidth / canvasAspect;
+    } else {
+        finalCanvasHeight = scaledVisibleHeight;
+        finalCanvasWidth = scaledVisibleHeight * canvasAspect;
+    }
+
+    // A mode that reconstructs detail wants to draw at the size it will be
+    // seen at, up to the limit it asks for. Drawing more than the display
+    // can show costs fragments and buys nothing, and for an expensive
+    // shader that is the difference between comfortable and not.
+    let backing = null;
+    if (displayConfig.maxCanvasScale) {
+        const wanted = (finalCanvasWidth * viewport.devicePixelRatio) / displayConfig.canvasWidth;
+        // Quantised, because resize fires continuously while a window is
+        // dragged and every distinct value reallocates the drawing buffer.
+        const quantised = Math.round(wanted / CanvasScaleStep) * CanvasScaleStep;
+        const scale = Math.min(displayConfig.maxCanvasScale, Math.max(1, quantised));
+        backing = {
+            width: Math.round(displayConfig.canvasWidth * scale),
+            height: Math.round(displayConfig.canvasHeight * scale),
+        };
+    }
+
+    return {
+        monitor: { width, height },
+        canvas: {
+            width: finalCanvasWidth,
+            height: finalCanvasHeight,
+            left: displayConfig.canvasLeft * containerScale,
+            top: displayConfig.canvasTop * containerScale,
+        },
+        backing,
+    };
+}
+
+/** Keeps the monitor and canvas fitted to the window, and wires the page furniture around them. */
+export class Layout {
+    constructor({ screenCanvas, display, embed, sidebars = {} }) {
+        this.screenCanvas = screenCanvas;
+        this.display = display;
+        this.cubMonitor = document.getElementById("cub-monitor");
+        this.cubMonitorPic = document.getElementById("cub-monitor-pic");
+        this.borderReservedSize = embed ? 0 : 100;
+        this.bottomReservedSize = embed ? 0 : 68;
+
+        window.addEventListener("resize", () => this.resize());
+        window.setTimeout(() => this.resize(), 1);
+        window.setTimeout(() => this.resize(), 500);
+
+        this.bindSidebar(".sidebar.left", sidebars.left, (div, img) => {
+            div.style.left = -img.naturalWidth - 5 + "px";
+        });
+        this.bindSidebar(".sidebar.right", sidebars.right, (div, img) => {
+            div.style.right = -img.naturalWidth - 5 + "px";
+        });
+        this.bindSidebar(".sidebar.bottom", sidebars.bottom, (div, img) => {
+            div.style.bottom = -img.naturalHeight + "px";
+        });
+
+        const fullscreenItem = document.getElementById("fs");
+        if (document.fullscreenEnabled) {
+            fullscreenItem.addEventListener("click", async (event) => {
+                event.preventDefault();
+                try {
+                    await screenCanvas.requestFullscreen();
+                } catch (error) {
+                    toast(`Could not go fullscreen: ${errorText(error)}`, { title: "Fullscreen" });
+                }
+            });
+        } else {
+            fullscreenItem.closest("li").hidden = true;
+        }
+    }
+
+    resize() {
+        // The display config can change when the display mode switches.
+        const displayConfig = this.display.filterClass.getDisplayConfig();
+        const fitted = fitMonitor(
+            displayConfig,
+            {
+                innerWidth: window.innerWidth,
+                innerHeight: window.innerHeight,
+                navbarHeight: document.getElementById("header-bar")?.offsetHeight || 0,
+                borderReservedSize: this.borderReservedSize,
+                bottomReservedSize: this.bottomReservedSize,
+                devicePixelRatio: window.devicePixelRatio || 1,
+            },
+            { width: this.screenCanvas.getAttribute("width"), height: this.screenCanvas.getAttribute("height") },
+        );
+
+        this.cubMonitor.style.height = fitted.monitor.height + "px";
+        this.cubMonitor.style.width = fitted.monitor.width + "px";
+        this.cubMonitorPic.style.height = fitted.monitor.height + "px";
+        this.cubMonitorPic.style.width = fitted.monitor.width + "px";
+
+        if (fitted.backing && this.screenCanvas.width !== fitted.backing.width) {
+            this.screenCanvas.width = fitted.backing.width;
+            this.screenCanvas.height = fitted.backing.height;
+            // Resizing threw the drawing buffer away.
+            this.display.video.paint();
+        }
+
+        this.screenCanvas.style.width = fitted.canvas.width + "px";
+        this.screenCanvas.style.height = fitted.canvas.height + "px";
+        this.screenCanvas.style.left = fitted.canvas.left + "px";
+        this.screenCanvas.style.top = fitted.canvas.top + "px";
+    }
+
+    bindSidebar(selector, url, onload) {
+        const div = document.querySelector(selector);
+        const img = div.querySelector("img");
+        img.style.display = "none";
+        if (!url) return;
+        img.addEventListener("load", () => {
+            onload(div, img);
+            img.style.display = "";
+        });
+        img.src = url;
+    }
+}

--- a/tests/unit/test-layout.js
+++ b/tests/unit/test-layout.js
@@ -1,0 +1,98 @@
+// @vitest-environment jsdom
+import { describe, expect, it } from "vitest";
+
+import { fitMonitor } from "../../src/web/layout.js";
+
+const Config = {
+    imageWidth: 800,
+    imageHeight: 600,
+    canvasLeft: 100,
+    canvasTop: 50,
+    visibleWidth: 600,
+    visibleHeight: 450,
+    canvasWidth: 800,
+    canvasHeight: 600,
+};
+
+const viewport = (innerWidth, innerHeight, extra = {}) => ({
+    innerWidth,
+    innerHeight,
+    navbarHeight: 40,
+    borderReservedSize: 100,
+    bottomReservedSize: 68,
+    devicePixelRatio: 1,
+    ...extra,
+});
+
+const native = { width: 800, height: 600 };
+
+describe("fitMonitor", () => {
+    it("fills the width of a tall window, keeping the picture's aspect", () => {
+        const fitted = fitMonitor(Config, viewport(1000, 2000), native);
+        expect(fitted.monitor.width).toBe(800);
+        expect(fitted.monitor.height).toBe(600);
+    });
+
+    it("fills the height of a wide window, keeping the picture's aspect", () => {
+        const fitted = fitMonitor(Config, viewport(4000, 708), native);
+        expect(fitted.monitor.height).toBe(600);
+        expect(fitted.monitor.width).toBe(800);
+    });
+
+    it("never shrinks below a quarter of the picture", () => {
+        const fitted = fitMonitor(Config, viewport(10, 10), native);
+        expect(fitted.monitor.width).toBe(200);
+        expect(fitted.monitor.height).toBe(150);
+    });
+
+    it("scales the canvas position and visible size with the monitor", () => {
+        const fitted = fitMonitor(Config, viewport(1700, 2000), native);
+        // Monitor is 1500 wide: containerScale 1.875.
+        expect(fitted.canvas.left).toBeCloseTo(187.5);
+        expect(fitted.canvas.top).toBeCloseTo(93.75);
+        expect(fitted.canvas.width).toBeCloseTo(600 * 1.875);
+        expect(fitted.canvas.height).toBeCloseTo(450 * 1.875);
+    });
+
+    it("letterboxes a canvas wider than the visible area", () => {
+        const fitted = fitMonitor(Config, viewport(1000, 2000), { width: 1600, height: 600 });
+        // canvasAspect 2.67 beats visibleAspect 1.33: width-limited.
+        expect(fitted.canvas.width).toBeCloseTo(600);
+        expect(fitted.canvas.height).toBeCloseTo(600 / (1600 / 600));
+    });
+
+    it("asks for no backing store change for a mode without a scale limit", () => {
+        expect(fitMonitor(Config, viewport(1000, 2000), native).backing).toBeNull();
+    });
+
+    describe("a mode that scales its drawing buffer", () => {
+        const scaled = { ...Config, maxCanvasScale: 3 };
+
+        it("quantises the scale so a drag does not thrash the buffer", () => {
+            // Canvas width 600 at dpr 1 wants scale 0.75, quantised then floored to 1.
+            const fitted = fitMonitor(scaled, viewport(1000, 2000), native);
+            expect(fitted.backing).toEqual({ width: 800, height: 600 });
+        });
+
+        it("grows with the device pixel ratio", () => {
+            const fitted = fitMonitor(scaled, viewport(1000, 2000, { devicePixelRatio: 2 }), native);
+            // Wants 1.5, on the quantisation grid already.
+            expect(fitted.backing).toEqual({ width: 1200, height: 900 });
+        });
+
+        it("stops at the mode's limit", () => {
+            const fitted = fitMonitor(scaled, viewport(1000, 2000, { devicePixelRatio: 10 }), native);
+            expect(fitted.backing).toEqual({ width: 2400, height: 1800 });
+        });
+    });
+
+    it("uses the whole window when embedded", () => {
+        const fitted = fitMonitor(
+            Config,
+            viewport(800, 640, { navbarHeight: 0, borderReservedSize: 0, bottomReservedSize: 0 }),
+            native,
+        );
+        expect(fitted.monitor.width).toBe(800);
+        expect(fitted.monitor.height).toBe(600);
+    });
+});


### PR DESCRIPTION
PR 10 of #638.

**Moved**: the `resizeTv` IIFE becomes a pure `fitMonitor(displayConfig, viewport, canvasNative)` returning the monitor, canvas and backing-store geometry, plus a `Layout` class that applies it, owns the sidebars and the fullscreen item, and repaints when a backing resize throws the drawing buffer away.

**Tests**: the geometry as arithmetic: aspect fitting each way, the quarter-size floor, the visible-area letterboxing, the quantised backing scale with its device-pixel-ratio growth and mode limit, and the embed case.

**Checked**: unit suite, all twelve smoke checks.
