### PR TITLE
refactor: build the loop first and hand it over whole

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -184,7 +184,7 @@ const quickSettings = new QuickSettings(
 );
 
 // ------------------------------------------------------------------------
-// The machine, and everything that feeds it.
+// The machine, the loop that runs it, and everything that feeds it.
 // ------------------------------------------------------------------------
 
 // Depends on the settings having applied the URL parameters.
@@ -308,7 +308,7 @@ keys.attach({ processor, dbgr, keyLayout });
 const frontPanel = new FrontPanel({ processor, model, printer });
 
 // ------------------------------------------------------------------------
-// Running it: the loop, rewind and the visualiser.
+// Rewind, the visualiser and the layout.
 // ------------------------------------------------------------------------
 
 const rewindUI = new RewindUI({

--- a/src/main.js
+++ b/src/main.js
@@ -141,12 +141,6 @@ if (cpuMultiplier !== 1) console.log(`CPU multiplier set to ${cpuMultiplier}`);
 const cpuSpeed = model.cyclesPerSecond;
 const clocksPerSecond = (cpuMultiplier * cpuSpeed) | 0;
 
-const modals = new Modals({
-    isRunning: () => loop.isRunning(),
-    stop: (debug) => loop.stop(debug),
-    go: () => loop.go(),
-});
-
 const screenCanvas = document.getElementById("screen");
 const display = new Display({
     screenCanvas,
@@ -211,6 +205,34 @@ const machine = new Machine({
 });
 const processor = machine.processor;
 
+const rewindBuffer = new RewindBuffer(30);
+const loop = new EmulationLoop({
+    processor,
+    display,
+    audioHandler,
+    dbgr,
+    gamepad,
+    keyboard: keys,
+    syncLights: () => frontPanel.syncLights(),
+    rewindBuffer,
+    onRewindCaptured: () => rewindUI.updateButtonState(),
+    clocksPerSecond,
+    cpuSpeed,
+    fastTape: !!parsedQuery.fasttape,
+    audioStatsNode,
+});
+
+const debugPause = document.getElementById("debug-pause");
+const debugPlay = document.getElementById("debug-play");
+loop.addEventListener("running", () => {
+    const running = loop.isRunning();
+    keys.setRunning(running);
+    debugPlay.disabled = running;
+    debugPause.disabled = !running;
+});
+
+const modals = new Modals({ loop });
+
 const drives = new Drives({ fdc: processor.fdc, driveTracks, areYouSure: modals.areYouSure.bind(modals) });
 const media = new MediaLoader({
     processor,
@@ -260,9 +282,7 @@ const snapshots = new SnapshotUI({
     drives,
     urlState,
     modals,
-    isRunning: () => loop.isRunning(),
-    stop: (debug) => loop.stop(debug),
-    go: () => loop.go(),
+    loop,
 });
 
 const inputs = new AnalogueInputs({
@@ -291,40 +311,12 @@ const frontPanel = new FrontPanel({ processor, model, printer });
 // Running it: the loop, rewind and the visualiser.
 // ------------------------------------------------------------------------
 
-const rewindBuffer = new RewindBuffer(30);
-const loop = new EmulationLoop({
-    processor,
-    display,
-    audioHandler,
-    dbgr,
-    gamepad,
-    keyboard: keys,
-    syncLights: () => frontPanel.syncLights(),
-    rewindBuffer,
-    onRewindCaptured: () => rewindUI.updateButtonState(),
-    clocksPerSecond,
-    cpuSpeed,
-    fastTape: !!parsedQuery.fasttape,
-    audioStatsNode,
-});
-
-const debugPause = document.getElementById("debug-pause");
-const debugPlay = document.getElementById("debug-play");
-loop.addEventListener("running", () => {
-    const running = loop.isRunning();
-    keys.setRunning(running);
-    debugPlay.disabled = running;
-    debugPause.disabled = !running;
-});
-
 const rewindUI = new RewindUI({
     rewindBuffer,
     processor,
     video,
     captureInterval: RewindCaptureInterval,
-    stop: (debug) => loop.stop(debug),
-    go: () => loop.go(),
-    isRunning: () => loop.isRunning(),
+    loop,
 });
 rewindUI.updateButtonState();
 

--- a/src/web/modals.js
+++ b/src/web/modals.js
@@ -7,7 +7,7 @@ import { toast } from "./toast.js";
  * if it was running before.
  */
 export class Modals {
-    constructor({ isRunning, stop, go }) {
+    constructor({ loop }) {
         this.errorDialog = document.getElementById("error-dialog");
         this.errorModal = new bootstrap.Modal(this.errorDialog);
         this.loadingDialog = document.getElementById("loading-dialog");
@@ -18,11 +18,11 @@ export class Modals {
 
         let savedRunning = false;
         document.addEventListener("show.bs.modal", () => {
-            if (!this.anyVisible()) savedRunning = isRunning();
-            if (isRunning()) stop(false);
+            if (!this.anyVisible()) savedRunning = loop.isRunning();
+            if (loop.isRunning()) loop.stop(false);
         });
         document.addEventListener("hidden.bs.modal", () => {
-            if (!this.anyVisible() && savedRunning) go();
+            if (!this.anyVisible() && savedRunning) loop.go();
         });
     }
 

--- a/src/web/rewind-ui.js
+++ b/src/web/rewind-ui.js
@@ -13,18 +13,14 @@ export class RewindUI {
      * @param {object} options.processor - Cpu6502 instance
      * @param {object} options.video - Video instance
      * @param {number} options.captureInterval - rewind capture interval in frames
-     * @param {function} options.stop - function to pause the emulator
-     * @param {function} options.go - function to resume the emulator
-     * @param {function} options.isRunning - function returning current running state
+     * @param {object} options.loop - the emulation loop, for pausing and resuming
      */
-    constructor({ rewindBuffer, processor, video, captureInterval, stop, go, isRunning }) {
+    constructor({ rewindBuffer, processor, video, captureInterval, loop }) {
         this.rewindBuffer = rewindBuffer;
         this.processor = processor;
         this.video = video;
         this.captureInterval = captureInterval;
-        this.stop = stop;
-        this.go = go;
-        this.isRunning = isRunning;
+        this.loop = loop;
 
         this.panel = document.getElementById("rewind-panel");
         this.filmstrip = document.getElementById("rewind-filmstrip");
@@ -52,8 +48,8 @@ export class RewindUI {
         this.snapshots = this.rewindBuffer.getAll();
         if (this.snapshots.length === 0) return;
 
-        this.wasRunning = this.isRunning();
-        if (this.wasRunning) this.stop(false);
+        this.wasRunning = this.loop.isRunning();
+        if (this.wasRunning) this.loop.stop(false);
 
         this.isOpen = true;
         this.savedState = this.processor.snapshotState();
@@ -70,7 +66,7 @@ export class RewindUI {
         } catch (e) {
             this.processor.restoreState(this.savedState);
             this._closePanel();
-            if (this.wasRunning) this.go();
+            if (this.wasRunning) this.loop.go();
             throw e;
         }
 
@@ -97,7 +93,7 @@ export class RewindUI {
             this.processor.restoreState(this.snapshots[this.selectedIndex]);
         }
         this._closePanel();
-        if (this.wasRunning) this.go();
+        if (this.wasRunning) this.loop.go();
     }
 
     /**
@@ -107,7 +103,7 @@ export class RewindUI {
         if (!this.isOpen) return;
         this._renderState(this.savedState);
         this._closePanel();
-        if (this.wasRunning) this.go();
+        if (this.wasRunning) this.loop.go();
     }
 
     /** Alias for cancel — closing the panel without explicit commit cancels. */

--- a/src/web/snapshot-ui.js
+++ b/src/web/snapshot-ui.js
@@ -84,7 +84,7 @@ export function snapshotMedia(fdcDrives, params) {
 
 /** Saving and restoring states: the menu item, the file input and the reload across a model change. */
 export class SnapshotUI {
-    constructor({ processor, model, video, media, drives, urlState, modals, isRunning, stop, go }) {
+    constructor({ processor, model, video, media, drives, urlState, modals, loop }) {
         this.processor = processor;
         this.model = model;
         this.video = video;
@@ -92,9 +92,7 @@ export class SnapshotUI {
         this.drives = drives;
         this.urlState = urlState;
         this.modals = modals;
-        this.isRunning = isRunning;
-        this.stop = stop;
-        this.go = go;
+        this.loop = loop;
 
         document.getElementById("save-state").addEventListener("click", async (event) => {
             event.preventDefault();
@@ -110,8 +108,8 @@ export class SnapshotUI {
     }
 
     async saveState() {
-        const wasRunning = this.isRunning();
-        if (wasRunning) this.stop(false);
+        const wasRunning = this.loop.isRunning();
+        if (wasRunning) this.loop.stop(false);
         try {
             const manifest = snapshotMedia(this.processor.fdc.drives, this.urlState.params);
             const snapshot = createSnapshot(this.processor, this.model, manifest);
@@ -122,12 +120,12 @@ export class SnapshotUI {
         } catch (e) {
             this.modals.showError("saving state", e);
         }
-        if (wasRunning) this.go();
+        if (wasRunning) this.loop.go();
     }
 
     async loadStateFromFile(file, preReadBuffer) {
-        const wasRunning = this.isRunning();
-        if (wasRunning) this.stop(false);
+        const wasRunning = this.loop.isRunning();
+        if (wasRunning) this.loop.stop(false);
         try {
             const arrayBuffer = preReadBuffer || (await file.arrayBuffer());
             const snapshot = await readSnapshot(arrayBuffer);
@@ -146,7 +144,7 @@ export class SnapshotUI {
         } catch (e) {
             this.modals.showError("loading state", e);
         }
-        if (wasRunning) this.go();
+        if (wasRunning) this.loop.go();
     }
 
     /** Picks up the state a cross-model reload stashed, once the matching machine is up. */

--- a/tests/unit/test-modals.js
+++ b/tests/unit/test-modals.js
@@ -26,14 +26,16 @@ describe("Modals", () => {
         document.body.innerHTML = Markup;
         emulator = { running: true, stop: vi.fn(), go: vi.fn() };
         modals = new Modals({
-            isRunning: () => emulator.running,
-            stop: (debug) => {
-                emulator.running = false;
-                emulator.stop(debug);
-            },
-            go: () => {
-                emulator.running = true;
-                emulator.go();
+            loop: {
+                isRunning: () => emulator.running,
+                stop: (debug) => {
+                    emulator.running = false;
+                    emulator.stop(debug);
+                },
+                go: () => {
+                    emulator.running = true;
+                    emulator.go();
+                },
             },
         });
     });

--- a/tests/unit/test-snapshot-ui.js
+++ b/tests/unit/test-snapshot-ui.js
@@ -82,9 +82,7 @@ describe("SnapshotUI", () => {
             drives: { putDiscIn: vi.fn() },
             urlState: { params: {}, urlWith: vi.fn() },
             modals: { showError: vi.fn() },
-            isRunning: () => true,
-            stop: vi.fn(),
-            go: vi.fn(),
+            loop: { isRunning: () => true, stop: vi.fn(), go: vi.fn() },
         };
     });
 
@@ -102,16 +100,16 @@ describe("SnapshotUI", () => {
     describe("loading a state", () => {
         it("stops the emulator, reports a file it cannot read, and runs on", async () => {
             await make().loadStateFromFile(null, new Uint8Array([0x00, 0x01, 0x02]).buffer);
-            expect(deps.stop).toHaveBeenCalledWith(false);
+            expect(deps.loop.stop).toHaveBeenCalledWith(false);
             expect(deps.modals.showError).toHaveBeenCalledWith("loading state", expect.anything());
-            expect(deps.go).toHaveBeenCalledTimes(1);
+            expect(deps.loop.go).toHaveBeenCalledTimes(1);
         });
 
         it("leaves a stopped emulator stopped afterwards", async () => {
-            deps.isRunning = () => false;
+            deps.loop.isRunning = () => false;
             await make().loadStateFromFile(null, new Uint8Array([0]).buffer);
-            expect(deps.stop).not.toHaveBeenCalled();
-            expect(deps.go).not.toHaveBeenCalled();
+            expect(deps.loop.stop).not.toHaveBeenCalled();
+            expect(deps.loop.go).not.toHaveBeenCalled();
         });
     });
 


### PR DESCRIPTION
Item 2 of #971.

`Modals`, `SnapshotUI` and `RewindUI` each took the same three hand-rolled `{isRunning, stop, go}` closures because `EmulationLoop` was constructed last. Its own late dependencies (`frontPanel`, `rewindUI`) were already closures, so nothing stopped it being built right after the machine; it moves up with its debug-button listener, and the three consumers now take `loop` itself. Their tests hand in a fake loop instead of three functions; no behaviour changes.

Checked: unit suite, all twelve smoke checks.
