### PR TITLE
refactor: move the emulation loop out of main.js

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -29,6 +29,7 @@ import { isSnapshotFile, SnapshotUI } from "./web/snapshot-ui.js";
 import { Autoboot } from "./web/autoboot.js";
 import { Display } from "./web/display.js";
 import { Layout } from "./web/layout.js";
+import { EmulationLoop, RewindCaptureInterval } from "./web/emulation-loop.js";
 import { Drives } from "./web/drives.js";
 import { UrlState } from "./web/url-state.js";
 import { Modals } from "./web/modals.js";
@@ -55,7 +56,6 @@ let video;
 let rewindUI;
 const dbgr = new Debugger();
 let syncLights;
-let running;
 let model;
 
 const gamepad = new GamePad();
@@ -77,8 +77,6 @@ let keyLayout = window.localStorage.keyLayout || "physical";
 const BBC = utils.BBC;
 const keyCodes = utils.keyCodes;
 const cpuMultiplier = parsedQuery.cpuMultiplier ?? 1;
-let fastAsPossible = false;
-let fastTape = false;
 let noSeek;
 let stationId = 101;
 let econet = null;
@@ -105,7 +103,6 @@ if (parsedQuery.embed) {
     document.body.style.backgroundColor = "transparent";
 }
 
-fastTape = !!parsedQuery.fasttape;
 noSeek = !!parsedQuery.noseek;
 
 if (parsedQuery.stationId !== undefined) stationId = parsedQuery.stationId;
@@ -287,7 +284,6 @@ const emulationConfig = {
 if (cpuMultiplier !== 1) console.log(`CPU multiplier set to ${cpuMultiplier}`);
 const cpuSpeed = model.cyclesPerSecond;
 const clocksPerSecond = (cpuMultiplier * cpuSpeed) | 0;
-const MaxCyclesPerTick = clocksPerSecond / 10;
 
 let tryGl = true;
 if (parsedQuery.glEnabled !== undefined) {
@@ -299,7 +295,11 @@ if (parsedQuery.lowLatency !== undefined) {
 }
 const screenCanvas = document.getElementById("screen");
 
-const modals = new Modals({ isRunning: () => running, stop, go });
+const modals = new Modals({
+    isRunning: () => loop.isRunning(),
+    stop: (debug) => loop.stop(debug),
+    go: () => loop.go(),
+});
 
 if (keyMappingWarnings.length) {
     toast(`${keyMappingWarnings.join(" ")} The key names are listed in the README.`, {
@@ -388,9 +388,9 @@ for (const eventType of ["mousemove", "mousedown", "mouseup"]) {
 
 window.addEventListener("blur", function () {
     keyboard.clearKeys();
-    setEmulationLead(audioHandler.setWindowFocused(false));
+    loop.setEmulationLead(audioHandler.setWindowFocused(false));
 });
-window.addEventListener("focus", () => setEmulationLead(audioHandler.setWindowFocused(true)));
+window.addEventListener("focus", () => loop.setEmulationLead(audioHandler.setWindowFocused(true)));
 
 let keyboard; // This will be initialised after the processor is created
 
@@ -398,7 +398,7 @@ const debugPause = document.getElementById("debug-pause");
 const debugPlay = document.getElementById("debug-play");
 
 function pauseIntoDebugger() {
-    stop(true);
+    loop.stop(true);
 }
 
 function resumeFromDebugger() {
@@ -420,7 +420,7 @@ document.addEventListener("drop", function (event) {
 });
 
 window.addEventListener("beforeunload", function (event) {
-    if (running && processor.sysvia.hasAnyKeyDown()) {
+    if (loop.isRunning() && processor.sysvia.hasAnyKeyDown()) {
         const message =
             "It seems like you're still using the emulator. If you're in Chrome, it's impossible for jsbeeb to prevent some shortcuts (like ctrl-W) from performing their default behaviour (e.g. closing the window).\n" +
             "As a workarond, create an 'Application Shortcut' from the Tools menu.  When jsbeeb runs as an application, it *can* prevent ctrl-W from closing the window.";
@@ -528,9 +528,9 @@ const snapshots = new SnapshotUI({
     drives,
     urlState,
     modals,
-    isRunning: () => running,
-    stop,
-    go,
+    isRunning: () => loop.isRunning(),
+    stop: (debug) => loop.stop(debug),
+    go: () => loop.go(),
 });
 
 processor.teletextAdaptor?.addEventListener("notice", showNotice);
@@ -643,8 +643,8 @@ keyboard = new Keyboard({
     dbgr,
 });
 keyboard.addEventListener("notice", showNotice);
-keyboard.addEventListener("pause", () => stop(false));
-keyboard.addEventListener("resume", () => go());
+keyboard.addEventListener("pause", () => loop.stop(false));
+keyboard.addEventListener("resume", () => loop.go());
 keyboard.addEventListener("break", (e) => {
     // F12/Break: Reset processor
     if (e.detail) utils.noteEvent("keyboard", "press", "break");
@@ -656,7 +656,7 @@ keyboard.registerKeyHandler(
     (down) => {
         if (down) {
             utils.noteEvent("keyboard", "press", "S");
-            stop(true);
+            loop.stop(true);
         }
     },
     { alt: true, ctrl: false },
@@ -676,7 +676,7 @@ keyboard.registerKeyHandler(
     (down) => {
         if (down) {
             utils.noteEvent("keyboard", "press", "home");
-            stop(true);
+            loop.stop(true);
         }
     },
     { alt: false, ctrl: true },
@@ -687,7 +687,7 @@ keyboard.registerKeyHandler(
     (down) => {
         if (down) {
             utils.noteEvent("keyboard", "press", "insert");
-            fastAsPossible = !fastAsPossible;
+            loop.toggleFastAsPossible();
         }
     },
     { alt: false, ctrl: true },
@@ -977,292 +977,50 @@ const startPromise = (async () => {
         // Restore the state a cross-model reload stashed, if there is one.
         await snapshots.restorePendingState();
 
-        go();
+        loop.go();
     } catch (error) {
         console.error("Error initialising emulator:", error);
         modals.showError("initialising", error);
     }
 })();
 
-function benchmarkCpu(numCycles) {
-    numCycles = numCycles || 10 * 1000 * 1000;
-    const oldFS = display.frameSkip;
-    display.frameSkip = 1000000;
-    const startTime = performance.now();
-    processor.execute(numCycles);
-    const endTime = performance.now();
-    display.frameSkip = oldFS;
-    const msTaken = endTime - startTime;
-    const virtualMhz = numCycles / msTaken / 1000;
-    console.log("Took " + msTaken + "ms to execute " + numCycles + " cycles");
-    console.log("Virtual " + virtualMhz.toFixed(2) + "MHz");
-}
-
-function benchmarkVideo(numCycles) {
-    numCycles = numCycles || 10 * 1000 * 1000;
-    const oldFS = display.frameSkip;
-    display.frameSkip = 1000000;
-    const startTime = performance.now();
-    video.polltime(numCycles);
-    const endTime = performance.now();
-    display.frameSkip = oldFS;
-    const msTaken = endTime - startTime;
-    const virtualMhz = numCycles / msTaken / 1000;
-    console.log("Took " + msTaken + "ms to execute " + numCycles + " video cycles");
-    console.log("Virtual " + virtualMhz.toFixed(2) + "MHz");
-}
-
-function profileCpu(arg) {
-    console.profile("CPU");
-    benchmarkCpu(arg);
-    console.profileEnd();
-}
-
-function profileVideo(arg) {
-    console.profile("Video");
-    benchmarkVideo(arg);
-    console.profileEnd();
-}
-
-let last = 0;
-let lastEnd = 0;
-
-function VirtualSpeedUpdater() {
-    this.cycles = 0;
-    this.time = 0;
-    this.v = document.querySelector(".virtualMHz");
-    this.header = document.getElementById("virtual-mhz-header");
-    this.speedy = false;
-
-    this.update = function (cycles, time, speedy) {
-        this.cycles += cycles;
-        this.time += time;
-        this.speedy = speedy;
-    };
-
-    this.display = function () {
-        // MRG would be nice to graph instantaneous speed to get some idea where the time goes.
-        if (this.cycles) {
-            const thisMHz = this.cycles / this.time / 1000;
-            this.v.textContent = thisMHz.toFixed(1);
-            if (this.cycles >= 10 * cpuSpeed) {
-                this.cycles = this.time = 0;
-            }
-            this.header.style.color = this.speedy ? "red" : "white";
-        }
-        setTimeout(this.display.bind(this), 3333);
-    };
-
-    this.display();
-}
-
-const virtualSpeedUpdater = new VirtualSpeedUpdater();
-
 const rewindBuffer = new RewindBuffer(30);
-let rewindCycleCounter = 0;
-const RewindCaptureInterval = 50; // emulated frames, ~1 second
-const RewindCaptureCycles = (RewindCaptureInterval * clocksPerSecond) / 50;
 
-// Under ?audioDebug, one console line per second in which the emulator sat
-// idle between ticks or a tick ran long, or the audio queue underran or
-// dropped, so a click can be matched to a cause. The sound chip posts samples
-// throughout execute(), so only the idle time starves the audio queue.
-const AudioDebugLogIntervalMs = 1000;
-const AudioDebugSlowTickMs = 30;
-const audioDebugLog = { start: 0, ticks: 0, cycles: 0, maxIdle: 0, maxExecute: 0, maxPaint: 0, maxSnapshot: 0 };
-const AudioDebugSlowPresentMs = 30;
-
-function logAudioDebugTick(now, cycles, idleMs, executeMs, paintMs, snapshotMs) {
-    const log = audioDebugLog;
-    if (log.start === 0) log.start = now;
-    log.ticks++;
-    log.cycles += cycles;
-    log.maxIdle = Math.max(log.maxIdle, idleMs);
-    log.maxExecute = Math.max(log.maxExecute, executeMs);
-    log.maxPaint = Math.max(log.maxPaint, paintMs);
-    log.maxSnapshot = Math.max(log.maxSnapshot, snapshotMs);
-    if (now - log.start < AudioDebugLogIntervalMs) return;
-    const audio = audioHandler.takeEventCounts();
-    const present = display.takePresentMs();
-    const leadMin = Number.isFinite(audio.leadMinMs) ? `${audio.leadMinMs.toFixed(1)}ms` : "(no stats)";
-    if (
-        log.maxIdle > AudioDebugSlowTickMs ||
-        log.maxExecute > AudioDebugSlowTickMs ||
-        present > AudioDebugSlowPresentMs ||
-        audio.stall ||
-        audio.skip
-    ) {
-        console.log(
-            `${(now / 1000).toFixed(0)}s: ${log.ticks} ticks emulating ${((1000 * log.cycles) / clocksPerSecond).toFixed(0)}ms, ` +
-                `idle max ${log.maxIdle.toFixed(0)}ms, ` +
-                `execute max ${log.maxExecute.toFixed(0)}ms (paint ${log.maxPaint.toFixed(1)}ms), ` +
-                `present max ${present.toFixed(0)}ms, snapshot ${log.maxSnapshot.toFixed(1)}ms; ` +
-                `audio lead min ${leadMin}, stalls ${audio.stall}, skipped ${audio.skip.toFixed(0)}ms`,
-        );
-    }
-    log.start = now;
-    log.ticks = log.cycles = log.maxIdle = log.maxExecute = log.maxPaint = log.maxSnapshot = 0;
-}
+const loop = new EmulationLoop({
+    processor,
+    display,
+    audioHandler,
+    dbgr,
+    gamepad,
+    keyboard,
+    syncLights: () => syncLights(),
+    rewindBuffer,
+    onRewindCaptured: () => rewindUI.updateButtonState(),
+    clocksPerSecond,
+    cpuSpeed,
+    fastTape: !!parsedQuery.fasttape,
+    audioStatsNode,
+});
+loop.addEventListener("running", () => {
+    const running = loop.isRunning();
+    keyboard.setRunning(running);
+    debugPlay.disabled = running;
+    debugPause.disabled = !running;
+});
 
 rewindUI = new RewindUI({
     rewindBuffer,
     processor,
     video,
     captureInterval: RewindCaptureInterval,
-    stop,
-    go,
-    isRunning: () => running,
+    stop: (debug) => loop.stop(debug),
+    go: () => loop.go(),
+    isRunning: () => loop.isRunning(),
 });
 rewindUI.updateButtonState();
 
 if (processor.fdc) new DiscVisualiser({ fdc: processor.fdc });
 else document.getElementById("disc-visualiser-open").classList.add("disabled");
-
-// A timer, not requestAnimationFrame: a display presentation stall withholds
-// animation frames, and with them the sound chip's samples (issue #885).
-const TickMs = 10;
-let tickToken = null;
-
-// A user-blocking task runs ahead of rendering and ordinary timers, so a stuck
-// compositor does not hold the tick off too.
-function scheduleTick(delayMs) {
-    const token = (tickToken = {});
-    const fire = () => {
-        if (tickToken === token) tick();
-    };
-    if (window.scheduler?.postTask) window.scheduler.postTask(fire, { delay: delayMs, priority: "user-blocking" });
-    else window.setTimeout(fire, delayMs);
-}
-
-function tick() {
-    if (!running) {
-        last = 0;
-        return;
-    }
-    const now = performance.now();
-
-    const motorOn = processor.acia.motorOn;
-    const speedy = fastAsPossible || (fastTape && motorOn);
-
-    // In speedy mode, we still run all the state machines accurately
-    // but we paint less often because painting is the most expensive
-    // part of jsbeeb at this time.
-    // We need need to paint per odd number of frames so that interlace
-    // modes, i.e. MODE 7, still look ok.
-    video.frameSkipCount = speedy ? 9 : 0;
-
-    scheduleTick(speedy ? 0 : TickMs);
-
-    gamepad.update(processor.sysvia);
-    syncLights();
-    if (last !== 0) {
-        let cycles;
-        if (!speedy) {
-            const sinceLast = Math.max(0, now - last);
-            cycles = (sinceLast * clocksPerSecond) / 1000;
-            cycles = Math.min(cycles, MaxCyclesPerTick);
-        } else {
-            cycles = clocksPerSecond / 50;
-        }
-        cycles |= 0;
-        try {
-            if (!processor.execute(cycles)) {
-                stop(true);
-            }
-            audioHandler.flushChipEvents();
-            const end = performance.now();
-            virtualSpeedUpdater.update(cycles, end - now, speedy);
-            let snapshotMs = 0;
-            rewindCycleCounter += cycles;
-            if (rewindCycleCounter >= RewindCaptureCycles) {
-                rewindCycleCounter -= RewindCaptureCycles;
-                rewindBuffer.push(processor.snapshotState());
-                rewindUI.updateButtonState();
-                snapshotMs = performance.now() - end;
-            }
-            if (audioStatsNode)
-                logAudioDebugTick(
-                    now,
-                    cycles,
-                    speedy ? 0 : now - lastEnd,
-                    end - now,
-                    display.takePaintMs(),
-                    snapshotMs,
-                );
-        } catch (e) {
-            running = false;
-            utils.noteEvent("exception", "thrown", e.stack);
-            dbgr.debug(processor.pc);
-            throw e;
-        }
-        if (keyboard.postFrameShouldPause()) {
-            stop(false);
-        }
-    }
-    last = Math.max(last, now);
-    lastEnd = performance.now();
-}
-
-function run() {
-    scheduleTick(0);
-}
-
-// A change of audio buffer depth is taken by the picture, not the sound:
-// gaining lead emulates ahead at once; losing it moves `last` forward so the
-// ticks emulate nothing until the queue has drained by that much.
-let emulationLeadMs = 0;
-
-function setEmulationLead(leadMs) {
-    if (!running) return;
-    const aheadMs = leadMs - emulationLeadMs;
-    emulationLeadMs = leadMs;
-    if (aheadMs > 0) {
-        if (!processor.execute((aheadMs * clocksPerSecond) / 1000)) stop(true);
-        audioHandler.flushChipEvents();
-    } else {
-        last -= aheadMs;
-    }
-}
-
-let wasPreviouslyRunning = false;
-
-function handleVisibilityChange() {
-    if (document.visibilityState === "hidden") {
-        wasPreviouslyRunning = running;
-        const keepRunningWhenHidden = processor.acia.motorOn || processor.fdc.motorOn[0] || processor.fdc.motorOn[1];
-        if (running && !keepRunningWhenHidden) {
-            stop(false);
-        }
-    } else {
-        if (wasPreviouslyRunning) {
-            go();
-        }
-    }
-}
-
-document.addEventListener("visibilitychange", handleVisibilityChange, false);
-
-function updateDebugButtons() {
-    debugPlay.disabled = running;
-    debugPause.disabled = !running;
-}
-
-function go() {
-    audioHandler.unmute();
-    running = true;
-    keyboard.setRunning(true);
-    updateDebugButtons();
-    run();
-}
-
-function stop(debug) {
-    running = false;
-    keyboard.setRunning(false);
-    processor.stop();
-    if (debug) dbgr.debug(processor.pc);
-    audioHandler.mute();
-    updateDebugButtons();
-}
 
 new Layout({
     screenCanvas,
@@ -1276,12 +1034,12 @@ if (Object.hasOwn(parsedQuery, "pp-tos")) modals.show("pp-tos");
 
 // Handy shortcuts. bench/profile stuff is delayed so that they can be
 // safely run from the JS console in firefox.
-window.benchmarkCpu = utils.debounce(benchmarkCpu, 1);
-window.profileCpu = utils.debounce(profileCpu, 1);
-window.benchmarkVideo = utils.debounce(benchmarkVideo, 1);
-window.profileVideo = utils.debounce(profileVideo, 1);
-window.go = go;
-window.stop = stop;
+window.benchmarkCpu = utils.debounce((numCycles) => loop.benchmarkCpu(numCycles), 1);
+window.profileCpu = utils.debounce((arg) => loop.profileCpu(arg), 1);
+window.benchmarkVideo = utils.debounce((numCycles) => loop.benchmarkVideo(numCycles), 1);
+window.profileVideo = utils.debounce((arg) => loop.profileVideo(arg), 1);
+window.go = () => loop.go();
+window.stop = (debug) => loop.stop(debug);
 window.soundChip = audioHandler.soundChip;
 window.processor = processor;
 window.video = video;

--- a/src/web/emulation-loop.js
+++ b/src/web/emulation-loop.js
@@ -1,0 +1,313 @@
+import * as utils from "../utils.js";
+
+// A timer, not requestAnimationFrame: a display presentation stall withholds
+// animation frames, and with them the sound chip's samples (issue #885).
+const TickMs = 10;
+
+export const RewindCaptureInterval = 50; // emulated frames, ~1 second
+
+// Under ?audioDebug, one console line per second in which the emulator sat
+// idle between ticks or a tick ran long, or the audio queue underran or
+// dropped, so a click can be matched to a cause. The sound chip posts samples
+// throughout execute(), so only the idle time starves the audio queue.
+const AudioDebugLogIntervalMs = 1000;
+const AudioDebugSlowTickMs = 30;
+const AudioDebugSlowPresentMs = 30;
+
+const VirtualMhzUpdateMs = 3333;
+
+class VirtualSpeedUpdater {
+    constructor(cpuSpeed) {
+        this.cpuSpeed = cpuSpeed;
+        this.cycles = 0;
+        this.time = 0;
+        this.v = document.querySelector(".virtualMHz");
+        this.header = document.getElementById("virtual-mhz-header");
+        this.speedy = false;
+        this.display();
+    }
+
+    update(cycles, time, speedy) {
+        this.cycles += cycles;
+        this.time += time;
+        this.speedy = speedy;
+    }
+
+    display() {
+        // MRG would be nice to graph instantaneous speed to get some idea where the time goes.
+        if (this.cycles) {
+            const thisMHz = this.cycles / this.time / 1000;
+            this.v.textContent = thisMHz.toFixed(1);
+            if (this.cycles >= 10 * this.cpuSpeed) {
+                this.cycles = this.time = 0;
+            }
+            this.header.style.color = this.speedy ? "red" : "white";
+        }
+        setTimeout(() => this.display(), VirtualMhzUpdateMs);
+    }
+}
+
+/**
+ * Runs the machine in real time: the tick that turns wall-clock time into
+ * cycles, starting and stopping, the audio lead, fast-forward, rewind capture
+ * and the speed readout. Owns `running`, and dispatches a "running" event
+ * whenever it changes hands.
+ */
+export class EmulationLoop extends EventTarget {
+    constructor({
+        processor,
+        display,
+        audioHandler,
+        dbgr,
+        gamepad,
+        keyboard,
+        syncLights,
+        rewindBuffer,
+        onRewindCaptured,
+        clocksPerSecond,
+        cpuSpeed,
+        fastTape,
+        audioStatsNode,
+    }) {
+        super();
+        this.processor = processor;
+        this.display = display;
+        this.audioHandler = audioHandler;
+        this.dbgr = dbgr;
+        this.gamepad = gamepad;
+        this.keyboard = keyboard;
+        this.syncLights = syncLights;
+        this.rewindBuffer = rewindBuffer;
+        this.onRewindCaptured = onRewindCaptured;
+        this.clocksPerSecond = clocksPerSecond;
+        this.maxCyclesPerTick = clocksPerSecond / 10;
+        this.rewindCaptureCycles = (RewindCaptureInterval * clocksPerSecond) / 50;
+        this.fastTape = fastTape;
+        this.audioStatsNode = audioStatsNode;
+
+        this.running = false;
+        this.fastAsPossible = false;
+        this.last = 0;
+        this.lastEnd = 0;
+        this.tickToken = null;
+        this.emulationLeadMs = 0;
+        this.rewindCycleCounter = 0;
+        this.wasPreviouslyRunning = false;
+
+        this.virtualSpeedUpdater = new VirtualSpeedUpdater(cpuSpeed);
+        this.audioDebugLog = { start: 0, ticks: 0, cycles: 0, maxIdle: 0, maxExecute: 0, maxPaint: 0, maxSnapshot: 0 };
+
+        document.addEventListener("visibilitychange", () => this.handleVisibilityChange(), false);
+    }
+
+    isRunning() {
+        return this.running;
+    }
+
+    go() {
+        this.audioHandler.unmute();
+        this.running = true;
+        this.dispatchEvent(new Event("running"));
+        this.run();
+    }
+
+    stop(debug) {
+        this.running = false;
+        this.dispatchEvent(new Event("running"));
+        this.processor.stop();
+        if (debug) this.dbgr.debug(this.processor.pc);
+        this.audioHandler.mute();
+    }
+
+    run() {
+        this.scheduleTick(0);
+    }
+
+    toggleFastAsPossible() {
+        this.fastAsPossible = !this.fastAsPossible;
+    }
+
+    // A user-blocking task runs ahead of rendering and ordinary timers, so a stuck
+    // compositor does not hold the tick off too.
+    scheduleTick(delayMs) {
+        const token = (this.tickToken = {});
+        const fire = () => {
+            if (this.tickToken === token) this.tick();
+        };
+        if (window.scheduler?.postTask) window.scheduler.postTask(fire, { delay: delayMs, priority: "user-blocking" });
+        else window.setTimeout(fire, delayMs);
+    }
+
+    tick() {
+        if (!this.running) {
+            this.last = 0;
+            return;
+        }
+        const now = performance.now();
+
+        const { processor, display, audioHandler } = this;
+        const motorOn = processor.acia.motorOn;
+        const speedy = this.fastAsPossible || (this.fastTape && motorOn);
+
+        // In speedy mode, we still run all the state machines accurately
+        // but we paint less often because painting is the most expensive
+        // part of jsbeeb at this time.
+        // We need need to paint per odd number of frames so that interlace
+        // modes, i.e. MODE 7, still look ok.
+        display.video.frameSkipCount = speedy ? 9 : 0;
+
+        this.scheduleTick(speedy ? 0 : TickMs);
+
+        this.gamepad.update(processor.sysvia);
+        this.syncLights();
+        if (this.last !== 0) {
+            let cycles;
+            if (!speedy) {
+                const sinceLast = Math.max(0, now - this.last);
+                cycles = (sinceLast * this.clocksPerSecond) / 1000;
+                cycles = Math.min(cycles, this.maxCyclesPerTick);
+            } else {
+                cycles = this.clocksPerSecond / 50;
+            }
+            cycles |= 0;
+            try {
+                if (!processor.execute(cycles)) {
+                    this.stop(true);
+                }
+                audioHandler.flushChipEvents();
+                const end = performance.now();
+                this.virtualSpeedUpdater.update(cycles, end - now, speedy);
+                let snapshotMs = 0;
+                this.rewindCycleCounter += cycles;
+                if (this.rewindCycleCounter >= this.rewindCaptureCycles) {
+                    this.rewindCycleCounter -= this.rewindCaptureCycles;
+                    this.rewindBuffer.push(processor.snapshotState());
+                    this.onRewindCaptured();
+                    snapshotMs = performance.now() - end;
+                }
+                if (this.audioStatsNode)
+                    this.logAudioDebugTick(
+                        now,
+                        cycles,
+                        speedy ? 0 : now - this.lastEnd,
+                        end - now,
+                        display.takePaintMs(),
+                        snapshotMs,
+                    );
+            } catch (e) {
+                this.running = false;
+                utils.noteEvent("exception", "thrown", e.stack);
+                this.dbgr.debug(processor.pc);
+                throw e;
+            }
+            if (this.keyboard.postFrameShouldPause()) {
+                this.stop(false);
+            }
+        }
+        this.last = Math.max(this.last, now);
+        this.lastEnd = performance.now();
+    }
+
+    // A change of audio buffer depth is taken by the picture, not the sound:
+    // gaining lead emulates ahead at once; losing it moves `last` forward so the
+    // ticks emulate nothing until the queue has drained by that much.
+    setEmulationLead(leadMs) {
+        if (!this.running) return;
+        const aheadMs = leadMs - this.emulationLeadMs;
+        this.emulationLeadMs = leadMs;
+        if (aheadMs > 0) {
+            if (!this.processor.execute((aheadMs * this.clocksPerSecond) / 1000)) this.stop(true);
+            this.audioHandler.flushChipEvents();
+        } else {
+            this.last -= aheadMs;
+        }
+    }
+
+    handleVisibilityChange() {
+        const { processor } = this;
+        if (document.visibilityState === "hidden") {
+            this.wasPreviouslyRunning = this.running;
+            const keepRunningWhenHidden =
+                processor.acia.motorOn || processor.fdc.motorOn[0] || processor.fdc.motorOn[1];
+            if (this.running && !keepRunningWhenHidden) {
+                this.stop(false);
+            }
+        } else {
+            if (this.wasPreviouslyRunning) {
+                this.go();
+            }
+        }
+    }
+
+    logAudioDebugTick(now, cycles, idleMs, executeMs, paintMs, snapshotMs) {
+        const log = this.audioDebugLog;
+        if (log.start === 0) log.start = now;
+        log.ticks++;
+        log.cycles += cycles;
+        log.maxIdle = Math.max(log.maxIdle, idleMs);
+        log.maxExecute = Math.max(log.maxExecute, executeMs);
+        log.maxPaint = Math.max(log.maxPaint, paintMs);
+        log.maxSnapshot = Math.max(log.maxSnapshot, snapshotMs);
+        if (now - log.start < AudioDebugLogIntervalMs) return;
+        const audio = this.audioHandler.takeEventCounts();
+        const present = this.display.takePresentMs();
+        const leadMin = Number.isFinite(audio.leadMinMs) ? `${audio.leadMinMs.toFixed(1)}ms` : "(no stats)";
+        if (
+            log.maxIdle > AudioDebugSlowTickMs ||
+            log.maxExecute > AudioDebugSlowTickMs ||
+            present > AudioDebugSlowPresentMs ||
+            audio.stall ||
+            audio.skip
+        ) {
+            console.log(
+                `${(now / 1000).toFixed(0)}s: ${log.ticks} ticks emulating ${((1000 * log.cycles) / this.clocksPerSecond).toFixed(0)}ms, ` +
+                    `idle max ${log.maxIdle.toFixed(0)}ms, ` +
+                    `execute max ${log.maxExecute.toFixed(0)}ms (paint ${log.maxPaint.toFixed(1)}ms), ` +
+                    `present max ${present.toFixed(0)}ms, snapshot ${log.maxSnapshot.toFixed(1)}ms; ` +
+                    `audio lead min ${leadMin}, stalls ${audio.stall}, skipped ${audio.skip.toFixed(0)}ms`,
+            );
+        }
+        log.start = now;
+        log.ticks = log.cycles = log.maxIdle = log.maxExecute = log.maxPaint = log.maxSnapshot = 0;
+    }
+
+    benchmarkCpu(numCycles) {
+        numCycles = numCycles || 10 * 1000 * 1000;
+        const oldFS = this.display.frameSkip;
+        this.display.frameSkip = 1000000;
+        const startTime = performance.now();
+        this.processor.execute(numCycles);
+        const endTime = performance.now();
+        this.display.frameSkip = oldFS;
+        const msTaken = endTime - startTime;
+        const virtualMhz = numCycles / msTaken / 1000;
+        console.log("Took " + msTaken + "ms to execute " + numCycles + " cycles");
+        console.log("Virtual " + virtualMhz.toFixed(2) + "MHz");
+    }
+
+    benchmarkVideo(numCycles) {
+        numCycles = numCycles || 10 * 1000 * 1000;
+        const oldFS = this.display.frameSkip;
+        this.display.frameSkip = 1000000;
+        const startTime = performance.now();
+        this.display.video.polltime(numCycles);
+        const endTime = performance.now();
+        this.display.frameSkip = oldFS;
+        const msTaken = endTime - startTime;
+        const virtualMhz = numCycles / msTaken / 1000;
+        console.log("Took " + msTaken + "ms to execute " + numCycles + " video cycles");
+        console.log("Virtual " + virtualMhz.toFixed(2) + "MHz");
+    }
+
+    profileCpu(arg) {
+        console.profile("CPU");
+        this.benchmarkCpu(arg);
+        console.profileEnd();
+    }
+
+    profileVideo(arg) {
+        console.profile("Video");
+        this.benchmarkVideo(arg);
+        console.profileEnd();
+    }
+}

--- a/tests/browser/smoke.js
+++ b/tests/browser/smoke.js
@@ -221,8 +221,8 @@ class Page {
         })()`);
     }
 
-    async pressKey(key, code, keyCode) {
-        const common = { key, code, windowsVirtualKeyCode: keyCode, nativeVirtualKeyCode: keyCode };
+    async pressKey(key, code, keyCode, modifiers = 0) {
+        const common = { key, code, windowsVirtualKeyCode: keyCode, nativeVirtualKeyCode: keyCode, modifiers };
         await this.send("Input.dispatchKeyEvent", { type: "keyDown", ...common });
         // Held long enough for the OS to scan the matrix and see it down.
         await sleep(KeyHoldMs);
@@ -323,6 +323,39 @@ check("every display mode and sound output on the bar can be picked", async (pag
         if (active !== output) throw new Error(`Picked sound output ${output} but ${active} is active`);
     }
     await page.waitForScreenText(">", StepTimeoutMs);
+});
+
+check("the pause and play buttons stop and start the emulator", async (page, base) => {
+    await page.goto(base);
+    await page.waitForScreenText(">");
+    await page.click("#debug-pause");
+    await waitUntil(
+        "the play button to wake",
+        () => page.evaluate(`!document.getElementById("debug-play").disabled`),
+        StepTimeoutMs,
+    );
+    const stopped = await page.cycles();
+    await sleep(300);
+    if ((await page.cycles()) !== stopped) throw new Error("The emulator ran while paused");
+    await page.click("#debug-play");
+    await waitUntil("the emulator to run again", async () => (await page.cycles()) > stopped, StepTimeoutMs);
+});
+
+check("Ctrl-Home stops into the debugger", async (page, base) => {
+    await page.goto(base);
+    await page.waitForScreenText(">");
+    const CtrlModifier = 2;
+    await page.pressKey("Home", "Home", 36, CtrlModifier);
+    await waitUntil(
+        "the emulator to stop",
+        () => page.evaluate(`document.getElementById("debug-pause").disabled`),
+        StepTimeoutMs,
+    );
+    const stopped = await page.cycles();
+    await sleep(200);
+    if ((await page.cycles()) !== stopped) throw new Error("The emulator ran in the debugger");
+    await page.click("#debug-play");
+    await waitUntil("the emulator to resume", async () => (await page.cycles()) > stopped, StepTimeoutMs);
 });
 
 check("a disc from the built-in list goes into drive 0", async (page, base) => {

--- a/tests/unit/test-emulation-loop.js
+++ b/tests/unit/test-emulation-loop.js
@@ -93,7 +93,8 @@ describe("EmulationLoop", () => {
         const loop = started();
         vi.advanceTimersByTime(10);
         // The page stalls for a second before the next tick gets to run.
-        vi.spyOn(performance, "now").mockReturnValue(performance.now() + 1000);
+        const afterTheStall = performance.now() + 1000;
+        vi.spyOn(performance, "now").mockReturnValue(afterTheStall);
         loop.tick();
         expect(cyclesExecuted().at(-1)).toBe(ClocksPerSecond / 10);
     });

--- a/tests/unit/test-emulation-loop.js
+++ b/tests/unit/test-emulation-loop.js
@@ -1,0 +1,218 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { EmulationLoop } from "../../src/web/emulation-loop.js";
+
+const ClocksPerSecond = 2000000;
+
+describe("EmulationLoop", () => {
+    let deps;
+
+    beforeEach(() => {
+        vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout", "Date", "performance"] });
+        // Move off zero: the loop uses last === 0 to mean "first tick".
+        vi.advanceTimersByTime(1000);
+        document.body.innerHTML = `<span class="virtualMHz"></span><span id="virtual-mhz-header"></span>`;
+        deps = {
+            processor: {
+                execute: vi.fn(() => true),
+                stop: vi.fn(),
+                pc: 0x1234,
+                acia: { motorOn: false },
+                fdc: { motorOn: [false, false] },
+                sysvia: {},
+                snapshotState: vi.fn(() => ({})),
+            },
+            display: {
+                video: { frameSkipCount: 0, polltime: vi.fn() },
+                takePaintMs: () => 0,
+                takePresentMs: () => 0,
+                frameSkip: 0,
+            },
+            audioHandler: {
+                mute: vi.fn(),
+                unmute: vi.fn(),
+                flushChipEvents: vi.fn(),
+                takeEventCounts: () => ({ leadMinMs: 1, stall: 0, skip: 0 }),
+            },
+            dbgr: { debug: vi.fn() },
+            gamepad: { update: vi.fn() },
+            keyboard: { postFrameShouldPause: vi.fn(() => false) },
+            syncLights: vi.fn(),
+            rewindBuffer: { push: vi.fn() },
+            onRewindCaptured: vi.fn(),
+            clocksPerSecond: ClocksPerSecond,
+            cpuSpeed: ClocksPerSecond,
+            fastTape: false,
+            audioStatsNode: null,
+        };
+    });
+
+    afterEach(() => {
+        vi.clearAllTimers();
+        vi.useRealTimers();
+        vi.restoreAllMocks();
+        document.body.innerHTML = "";
+    });
+
+    const make = () => new EmulationLoop(deps);
+    const cyclesExecuted = () => deps.processor.execute.mock.calls.map(([cycles]) => cycles);
+
+    const started = () => {
+        const loop = make();
+        loop.go();
+        // The first tick only takes the time; the second emulates what passed.
+        vi.advanceTimersByTime(0);
+        return loop;
+    };
+
+    it("announces running and wakes the audio when started", () => {
+        const loop = make();
+        const onRunning = vi.fn(() => onRunning.runningWas.push(loop.isRunning()));
+        onRunning.runningWas = [];
+        loop.addEventListener("running", onRunning);
+        loop.go();
+        expect(deps.audioHandler.unmute).toHaveBeenCalled();
+        loop.stop(false);
+        expect(onRunning.runningWas).toEqual([true, false]);
+        expect(deps.processor.stop).toHaveBeenCalled();
+        expect(deps.audioHandler.mute).toHaveBeenCalled();
+        expect(deps.dbgr.debug).not.toHaveBeenCalled();
+    });
+
+    it("turns the wall clock into cycles", () => {
+        started();
+        vi.advanceTimersByTime(10);
+        expect(cyclesExecuted()).toEqual([(10 * ClocksPerSecond) / 1000]);
+        expect(deps.audioHandler.flushChipEvents).toHaveBeenCalled();
+        expect(deps.gamepad.update).toHaveBeenCalledWith(deps.processor.sysvia);
+        expect(deps.syncLights).toHaveBeenCalled();
+    });
+
+    it("never emulates more than a tenth of a second in one tick", () => {
+        const loop = started();
+        vi.advanceTimersByTime(10);
+        // The page stalls for a second before the next tick gets to run.
+        vi.spyOn(performance, "now").mockReturnValue(performance.now() + 1000);
+        loop.tick();
+        expect(cyclesExecuted().at(-1)).toBe(ClocksPerSecond / 10);
+    });
+
+    it("runs a fiftieth of a second per tick when going as fast as possible", () => {
+        const loop = started();
+        loop.toggleFastAsPossible();
+        vi.advanceTimersByTime(10);
+        expect(cyclesExecuted().at(-1)).toBe(ClocksPerSecond / 50);
+        expect(deps.display.video.frameSkipCount).toBe(9);
+    });
+
+    it("speeds up for a tape motor only when told fast tape", () => {
+        deps.fastTape = true;
+        const loop = started();
+        deps.processor.acia.motorOn = true;
+        vi.advanceTimersByTime(10);
+        expect(cyclesExecuted().at(-1)).toBe(ClocksPerSecond / 50);
+        expect(loop.isRunning()).toBe(true);
+    });
+
+    it("stops into the debugger when the processor stops itself", () => {
+        const loop = started();
+        deps.processor.execute.mockReturnValue(false);
+        vi.advanceTimersByTime(10);
+        expect(loop.isRunning()).toBe(false);
+        expect(deps.dbgr.debug).toHaveBeenCalledWith(0x1234);
+        expect(deps.audioHandler.mute).toHaveBeenCalled();
+    });
+
+    it("pauses when the keyboard asks after a frame", () => {
+        const loop = started();
+        deps.keyboard.postFrameShouldPause.mockReturnValue(true);
+        vi.advanceTimersByTime(10);
+        expect(loop.isRunning()).toBe(false);
+        expect(deps.dbgr.debug).not.toHaveBeenCalled();
+    });
+
+    it("emulates ahead at once when the audio queue deepens", () => {
+        const loop = started();
+        loop.setEmulationLead(50);
+        expect(cyclesExecuted()).toEqual([(50 * ClocksPerSecond) / 1000]);
+        expect(deps.audioHandler.flushChipEvents).toHaveBeenCalled();
+    });
+
+    it("emulates nothing until a shallower queue has drained", () => {
+        const loop = started();
+        loop.setEmulationLead(50);
+        deps.processor.execute.mockClear();
+        loop.setEmulationLead(20);
+        expect(deps.processor.execute).not.toHaveBeenCalled();
+        // The 30ms handed back come out of the next ticks' budget.
+        vi.advanceTimersByTime(10);
+        expect(cyclesExecuted()).toEqual([0]);
+        vi.advanceTimersByTime(40);
+        expect(cyclesExecuted().at(-1)).toBe((10 * ClocksPerSecond) / 1000);
+    });
+
+    it("ignores a lead change while stopped", () => {
+        const loop = make();
+        loop.setEmulationLead(50);
+        expect(deps.processor.execute).not.toHaveBeenCalled();
+    });
+
+    it("captures a rewind snapshot every interval", () => {
+        started();
+        // The capture interval is one emulated second.
+        vi.advanceTimersByTime(1500);
+        expect(deps.rewindBuffer.push).toHaveBeenCalledTimes(1);
+        expect(deps.onRewindCaptured).toHaveBeenCalledTimes(1);
+        vi.advanceTimersByTime(1000);
+        expect(deps.rewindBuffer.push).toHaveBeenCalledTimes(2);
+    });
+
+    describe("a hidden tab", () => {
+        let visibility;
+        beforeEach(() => {
+            visibility = "visible";
+            Object.defineProperty(document, "visibilityState", { configurable: true, get: () => visibility });
+        });
+        const hide = () => {
+            visibility = "hidden";
+            document.dispatchEvent(new Event("visibilitychange"));
+        };
+        const show = () => {
+            visibility = "visible";
+            document.dispatchEvent(new Event("visibilitychange"));
+        };
+
+        it("pauses while hidden and resumes on return", () => {
+            const loop = started();
+            hide();
+            expect(loop.isRunning()).toBe(false);
+            show();
+            expect(loop.isRunning()).toBe(true);
+        });
+
+        it("keeps running while a motor is on", () => {
+            const loop = started();
+            deps.processor.fdc.motorOn[0] = true;
+            hide();
+            expect(loop.isRunning()).toBe(true);
+        });
+
+        it("stays stopped on return when it was stopped before", () => {
+            const loop = started();
+            loop.stop(false);
+            hide();
+            show();
+            expect(loop.isRunning()).toBe(false);
+        });
+    });
+
+    it("does nothing once stopped, even with a tick in flight", () => {
+        const loop = started();
+        vi.advanceTimersByTime(10);
+        const executed = cyclesExecuted().length;
+        loop.stop(false);
+        vi.advanceTimersByTime(100);
+        expect(cyclesExecuted().length).toBe(executed);
+    });
+});


### PR DESCRIPTION
PR 11 of #638, the one the plan called the payoff.

**First commit** adds two smoke checks against the old code: the pause and play buttons stop and start the emulator (checked against the cycle counter), and Ctrl-Home stops into the debugger.

**Moved** to an `EmulationLoop` class (an `EventTarget`): the tick that turns wall-clock time into cycles, `go`/`stop`, the audio lead handoff, fast-forward and fast tape, visibility pausing, rewind capture, the virtual MHz readout, the `?audioDebug` log and the benchmarks. It owns `running` and dispatches a `running` event; the debug buttons and the keyboard's running flag follow it from `main.js`, and everything else asks `loop.isRunning()`.

**Why it matters**: #885, #889 and #891 all lived in this code and none of it was testable. The timing rules are now under fake timers: the cycle budget follows the clock and clamps at a tenth of a second after a stall; speedy mode runs a fiftieth of a second per tick and skips frames; a deepening audio queue emulates ahead at once while a shallower one holds the emulator back until it has drained; rewind captures once per emulated second; a hidden tab pauses unless a motor is running.

**Checked**: unit suite, all twelve smoke checks.
