### PR TITLE
fix: five smallnesses from the fresh-eyes sweep

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -63,10 +63,7 @@ const noSeek = !!parsedQuery.noseek;
 const stationId = parsedQuery.stationId !== undefined ? parsedQuery.stationId : 101;
 
 const tryGl = parsedQuery.glEnabled ?? true;
-let lowLatency = true;
-if (parsedQuery.lowLatency !== undefined) {
-    lowLatency = parsedQuery.lowLatency === "true";
-}
+const lowLatency = parsedQuery.lowLatency ?? true;
 
 if (parsedQuery.embed) {
     for (const el of document.querySelectorAll(".embed-hide")) el.style.display = "none";
@@ -99,9 +96,7 @@ const keys = new KeyboardSetup({
     enterDebugger: () => loop.stop(true),
     reload: () => window.location.reload(),
     toggleFast: () => loop.toggleFastAsPossible(),
-    openRewind: () => {
-        if (rewindUI) rewindUI.open();
-    },
+    openRewind: () => rewindUI.open(),
     openPrinter: () => frontPanel.checkPrinterWindow(),
     pause: () => loop.stop(false),
     resume: () => loop.go(),

--- a/src/web/audio-handler.js
+++ b/src/web/audio-handler.js
@@ -14,8 +14,8 @@ const StallSpikeHeight = 20;
 
 // Nobody is watching an unfocused window, so its sound can run far behind
 // the picture, deep enough to ride out the browser starving the tab.
-export const UnfocusedLatencyMs = 200;
-export const DefaultLatencyMs = 20;
+const UnfocusedLatencyMs = 200;
+const DefaultLatencyMs = 20;
 
 export class AudioHandler {
     constructor({

--- a/src/web/config.js
+++ b/src/web/config.js
@@ -25,7 +25,7 @@ export function fittedRoms({ model, hasEconet, hasMusic5000, hasTeletextAdaptor 
 }
 
 /** The settings the dialog presents as checkboxes. `enables` names a control only usable while ticked. */
-export const CheckboxSettings = [
+const CheckboxSettings = [
     { id: "65c02", field: "coProcessor", restartRequired: true, enables: "tubeCpuMultiplier" },
     { id: "hasTeletextAdaptor", field: "hasTeletextAdaptor", restartRequired: true },
     { id: "hasEconet", field: "hasEconet", restartRequired: true },

--- a/src/web/google-drive-picker.js
+++ b/src/web/google-drive-picker.js
@@ -132,7 +132,6 @@ export class GoogleDrivePicker {
         let name = document.querySelector("#google-drive .disc-name").value;
         if (!name) return;
 
-        this.modals.popupLoading("Connecting to Google Drive");
         this.modal.hide();
         this.modals.popupLoading("Creating '" + name + "' on Google Drive");
 

--- a/src/web/snapshot-ui.js
+++ b/src/web/snapshot-ui.js
@@ -38,7 +38,7 @@ export function isSnapshotFile(filename, arrayBuffer) {
 }
 
 /** The saved snapshot in whichever of the formats we read the buffer holds. */
-export async function readSnapshot(arrayBuffer) {
+async function readSnapshot(arrayBuffer) {
     if (isBemSnapshot(arrayBuffer)) return await parseBemSnapshot(arrayBuffer);
     if (isUefSnapshot(arrayBuffer)) return parseUefSnapshot(arrayBuffer);
     // Detect gzip (magic bytes 0x1f 0x8b) or plain JSON

--- a/src/web/sth-picker.js
+++ b/src/web/sth-picker.js
@@ -117,7 +117,7 @@ export class SthPicker {
             const Delay = 30;
             const batch = all.slice(0, MaxAtATime);
             const remaining = all.slice(MaxAtATime);
-            const filter = document.getElementById("sth-filter").value;
+            const filter = document.getElementById("sth-filter").value.toLowerCase();
             for (const name of batch) {
                 const row = template.cloneNode(true);
                 row.classList.remove("template");

--- a/src/web/url-state.js
+++ b/src/web/url-state.js
@@ -18,6 +18,7 @@ export const UrlParamTypes = {
     hasTeletextAdaptor: ParamTypes.BOOL,
     hasEconet: ParamTypes.BOOL,
     glEnabled: ParamTypes.BOOL,
+    lowLatency: ParamTypes.BOOL,
     fakeVideo: ParamTypes.BOOL,
     logFdcCommands: ParamTypes.BOOL,
     logFdcStateChanges: ParamTypes.BOOL,

--- a/tests/unit/test-sth-picker.js
+++ b/tests/unit/test-sth-picker.js
@@ -55,7 +55,7 @@ describe("SthPicker", () => {
         });
 
         it("renders every batch honouring the filter already typed", () => {
-            document.getElementById("sth-filter").value = "elite";
+            document.getElementById("sth-filter").value = "ELITE";
             const names = ["ELITE.zip", ...Array.from({ length: 150 }, (_, i) => `GAME${i}.zip`)];
             make().renderCatalogue(names, () => {});
             vi.runAllTimers();


### PR DESCRIPTION
The post-merge sweep of the #968/#971 fix round verified all eight PRs landed intact and turned up only small things; these are the ones worth changing (its finding 4, garbage microphone channels coercing to 0, was judged not worth guarding):

- **STH filter case** (the sweep's one real unlisted bug): `renderCatalogue` read the filter box raw but matched lowercased names, so batches rendered while a capitalised filter was typed were hidden until the next keyup. Now lowercased at render, as the HFE picker and `filterArchiveList` already do; the existing batch-filter test now types in capitals to pin it.
- **`lowLatency` becomes a declared boolean parameter** and `main.js` reads it as `?? true`, the same shape #969 gave `glEnabled`. Behaviour change only for a bare `?lowLatency`, which used to mean false against every other boolean's convention; it stays an undocumented option.
- The vestigial `if (rewindUI)` guard in `openRewind` goes, matching #978's removal of its sibling.
- Four exports with no importers become private: `readSnapshot`, `CheckboxSettings`, and the two audio-handler latency constants.
- The Drive create flow's first `popupLoading` was overwritten on the next line; deleted.

Checked: unit suite, all twelve smoke checks.