### PR TITLE
fix: let glEnabled=true mean what it says

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -62,10 +62,7 @@ const cpuMultiplier = parsedQuery.cpuMultiplier ?? 1;
 const noSeek = !!parsedQuery.noseek;
 const stationId = parsedQuery.stationId !== undefined ? parsedQuery.stationId : 101;
 
-let tryGl = true;
-if (parsedQuery.glEnabled !== undefined) {
-    tryGl = parsedQuery.glEnabled === "true";
-}
+const tryGl = parsedQuery.glEnabled ?? true;
 let lowLatency = true;
 if (parsedQuery.lowLatency !== undefined) {
     lowLatency = parsedQuery.lowLatency === "true";


### PR DESCRIPTION
Found by review on #965, and older than the refactor: `glEnabled` is parsed as a boolean (`ParamTypes.BOOL`), but the check compared it to the string "true", which is never equal. So any `?glEnabled`, including `glEnabled=true`, forced the standard canvas, and the parameter only ever worked as a disable.

Now `tryGl = parsedQuery.glEnabled ?? true`: absent means WebGL as before, `glEnabled=false` keeps its meaning, and `glEnabled=true` (or the bare parameter, which the BOOL parse reads as true) asks for WebGL as named. The one behaviour change is for anyone who typed a bare `?glEnabled` expecting it to disable, which was only ever true by accident.

Checked: the twelve smoke checks pass; the tryGl branch itself is covered by the Display tests via the injectable canvas factory.