### PR TITLE
refactor: MediaLoader owns the media-changed event (#971 item 1)

### DIFF
--- a/src/app/electron.js
+++ b/src/app/electron.js
@@ -4,7 +4,7 @@
 // Handles IPC communication for loading disc/tape images and showing modals from Electron's main process.
 
 function init(args) {
-    const { loadDiscImage, loadTapeImage, loadStateFile, processor, modals, actions, config } = args;
+    const { loadDiscImage, loadTapeImage, loadStateFile, processor, modals, actions, config, media } = args;
     const api = window.electronAPI;
 
     api.onLoadDisc(async (message) => {
@@ -58,7 +58,9 @@ function init(args) {
         config.addEventListener("settings-changed", (e) => {
             api.saveSettings(e.detail);
         });
-        config.addEventListener("media-changed", (e) => {
+    }
+    if (media) {
+        media.addEventListener("media-changed", (e) => {
             api.saveSettings(e.detail);
         });
     }

--- a/src/main.js
+++ b/src/main.js
@@ -231,7 +231,6 @@ const media = new MediaLoader({
     model,
     drives,
     urlState,
-    config,
     modals,
     isSnapshotFile,
     loadSnapshot: (file, buffer) => snapshots.loadStateFromFile(file, buffer),
@@ -500,6 +499,7 @@ electron({
     loadTapeImage: media.loadTapeImage.bind(media),
     processor,
     config,
+    media,
     modals: {
         show: (modalId, sthType) => {
             if (modalId === "sth" && sthType) {

--- a/src/web/media-loader.js
+++ b/src/web/media-loader.js
@@ -50,7 +50,7 @@ function readFileAsBinaryString(file) {
  * URL schema can name, the local file inputs, the drop zone and the built-in
  * list. Choosing what goes in a drive funnels through drives.putDiscIn.
  */
-export class MediaLoader {
+export class MediaLoader extends EventTarget {
     /**
      * @param {object} deps
      * @param {object} deps.sources fetchers keyed by schema: sth, tapeSth and hfe
@@ -58,12 +58,12 @@ export class MediaLoader {
      * @param {Function} deps.isSnapshotFile says whether a dropped file is a save state
      * @param {Function} deps.loadSnapshot restores a dropped save state
      */
-    constructor({ processor, model, drives, urlState, config, modals, sources, isSnapshotFile, loadSnapshot }) {
+    constructor({ processor, model, drives, urlState, modals, sources, isSnapshotFile, loadSnapshot }) {
+        super();
         this.processor = processor;
         this.model = model;
         this.drives = drives;
         this.urlState = urlState;
-        this.config = config;
         this.modals = modals;
         this.sources = sources;
 
@@ -180,19 +180,19 @@ export class MediaLoader {
         delete this.params.disc;
         this.params.disc1 = name;
         this.urlState.updateUrl();
-        this.config.dispatchEvent(new CustomEvent("media-changed", { detail: { disc1: name } }));
+        this.dispatchEvent(new CustomEvent("media-changed", { detail: { disc1: name } }));
     }
 
     setDisc2Image(name) {
         this.params.disc2 = name;
         this.urlState.updateUrl();
-        this.config.dispatchEvent(new CustomEvent("media-changed", { detail: { disc2: name } }));
+        this.dispatchEvent(new CustomEvent("media-changed", { detail: { disc2: name } }));
     }
 
     setTapeImage(name) {
         this.params.tape = name;
         this.urlState.updateUrl();
-        this.config.dispatchEvent(new CustomEvent("media-changed", { detail: { tape: name } }));
+        this.dispatchEvent(new CustomEvent("media-changed", { detail: { tape: name } }));
     }
 
     async loadHTMLFile(file) {

--- a/tests/unit/test-media-loader.js
+++ b/tests/unit/test-media-loader.js
@@ -47,7 +47,6 @@ describe("MediaLoader", () => {
             model: { isAtom: false },
             drives: { layoutForDrive: () => DiscLayout.auto, putDiscIn: vi.fn() },
             urlState: { params: {}, updateUrl: vi.fn() },
-            config: new EventTarget(),
             modals: { hide: vi.fn() },
             sources: { sth: vi.fn(), tapeSth: vi.fn(), hfe: vi.fn(), drive: vi.fn() },
             isSnapshotFile: (name) => name.endsWith(".snp"),
@@ -135,19 +134,23 @@ describe("MediaLoader", () => {
         const mediaEvents = [];
         beforeEach(() => {
             mediaEvents.length = 0;
-            deps.config.addEventListener("media-changed", (e) => mediaEvents.push(e.detail));
         });
+        const makeWatched = () => {
+            const media = make();
+            media.addEventListener("media-changed", (e) => mediaEvents.push(e.detail));
+            return media;
+        };
 
         it("names drive 0's disc, displacing any bare disc parameter", () => {
             deps.urlState.params.disc = "old.ssd";
-            make().setDisc1Image("sth:ELITE.zip");
+            makeWatched().setDisc1Image("sth:ELITE.zip");
             expect(deps.urlState.params).toEqual({ disc1: "sth:ELITE.zip" });
             expect(deps.urlState.updateUrl).toHaveBeenCalledTimes(1);
             expect(mediaEvents).toEqual([{ disc1: "sth:ELITE.zip" }]);
         });
 
         it("names drive 1's disc and the tape", () => {
-            const media = make();
+            const media = makeWatched();
             media.setDisc2Image("b.ssd");
             media.setTapeImage("sth:Chuckie.zip");
             expect(deps.urlState.params).toEqual({ disc2: "b.ssd", tape: "sth:Chuckie.zip" });


### PR DESCRIPTION
Item 1 of #971.

`MediaLoader.setDisc1Image`, `setDisc2Image` and `setTapeImage` used to dispatch `media-changed` on the settings `Config`, purely because the Electron integration listened there; the settings dialog was acting as a media bus. `MediaLoader` now extends `EventTarget` and dispatches `media-changed` on itself, and its `config` dependency is gone. `main.js` passes the loader to `electron()`, which subscribes to it directly; `config` keeps only its own `settings-changed` listener.

No behaviour change: the same three events fire with the same details, and the Electron app still saves them via `api.saveSettings`. The `media-changed` tests in `test-media-loader.js` now listen on the loader instance instead of a config stand-in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
