### PR TITLE
fix: report Google Drive picker errors instead of failing silently

### DIFF
--- a/src/web/google-drive-picker.js
+++ b/src/web/google-drive-picker.js
@@ -33,18 +33,18 @@ export class GoogleDrivePicker {
 
         // Loading the Google client holds the main thread for ~100ms, so it waits for
         // someone to ask for Drive.
-        document.getElementById("open-drive-link").addEventListener("click", async () => {
+        document.getElementById("open-drive-link").addEventListener("click", async (e) => {
+            e.preventDefault();
             try {
                 await this.googleDrive.initialise();
             } catch (error) {
                 toast(`Google Drive is unavailable: ${errorText(error)}`, { title: "Google Drive" });
-                return false;
+                return;
             }
             const authed = await this.auth(false);
             if (authed) {
                 this.modal.show();
             }
-            return false;
         });
 
         this.el.addEventListener("show.bs.modal", () => this.showList());
@@ -57,7 +57,7 @@ export class GoogleDrivePicker {
         } catch (err) {
             console.log("Error handling google auth: " + err);
             this.el.querySelector(".loading").textContent =
-                "There was an error accessing your Google Drive account: " + err;
+                `There was an error accessing your Google Drive account: ${errorText(err)}`;
         }
     }
 
@@ -150,7 +150,10 @@ export class GoogleDrivePicker {
             // TODO support HFE, I guess?
             const discType = disc.guessDiscTypeFromName(name);
             if (!discType.byteSize) {
-                throw new Error(`Cannot create blank disc of type ${discType.extension} - unknown size`);
+                this.modals.loadingFinished(
+                    `Unable to create ${name} on Google Drive: blank ${discType.extension} discs have no known size`,
+                );
+                return;
             }
             data = new Uint8Array(discType.byteSize);
             if (discType.supportsCatalogue) {

--- a/src/web/google-drive-picker.js
+++ b/src/web/google-drive-picker.js
@@ -55,9 +55,10 @@ export class GoogleDrivePicker {
         try {
             return await this.googleDrive.authorize(imm);
         } catch (err) {
-            console.log("Error handling google auth: " + err);
+            console.log("Error handling google auth: " + errorText(err));
             this.el.querySelector(".loading").textContent =
                 `There was an error accessing your Google Drive account: ${errorText(err)}`;
+            return false;
         }
     }
 

--- a/tests/unit/test-google-drive-picker.js
+++ b/tests/unit/test-google-drive-picker.js
@@ -86,6 +86,27 @@ describe("GoogleDrivePicker", () => {
         });
     });
 
+    describe("signing in", () => {
+        it("shows the error's message when authorization fails", async () => {
+            loader.authorize.mockRejectedValue(new Error("denied"));
+            await make().auth(false);
+            expect(document.querySelector("#google-drive .loading").textContent).toContain(
+                "There was an error accessing your Google Drive account: denied",
+            );
+        });
+    });
+
+    describe("the drive link", () => {
+        it("keeps the link's hash out of the URL", async () => {
+            const picker = make();
+            const show = vi.spyOn(picker.modal, "show").mockImplementation(() => {});
+            const click = new MouseEvent("click", { bubbles: true, cancelable: true });
+            document.getElementById("open-drive-link").dispatchEvent(click);
+            expect(click.defaultPrevented).toBe(true);
+            await vi.waitFor(() => expect(show).toHaveBeenCalled());
+        });
+    });
+
     describe("the file list", () => {
         it("lists the files and loads the one clicked", async () => {
             loader.listFiles.mockResolvedValue([{ id: "abc", name: "mine.ssd" }]);
@@ -139,6 +160,19 @@ describe("GoogleDrivePicker", () => {
             await vi.waitFor(() =>
                 expect(deps.modals.loadingFinished).toHaveBeenCalledWith(
                     expect.stringContaining("Unable to create copy.ssd on Google Drive"),
+                ),
+            );
+            expect(loader.create).not.toHaveBeenCalled();
+        });
+
+        it("reports a blank disc name whose format has no known size", async () => {
+            const picker = make();
+            vi.spyOn(picker.modal, "hide").mockImplementation(() => {});
+            document.querySelector("#google-drive .disc-name").value = "fresh.hfe";
+            submit();
+            await vi.waitFor(() =>
+                expect(deps.modals.loadingFinished).toHaveBeenCalledWith(
+                    expect.stringContaining("Unable to create fresh.hfe on Google Drive"),
                 ),
             );
             expect(loader.create).not.toHaveBeenCalled();


### PR DESCRIPTION
Three small Google Drive picker bugs, all in `src/web/google-drive-picker.js`.

## Symptoms and fixes

- **Creating a blank disc could hang the loading dialog.** A typed name whose format has no known `byteSize` (such as `.hfe`) threw before `create()`'s try block, surfacing as an unhandled rejection with the loading dialog left up. It now reports through `this.modals.loadingFinished(...)` like the surrounding failures and returns.
- **A failed Drive sign-in could show `[object Object]`.** `auth()` built its user-visible text with `"..." + err`; it now uses `errorText(err)` like the rest of the module.
- **Clicking the Google Drive menu link polluted the URL and history.** The `#open-drive-link` handler returned `false` from an `addEventListener` callback, which does nothing, so the anchor's `href="#google-drive"` landed the hash on every click. The handler now takes the event and calls `preventDefault()`; the meaningless return values are gone.

## Tests

`tests/unit/test-google-drive-picker.js` gains:

- the create form with a name of an unknown format reports through `loadingFinished`, calls no `create`, and leaves no unhandled rejection
- an auth failure (`authorize` rejecting with `new Error("denied")`) shows the error's message text
- a cancelable click on `#open-drive-link` has its default prevented

`npx vitest run tests/unit` passes in full.

Part of #968.

🤖 Generated with [Claude Code](https://claude.com/claude-code)