### PR TITLE
refactor: move the keyboard and analogue inputs out of main.js

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -17,8 +17,6 @@ import { AudioHandler } from "./web/audio-handler.js";
 import { DefaultAudioOutput, isAudioOutput } from "./audio-output.js";
 import { QuickSettings } from "./web/quick-settings.js";
 import { Econet } from "./econet.js";
-import { Keyboard } from "./keyboard.js";
-import { GamepadSource } from "./gamepad-source.js";
 import { toast } from "./web/toast.js";
 import { BuiltInImages, MediaLoader } from "./web/media-loader.js";
 import { AutobootTicks } from "./web/archive-list.js";
@@ -30,15 +28,14 @@ import { Autoboot } from "./web/autoboot.js";
 import { Display } from "./web/display.js";
 import { Layout } from "./web/layout.js";
 import { EmulationLoop, RewindCaptureInterval } from "./web/emulation-loop.js";
+import { KeyboardSetup } from "./web/keyboard-setup.js";
+import { AnalogueInputs } from "./web/analogue-inputs.js";
 import { Drives } from "./web/drives.js";
 import { UrlState } from "./web/url-state.js";
 import { Modals } from "./web/modals.js";
 import { errorText, reportLoadFailure, showNotice } from "./web/reporting.js";
-import { MicrophoneInput } from "./microphone-input.js";
 import { SpeechOutput } from "./speech-output.js";
 import { Printer } from "./printer.js";
-import { MouseJoystickSource } from "./mouse-joystick-source.js";
-import { calculateMouseCoordinates } from "./mouse-coordinates.js";
 import { RewindBuffer } from "./rewind.js";
 import { RewindUI } from "./rewind-ui.js";
 import { DiscVisualiser } from "./disc-visualiser.js";
@@ -118,16 +115,21 @@ const printer = new Printer({
         }),
 });
 
-// Accessibility switch state — bits 0-7 correspond to switches 1-8.
-// Active low: 0xff = no switches pressed; clearing a bit = that switch is pressed.
-let switchState = 0xff;
-
-const userPort = {
-    write() {},
-    read() {
-        return switchState;
+const keys = new KeyboardSetup({
+    enterDebugger: () => loop.stop(true),
+    reload: () => window.location.reload(),
+    toggleFast: () => loop.toggleFastAsPossible(),
+    openRewind: () => {
+        if (rewindUI) rewindUI.open();
     },
-};
+    openPrinter: () => checkPrinterWindow(),
+    pause: () => loop.stop(false),
+    resume: () => loop.go(),
+    onAnyKeyDown: () => {
+        audioHandler.tryResume();
+        inputs.ensureMicrophoneRunning();
+    },
+});
 
 // Speech output: initialised from URL param; can be toggled at runtime via the Settings panel.
 // Must be created before Config so the onClose callback and the initial checkbox state can reference it.
@@ -153,13 +155,13 @@ const config = new Config(
         if (changed.keyLayout) {
             window.localStorage.keyLayout = changed.keyLayout;
             emulationConfig.keyLayout = changed.keyLayout;
-            keyboard.setKeyLayout(changed.keyLayout);
+            keys.setKeyLayout(changed.keyLayout);
         }
         if (changed.mouseJoystickEnabled !== undefined || changed.microphoneChannel !== undefined) {
-            updateAdcSources(parsedQuery.mouseJoystickEnabled, parsedQuery.microphoneChannel);
+            inputs.updateAdcSources(parsedQuery.mouseJoystickEnabled, parsedQuery.microphoneChannel);
 
             if (changed.microphoneChannel !== undefined) {
-                setupMicrophone();
+                inputs.setupMicrophone();
             }
         }
         if (changed.speechOutput !== undefined) setSpeechOutput(!!changed.speechOutput);
@@ -269,7 +271,7 @@ const emulationConfig = {
     // ROM order determines sideways bank allocation, and the fittings' ROMs claim banks
     // before any the user asked for with ?rom=.
     extraRoms: [...config.extraRoms, ...extraRoms],
-    userPort,
+    userPort: keys.userPort,
     printerPort: printer,
     getGamepads: function () {
         // Gamepads are only available in secure contexts. If e.g. loading from http:// urls they aren't there.
@@ -355,44 +357,13 @@ const pastetext = document.getElementById("paste-text");
 pastetext.closest("form").addEventListener("submit", (event) => event.preventDefault());
 pastetext.addEventListener("paste", function (event) {
     const text = event.clipboardData.getData("text/plain");
-    sendRawKeyboard(autoBoot.stringToMachineKeys(text), true);
+    keys.sendRawKeyboard(autoBoot.stringToMachineKeys(text), true);
 });
-const cubMonitor = document.getElementById("cub-monitor");
-function onCubMouseEvent(evt) {
-    audioHandler.tryResume();
-    if (document.activeElement !== document.body) document.activeElement.blur();
-    const screenRect = screenCanvas.getBoundingClientRect();
-    const { x, y } = calculateMouseCoordinates(evt, screenRect);
-
-    // Handle touchscreen
-    if (processor.touchScreen) processor.touchScreen.onMouse(x, y, evt.buttons);
-
-    // Handle mouse joystick if enabled
-    if (parsedQuery.mouseJoystickEnabled && mouseJoystickSource.isEnabled()) {
-        // Use the API methods instead of direct manipulation
-        mouseJoystickSource.onMouseMove(x, y);
-
-        // Handle button events
-        if (evt.type === "mousedown" && evt.button === 0) {
-            mouseJoystickSource.onMouseDown(0);
-        } else if (evt.type === "mouseup" && evt.button === 0) {
-            mouseJoystickSource.onMouseUp(0);
-        }
-    }
-
-    evt.preventDefault();
-}
-for (const eventType of ["mousemove", "mousedown", "mouseup"]) {
-    cubMonitor.addEventListener(eventType, onCubMouseEvent);
-}
-
 window.addEventListener("blur", function () {
-    keyboard.clearKeys();
+    keys.clearKeys();
     loop.setEmulationLead(audioHandler.setWindowFocused(false));
 });
 window.addEventListener("focus", () => loop.setEmulationLead(audioHandler.setWindowFocused(true)));
-
-let keyboard; // This will be initialised after the processor is created
 
 const debugPause = document.getElementById("debug-pause");
 const debugPlay = document.getElementById("debug-play");
@@ -403,7 +374,7 @@ function pauseIntoDebugger() {
 
 function resumeFromDebugger() {
     dbgr.hide();
-    keyboard.resumeEmulation();
+    keys.resumeEmulation();
 }
 
 debugPause.addEventListener("click", pauseIntoDebugger);
@@ -501,7 +472,11 @@ const media = new MediaLoader({
         drive: (cat, layout) => drivePicker.load(cat, layout),
     },
 });
-const autoBoot = new Autoboot({ model, processor, sendKeys: sendRawKeyboard });
+const autoBoot = new Autoboot({
+    model,
+    processor,
+    sendKeys: (keysToSend, check) => keys.sendRawKeyboard(keysToSend, check),
+});
 const autobootTicks = new AutobootTicks({ urlState });
 const sthPicker = new SthPicker({
     media,
@@ -537,15 +512,14 @@ processor.teletextAdaptor?.addEventListener("notice", showNotice);
 processor.acia.addEventListener("notice", showNotice);
 
 // Create input sources
-const gamepadSource = new GamepadSource(emulationConfig.getGamepads);
-// Create MicrophoneInput but don't enable by default
-const microphoneInput = new MicrophoneInput();
-microphoneInput.setErrorCallback((message) => {
-    toast(`${message} The microphone channel has been turned off.`, { title: "Microphone" });
+const inputs = new AnalogueInputs({
+    processor,
+    screenCanvas,
+    getGamepads: emulationConfig.getGamepads,
+    urlState,
+    config,
+    audioHandler,
 });
-
-// Create MouseJoystickSource but don't enable by default
-const mouseJoystickSource = new MouseJoystickSource(screenCanvas);
 
 /**
  * Attach an RS-423 composite handler to the ACIA that combines the touchscreen
@@ -564,207 +538,18 @@ function setupRs423Handler() {
     });
 }
 
-// Helper to manage ADC source configuration
-function updateAdcSources(mouseJoystickEnabled, microphoneChannel) {
-    // Default all channels to the gamepad source.
-    for (let ch = 0; ch < 4; ch++) {
-        processor.adconverter.setChannelSource(ch, gamepadSource);
-    }
-
-    // Apply mouse joystick if enabled (takes priority on channels 0 & 1)
-    if (mouseJoystickEnabled) {
-        processor.adconverter.setChannelSource(0, mouseJoystickSource);
-        processor.adconverter.setChannelSource(1, mouseJoystickSource);
-        mouseJoystickSource.setVia(processor.sysvia);
-    } else {
-        mouseJoystickSource.setVia(null);
-    }
-
-    // Apply microphone if configured (can override any channel)
-    if (microphoneChannel !== undefined) {
-        processor.adconverter.setChannelSource(microphoneChannel, microphoneInput);
-    }
-}
-
-async function ensureMicrophoneRunning() {
-    if (microphoneInput.audioContext && microphoneInput.audioContext.state !== "running") {
-        try {
-            await microphoneInput.audioContext.resume();
-            console.log("Microphone: Audio context resumed, new state:", microphoneInput.audioContext.state);
-        } catch (err) {
-            console.error("Microphone: Error resuming audio context:", err);
-            return false;
-        }
-    }
-    return true;
-}
-
-async function setupMicrophone() {
-    const micPermissionStatus = document.getElementById("micPermissionStatus");
-    micPermissionStatus.textContent = "Requesting microphone access...";
-
-    // Try to initialise the microphone
-    const success = await microphoneInput.initialise();
-    if (success) {
-        // Note: Channel assignment is handled by updateAdcSources()
-        micPermissionStatus.textContent = "Microphone connected successfully";
-        await ensureMicrophoneRunning();
-
-        // Try starting audio context from user gesture
-        const tryAgain = async () => {
-            if (await ensureMicrophoneRunning()) document.removeEventListener("click", tryAgain);
-        };
-        document.addEventListener("click", tryAgain);
-    } else {
-        micPermissionStatus.textContent = `Error: ${microphoneInput.getErrorMessage() || "Unknown error"}`;
-        config.setMicrophoneChannel(undefined);
-        // Update URL to remove the parameter
-        delete parsedQuery.microphoneChannel;
-        urlState.updateUrl();
-    }
-}
-
 if (parsedQuery.microphoneChannel !== undefined) {
     // We need to use setTimeout to make sure this runs after the page has loaded
     // This is needed because some browsers require user interaction for audio context
     setTimeout(async () => {
-        await setupMicrophone();
+        await inputs.setupMicrophone();
     }, 1000);
 }
 
 // Apply ADC source settings from URL parameters
-updateAdcSources(parsedQuery.mouseJoystickEnabled, parsedQuery.microphoneChannel);
+inputs.updateAdcSources(parsedQuery.mouseJoystickEnabled, parsedQuery.microphoneChannel);
 
-// Initialise keyboard now that processor exists
-keyboard = new Keyboard({
-    processor,
-    inputEnabledFunction: () => document.activeElement && document.activeElement.id === "paste-text",
-    keyLayout,
-    dbgr,
-});
-keyboard.addEventListener("notice", showNotice);
-keyboard.addEventListener("pause", () => loop.stop(false));
-keyboard.addEventListener("resume", () => loop.go());
-keyboard.addEventListener("break", (e) => {
-    // F12/Break: Reset processor
-    if (e.detail) utils.noteEvent("keyboard", "press", "break");
-});
-
-// Register default key handlers
-keyboard.registerKeyHandler(
-    utils.keyCodes.S,
-    (down) => {
-        if (down) {
-            utils.noteEvent("keyboard", "press", "S");
-            loop.stop(true);
-        }
-    },
-    { alt: true, ctrl: false },
-);
-
-keyboard.registerKeyHandler(
-    utils.keyCodes.R,
-    (down) => {
-        if (down) window.location.reload();
-    },
-    { alt: true, ctrl: false },
-);
-
-// Register Ctrl key handlers
-keyboard.registerKeyHandler(
-    utils.keyCodes.HOME,
-    (down) => {
-        if (down) {
-            utils.noteEvent("keyboard", "press", "home");
-            loop.stop(true);
-        }
-    },
-    { alt: false, ctrl: true },
-);
-
-keyboard.registerKeyHandler(
-    utils.keyCodes.INSERT,
-    (down) => {
-        if (down) {
-            utils.noteEvent("keyboard", "press", "insert");
-            loop.toggleFastAsPossible();
-        }
-    },
-    { alt: false, ctrl: true },
-);
-
-keyboard.registerKeyHandler(
-    utils.keyCodes.END,
-    (down) => {
-        if (down) {
-            utils.noteEvent("keyboard", "press", "end");
-            keyboard.pauseEmulation();
-        }
-    },
-    { alt: false, ctrl: true },
-);
-
-keyboard.registerKeyHandler(
-    utils.keyCodes.PAGEDOWN,
-    (down) => {
-        if (down) {
-            utils.noteEvent("keyboard", "press", "pagedown");
-            if (rewindUI) rewindUI.open();
-        }
-    },
-    { alt: true, ctrl: false },
-);
-
-keyboard.registerKeyHandler(
-    utils.keyCodes.B,
-    (down) => {
-        if (down) {
-            checkPrinterWindow();
-        }
-    },
-    { alt: false, ctrl: true },
-);
-
-// Register accessibility switch key handlers.
-// Keys 1–8 (K1–K8) and function keys F1–F8 both map to user port bits 0–7
-// (active low: pressing the key clears the corresponding bit in &FE60).
-//
-// On real hardware, the Brilliant Computing switch interface box and special-ed
-// joystick connect to the User Port only — they do not touch the analogue port
-// or the System VIA fire buttons (PB4/PB5), which belong to the standard
-// analogue joystick connector.  So we only update switchState here.
-{
-    const handleSwitch = (bit) => (down) => {
-        if (down) switchState &= ~(1 << bit);
-        else switchState |= 1 << bit;
-    };
-
-    // Alt+1–8 and Alt+F1–F8 trigger the switches.  Using Alt means the underlying
-    // key is never forwarded to the BBC Micro (keyboard.js bails out early when a
-    // handler fires), so typing numbers or using function keys works normally.
-    const altMod = { alt: true, ctrl: false };
-    for (let i = 0; i < 8; i++) {
-        keyboard.registerKeyHandler(utils.keyCodes.K1 + i, handleSwitch(i), altMod);
-        keyboard.registerKeyHandler(utils.keyCodes.F1 + i, handleSwitch(i), altMod);
-    }
-}
-
-// Setup key handlers
-document.addEventListener("keydown", (evt) => {
-    audioHandler.tryResume();
-    ensureMicrophoneRunning();
-    keyboard.keyDown(evt);
-});
-document.addEventListener("keypress", (evt) => keyboard.keyPress(evt));
-document.addEventListener("keyup", (evt) => keyboard.keyUp(evt));
-
-function sendRawKeyboard(keysToSend, checkCapsAndShiftLocks) {
-    if (keyboard) {
-        keyboard.sendRawKeyboard(keysToSend, checkCapsAndShiftLocks);
-    } else {
-        console.warn("Tried to send keys before keyboard was initialised");
-    }
-}
+keys.attach({ processor, dbgr, keyLayout });
 
 document.getElementById("download-filestore-link").addEventListener("click", function () {
     downloadDriveData(processor.filestore.scsi, "scsi", ".dat");
@@ -992,7 +777,7 @@ const loop = new EmulationLoop({
     audioHandler,
     dbgr,
     gamepad,
-    keyboard,
+    keyboard: keys,
     syncLights: () => syncLights(),
     rewindBuffer,
     onRewindCaptured: () => rewindUI.updateButtonState(),
@@ -1003,7 +788,7 @@ const loop = new EmulationLoop({
 });
 loop.addEventListener("running", () => {
     const running = loop.isRunning();
-    keyboard.setRunning(running);
+    keys.setRunning(running);
     debugPlay.disabled = running;
     debugPause.disabled = !running;
 });

--- a/src/web/analogue-inputs.js
+++ b/src/web/analogue-inputs.js
@@ -1,0 +1,119 @@
+import { GamepadSource } from "../gamepad-source.js";
+import { MicrophoneInput } from "../microphone-input.js";
+import { MouseJoystickSource } from "../mouse-joystick-source.js";
+import { calculateMouseCoordinates } from "../mouse-coordinates.js";
+import { toast } from "./toast.js";
+
+/**
+ * What feeds the analogue port and the touchscreen: the gamepad, the mouse
+ * acting as a joystick, and the microphone, with the mouse on the monitor
+ * routed to whichever of them wants it.
+ */
+export class AnalogueInputs {
+    constructor({ processor, screenCanvas, getGamepads, urlState, config, audioHandler }) {
+        this.processor = processor;
+        this.urlState = urlState;
+        this.config = config;
+
+        this.gamepadSource = new GamepadSource(getGamepads);
+        // Create MicrophoneInput but don't enable by default
+        this.microphoneInput = new MicrophoneInput();
+        this.microphoneInput.setErrorCallback((message) => {
+            toast(`${message} The microphone channel has been turned off.`, { title: "Microphone" });
+        });
+
+        // Create MouseJoystickSource but don't enable by default
+        this.mouseJoystickSource = new MouseJoystickSource(screenCanvas);
+
+        const cubMonitor = document.getElementById("cub-monitor");
+        const onCubMouseEvent = (evt) => {
+            audioHandler.tryResume();
+            if (document.activeElement !== document.body) document.activeElement.blur();
+            const screenRect = screenCanvas.getBoundingClientRect();
+            const { x, y } = calculateMouseCoordinates(evt, screenRect);
+
+            // Handle touchscreen
+            if (processor.touchScreen) processor.touchScreen.onMouse(x, y, evt.buttons);
+
+            // Handle mouse joystick if enabled
+            if (urlState.params.mouseJoystickEnabled && this.mouseJoystickSource.isEnabled()) {
+                // Use the API methods instead of direct manipulation
+                this.mouseJoystickSource.onMouseMove(x, y);
+
+                // Handle button events
+                if (evt.type === "mousedown" && evt.button === 0) {
+                    this.mouseJoystickSource.onMouseDown(0);
+                } else if (evt.type === "mouseup" && evt.button === 0) {
+                    this.mouseJoystickSource.onMouseUp(0);
+                }
+            }
+
+            evt.preventDefault();
+        };
+        for (const eventType of ["mousemove", "mousedown", "mouseup"]) {
+            cubMonitor.addEventListener(eventType, onCubMouseEvent);
+        }
+    }
+
+    /** Helper to manage ADC source configuration */
+    updateAdcSources(mouseJoystickEnabled, microphoneChannel) {
+        const { processor } = this;
+        // Default all channels to the gamepad source.
+        for (let ch = 0; ch < 4; ch++) {
+            processor.adconverter.setChannelSource(ch, this.gamepadSource);
+        }
+
+        // Apply mouse joystick if enabled (takes priority on channels 0 & 1)
+        if (mouseJoystickEnabled) {
+            processor.adconverter.setChannelSource(0, this.mouseJoystickSource);
+            processor.adconverter.setChannelSource(1, this.mouseJoystickSource);
+            this.mouseJoystickSource.setVia(processor.sysvia);
+        } else {
+            this.mouseJoystickSource.setVia(null);
+        }
+
+        // Apply microphone if configured (can override any channel)
+        if (microphoneChannel !== undefined) {
+            processor.adconverter.setChannelSource(microphoneChannel, this.microphoneInput);
+        }
+    }
+
+    async ensureMicrophoneRunning() {
+        const { microphoneInput } = this;
+        if (microphoneInput.audioContext && microphoneInput.audioContext.state !== "running") {
+            try {
+                await microphoneInput.audioContext.resume();
+                console.log("Microphone: Audio context resumed, new state:", microphoneInput.audioContext.state);
+            } catch (err) {
+                console.error("Microphone: Error resuming audio context:", err);
+                return false;
+            }
+        }
+        return true;
+    }
+
+    async setupMicrophone() {
+        const micPermissionStatus = document.getElementById("micPermissionStatus");
+        micPermissionStatus.textContent = "Requesting microphone access...";
+
+        // Try to initialise the microphone
+        const success = await this.microphoneInput.initialise();
+        if (success) {
+            // Note: Channel assignment is handled by updateAdcSources()
+            micPermissionStatus.textContent = "Microphone connected successfully";
+            await this.ensureMicrophoneRunning();
+
+            // Try starting audio context from user gesture
+            const tryAgain = async () => {
+                if (await this.ensureMicrophoneRunning()) document.removeEventListener("click", tryAgain);
+            };
+            document.addEventListener("click", tryAgain);
+        } else {
+            micPermissionStatus.textContent = `Error: ${this.microphoneInput.getErrorMessage() || "Unknown error"}`;
+            this.config.setMicrophoneChannel(undefined);
+            // Update URL to remove the parameter
+            delete this.urlState.params.microphoneChannel;
+            this.urlState.updateUrl();
+        }
+    }
+}

--- a/src/web/keyboard-setup.js
+++ b/src/web/keyboard-setup.js
@@ -1,0 +1,125 @@
+import * as utils from "../utils.js";
+import { Keyboard } from "../keyboard.js";
+import { showNotice } from "./reporting.js";
+
+/**
+ * The page's keyboard: the emulated one, the browser shortcuts around it, and
+ * the accessibility switches on the user port. Built in two steps because the
+ * user port has to exist before the processor does, and the keyboard after.
+ */
+export class KeyboardSetup {
+    /**
+     * @param {object} actions what each shortcut does, supplied late-bound:
+     *   enterDebugger, reload, toggleFast, openRewind, openPrinter,
+     *   pause, resume, onAnyKeyDown
+     */
+    constructor(actions) {
+        this.actions = actions;
+        this.keyboard = null;
+
+        // Accessibility switch state — bits 0-7 correspond to switches 1-8.
+        // Active low: 0xff = no switches pressed; clearing a bit = that switch is pressed.
+        this.switchState = 0xff;
+        const setup = this;
+        this.userPort = {
+            write() {},
+            read() {
+                return setup.switchState;
+            },
+        };
+    }
+
+    /** Initialise keyboard now that processor exists */
+    attach({ processor, dbgr, keyLayout }) {
+        const { actions } = this;
+        const keyboard = (this.keyboard = new Keyboard({
+            processor,
+            inputEnabledFunction: () => document.activeElement && document.activeElement.id === "paste-text",
+            keyLayout,
+            dbgr,
+        }));
+        keyboard.addEventListener("notice", showNotice);
+        keyboard.addEventListener("pause", () => actions.pause());
+        keyboard.addEventListener("resume", () => actions.resume());
+        keyboard.addEventListener("break", (e) => {
+            // F12/Break: Reset processor
+            if (e.detail) utils.noteEvent("keyboard", "press", "break");
+        });
+
+        const onDown = (note, action) => (down) => {
+            if (down) {
+                if (note) utils.noteEvent("keyboard", "press", note);
+                action();
+            }
+        };
+        const alt = { alt: true, ctrl: false };
+        const ctrl = { alt: false, ctrl: true };
+        keyboard.registerKeyHandler(utils.keyCodes.S, onDown("S", actions.enterDebugger), alt);
+        keyboard.registerKeyHandler(utils.keyCodes.R, onDown(null, actions.reload), alt);
+        keyboard.registerKeyHandler(utils.keyCodes.HOME, onDown("home", actions.enterDebugger), ctrl);
+        keyboard.registerKeyHandler(utils.keyCodes.INSERT, onDown("insert", actions.toggleFast), ctrl);
+        keyboard.registerKeyHandler(
+            utils.keyCodes.END,
+            onDown("end", () => keyboard.pauseEmulation()),
+            ctrl,
+        );
+        keyboard.registerKeyHandler(utils.keyCodes.PAGEDOWN, onDown("pagedown", actions.openRewind), alt);
+        keyboard.registerKeyHandler(utils.keyCodes.B, onDown(null, actions.openPrinter), ctrl);
+
+        // Register accessibility switch key handlers.
+        // Keys 1–8 (K1–K8) and function keys F1–F8 both map to user port bits 0–7
+        // (active low: pressing the key clears the corresponding bit in &FE60).
+        //
+        // On real hardware, the Brilliant Computing switch interface box and special-ed
+        // joystick connect to the User Port only — they do not touch the analogue port
+        // or the System VIA fire buttons (PB4/PB5), which belong to the standard
+        // analogue joystick connector.  So we only update switchState here.
+        const handleSwitch = (bit) => (down) => {
+            if (down) this.switchState &= ~(1 << bit);
+            else this.switchState |= 1 << bit;
+        };
+
+        // Alt+1–8 and Alt+F1–F8 trigger the switches.  Using Alt means the underlying
+        // key is never forwarded to the BBC Micro (keyboard.js bails out early when a
+        // handler fires), so typing numbers or using function keys works normally.
+        for (let i = 0; i < 8; i++) {
+            keyboard.registerKeyHandler(utils.keyCodes.K1 + i, handleSwitch(i), alt);
+            keyboard.registerKeyHandler(utils.keyCodes.F1 + i, handleSwitch(i), alt);
+        }
+
+        document.addEventListener("keydown", (evt) => {
+            actions.onAnyKeyDown();
+            keyboard.keyDown(evt);
+        });
+        document.addEventListener("keypress", (evt) => keyboard.keyPress(evt));
+        document.addEventListener("keyup", (evt) => keyboard.keyUp(evt));
+    }
+
+    sendRawKeyboard(keysToSend, checkCapsAndShiftLocks) {
+        if (this.keyboard) {
+            this.keyboard.sendRawKeyboard(keysToSend, checkCapsAndShiftLocks);
+        } else {
+            console.warn("Tried to send keys before keyboard was initialised");
+        }
+    }
+
+    clearKeys() {
+        this.keyboard.clearKeys();
+    }
+
+    setKeyLayout(keyLayout) {
+        this.keyboard.setKeyLayout(keyLayout);
+    }
+
+    resumeEmulation() {
+        this.keyboard.resumeEmulation();
+    }
+
+    setRunning(running) {
+        this.keyboard.setRunning(running);
+    }
+
+    postFrameShouldPause() {
+        return this.keyboard.postFrameShouldPause();
+    }
+}

--- a/src/web/keyboard-setup.js
+++ b/src/web/keyboard-setup.js
@@ -17,7 +17,7 @@ export class KeyboardSetup {
         this.actions = actions;
         this.keyboard = null;
 
-        // Accessibility switch state — bits 0-7 correspond to switches 1-8.
+        // Accessibility switch state: bits 0-7 correspond to switches 1-8.
         // Active low: 0xff = no switches pressed; clearing a bit = that switch is pressed.
         this.switchState = 0xff;
         const setup = this;
@@ -67,11 +67,11 @@ export class KeyboardSetup {
         keyboard.registerKeyHandler(utils.keyCodes.B, onDown(null, actions.openPrinter), ctrl);
 
         // Register accessibility switch key handlers.
-        // Keys 1–8 (K1–K8) and function keys F1–F8 both map to user port bits 0–7
+        // Keys 1-8 (K1-K8) and function keys F1-F8 both map to user port bits 0-7
         // (active low: pressing the key clears the corresponding bit in &FE60).
         //
         // On real hardware, the Brilliant Computing switch interface box and special-ed
-        // joystick connect to the User Port only — they do not touch the analogue port
+        // joystick connect to the User Port only; they do not touch the analogue port
         // or the System VIA fire buttons (PB4/PB5), which belong to the standard
         // analogue joystick connector.  So we only update switchState here.
         const handleSwitch = (bit) => (down) => {
@@ -79,7 +79,7 @@ export class KeyboardSetup {
             else this.switchState |= 1 << bit;
         };
 
-        // Alt+1–8 and Alt+F1–F8 trigger the switches.  Using Alt means the underlying
+        // Alt+1-8 and Alt+F1-F8 trigger the switches.  Using Alt means the underlying
         // key is never forwarded to the BBC Micro (keyboard.js bails out early when a
         // handler fires), so typing numbers or using function keys works normally.
         for (let i = 0; i < 8; i++) {

--- a/tests/unit/test-analogue-inputs.js
+++ b/tests/unit/test-analogue-inputs.js
@@ -1,0 +1,101 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { AnalogueInputs } from "../../src/web/analogue-inputs.js";
+
+const Markup = `<div id="cub-monitor"><canvas id="screen"></canvas></div><span id="micPermissionStatus"></span>`;
+
+describe("AnalogueInputs", () => {
+    let deps;
+    let channels;
+
+    beforeEach(() => {
+        document.body.innerHTML = Markup;
+        channels = {};
+        deps = {
+            processor: {
+                adconverter: { setChannelSource: vi.fn((ch, source) => (channels[ch] = source)) },
+                sysvia: {},
+                touchScreen: { onMouse: vi.fn() },
+            },
+            screenCanvas: document.getElementById("screen"),
+            getGamepads: () => [],
+            urlState: { params: {}, updateUrl: vi.fn() },
+            config: { setMicrophoneChannel: vi.fn() },
+            audioHandler: { tryResume: vi.fn() },
+        };
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+        document.body.innerHTML = "";
+    });
+
+    const make = () => new AnalogueInputs(deps);
+
+    describe("who feeds the analogue channels", () => {
+        it("gives every channel to the gamepad by default", () => {
+            const inputs = make();
+            inputs.updateAdcSources(false, undefined);
+            expect(Object.keys(channels)).toHaveLength(4);
+            for (let ch = 0; ch < 4; ch++) expect(channels[ch]).toBe(inputs.gamepadSource);
+        });
+
+        it("gives the mouse joystick channels 0 and 1 when enabled", () => {
+            const inputs = make();
+            inputs.updateAdcSources(true, undefined);
+            expect(channels[0]).toBe(inputs.mouseJoystickSource);
+            expect(channels[1]).toBe(inputs.mouseJoystickSource);
+            expect(channels[2]).toBe(inputs.gamepadSource);
+        });
+
+        it("lets the microphone take any channel, even from the mouse", () => {
+            const inputs = make();
+            inputs.updateAdcSources(true, 1);
+            expect(channels[0]).toBe(inputs.mouseJoystickSource);
+            expect(channels[1]).toBe(inputs.microphoneInput);
+        });
+    });
+
+    describe("the mouse on the monitor", () => {
+        const mouse = (type) => {
+            const event = new MouseEvent(type, { bubbles: true, cancelable: true, buttons: 1, button: 0 });
+            document.getElementById("cub-monitor").dispatchEvent(event);
+            return event;
+        };
+
+        it("wakes the audio and feeds the touchscreen", () => {
+            make();
+            const event = mouse("mousedown");
+            expect(deps.audioHandler.tryResume).toHaveBeenCalled();
+            expect(deps.processor.touchScreen.onMouse).toHaveBeenCalled();
+            expect(event.defaultPrevented).toBe(true);
+        });
+
+        it("drives the mouse joystick's button only when it is enabled", () => {
+            const inputs = make();
+            const down = vi.spyOn(inputs.mouseJoystickSource, "onMouseDown");
+            mouse("mousedown");
+            expect(down).not.toHaveBeenCalled();
+
+            deps.urlState.params.mouseJoystickEnabled = true;
+            vi.spyOn(inputs.mouseJoystickSource, "isEnabled").mockReturnValue(true);
+            mouse("mousedown");
+            expect(down).toHaveBeenCalledWith(0);
+        });
+    });
+
+    describe("a microphone that cannot start", () => {
+        it("reports, clears the setting and takes it out of the URL", async () => {
+            deps.urlState.params.microphoneChannel = 2;
+            const inputs = make();
+            vi.spyOn(inputs.microphoneInput, "initialise").mockResolvedValue(false);
+            vi.spyOn(inputs.microphoneInput, "getErrorMessage").mockReturnValue("denied");
+            await inputs.setupMicrophone();
+            expect(document.getElementById("micPermissionStatus").textContent).toBe("Error: denied");
+            expect(deps.config.setMicrophoneChannel).toHaveBeenCalledWith(undefined);
+            expect(deps.urlState.params.microphoneChannel).toBeUndefined();
+            expect(deps.urlState.updateUrl).toHaveBeenCalled();
+        });
+    });
+});

--- a/tests/unit/test-keyboard-setup.js
+++ b/tests/unit/test-keyboard-setup.js
@@ -1,0 +1,127 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { KeyboardSetup } from "../../src/web/keyboard-setup.js";
+import * as utils from "../../src/utils.js";
+
+const keyEvent = (type, which, { alt = false, ctrl = false } = {}) => {
+    const event = new KeyboardEvent(type, { altKey: alt, ctrlKey: ctrl, cancelable: true });
+    Object.defineProperty(event, "which", { value: which });
+    return event;
+};
+
+describe("KeyboardSetup", () => {
+    let actions;
+    let setup;
+
+    beforeEach(() => {
+        vi.spyOn(console, "warn").mockImplementation(() => {});
+        document.body.innerHTML = "";
+        actions = {
+            enterDebugger: vi.fn(),
+            reload: vi.fn(),
+            toggleFast: vi.fn(),
+            openRewind: vi.fn(),
+            openPrinter: vi.fn(),
+            pause: vi.fn(),
+            resume: vi.fn(),
+            onAnyKeyDown: vi.fn(),
+        };
+        setup = new KeyboardSetup(actions);
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+        document.body.innerHTML = "";
+    });
+
+    const attach = () => {
+        const processor = {
+            model: { isAtom: false },
+            scheduler: {
+                newTask: () => ({
+                    schedule: () => {},
+                    cancel: () => {},
+                    ensureScheduled: () => {},
+                    scheduled: () => false,
+                }),
+            },
+            sysvia: {
+                keyDown: vi.fn(),
+                keyUp: vi.fn(),
+                keyDownRaw: vi.fn(),
+                keyUpRaw: vi.fn(),
+                clearKeys: vi.fn(),
+                setKeyLayout: vi.fn(),
+                keyboardEnabled: true,
+            },
+        };
+        setup.attach({ processor, dbgr: {}, keyLayout: "physical" });
+        setup.setRunning(true);
+        return processor;
+    };
+
+    describe("the user port", () => {
+        it("reads as no switches pressed to begin with", () => {
+            expect(setup.userPort.read()).toBe(0xff);
+        });
+
+        it("clears a bit while its switch is held, keys and function keys alike", () => {
+            attach();
+            document.dispatchEvent(keyEvent("keydown", utils.keyCodes.K1, { alt: true }));
+            expect(setup.userPort.read()).toBe(0xfe);
+            document.dispatchEvent(keyEvent("keyup", utils.keyCodes.K1, { alt: true }));
+            expect(setup.userPort.read()).toBe(0xff);
+
+            document.dispatchEvent(keyEvent("keydown", utils.keyCodes.F8, { alt: true }));
+            expect(setup.userPort.read()).toBe(0x7f);
+        });
+    });
+
+    describe("the shortcuts", () => {
+        it.each([
+            ["Alt-S", utils.keyCodes.S, { alt: true }, "enterDebugger"],
+            ["Ctrl-Home", utils.keyCodes.HOME, { ctrl: true }, "enterDebugger"],
+            ["Alt-R", utils.keyCodes.R, { alt: true }, "reload"],
+            ["Ctrl-Insert", utils.keyCodes.INSERT, { ctrl: true }, "toggleFast"],
+            ["Alt-PageDown", utils.keyCodes.PAGEDOWN, { alt: true }, "openRewind"],
+            ["Ctrl-B", utils.keyCodes.B, { ctrl: true }, "openPrinter"],
+        ])("%s fires %s on the way down only", (name, which, modifiers, action) => {
+            attach();
+            document.dispatchEvent(keyEvent("keydown", which, modifiers));
+            expect(actions[action]).toHaveBeenCalledTimes(1);
+            document.dispatchEvent(keyEvent("keyup", which, modifiers));
+            expect(actions[action]).toHaveBeenCalledTimes(1);
+        });
+
+        it("does nothing without the modifier", () => {
+            const processor = attach();
+            document.dispatchEvent(keyEvent("keydown", utils.keyCodes.S));
+            expect(actions.enterDebugger).not.toHaveBeenCalled();
+            expect(processor.sysvia.keyDown).toHaveBeenCalled();
+        });
+
+        it("tells the page about every key on the way down", () => {
+            attach();
+            document.dispatchEvent(keyEvent("keydown", utils.keyCodes.A));
+            expect(actions.onAnyKeyDown).toHaveBeenCalledTimes(1);
+        });
+    });
+
+    describe("the keyboard's own events", () => {
+        it("routes pause and resume to the loop's actions", () => {
+            attach();
+            setup.keyboard.dispatchEvent(new CustomEvent("pause"));
+            setup.keyboard.dispatchEvent(new CustomEvent("resume"));
+            expect(actions.pause).toHaveBeenCalledTimes(1);
+            expect(actions.resume).toHaveBeenCalledTimes(1);
+        });
+    });
+
+    describe("before the keyboard exists", () => {
+        it("swallows raw keys with a warning rather than throwing", () => {
+            expect(() => setup.sendRawKeyboard([1000], false)).not.toThrow();
+            expect(console.warn).toHaveBeenCalled();
+        });
+    });
+});


### PR DESCRIPTION
PR 12 of #638.

**Moved**: `KeyboardSetup` owns the emulated keyboard, the browser shortcuts and the accessibility switches with their user port, built in two steps because the port must exist before the processor and the keyboard after; every shortcut's effect is a named action handed in from `main.js`, and the seven typed registrations collapse into one shape. `AnalogueInputs` owns the gamepad, mouse joystick and microphone sources, the ADC channel routing and the mouse on the monitor.

**Tests**: the switch bits clear and restore on the user port; each shortcut fires its action on the way down only and not without its modifier; an unclaimed key reaches the machine; the ADC priority rules (gamepad everywhere, mouse joystick on 0 and 1, microphone over anything); the monitor mouse waking audio and feeding the touchscreen; a refused microphone clearing its setting and the URL.

**Deviation from the plan**: no new smoke check; the typing and Ctrl-Home checks already cover the wiring this PR moves, and the analogue sources have nothing observable headlessly.

**Checked**: unit suite, all twelve smoke checks.
