### PR TITLE
ci: report unit coverage on PRs and badge it on the README

### DIFF
--- a/.github/workflows/test-and-deploy.yml
+++ b/.github/workflows/test-and-deploy.yml
@@ -27,9 +27,9 @@ jobs:
       - name: Unit tests
         run: |
           echo "# Unit tests" >> "$GITHUB_STEP_SUMMARY"
-          npx vitest run --silent=true tests/unit --coverage
+          npm run coverage:unit -- --silent=true
       - name: Coverage report
-        if: always()
+        if: always() && hashFiles('coverage/coverage-summary.json') != ''
         uses: davelosert/vitest-coverage-report-action@v2
         with:
           json-summary-path: coverage/coverage-summary.json

--- a/.github/workflows/test-and-deploy.yml
+++ b/.github/workflows/test-and-deploy.yml
@@ -5,6 +5,9 @@ on: [push]
 jobs:
   build-and-test:
     runs-on: ubuntu-24.04
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - uses: actions/checkout@v7
         with:
@@ -24,7 +27,27 @@ jobs:
       - name: Unit tests
         run: |
           echo "# Unit tests" >> "$GITHUB_STEP_SUMMARY"
-          npm run test:unit
+          npx vitest run --silent=true tests/unit --coverage
+      - name: Coverage report
+        if: always()
+        uses: davelosert/vitest-coverage-report-action@v2
+        with:
+          json-summary-path: coverage/coverage-summary.json
+          json-final-path: coverage/coverage-final.json
+      # Vitest 5 may bring a first-party badge story; until then the badge JSON
+      # lives on the badges branch and shields.io renders it.
+      - name: Publish coverage badge
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          PCT=$(node -p "require('./coverage/coverage-summary.json').total.lines.pct.toFixed(1)")
+          COLOR=$(node -p "const p=$PCT; p>=90?'brightgreen':p>=75?'green':p>=60?'yellowgreen':p>=45?'yellow':'orange'")
+          printf '{"schemaVersion":1,"label":"coverage","message":"%s%%","color":"%s"}' "$PCT" "$COLOR" > /tmp/badge.json
+          SHA=$(gh api "repos/${{ github.repository }}/contents/coverage.json?ref=badges" --jq .sha 2>/dev/null || true)
+          gh api -X PUT "repos/${{ github.repository }}/contents/coverage.json" \
+            -f branch=badges -f message="coverage badge: ${PCT}%" \
+            -f content="$(base64 -w0 /tmp/badge.json)" ${SHA:+-f sha=$SHA}
       - name: Integration tests
         run: |
           echo "# Integration tests" >> "$GITHUB_STEP_SUMMARY"

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 [![jsbeeb tests](https://github.com/mattgodbolt/jsbeeb/actions/workflows/test-and-deploy.yml/badge.svg)](https://github.com/mattgodbolt/jsbeeb/actions/workflows/test-and-deploy.yml)
+[![coverage](https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2Fmattgodbolt%2Fjsbeeb%2Fbadges%2Fcoverage.json)](https://github.com/mattgodbolt/jsbeeb/actions/workflows/test-and-deploy.yml)
 
 # jsbeeb - JavaScript BBC Micro Emulator
 

--- a/tests/unit/test-disc.js
+++ b/tests/unit/test-disc.js
@@ -336,7 +336,8 @@ describe("40 track SSD images", () => {
         for (const physical of [1, 3, 77]) expect(disc.getTrack(false, physical).findSectors()).toEqual([]);
     });
 
-    it("saves back to the image it was loaded from", () => {
+    // Whole-image round trips are slow under coverage instrumentation on CI.
+    it("saves back to the image it was loaded from", { timeout: 60000 }, () => {
         for (const numSides of [1, 2]) {
             const image = numberedImage(40, numSides);
             expect(toSsdOrDsd(fortyTrackDisc(image, numSides === 2))).toEqual(image);

--- a/vite.config.js
+++ b/vite.config.js
@@ -23,7 +23,7 @@ export default defineConfig({
         slowTestThreshold: 1000,
         coverage: {
             provider: "v8",
-            reporter: ["text", "html", "lcov"],
+            reporter: ["text", "html", "lcov", "json", "json-summary"],
             include: [
                 "src/**/*.js", // Only include project source files
             ],


### PR DESCRIPTION
Options 1 and 4 from the coverage discussion, no third-party service:

- The build-and-test job's unit step now runs under coverage (`json` and `json-summary` reporters added to the existing v8 config).
- `davelosert/vitest-coverage-report-action` writes the coverage table into the job summary, next to the named Vitest reports from #946. A true PR comment would need the workflow to trigger on `pull_request` as well as `push`, which changes the repo's CI model (duplicate runs, or no CI on pre-PR branch pushes); that is a separate decision, so this PR sticks to the summary. The `pull-requests: write` permission stays so flipping the trigger later needs no permission change.
- On pushes to main, the job writes a shields endpoint JSON to the `badges` branch through the contents API (`contents: write`), and the README's new badge renders it via img.shields.io. The branch exists already, seeded with the current number so the badge works before this even merges: unit coverage is 61.2% of lines today.

The badge reads unit coverage, since that is what the job measures; `coverage:all-tests` would be truer but doubles the job. Flagged as the one judgment call.

Checked: prettier on the workflow, the badge JSON renders through shields against the live branch, and the coverage run locally produces both JSON files the action needs.
