### PR TITLE
refactor: wire Layout into Settings and drop the synthetic resize events (#971 item 4)

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -315,7 +315,7 @@ rewindUI.updateButtonState();
 if (processor.fdc) new DiscVisualiser({ fdc: processor.fdc });
 else document.getElementById("disc-visualiser-open").classList.add("disabled");
 
-new Layout({
+const layout = new Layout({
     screenCanvas,
     display,
     embed: parsedQuery.embed !== undefined,
@@ -323,7 +323,7 @@ new Layout({
 });
 
 // Everything a setting can reach now exists.
-settings.wire({ audioHandler, display, quickSettings, machine, keys, inputs, modals });
+settings.wire({ audioHandler, display, layout, quickSettings, machine, keys, inputs, modals });
 
 // ------------------------------------------------------------------------
 // The page's own handlers.

--- a/src/web/display.js
+++ b/src/web/display.js
@@ -111,9 +111,6 @@ export class Display {
         this.sizeCanvasFor(this.filterClass);
         this.video.paint();
         this.setCrtPic();
-        window.setTimeout(() => window.dispatchEvent(new Event("resize")), 1);
-        // Relayout now as well: the monitor picture may have changed shape.
-        window.dispatchEvent(new Event("resize"));
     }
 
     sizeCanvasFor(filterClass) {

--- a/src/web/settings.js
+++ b/src/web/settings.js
@@ -123,6 +123,8 @@ export class Settings {
     applyDisplayMode(mode) {
         this.displayMode = mode;
         this.targets.display.setMode(mode);
+        // The monitor picture may have changed shape.
+        this.targets.layout.resize();
         this.config.setDisplayMode(mode);
         this.targets.quickSettings?.showDisplayMode(mode);
         window.localStorage.displayMode = mode;

--- a/tests/unit/test-settings.js
+++ b/tests/unit/test-settings.js
@@ -35,6 +35,7 @@ describe("Settings", () => {
         targets = {
             audioHandler: { setAudioOutput: vi.fn(), setSpeakerAmount: vi.fn() },
             display: { setMode: vi.fn() },
+            layout: { resize: vi.fn() },
             quickSettings: { showAudioOutput: vi.fn(), showSpeakerAmount: vi.fn(), showDisplayMode: vi.fn() },
             machine: { emulationConfig: {}, processor: { hasTube: false, tube: {} } },
             keys: { setKeyLayout: vi.fn() },
@@ -115,6 +116,7 @@ describe("Settings", () => {
             const settings = make();
             settings.applyDisplayMode("pal");
             expect(targets.display.setMode).toHaveBeenCalledWith("pal");
+            expect(targets.layout.resize).toHaveBeenCalledTimes(1);
             expect(settings.displayMode).toBe("pal");
             expect(urlState.params.displayMode).toBe("pal");
             expect(urlState.updateUrl).toHaveBeenCalledTimes(1);


### PR DESCRIPTION
Item 4 of #971.

**What moved**

- `Display.setMode` no longer dispatches window `resize` events. Both synthetic dispatches go: the deferred `setTimeout(..., 1)` one and the immediate one (which #970 had restored), along with the comment that explained them.
- `Layout` is now a Settings wire target. `main.js` keeps the constructed `Layout` in a `const` and passes it to `settings.wire(...)`, which already runs after Layout exists.
- `Settings.applyDisplayMode` calls `layout.resize()` directly, after `display.setMode(mode)`, so the layout refits once the canvas has taken its new size.

**Why behaviour is unchanged**

The synthetic events existed only so Layout would relayout after a mode change; the direct call does the same thing at the same point, without waking every other window-resize listener in the page. Layout's real `window.addEventListener("resize", ...)` is untouched, as are its startup deferred resizes. Nothing else in `src/` listened for the synthetic events (the disc visualiser's resize listener tracks real window resizes). Nothing can call `applyDisplayMode` before `wire`: the quick-settings and dialog callbacks only fire on user interaction, and `Config.setDisplayMode` in the Settings constructor only updates label text.

**Tests**

`test-settings.js` now wires a `layout` target and asserts `applyDisplayMode` calls `resize()` exactly once. No existing unit test asserted the synthetic dispatches. `npm run lint` and `npm run test:unit` (1494 tests) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)