### PR TITLE
ci: host the coverage report and badge on the site instead of a badges branch

### DIFF
--- a/.github/workflows/test-and-deploy.yml
+++ b/.github/workflows/test-and-deploy.yml
@@ -6,7 +6,7 @@ jobs:
   build-and-test:
     runs-on: ubuntu-24.04
     permissions:
-      contents: write
+      contents: read
       pull-requests: write
     steps:
       - uses: actions/checkout@v7
@@ -34,20 +34,22 @@ jobs:
         with:
           json-summary-path: coverage/coverage-summary.json
           json-final-path: coverage/coverage-final.json
-      # Vitest 5 may bring a first-party badge story; until then the badge JSON
-      # lives on the badges branch and shields.io renders it.
-      - name: Publish coverage badge
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+      # Vitest 5 may bring a first-party badge story; until then shields.io
+      # renders badge.json from the deployed report.
+      - name: Publish coverage report and badge
+        if: github.ref == 'refs/heads/main'
         env:
-          GH_TOKEN: ${{ github.token }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_REGION: us-east-1
         run: |
           PCT=$(node -p "require('./coverage/coverage-summary.json').total.lines.pct.toFixed(1)")
           COLOR=$(node -p "const p=$PCT; p>=90?'brightgreen':p>=75?'green':p>=60?'yellowgreen':p>=45?'yellow':'orange'")
-          printf '{"schemaVersion":1,"label":"coverage","message":"%s%%","color":"%s"}' "$PCT" "$COLOR" > /tmp/badge.json
-          SHA=$(gh api "repos/${{ github.repository }}/contents/coverage.json?ref=badges" --jq .sha 2>/dev/null || true)
-          gh api -X PUT "repos/${{ github.repository }}/contents/coverage.json" \
-            -f branch=badges -f message="coverage badge: ${PCT}%" \
-            -f content="$(base64 -w0 /tmp/badge.json)" ${SHA:+-f sha=$SHA}
+          printf '{"schemaVersion":1,"label":"coverage","message":"%s%%","color":"%s"}' "$PCT" "$COLOR" > coverage/badge.json
+          aws s3 sync coverage s3://bbc.xania.org/coverage \
+            --no-progress --delete \
+            --exclude "coverage-final.json" --exclude "lcov.info" --exclude "lcov-report/*" --exclude ".tmp/*" \
+            --cache-control max-age=30 --metadata-directive REPLACE
       - name: Integration tests
         run: |
           echo "# Integration tests" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/test-and-deploy.yml
+++ b/.github/workflows/test-and-deploy.yml
@@ -34,8 +34,7 @@ jobs:
         with:
           json-summary-path: coverage/coverage-summary.json
           json-final-path: coverage/coverage-final.json
-      # Vitest 5 may bring a first-party badge story; until then shields.io
-      # renders badge.json from the deployed report.
+      # shields.io renders badge.json from the deployed report.
       - name: Publish coverage report and badge
         if: github.ref == 'refs/heads/main'
         env:

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![jsbeeb tests](https://github.com/mattgodbolt/jsbeeb/actions/workflows/test-and-deploy.yml/badge.svg)](https://github.com/mattgodbolt/jsbeeb/actions/workflows/test-and-deploy.yml)
-[![coverage](https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2Fmattgodbolt%2Fjsbeeb%2Fbadges%2Fcoverage.json)](https://github.com/mattgodbolt/jsbeeb/actions/workflows/test-and-deploy.yml)
+[![coverage](https://img.shields.io/endpoint?url=https%3A%2F%2Fbbc.xania.org%2Fcoverage%2Fbadge.json)](https://bbc.xania.org/coverage/index.html)
 
 # jsbeeb - JavaScript BBC Micro Emulator
 


### PR DESCRIPTION
The badge Matt clicks should land on actual coverage, not the workflow-runs list. On main pushes CI now writes the shields endpoint JSON and syncs the HTML report to `s3://bbc.xania.org/coverage/`, so the README badge reads its number from https://bbc.xania.org/coverage/badge.json and links to the line-by-line report at https://bbc.xania.org/coverage/index.html.

Details:

- The sync excludes `coverage-final.json`, `lcov.info` and the duplicate `lcov-report/` tree, so only the html report, the summary JSON and the badge JSON are published. `--delete` keeps stale per-file pages from lingering across refactors, and only within the `coverage/` prefix.
- The badge links to `index.html` explicitly rather than the bare directory, so it works whether or not the bucket's hosting resolves directory indexes.
- `build-and-test` drops back to `contents: read`; the write permission only existed for the badges-branch push.
- The badge will show "invalid response" between merging this and the first main run completing, since the S3 JSON won't exist yet. After that run I'll delete the orphan `badges` branch, which nothing will reference any more.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019CJ9csHch7kjzF3DKzR5DP