### PR TITLE
fix: route the ADC when the microphone is disabled and reject invalid channels

### DIFF
--- a/src/web/analogue-inputs.js
+++ b/src/web/analogue-inputs.js
@@ -4,6 +4,8 @@ import { MouseJoystickSource } from "../mouse-joystick-source.js";
 import { calculateMouseCoordinates } from "../mouse-coordinates.js";
 import { toast } from "./toast.js";
 
+const AdcChannelCount = 4;
+
 /**
  * What feeds the analogue port and the touchscreen: the gamepad, the mouse
  * acting as a joystick, and the microphone, with the mouse on the monitor
@@ -59,7 +61,7 @@ export class AnalogueInputs {
     updateAdcSources(mouseJoystickEnabled, microphoneChannel) {
         const { processor } = this;
         // Default all channels to the gamepad source.
-        for (let ch = 0; ch < 4; ch++) {
+        for (let ch = 0; ch < AdcChannelCount; ch++) {
             processor.adconverter.setChannelSource(ch, this.gamepadSource);
         }
 
@@ -73,9 +75,23 @@ export class AnalogueInputs {
         }
 
         // Apply microphone if configured (can override any channel)
-        if (microphoneChannel !== undefined) {
+        if (microphoneChannel === undefined) return;
+        if (Number.isInteger(microphoneChannel) && microphoneChannel >= 0 && microphoneChannel < AdcChannelCount) {
             processor.adconverter.setChannelSource(microphoneChannel, this.microphoneInput);
+        } else {
+            toast(
+                `There is no analogue channel ${microphoneChannel}; channels are 0 to 3. ` +
+                    `The microphone channel has been turned off.`,
+                { title: "Microphone" },
+            );
+            this.clearMicrophoneChannel();
         }
+    }
+
+    clearMicrophoneChannel() {
+        this.config.setMicrophoneChannel(undefined);
+        delete this.urlState.params.microphoneChannel;
+        this.urlState.updateUrl();
     }
 
     async ensureMicrophoneRunning() {
@@ -110,10 +126,7 @@ export class AnalogueInputs {
             document.addEventListener("click", tryAgain);
         } else {
             micPermissionStatus.textContent = `Error: ${this.microphoneInput.getErrorMessage() || "Unknown error"}`;
-            this.config.setMicrophoneChannel(undefined);
-            // Update URL to remove the parameter
-            delete this.urlState.params.microphoneChannel;
-            this.urlState.updateUrl();
+            this.clearMicrophoneChannel();
         }
     }
 }

--- a/src/web/analogue-inputs.js
+++ b/src/web/analogue-inputs.js
@@ -109,6 +109,8 @@ export class AnalogueInputs {
     }
 
     async setupMicrophone() {
+        // The channel can have been turned off between the request and now.
+        if (this.urlState.params.microphoneChannel === undefined) return;
         const micPermissionStatus = document.getElementById("micPermissionStatus");
         micPermissionStatus.textContent = "Requesting microphone access...";
 

--- a/src/web/settings.js
+++ b/src/web/settings.js
@@ -140,7 +140,7 @@ export class Settings {
             machine.emulationConfig.keyLayout = changed.keyLayout;
             keys.setKeyLayout(changed.keyLayout);
         }
-        if (changed.mouseJoystickEnabled !== undefined || changed.microphoneChannel !== undefined) {
+        if (changed.mouseJoystickEnabled !== undefined || Object.hasOwn(changed, "microphoneChannel")) {
             inputs.updateAdcSources(parsedQuery.mouseJoystickEnabled, parsedQuery.microphoneChannel);
 
             if (changed.microphoneChannel !== undefined) {

--- a/tests/unit/test-analogue-inputs.js
+++ b/tests/unit/test-analogue-inputs.js
@@ -107,6 +107,15 @@ describe("AnalogueInputs", () => {
         });
     });
 
+    describe("a microphone whose channel was turned off", () => {
+        it("never asks for microphone access", async () => {
+            const inputs = make();
+            const initialise = vi.spyOn(inputs.microphoneInput, "initialise");
+            await inputs.setupMicrophone();
+            expect(initialise).not.toHaveBeenCalled();
+        });
+    });
+
     describe("a microphone that cannot start", () => {
         it("reports, clears the setting and takes it out of the URL", async () => {
             deps.urlState.params.microphoneChannel = 2;

--- a/tests/unit/test-analogue-inputs.js
+++ b/tests/unit/test-analogue-inputs.js
@@ -10,6 +10,7 @@ describe("AnalogueInputs", () => {
     let channels;
 
     beforeEach(() => {
+        vi.useFakeTimers();
         document.body.innerHTML = Markup;
         channels = {};
         deps = {
@@ -27,6 +28,8 @@ describe("AnalogueInputs", () => {
     });
 
     afterEach(() => {
+        vi.runAllTimers();
+        vi.useRealTimers();
         vi.restoreAllMocks();
         document.body.innerHTML = "";
     });
@@ -54,6 +57,25 @@ describe("AnalogueInputs", () => {
             inputs.updateAdcSources(true, 1);
             expect(channels[0]).toBe(inputs.mouseJoystickSource);
             expect(channels[1]).toBe(inputs.microphoneInput);
+        });
+
+        it("lets the microphone take the first and last channels", () => {
+            const inputs = make();
+            inputs.updateAdcSources(false, 0);
+            expect(channels[0]).toBe(inputs.microphoneInput);
+            inputs.updateAdcSources(false, 3);
+            expect(channels[3]).toBe(inputs.microphoneInput);
+        });
+
+        it("refuses a channel that does not exist, says so, and clears the setting", () => {
+            deps.urlState.params.microphoneChannel = 5;
+            const inputs = make();
+            inputs.updateAdcSources(false, 5);
+            for (let ch = 0; ch < 4; ch++) expect(channels[ch]).toBe(inputs.gamepadSource);
+            expect(document.querySelector(".toast .message").textContent).toContain("no analogue channel 5");
+            expect(deps.config.setMicrophoneChannel).toHaveBeenCalledWith(undefined);
+            expect(deps.urlState.params.microphoneChannel).toBeUndefined();
+            expect(deps.urlState.updateUrl).toHaveBeenCalled();
         });
     });
 

--- a/tests/unit/test-settings.js
+++ b/tests/unit/test-settings.js
@@ -167,6 +167,14 @@ describe("Settings", () => {
             expect(targets.inputs.setupMicrophone).toHaveBeenCalled();
         });
 
+        it("reroutes the analogue channels when the microphone is disabled, without starting it", () => {
+            urlState.params.microphoneChannel = 2;
+            const settings = make();
+            settings.config.onClose({ microphoneChannel: undefined });
+            expect(targets.inputs.updateAdcSources).toHaveBeenCalledWith(undefined, undefined);
+            expect(targets.inputs.setupMicrophone).not.toHaveBeenCalled();
+        });
+
         it("passes a tube multiplier to a fitted tube only", () => {
             const settings = make();
             settings.config.onClose({ tubeCpuMultiplier: 4 });


### PR DESCRIPTION
Two of the microphone items from #968.

**Disabling the microphone in the Settings dialog never rerouted the ADC.** The dialog records `microphoneChannel: undefined` for Disabled, but `onDialogClosed` tested `!== undefined`, so the change was ignored until a reload. The handler now detects the key with `Object.hasOwn` and calls `setupMicrophone()` only when the new channel is defined.

**A microphone channel from the URL was passed to the ADC unvalidated.** An out-of-range `?microphoneChannel=` was logged and ignored by the ADC, leaving the URL and dialog claiming a channel that was not routed. `updateAdcSources` now accepts only an integer channel 0 to 3; anything else routes nothing, raises a toast, and clears the setting and the URL parameter the same way a failed microphone start does (now a shared `clearMicrophoneChannel`).

Tested: disabling the microphone reroutes the ADC without starting the microphone; channel 5 routes nothing, toasts, and clears the config and URL parameter; channels 0 and 3 still route.

Part of #968

🤖 Generated with [Claude Code](https://claude.com/claude-code)