### PR TITLE
refactor: move the front panel out of main.js

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -30,6 +30,7 @@ import { Layout } from "./web/layout.js";
 import { EmulationLoop, RewindCaptureInterval } from "./web/emulation-loop.js";
 import { KeyboardSetup } from "./web/keyboard-setup.js";
 import { AnalogueInputs } from "./web/analogue-inputs.js";
+import { FrontPanel } from "./web/front-panel.js";
 import { Drives } from "./web/drives.js";
 import { UrlState } from "./web/url-state.js";
 import { Modals } from "./web/modals.js";
@@ -52,7 +53,6 @@ let processor;
 let video;
 let rewindUI;
 const dbgr = new Debugger();
-let syncLights;
 let model;
 
 const gamepad = new GamePad();
@@ -105,9 +105,7 @@ noSeek = !!parsedQuery.noseek;
 if (parsedQuery.stationId !== undefined) stationId = parsedQuery.stationId;
 
 const printer = new Printer({
-    onOutput: (char) => {
-        if (printerTextArea) printerTextArea.value += char;
-    },
+    onOutput: (char) => frontPanel.printChar(char),
     onFirstOutput: () =>
         toast("Printer output is being kept. Press Ctrl-B to open the printer window.", {
             title: "Printer",
@@ -122,7 +120,7 @@ const keys = new KeyboardSetup({
     openRewind: () => {
         if (rewindUI) rewindUI.open();
     },
-    openPrinter: () => checkPrinterWindow(),
+    openPrinter: () => frontPanel.checkPrinterWindow(),
     pause: () => loop.stop(false),
     resume: () => loop.go(),
     onAnyKeyDown: () => {
@@ -420,26 +418,6 @@ const cmos = new Cmos(
     econet,
 );
 
-let printerWindow = null;
-let printerTextArea = null;
-
-function checkPrinterWindow() {
-    if (printerWindow && !printerWindow.closed) return;
-
-    printerWindow = window.open("", "_blank", "height=300,width=400");
-    if (!printerWindow) {
-        toast("The printer output window was blocked. Allow pop-up windows for this site, then press Ctrl-B again.", {
-            title: "Printer",
-        });
-        return;
-    }
-    printerWindow.document.write(
-        '<textarea id="text" rows="15" cols="40" placeholder="Printer outputs here..."></textarea>',
-    );
-    printerTextArea = printerWindow.document.getElementById("text");
-    printerTextArea.value = printer.text;
-}
-
 const CpuClass = model.isAtom ? AtomCpu6502 : Cpu6502;
 processor = new CpuClass(model, {
     dbgr,
@@ -574,96 +552,7 @@ document.getElementById("soft-reset").addEventListener("click", function (event)
     event.preventDefault();
 });
 
-for (const link of document.querySelectorAll("#tape-menu a")) {
-    link.addEventListener("click", function (e) {
-        const type = e.target.dataset.id;
-        if (type === undefined) return;
-
-        if (type === "rewind") {
-            console.log("Rewinding tape to the start");
-            if (model.isAtom) {
-                processor.atomppia.stopTape();
-                processor.atomppia.rewindTape();
-                updateTapeButton();
-            } else {
-                processor.acia.rewindTape();
-            }
-        } else {
-            console.log("unknown type", type);
-        }
-    });
-}
-
-const tapePlayStopBtn = document.getElementById("tape-play-stop");
-const tapeControlHeader = document.getElementById("tape-control-header");
-const tapeControlCell = document.getElementById("tape-control-cell");
-
-function updateTapeButton() {
-    if (!model.isAtom) return;
-    const playing = processor.atomppia.motorOn;
-    const label = playing ? "Stop cassette" : "Play cassette";
-    tapePlayStopBtn.textContent = playing ? "\u25A0" : "\u25B6";
-    tapePlayStopBtn.title = label;
-    tapePlayStopBtn.setAttribute("aria-label", label);
-    tapePlayStopBtn.classList.toggle("playing", playing);
-}
-
-function showTapeControl(visible) {
-    const display = visible ? "" : "none";
-    tapeControlHeader.style.display = display;
-    tapeControlCell.style.display = display;
-}
-
-function updateLedVisibility() {
-    const bbcDisplay = model.isAtom ? "none" : "";
-    for (const el of document.querySelectorAll(".bbc-only")) {
-        el.style.display = bbcDisplay;
-    }
-    showTapeControl(model.isAtom);
-}
-
-updateLedVisibility();
-
-tapePlayStopBtn.addEventListener("click", () => {
-    if (processor.atomppia.motorOn) {
-        processor.atomppia.stopTape();
-    } else {
-        processor.atomppia.playTape();
-    }
-    updateTapeButton();
-});
-
-function Light(name) {
-    const dom = document.getElementById(name);
-    let on = false;
-    this.update = function (val) {
-        if (val === on) return;
-        on = val;
-        dom.classList.toggle("on", on);
-    };
-}
-
-const cassette = new Light("motorlight");
-const caps = new Light("capslight");
-const shift = new Light("shiftlight");
-const drive0 = new Light("drive0");
-const drive1 = new Light("drive1");
-const network = new Light("networklight");
-
-syncLights = function () {
-    if (model.isAtom) {
-        cassette.update(processor.atomppia.motorOn);
-    } else {
-        caps.update(processor.sysvia.capsLockLight);
-        shift.update(processor.sysvia.shiftLockLight);
-        drive0.update(processor.fdc.motorOn[0]);
-        drive1.update(processor.fdc.motorOn[1]);
-        cassette.update(processor.acia.motorOn);
-        if (processor.econet) {
-            network.update(processor.econet.activityLight());
-        }
-    }
-};
+const frontPanel = new FrontPanel({ processor, model, printer });
 
 const startPromise = (async () => {
     await Promise.all([audioHandler.initialise(), processor.initialise()]);
@@ -778,7 +667,7 @@ const loop = new EmulationLoop({
     dbgr,
     gamepad,
     keyboard: keys,
-    syncLights: () => syncLights(),
+    syncLights: () => frontPanel.syncLights(),
     rewindBuffer,
     onRewindCaptured: () => rewindUI.updateButtonState(),
     clocksPerSecond,

--- a/src/web/front-panel.js
+++ b/src/web/front-panel.js
@@ -1,0 +1,135 @@
+import { toast } from "./toast.js";
+
+class Light {
+    constructor(name) {
+        this.dom = document.getElementById(name);
+        this.on = false;
+    }
+
+    update(val) {
+        if (val === this.on) return;
+        this.on = val;
+        this.dom.classList.toggle("on", this.on);
+    }
+}
+
+/**
+ * The furniture around the screen: the keyboard and drive lights, the tape
+ * controls, and the pop-up window the printer prints into.
+ */
+export class FrontPanel {
+    constructor({ processor, model, printer }) {
+        this.processor = processor;
+        this.model = model;
+        this.printer = printer;
+        this.printerWindow = null;
+        this.printerTextArea = null;
+
+        for (const link of document.querySelectorAll("#tape-menu a")) {
+            link.addEventListener("click", (e) => {
+                const type = e.target.dataset.id;
+                if (type === undefined) return;
+
+                if (type === "rewind") {
+                    console.log("Rewinding tape to the start");
+                    if (model.isAtom) {
+                        processor.atomppia.stopTape();
+                        processor.atomppia.rewindTape();
+                        this.updateTapeButton();
+                    } else {
+                        processor.acia.rewindTape();
+                    }
+                } else {
+                    console.log("unknown type", type);
+                }
+            });
+        }
+
+        this.tapePlayStopBtn = document.getElementById("tape-play-stop");
+        this.tapeControlHeader = document.getElementById("tape-control-header");
+        this.tapeControlCell = document.getElementById("tape-control-cell");
+
+        this.tapePlayStopBtn.addEventListener("click", () => {
+            if (processor.atomppia.motorOn) {
+                processor.atomppia.stopTape();
+            } else {
+                processor.atomppia.playTape();
+            }
+            this.updateTapeButton();
+        });
+
+        this.cassette = new Light("motorlight");
+        this.caps = new Light("capslight");
+        this.shift = new Light("shiftlight");
+        this.drive0 = new Light("drive0");
+        this.drive1 = new Light("drive1");
+        this.network = new Light("networklight");
+
+        this.updateLedVisibility();
+    }
+
+    updateTapeButton() {
+        if (!this.model.isAtom) return;
+        const playing = this.processor.atomppia.motorOn;
+        const label = playing ? "Stop cassette" : "Play cassette";
+        this.tapePlayStopBtn.textContent = playing ? "■" : "▶";
+        this.tapePlayStopBtn.title = label;
+        this.tapePlayStopBtn.setAttribute("aria-label", label);
+        this.tapePlayStopBtn.classList.toggle("playing", playing);
+    }
+
+    showTapeControl(visible) {
+        const display = visible ? "" : "none";
+        this.tapeControlHeader.style.display = display;
+        this.tapeControlCell.style.display = display;
+    }
+
+    updateLedVisibility() {
+        const bbcDisplay = this.model.isAtom ? "none" : "";
+        for (const el of document.querySelectorAll(".bbc-only")) {
+            el.style.display = bbcDisplay;
+        }
+        this.showTapeControl(this.model.isAtom);
+    }
+
+    syncLights() {
+        const { processor } = this;
+        if (this.model.isAtom) {
+            this.cassette.update(processor.atomppia.motorOn);
+        } else {
+            this.caps.update(processor.sysvia.capsLockLight);
+            this.shift.update(processor.sysvia.shiftLockLight);
+            this.drive0.update(processor.fdc.motorOn[0]);
+            this.drive1.update(processor.fdc.motorOn[1]);
+            this.cassette.update(processor.acia.motorOn);
+            if (processor.econet) {
+                this.network.update(processor.econet.activityLight());
+            }
+        }
+    }
+
+    /** What the printer prints lands in its window, when one is open. */
+    printChar(char) {
+        if (this.printerTextArea) this.printerTextArea.value += char;
+    }
+
+    checkPrinterWindow() {
+        if (this.printerWindow && !this.printerWindow.closed) return;
+
+        this.printerWindow = window.open("", "_blank", "height=300,width=400");
+        if (!this.printerWindow) {
+            toast(
+                "The printer output window was blocked. Allow pop-up windows for this site, then press Ctrl-B again.",
+                {
+                    title: "Printer",
+                },
+            );
+            return;
+        }
+        this.printerWindow.document.write(
+            '<textarea id="text" rows="15" cols="40" placeholder="Printer outputs here..."></textarea>',
+        );
+        this.printerTextArea = this.printerWindow.document.getElementById("text");
+        this.printerTextArea.value = this.printer.text;
+    }
+}

--- a/tests/unit/test-front-panel.js
+++ b/tests/unit/test-front-panel.js
@@ -1,0 +1,135 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { FrontPanel } from "../../src/web/front-panel.js";
+
+const Markup = `
+<div id="tape-menu"><a data-id="rewind">Rewind</a></div>
+<table><tbody><tr><th id="tape-control-header"></th><td id="tape-control-cell"></td></tr></tbody></table>
+<button id="tape-play-stop"></button>
+<span id="motorlight"></span><span id="capslight" class="bbc-only"></span><span id="shiftlight" class="bbc-only"></span>
+<span id="drive0" class="bbc-only"></span><span id="drive1" class="bbc-only"></span><span id="networklight" class="bbc-only"></span>`;
+
+describe("FrontPanel", () => {
+    let processor;
+
+    beforeEach(() => {
+        vi.spyOn(console, "log").mockImplementation(() => {});
+        document.body.innerHTML = Markup;
+        processor = {
+            sysvia: { capsLockLight: false, shiftLockLight: false },
+            fdc: { motorOn: [false, false] },
+            acia: { motorOn: false, rewindTape: vi.fn() },
+            atomppia: { motorOn: false, playTape: vi.fn(), stopTape: vi.fn(), rewindTape: vi.fn() },
+            econet: null,
+        };
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+        document.body.innerHTML = "";
+        window.localStorage.clear();
+    });
+
+    const make = (isAtom = false, printer = { text: "" }) => new FrontPanel({ processor, model: { isAtom }, printer });
+    const lit = (id) => document.getElementById(id).classList.contains("on");
+
+    describe("the lights", () => {
+        it("follow the machine", () => {
+            const panel = make();
+            processor.sysvia.capsLockLight = true;
+            processor.fdc.motorOn[1] = true;
+            panel.syncLights();
+            expect(lit("capslight")).toBe(true);
+            expect(lit("drive1")).toBe(true);
+            expect(lit("shiftlight")).toBe(false);
+        });
+
+        it("only touch the DOM when something changed", () => {
+            const panel = make();
+            processor.sysvia.capsLockLight = true;
+            panel.syncLights();
+            const toggled = vi.spyOn(document.getElementById("capslight").classList, "toggle");
+            panel.syncLights();
+            expect(toggled).not.toHaveBeenCalled();
+        });
+
+        it("show only the cassette motor on an Atom", () => {
+            const panel = make(true);
+            processor.atomppia.motorOn = true;
+            panel.syncLights();
+            expect(lit("motorlight")).toBe(true);
+        });
+    });
+
+    describe("what each machine shows", () => {
+        it("hides the BBC lights and shows the tape control on an Atom", () => {
+            make(true);
+            expect(document.getElementById("capslight").style.display).toBe("none");
+            expect(document.getElementById("tape-control-header").style.display).toBe("");
+        });
+
+        it("shows the BBC lights and hides the tape control on a BBC", () => {
+            make(false);
+            expect(document.getElementById("capslight").style.display).toBe("");
+            expect(document.getElementById("tape-control-header").style.display).toBe("none");
+        });
+    });
+
+    describe("the tape controls", () => {
+        it("plays and stops the Atom's cassette, showing which is next", () => {
+            make(true);
+            const button = document.getElementById("tape-play-stop");
+            button.click();
+            expect(processor.atomppia.playTape).toHaveBeenCalled();
+            processor.atomppia.motorOn = true;
+            button.click();
+            expect(processor.atomppia.stopTape).toHaveBeenCalled();
+            expect(button.textContent).toBe("■");
+        });
+
+        it("rewinds through the right interface for the machine", () => {
+            make(false);
+            document.querySelector('#tape-menu a[data-id="rewind"]').click();
+            expect(processor.acia.rewindTape).toHaveBeenCalled();
+            expect(processor.atomppia.rewindTape).not.toHaveBeenCalled();
+        });
+
+        it("stops the Atom's tape before rewinding it", () => {
+            make(true);
+            document.querySelector('#tape-menu a[data-id="rewind"]').click();
+            expect(processor.atomppia.stopTape).toHaveBeenCalled();
+            expect(processor.atomppia.rewindTape).toHaveBeenCalled();
+        });
+    });
+
+    describe("the printer window", () => {
+        it("says when the pop-up was blocked", () => {
+            vi.spyOn(window, "open").mockReturnValue(null);
+            make().checkPrinterWindow();
+            expect(document.querySelector(".toast").textContent).toContain("blocked");
+        });
+
+        it("quietly keeps output until a window is open", () => {
+            const panel = make();
+            expect(() => panel.printChar("A")).not.toThrow();
+        });
+
+        it("seeds a new window with what has printed so far", () => {
+            const fakeArea = { value: "" };
+            const fakeWindow = {
+                closed: false,
+                document: { write: vi.fn(), getElementById: () => fakeArea },
+            };
+            vi.spyOn(window, "open").mockReturnValue(fakeWindow);
+            const panel = make(false, { text: "so far" });
+            panel.checkPrinterWindow();
+            expect(fakeArea.value).toBe("so far");
+            panel.printChar("!");
+            expect(fakeArea.value).toBe("so far!");
+            // A second check leaves the open window alone.
+            panel.checkPrinterWindow();
+            expect(window.open).toHaveBeenCalledTimes(1);
+        });
+    });
+});


### PR DESCRIPTION
PR 13 of #638, the last of Phase 3.

**Moved**: `FrontPanel` owns the keyboard and drive lights, the tape menu and the Atom's play/stop button, which machine shows what, and the pop-up window the printer prints into.

**Tests**: lights follow the machine and only touch the DOM on change; the Atom hides the BBC lights and shows the tape control; play/stop and rewind go through the right interface per machine; a blocked printer pop-up toasts; a new window is seeded with what has printed so far.

**Checked**: unit suite, all twelve smoke checks. After this, `main.js` is 774 lines: the URL and settings bootstrap, the machine construction and `startPromise`, the composition, and the console surface.
