### PR TITLE
fix: guard loadTapeImage against an empty reference and quieten the tape menu

### DIFF
--- a/src/web/front-panel.js
+++ b/src/web/front-panel.js
@@ -39,8 +39,6 @@ export class FrontPanel {
                     } else {
                         processor.acia.rewindTape();
                     }
-                } else {
-                    console.log("unknown type", type);
                 }
             });
         }

--- a/src/web/media-loader.js
+++ b/src/web/media-loader.js
@@ -309,6 +309,7 @@ export class MediaLoader {
     }
 
     async loadTapeImage(tapeImage) {
+        if (!tapeImage) return null;
         const split = splitImage(tapeImage);
         tapeImage = split.image;
         const schema = split.schema;

--- a/tests/unit/test-front-panel.js
+++ b/tests/unit/test-front-panel.js
@@ -4,7 +4,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { FrontPanel } from "../../src/web/front-panel.js";
 
 const Markup = `
-<div id="tape-menu"><a data-id="rewind">Rewind</a></div>
+<div id="tape-menu"><a data-id="rewind">Rewind</a><a data-id="archive">Archive</a></div>
 <table><tbody><tr><th id="tape-control-header"></th><td id="tape-control-cell"></td></tr></tbody></table>
 <button id="tape-play-stop"></button>
 <span id="motorlight"></span><span id="capslight" class="bbc-only"></span><span id="shiftlight" class="bbc-only"></span>
@@ -100,6 +100,13 @@ describe("FrontPanel", () => {
             document.querySelector('#tape-menu a[data-id="rewind"]').click();
             expect(processor.atomppia.stopTape).toHaveBeenCalled();
             expect(processor.atomppia.rewindTape).toHaveBeenCalled();
+        });
+
+        it("ignores menu links it does not handle", () => {
+            make(false);
+            document.querySelector('#tape-menu a[data-id="archive"]').click();
+            expect(processor.acia.rewindTape).not.toHaveBeenCalled();
+            expect(console.log).not.toHaveBeenCalledWith("unknown type", "archive");
         });
     });
 

--- a/tests/unit/test-media-loader.js
+++ b/tests/unit/test-media-loader.js
@@ -125,6 +125,12 @@ describe("MediaLoader", () => {
         });
     });
 
+    describe("loadTapeImage", () => {
+        it("returns nothing for no reference", async () => {
+            expect(await make().loadTapeImage(undefined)).toBeNull();
+        });
+    });
+
     describe("the URL and the media-changed events", () => {
         const mediaEvents = [];
         beforeEach(() => {


### PR DESCRIPTION
Two small fixes from the pre-existing-bug sweep:

- `loadTapeImage` (src/web/media-loader.js) now returns null for a missing reference, matching `loadDiscImage`'s first-line guard, instead of throwing from `splitImage` on undefined. Every caller guards today, so this only changes the latent case.
- The tape menu's click handler (src/web/front-panel.js) no longer logs "unknown type" for the menu's ordinary archive links; they carry other data-id values and are handled elsewhere, so the log was console noise on normal navigation. The rewind branch is unchanged.

Tested: `loadTapeImage(undefined)` resolves to null in test-media-loader.js, and clicking a tape-menu link with an unrelated data-id neither throws nor logs in test-front-panel.js. Full unit suite passes.

Part of #968.

🤖 Generated with [Claude Code](https://claude.com/claude-code)