### PR TITLE
refactor: move the machine construction and start-up out of main.js

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -5,18 +5,14 @@ import "./jsbeeb.css";
 
 import * as utils from "./utils.js";
 import { Debugger } from "./web/debug.js";
-import { Cpu6502, AtomCpu6502 } from "./6502.js";
 import * as utils_atom from "./utils_atom.js";
-import { LoadSD } from "./mmc.js";
-import { Cmos, localStoragePersistence } from "./cmos.js";
 import { GamePad } from "./gamepads.js";
 import { Config } from "./config.js";
-import { DefaultModel, findModel, tubeModelFor } from "./models.js";
+import { DefaultModel, findModel } from "./models.js";
 import { initialise as electron } from "./app/electron.js";
 import { AudioHandler } from "./web/audio-handler.js";
 import { DefaultAudioOutput, isAudioOutput } from "./audio-output.js";
 import { QuickSettings } from "./web/quick-settings.js";
-import { Econet } from "./econet.js";
 import { toast } from "./web/toast.js";
 import { BuiltInImages, MediaLoader } from "./web/media-loader.js";
 import { AutobootTicks } from "./web/archive-list.js";
@@ -31,10 +27,10 @@ import { EmulationLoop, RewindCaptureInterval } from "./web/emulation-loop.js";
 import { KeyboardSetup } from "./web/keyboard-setup.js";
 import { AnalogueInputs } from "./web/analogue-inputs.js";
 import { FrontPanel } from "./web/front-panel.js";
+import { Machine } from "./web/machine.js";
 import { Drives } from "./web/drives.js";
 import { UrlState } from "./web/url-state.js";
 import { Modals } from "./web/modals.js";
-import { errorText, reportLoadFailure, showNotice } from "./web/reporting.js";
 import { SpeechOutput } from "./speech-output.js";
 import { Printer } from "./printer.js";
 import { RewindBuffer } from "./rewind.js";
@@ -76,7 +72,6 @@ const keyCodes = utils.keyCodes;
 const cpuMultiplier = parsedQuery.cpuMultiplier ?? 1;
 let noSeek;
 let stationId = 101;
-let econet = null;
 
 // Parse disc and tape images from query parameters
 const { discImage: queryDiscImage, secondDiscImage: querySecondDisc, mmcImage } = parseMediaParams(parsedQuery);
@@ -152,7 +147,7 @@ const config = new Config(
         Object.assign(parsedQuery, changed);
         if (changed.keyLayout) {
             window.localStorage.keyLayout = changed.keyLayout;
-            emulationConfig.keyLayout = changed.keyLayout;
+            machine.emulationConfig.keyLayout = changed.keyLayout;
             keys.setKeyLayout(changed.keyLayout);
         }
         if (changed.mouseJoystickEnabled !== undefined || changed.microphoneChannel !== undefined) {
@@ -164,7 +159,7 @@ const config = new Config(
         }
         if (changed.speechOutput !== undefined) setSpeechOutput(!!changed.speechOutput);
         if (changed.tubeCpuMultiplier !== undefined) {
-            emulationConfig.tubeCpuMultiplier = changed.tubeCpuMultiplier;
+            machine.emulationConfig.tubeCpuMultiplier = changed.tubeCpuMultiplier;
             config.setTubeCpuMultiplier(changed.tubeCpuMultiplier);
             if (processor.hasTube) {
                 processor.tube.cpuMultiplier = changed.tubeCpuMultiplier;
@@ -256,30 +251,6 @@ const keyMappingWarnings = processInputParams(
     utils.userKeymap,
     gamepad,
 );
-
-// Depends on the config.setX calls above having applied the URL parameters.
-const emulationConfig = {
-    keyLayout,
-    cpuMultiplier,
-    tubeCpuMultiplier: config.tubeCpuMultiplier,
-    videoCyclesBatch: parsedQuery.videoCyclesBatch,
-    tube: config.coProcessor ? tubeModelFor(config.model) : null,
-    hasMusic5000: config.hasMusic5000,
-    hasTeletextAdaptor: config.hasTeletextAdaptor,
-    // ROM order determines sideways bank allocation, and the fittings' ROMs claim banks
-    // before any the user asked for with ?rom=.
-    extraRoms: [...config.extraRoms, ...extraRoms],
-    userPort: keys.userPort,
-    printerPort: printer,
-    getGamepads: function () {
-        // Gamepads are only available in secure contexts. If e.g. loading from http:// urls they aren't there.
-        return navigator.getGamepads ? navigator.getGamepads() : [];
-    },
-    debugFlags: {
-        logFdcCommands: parsedQuery.logFdcCommands !== undefined,
-        logFdcStateChanges: parsedQuery.logFdcStateChanges !== undefined,
-    },
-};
 
 if (cpuMultiplier !== 1) console.log(`CPU multiplier set to ${cpuMultiplier}`);
 const cpuSpeed = model.cyclesPerSecond;
@@ -399,39 +370,23 @@ window.addEventListener("beforeunload", function (event) {
     }
 });
 
-if (config.hasEconet) {
-    econet = new Econet(stationId, model.cyclesPerSecond);
-} else {
-    document.getElementById("fsmenuitem").style.display = "none";
-}
-
-const cmos = new Cmos(
-    localStoragePersistence(
-        () => window.localStorage,
-        (error) =>
-            toast(
-                `Settings changed with *CONFIGURE will not be kept (${errorText(error)}). Check that this site is allowed to store data, and that its storage is not full.`,
-                { title: "Settings", quietKey: "quietCmosSave" },
-            ),
-    ),
-    model.cmosOverride,
-    econet,
-);
-
-const CpuClass = model.isAtom ? AtomCpu6502 : Cpu6502;
-processor = new CpuClass(model, {
-    dbgr,
+// Depends on the config.setX calls having applied the URL parameters.
+const machine = new Machine({
+    model,
+    config,
+    parsedQuery,
+    keyLayout,
+    cpuMultiplier,
+    extraRoms,
+    stationId,
+    userPort: keys.userPort,
+    printer,
+    speechOutput,
     video,
-    soundChip: audioHandler.soundChip,
-    ddNoise: audioHandler.ddNoise,
-    relayNoise: audioHandler.relayNoise,
-    music5000: config.hasMusic5000 ? audioHandler.music5000 : null,
-    cmos,
-    config: emulationConfig,
-    econet,
+    audioHandler,
+    dbgr,
 });
-
-printer.attach(processor.uservia);
+processor = machine.processor;
 const drives = new Drives({ fdc: processor.fdc, driveTracks, areYouSure: modals.areYouSure.bind(modals) });
 const media = new MediaLoader({
     processor,
@@ -486,35 +441,15 @@ const snapshots = new SnapshotUI({
     go: () => loop.go(),
 });
 
-processor.teletextAdaptor?.addEventListener("notice", showNotice);
-processor.acia.addEventListener("notice", showNotice);
-
 // Create input sources
 const inputs = new AnalogueInputs({
     processor,
     screenCanvas,
-    getGamepads: emulationConfig.getGamepads,
+    getGamepads: machine.emulationConfig.getGamepads,
     urlState,
     config,
     audioHandler,
 });
-
-/**
- * Attach an RS-423 composite handler to the ACIA that combines the touchscreen
- * (which sends position data to the BBC) with the speech output (which speaks
- * text the BBC sends out).
- */
-function setupRs423Handler() {
-    processor.acia.setRs423Handler({
-        onTransmit(val) {
-            processor.touchScreen.onTransmit(val);
-            speechOutput.onTransmit(val);
-        },
-        tryReceive(rts) {
-            return processor.touchScreen.tryReceive(rts);
-        },
-    });
-}
 
 if (parsedQuery.microphoneChannel !== undefined) {
     // We need to use setTimeout to make sure this runs after the page has loaded
@@ -554,72 +489,20 @@ document.getElementById("soft-reset").addEventListener("click", function (event)
 
 const frontPanel = new FrontPanel({ processor, model, printer });
 
-const startPromise = (async () => {
-    await Promise.all([audioHandler.initialise(), processor.initialise()]);
-
-    // Wire up the composite RS-423 handler now that the touchscreen exists.
-    setupRs423Handler();
-
-    // Ideally would start the loads first. But their completion needs the FDC from the processor
-    const imageLoads = [];
-
-    function startImageLoad(description, load) {
-        const loading = (async () => {
-            try {
-                await load();
-            } catch (error) {
-                reportLoadFailure(description, error);
-            }
-        })();
-        imageLoads.push(loading);
-        return loading;
-    }
-
-    if (discImage) {
-        startImageLoad(`disc ${discImage}`, async () =>
-            drives.putDiscIn(0, await media.loadDiscImage(discImage, drives.layoutForDrive(0))),
-        );
-    }
-
-    if (secondDiscImage) {
-        startImageLoad(`disc ${secondDiscImage}`, async () =>
-            drives.putDiscIn(1, await media.loadDiscImage(secondDiscImage, drives.layoutForDrive(1))),
-        );
-    }
-
-    if (parsedQuery.tape) {
-        startImageLoad(`tape ${parsedQuery.tape}`, async () =>
-            media.setProcessorTape(await media.loadTapeImage(parsedQuery.tape)),
-        );
-    }
-
-    if (mmcImage && model.isAtom) {
-        startImageLoad(`MMC image ${mmcImage}`, async () => processor.atommc.SetMMCData(await LoadSD(mmcImage)));
-    }
-
-    if (parsedQuery.loadBasic) {
-        const needsRun = needsAutoboot === "run";
-        needsAutoboot = "";
-
-        await startImageLoad(`BASIC program ${parsedQuery.loadBasic}`, () =>
-            autoBoot.insertBasic(
-                (async () => {
-                    const data = await utils.loadData(parsedQuery.loadBasic);
-                    return String.fromCharCode.apply(null, data);
-                })(),
-                needsRun,
-            ),
-        );
-    }
-
-    if (parsedQuery.embedBasic) {
-        await startImageLoad("the BASIC program from the URL", () =>
-            autoBoot.insertBasic(Promise.resolve(parsedQuery.embedBasic), true),
-        );
-    }
-
-    return Promise.all(imageLoads);
-})();
+const basicNeedsRun = parsedQuery.loadBasic !== undefined && needsAutoboot === "run";
+if (parsedQuery.loadBasic) needsAutoboot = "";
+const startPromise = machine.start({
+    media,
+    drives,
+    autoBoot,
+    discImage,
+    secondDiscImage,
+    tape: parsedQuery.tape,
+    mmcImage,
+    loadBasic: parsedQuery.loadBasic,
+    embedBasic: parsedQuery.embedBasic,
+    basicNeedsRun,
+});
 
 (async () => {
     try {

--- a/src/web/machine.js
+++ b/src/web/machine.js
@@ -1,0 +1,204 @@
+import { AtomCpu6502, Cpu6502 } from "../6502.js";
+import { Cmos, localStoragePersistence } from "../cmos.js";
+import { Econet } from "../econet.js";
+import { LoadSD } from "../mmc.js";
+import { tubeModelFor } from "../models.js";
+import * as utils from "../utils.js";
+import { toast } from "./toast.js";
+import { errorText, reportLoadFailure, showNotice } from "./reporting.js";
+
+/**
+ * The machine's fittings as the CPU wants them handed over. Pure, so the bank
+ * and flag decisions are testable on their own.
+ */
+export function buildEmulationConfig({ config, parsedQuery, keyLayout, cpuMultiplier, extraRoms, userPort, printer }) {
+    return {
+        keyLayout,
+        cpuMultiplier,
+        tubeCpuMultiplier: config.tubeCpuMultiplier,
+        videoCyclesBatch: parsedQuery.videoCyclesBatch,
+        tube: config.coProcessor ? tubeModelFor(config.model) : null,
+        hasMusic5000: config.hasMusic5000,
+        hasTeletextAdaptor: config.hasTeletextAdaptor,
+        // ROM order determines sideways bank allocation, and the fittings' ROMs claim banks
+        // before any the user asked for with ?rom=.
+        extraRoms: [...config.extraRoms, ...extraRoms],
+        userPort,
+        printerPort: printer,
+        getGamepads: function () {
+            // Gamepads are only available in secure contexts. If e.g. loading from http:// urls they aren't there.
+            return navigator.getGamepads ? navigator.getGamepads() : [];
+        },
+        debugFlags: {
+            logFdcCommands: parsedQuery.logFdcCommands !== undefined,
+            logFdcStateChanges: parsedQuery.logFdcStateChanges !== undefined,
+        },
+    };
+}
+
+/** The emulated machine itself: the processor with everything bolted to it, and its start-up. */
+export class Machine {
+    constructor({
+        model,
+        config,
+        parsedQuery,
+        keyLayout,
+        cpuMultiplier,
+        extraRoms,
+        stationId,
+        userPort,
+        printer,
+        speechOutput,
+        video,
+        audioHandler,
+        dbgr,
+        makeCpu = (CpuClass, ...args) => new CpuClass(...args),
+    }) {
+        this.model = model;
+        this.audioHandler = audioHandler;
+        this.speechOutput = speechOutput;
+
+        this.econet = null;
+        if (config.hasEconet) {
+            this.econet = new Econet(stationId, model.cyclesPerSecond);
+        } else {
+            document.getElementById("fsmenuitem").style.display = "none";
+        }
+
+        this.cmos = new Cmos(
+            localStoragePersistence(
+                () => window.localStorage,
+                (error) =>
+                    toast(
+                        `Settings changed with *CONFIGURE will not be kept (${errorText(error)}). Check that this site is allowed to store data, and that its storage is not full.`,
+                        { title: "Settings", quietKey: "quietCmosSave" },
+                    ),
+            ),
+            model.cmosOverride,
+            this.econet,
+        );
+
+        this.emulationConfig = buildEmulationConfig({
+            config,
+            parsedQuery,
+            keyLayout,
+            cpuMultiplier,
+            extraRoms,
+            userPort,
+            printer,
+        });
+
+        const CpuClass = model.isAtom ? AtomCpu6502 : Cpu6502;
+        this.processor = makeCpu(CpuClass, model, {
+            dbgr,
+            video,
+            soundChip: audioHandler.soundChip,
+            ddNoise: audioHandler.ddNoise,
+            relayNoise: audioHandler.relayNoise,
+            music5000: config.hasMusic5000 ? audioHandler.music5000 : null,
+            cmos: this.cmos,
+            config: this.emulationConfig,
+            econet: this.econet,
+        });
+
+        printer.attach(this.processor.uservia);
+        this.processor.teletextAdaptor?.addEventListener("notice", showNotice);
+        this.processor.acia.addEventListener("notice", showNotice);
+    }
+
+    /**
+     * Attach an RS-423 composite handler to the ACIA that combines the touchscreen
+     * (which sends position data to the BBC) with the speech output (which speaks
+     * text the BBC sends out).
+     */
+    setupRs423Handler() {
+        const { processor, speechOutput } = this;
+        processor.acia.setRs423Handler({
+            onTransmit(val) {
+                processor.touchScreen.onTransmit(val);
+                speechOutput.onTransmit(val);
+            },
+            tryReceive(rts) {
+                return processor.touchScreen.tryReceive(rts);
+            },
+        });
+    }
+
+    /**
+     * Initialises the machine and starts every image the URL asked for, each
+     * reporting its own failure without stopping the boot (#808).
+     */
+    async start({
+        media,
+        drives,
+        autoBoot,
+        discImage,
+        secondDiscImage,
+        tape,
+        mmcImage,
+        loadBasic,
+        embedBasic,
+        basicNeedsRun,
+    }) {
+        const { processor } = this;
+        await Promise.all([this.audioHandler.initialise(), processor.initialise()]);
+
+        // Wire up the composite RS-423 handler now that the touchscreen exists.
+        this.setupRs423Handler();
+
+        // Ideally would start the loads first. But their completion needs the FDC from the processor
+        const imageLoads = [];
+
+        function startImageLoad(description, load) {
+            const loading = (async () => {
+                try {
+                    await load();
+                } catch (error) {
+                    reportLoadFailure(description, error);
+                }
+            })();
+            imageLoads.push(loading);
+            return loading;
+        }
+
+        if (discImage) {
+            startImageLoad(`disc ${discImage}`, async () =>
+                drives.putDiscIn(0, await media.loadDiscImage(discImage, drives.layoutForDrive(0))),
+            );
+        }
+
+        if (secondDiscImage) {
+            startImageLoad(`disc ${secondDiscImage}`, async () =>
+                drives.putDiscIn(1, await media.loadDiscImage(secondDiscImage, drives.layoutForDrive(1))),
+            );
+        }
+
+        if (tape) {
+            startImageLoad(`tape ${tape}`, async () => media.setProcessorTape(await media.loadTapeImage(tape)));
+        }
+
+        if (mmcImage && this.model.isAtom) {
+            startImageLoad(`MMC image ${mmcImage}`, async () => processor.atommc.SetMMCData(await LoadSD(mmcImage)));
+        }
+
+        if (loadBasic) {
+            await startImageLoad(`BASIC program ${loadBasic}`, () =>
+                autoBoot.insertBasic(
+                    (async () => {
+                        const data = await utils.loadData(loadBasic);
+                        return String.fromCharCode.apply(null, data);
+                    })(),
+                    basicNeedsRun,
+                ),
+            );
+        }
+
+        if (embedBasic) {
+            await startImageLoad("the BASIC program from the URL", () =>
+                autoBoot.insertBasic(Promise.resolve(embedBasic), true),
+            );
+        }
+
+        return Promise.all(imageLoads);
+    }
+}

--- a/tests/unit/test-web-machine.js
+++ b/tests/unit/test-web-machine.js
@@ -1,0 +1,172 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { Machine, buildEmulationConfig } from "../../src/web/machine.js";
+
+const config = (overrides = {}) => ({
+    tubeCpuMultiplier: 1,
+    coProcessor: false,
+    model: { name: "B-DFS1.2" },
+    hasMusic5000: false,
+    hasTeletextAdaptor: false,
+    hasEconet: false,
+    extraRoms: [],
+    ...overrides,
+});
+
+describe("buildEmulationConfig", () => {
+    const build = (overrides = {}) =>
+        buildEmulationConfig({
+            config: config(),
+            parsedQuery: {},
+            keyLayout: "physical",
+            cpuMultiplier: 1,
+            extraRoms: [],
+            userPort: { read: () => 0xff, write: () => {} },
+            printer: {},
+            ...overrides,
+        });
+
+    it("lets the fittings' ROMs claim banks before the URL's", () => {
+        const built = build({ config: config({ extraRoms: ["fitted.rom"] }), extraRoms: ["user.rom"] });
+        expect(built.extraRoms).toEqual(["fitted.rom", "user.rom"]);
+    });
+
+    it("fits a tube only when a co-processor was asked for", () => {
+        expect(build().tube).toBeNull();
+        expect(build({ config: config({ coProcessor: true }) }).tube).toBeTruthy();
+    });
+
+    it("turns the FDC logging flags on by their presence alone", () => {
+        expect(build().debugFlags).toEqual({ logFdcCommands: false, logFdcStateChanges: false });
+        expect(build({ parsedQuery: { logFdcCommands: "" } }).debugFlags.logFdcCommands).toBe(true);
+    });
+});
+
+describe("Machine", () => {
+    let deps;
+    let fakeProcessor;
+
+    beforeEach(() => {
+        document.body.innerHTML = `<span id="fsmenuitem"></span>`;
+        fakeProcessor = {
+            uservia: {},
+            acia: { addEventListener: vi.fn(), setRs423Handler: vi.fn() },
+            teletextAdaptor: undefined,
+            touchScreen: { onTransmit: vi.fn(), tryReceive: vi.fn(() => -1) },
+            atommc: { SetMMCData: vi.fn() },
+            initialise: vi.fn().mockResolvedValue(),
+        };
+        deps = {
+            model: { isAtom: false, cyclesPerSecond: 2000000, cmosOverride: undefined },
+            config: config(),
+            parsedQuery: {},
+            keyLayout: "physical",
+            cpuMultiplier: 1,
+            extraRoms: [],
+            stationId: 101,
+            userPort: {},
+            printer: { attach: vi.fn() },
+            speechOutput: { onTransmit: vi.fn() },
+            video: {},
+            audioHandler: { soundChip: {}, ddNoise: {}, relayNoise: {}, initialise: vi.fn().mockResolvedValue() },
+            dbgr: {},
+            makeCpu: vi.fn(() => fakeProcessor),
+        };
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+        document.body.innerHTML = "";
+        window.localStorage.clear();
+    });
+
+    const make = () => new Machine(deps);
+    const toasts = () =>
+        [...document.querySelectorAll(".toast")].map((el) => el.textContent.replace(/\s+/g, " ").trim());
+
+    it("builds the processor with everything bolted on and attaches the printer", () => {
+        const machine = make();
+        expect(machine.processor).toBe(fakeProcessor);
+        const [, model, fittings] = deps.makeCpu.mock.calls[0];
+        expect(model).toBe(deps.model);
+        expect(fittings.cmos).toBe(machine.cmos);
+        expect(fittings.config).toBe(machine.emulationConfig);
+        expect(fittings.music5000).toBeNull();
+        expect(deps.printer.attach).toHaveBeenCalledWith(fakeProcessor.uservia);
+    });
+
+    it("hides the filestore menu on a machine without Econet", () => {
+        const machine = make();
+        expect(machine.econet).toBeNull();
+        expect(document.getElementById("fsmenuitem").style.display).toBe("none");
+    });
+
+    it("fits an Econet when asked, sharing it with the CMOS", () => {
+        deps.config = config({ hasEconet: true });
+        const machine = make();
+        expect(machine.econet).toBeTruthy();
+        expect(document.getElementById("fsmenuitem").style.display).toBe("");
+    });
+
+    describe("start", () => {
+        const startDeps = () => ({
+            media: {
+                loadDiscImage: vi.fn().mockResolvedValue({ name: "loaded" }),
+                loadTapeImage: vi.fn().mockResolvedValue({}),
+                setProcessorTape: vi.fn(),
+            },
+            drives: { putDiscIn: vi.fn(), layoutForDrive: () => "auto" },
+            autoBoot: { insertBasic: vi.fn().mockResolvedValue() },
+        });
+
+        it("initialises the audio and the processor, then wires the RS-423 handler", async () => {
+            const machine = make();
+            await machine.start(startDeps());
+            expect(deps.audioHandler.initialise).toHaveBeenCalled();
+            expect(fakeProcessor.initialise).toHaveBeenCalled();
+            expect(fakeProcessor.acia.setRs423Handler).toHaveBeenCalled();
+        });
+
+        it("speaks what the machine transmits and forwards it to the touchscreen", async () => {
+            const machine = make();
+            await machine.start(startDeps());
+            const handler = fakeProcessor.acia.setRs423Handler.mock.calls[0][0];
+            handler.onTransmit(65);
+            expect(fakeProcessor.touchScreen.onTransmit).toHaveBeenCalledWith(65);
+            expect(deps.speechOutput.onTransmit).toHaveBeenCalledWith(65);
+        });
+
+        it("loads both discs and the tape", async () => {
+            const machine = make();
+            const started = startDeps();
+            await machine.start({ ...started, discImage: "elite.ssd", secondDiscImage: "b.ssd", tape: "t.uef" });
+            expect(started.drives.putDiscIn).toHaveBeenCalledWith(0, { name: "loaded" });
+            expect(started.drives.putDiscIn).toHaveBeenCalledWith(1, { name: "loaded" });
+            expect(started.media.setProcessorTape).toHaveBeenCalled();
+        });
+
+        it("reports a failed image and finishes booting anyway", async () => {
+            vi.spyOn(console, "error").mockImplementation(() => {});
+            const machine = make();
+            const started = startDeps();
+            started.media.loadDiscImage.mockRejectedValue(new Error("404"));
+            await expect(machine.start({ ...started, discImage: "gone.ssd", tape: "t.uef" })).resolves.toBeDefined();
+            expect(toasts()).toEqual([expect.stringContaining("Could not load disc gone.ssd: 404")]);
+            expect(started.media.setProcessorTape).toHaveBeenCalled();
+        });
+
+        it("only loads an MMC image on an Atom", async () => {
+            const machine = make();
+            await machine.start({ ...startDeps(), mmcImage: "sd.img" });
+            expect(fakeProcessor.atommc.SetMMCData).not.toHaveBeenCalled();
+        });
+
+        it("inserts a BASIC program to run when asked", async () => {
+            const machine = make();
+            const started = startDeps();
+            await machine.start({ ...started, embedBasic: "10 PRINT", basicNeedsRun: false });
+            expect(started.autoBoot.insertBasic).toHaveBeenCalledWith(expect.anything(), true);
+        });
+    });
+});


### PR DESCRIPTION
PR 14 of #638: the machine itself, the penultimate extraction.

**Moved** to `src/web/machine.js`: the Econet and filestore-menu decision, the CMOS with its localStorage persistence, `emulationConfig`, the processor construction with everything bolted to it, the printer attachment and notice listeners, the RS-423 composite handler, and `start()` (the old `startPromise`): initialise the audio and processor, then every image the URL asked for, each reporting its own failure without stopping the boot (#808).

**Changed**: `buildEmulationConfig` comes out as a pure function, so the sideways-bank ordering (fittings' ROMs before `?rom=`), the tube decision and the FDC debug flags are tested as data. The CPU factory is a constructor argument defaulting to the real classes, so `start`'s sequencing and failure reporting are tested without loading ROMs. The `needsAutoboot = ""` consumption for `loadBasic` moves to the caller, computed before `start` is invoked; the switch that reads it only runs after `start` resolves, so the ordering is unchanged.

**Deviation from the plan**: `speechOutput` stays in `main.js`. Its own comment says why: it must exist before `Config`, and `Machine` cannot be built until after `Config` has resolved the model. It is handed in for the RS-423 handler.

**Checked**: unit suite, all twelve smoke checks (the boot, autoboot, disc, tape and snapshot checks all pass through `start()`). Self-review caught `printer.attach` surviving in `main.js` alongside the moved one, which would have attached the printer twice; removed before pushing.

`main.js` is now 657 lines. PR 15, the composition-root tidy and the `src/web` moves, follows once this lands.
