### PR TITLE
fix: stop STH catalogue renders interleaving disc and tape lists

### DIFF
--- a/src/web/sth-picker.js
+++ b/src/web/sth-picker.js
@@ -22,8 +22,18 @@ export class SthPicker {
             document.getElementById("sth-filter").focus();
         });
 
-        const startLoad = () => showArchiveMessage("sth", "sth-list", "Loading catalog from STH archive");
-        const onError = () => showArchiveMessage("sth", "sth-list", "There was an error accessing the STH archive");
+        // Anything that clears the list takes a new ticket; a chain whose ticket is
+        // stale gives up (the same scheme as hfe-picker.js).
+        this.renderTicket = 0;
+
+        const startLoad = () => {
+            this.renderTicket++;
+            showArchiveMessage("sth", "sth-list", "Loading catalog from STH archive");
+        };
+        const onError = () => {
+            this.renderTicket++;
+            showArchiveMessage("sth", "sth-list", "There was an error accessing the STH archive");
+        };
         this.discs = new StairwayToHell(
             startLoad,
             (cat) => this.renderCatalogue(cat, (item) => this.pickDisc(item)),
@@ -95,12 +105,14 @@ export class SthPicker {
     }
 
     renderCatalogue(cat, onClick) {
+        const ticket = ++this.renderTicket;
         clearArchiveList("sth-list");
         const sthList = document.getElementById("sth-list");
         document.querySelector("#sth .loading").style.display = "none";
         const template = sthList.querySelector(".template");
 
         const doSome = (all) => {
+            if (ticket !== this.renderTicket) return;
             const MaxAtATime = 100;
             const Delay = 30;
             const batch = all.slice(0, MaxAtATime);

--- a/src/web/sth-picker.js
+++ b/src/web/sth-picker.js
@@ -129,7 +129,7 @@ export class SthPicker {
                 });
                 row.style.display = name.toLowerCase().indexOf(filter) >= 0 ? "" : "none";
             }
-            if (all.length) setTimeout(() => doSome(remaining), Delay);
+            if (remaining.length) setTimeout(() => doSome(remaining), Delay);
         };
 
         doSome(cat);

--- a/tests/unit/test-sth-picker.js
+++ b/tests/unit/test-sth-picker.js
@@ -79,6 +79,20 @@ describe("SthPicker", () => {
             expect(document.querySelector("#sth .loading").style.display).toBe("none");
         });
 
+        it("gives up a stale render when the list is cleared under it", () => {
+            const picker = make();
+            picker.renderCatalogue(
+                Array.from({ length: 150 }, (_, i) => `GAME${i}.zip`),
+                () => {},
+            );
+            expect(rows()).toHaveLength(100);
+            picker.renderCatalogue(["ONLY.zip"], () => {});
+            vi.runAllTimers();
+            // The first chain's second batch must not append to the new list.
+            expect(rows()).toHaveLength(1);
+            expect(rows()[0].querySelector(".name").textContent).toBe("ONLY.zip");
+        });
+
         it("answers a click with the name and puts the modal away", () => {
             const onClick = vi.fn();
             const picker = make();


### PR DESCRIPTION
The Stairway to Hell picker renders its catalogue 100 rows at a time on 30ms timers, but `renderCatalogue` had no way to cancel a chain already in flight. Switching between the Discs and Tapes catalogues (or a reload racing an error message) while a chain was still running left both lists interleaved in the modal.

This mirrors the HFE picker's existing render ticket: the start-load and error callbacks bump the ticket, each render takes a fresh one, and a batch chain whose ticket has gone stale gives up instead of appending to a list that was cleared under it.

Tested with a new unit test in the style of the HFE picker's: a 150-entry catalogue is interrupted after its first batch by a second render, all timers are run, and only the second catalogue's row is present.

Part of #968.

🤖 Generated with [Claude Code](https://claude.com/claude-code)