### PR TITLE
refactor: three ownership one-liners

### DIFF
--- a/src/basic-loader.js
+++ b/src/basic-loader.js
@@ -1,5 +1,10 @@
 "use strict";
 
+/** Where the OS sits waiting for a keypress, per machine: the place to interrupt with a program. */
+export function basicIdleAddr(model) {
+    return model.isMaster ? 0xe7e6 : 0xe581;
+}
+
 /**
  * Pokes a tokenised BASIC program into memory at PAGE, and sets TOP and
  * VARTOP after it, exactly as if it had just been typed.

--- a/src/main.js
+++ b/src/main.js
@@ -386,11 +386,7 @@ window.addEventListener("beforeunload", function (event) {
 });
 
 function hardReset() {
-    if (rewindUI) {
-        rewindUI.close();
-        rewindBuffer.clear();
-        rewindUI.updateButtonState();
-    }
+    rewindUI.reset();
     processor.reset(true);
 }
 
@@ -525,7 +521,7 @@ electron({
     actions: {
         "soft-reset": () => processor.reset(false),
         "hard-reset": hardReset,
-        "save-state": () => document.getElementById("save-state").click(),
+        "save-state": () => snapshots.saveState(),
         rewind: () => rewindUI.open(),
         pause: pauseIntoDebugger,
         resume: resumeFromDebugger,

--- a/src/web/autoboot.js
+++ b/src/web/autoboot.js
@@ -1,7 +1,7 @@
 import * as utils from "../utils.js";
 import * as utils_atom from "../utils_atom.js";
 import * as tokeniser from "../basic-tokenise.js";
-import { installBasic } from "../basic-loader.js";
+import { basicIdleAddr, installBasic } from "../basic-loader.js";
 
 /** Booting and typing for the machine at startup: shift-break, *TAPE incantations and BASIC programs. */
 export class Autoboot {
@@ -69,7 +69,7 @@ export class Autoboot {
         const tokenised = await t.tokenise(prog);
 
         const { processor } = this;
-        const idleAddr = processor.model.isMaster ? 0xe7e6 : 0xe581;
+        const idleAddr = basicIdleAddr(processor.model);
         const hook = processor.debugInstruction.add((addr) => {
             if (addr !== idleAddr) return;
             installBasic(tokenised, {

--- a/src/web/rewind-ui.js
+++ b/src/web/rewind-ui.js
@@ -41,6 +41,13 @@ export class RewindUI {
         });
     }
 
+    /** Forget everything captured, as on a hard reset. */
+    reset() {
+        this.close();
+        this.rewindBuffer.clear();
+        this.updateButtonState();
+    }
+
     /** Open the rewind scrubber panel. */
     open() {
         if (this.isOpen) return;

--- a/tests/test-machine.js
+++ b/tests/test-machine.js
@@ -1,4 +1,4 @@
-import { installBasic } from "../src/basic-loader.js";
+import { basicIdleAddr, installBasic } from "../src/basic-loader.js";
 import * as fdc from "../src/fdc.js";
 import { fake6502 } from "../src/fake6502.js";
 import { findModel } from "../src/models.js";
@@ -182,7 +182,7 @@ export class TestMachine {
             assert(hit, "Atom did not reach keyboard input in time");
             return this.runFor(10 * 1000);
         }
-        const idleAddr = this.processor.model.isMaster ? 0xe7e6 : 0xe581;
+        const idleAddr = basicIdleAddr(this.processor.model);
         let hit = false;
         const hook = this.processor.debugInstruction.add((addr) => {
             if (addr === idleAddr) {

--- a/tests/unit/test-basic-loader.js
+++ b/tests/unit/test-basic-loader.js
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { installBasic } from "../../src/basic-loader.js";
+import { basicIdleAddr, installBasic } from "../../src/basic-loader.js";
 
 describe("installBasic", () => {
     const machine = (page = 0x19) => {
@@ -23,5 +23,12 @@ describe("installBasic", () => {
         const end = 0x0e00 + 0x105;
         expect(m.memory[0x02] | (m.memory[0x03] << 8)).toBe(end);
         expect(m.memory[0x12] | (m.memory[0x13] << 8)).toBe(end);
+    });
+});
+
+describe("basicIdleAddr", () => {
+    it("names each machine's idle loop", () => {
+        expect(basicIdleAddr({ isMaster: false })).toBe(0xe581);
+        expect(basicIdleAddr({ isMaster: true })).toBe(0xe7e6);
     });
 });


### PR DESCRIPTION
Item 5 of #971, three ownership one-liners:

- the desktop app's save-state action calls `snapshots.saveState()` instead of clicking the menu item's DOM node;
- `hardReset` calls a new `rewindUI.reset()` instead of repeating the close/clear/update triple that is the rewind UI's own business;
- the OS idle addresses become `basicIdleAddr(model)` in `src/basic-loader.js`, used by `Autoboot.insertBasic` and `tests/test-machine.js`, deleting the last duplicated pair from the #954 dedupe.

Checked: unit suite, the nops integration test (which drives `runUntilInput` through the shared address), all twelve smoke checks.
