### PR TITLE
fix: restore two details the main.js split dropped

### DIFF
--- a/src/web/display.js
+++ b/src/web/display.js
@@ -112,6 +112,8 @@ export class Display {
         this.video.paint();
         this.setCrtPic();
         window.setTimeout(() => window.dispatchEvent(new Event("resize")), 1);
+        // Relayout now as well: the monitor picture may have changed shape.
+        window.dispatchEvent(new Event("resize"));
     }
 
     sizeCanvasFor(filterClass) {

--- a/src/web/emulation-loop.js
+++ b/src/web/emulation-loop.js
@@ -177,6 +177,7 @@ export class EmulationLoop extends EventTarget {
                 audioHandler.flushChipEvents();
                 const end = performance.now();
                 this.virtualSpeedUpdater.update(cycles, end - now, speedy);
+                const paintMs = display.takePaintMs();
                 let snapshotMs = 0;
                 this.rewindCycleCounter += cycles;
                 if (this.rewindCycleCounter >= this.rewindCaptureCycles) {
@@ -191,7 +192,7 @@ export class EmulationLoop extends EventTarget {
                         cycles,
                         speedy ? 0 : now - this.lastEnd,
                         end - now,
-                        display.takePaintMs(),
+                        paintMs,
                         snapshotMs,
                     );
             } catch (e) {

--- a/tests/unit/test-emulation-loop.js
+++ b/tests/unit/test-emulation-loop.js
@@ -87,7 +87,6 @@ describe("EmulationLoop", () => {
         expect(deps.audioHandler.flushChipEvents).toHaveBeenCalled();
         expect(deps.gamepad.update).toHaveBeenCalledWith(deps.processor.sysvia);
         expect(deps.syncLights).toHaveBeenCalled();
-        // The paint timer drains every tick, audio debug or not.
         expect(deps.display.takePaintMs).toHaveBeenCalled();
     });
 

--- a/tests/unit/test-emulation-loop.js
+++ b/tests/unit/test-emulation-loop.js
@@ -25,8 +25,8 @@ describe("EmulationLoop", () => {
             },
             display: {
                 video: { frameSkipCount: 0, polltime: vi.fn() },
-                takePaintMs: () => 0,
-                takePresentMs: () => 0,
+                takePaintMs: vi.fn(() => 0),
+                takePresentMs: vi.fn(() => 0),
                 frameSkip: 0,
             },
             audioHandler: {
@@ -87,6 +87,8 @@ describe("EmulationLoop", () => {
         expect(deps.audioHandler.flushChipEvents).toHaveBeenCalled();
         expect(deps.gamepad.update).toHaveBeenCalledWith(deps.processor.sysvia);
         expect(deps.syncLights).toHaveBeenCalled();
+        // The paint timer drains every tick, audio debug or not.
+        expect(deps.display.takePaintMs).toHaveBeenCalled();
     });
 
     it("never emulates more than a tenth of a second in one tick", () => {


### PR DESCRIPTION
A post-#638 review compared the pre-refactor `main.js` (335de1b) statement by statement against the extracted modules and found two dropped details; everything else checked out. This restores them:

- **The immediate relayout on a display-mode change.** The old `applyDisplayMode` dispatched `resize` at once as well as a task later; `Display.setMode` had kept only the deferred one, so the monitor geometry settled a task late. (A cleaner shape, calling the layout directly instead of raising a synthetic window event, is specced in the follow-up issue; this PR only restores the old behaviour.)
- **The paint timer drains every tick.** It was reset unconditionally before; the loop had come to drain it only under `?audioDebug`, leaving the counter accumulating unread otherwise. Now taken every tick and passed into the debug log when that is on, with a test pinning the drain.

Checked: unit suite, all twelve smoke checks.