### PR TITLE
refactor: pickers register their media sources (#971 item 3)

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -234,13 +234,6 @@ const media = new MediaLoader({
     modals,
     isSnapshotFile,
     loadSnapshot: (file, buffer) => snapshots.loadStateFromFile(file, buffer),
-    // The archives are created further down; each source resolves when used.
-    sources: {
-        sth: (name) => sthPicker.discs.fetch(name),
-        tapeSth: (name) => sthPicker.tapes.fetch(name),
-        hfe: (path) => hfePicker.archive.fetch(path),
-        drive: (cat, layout) => drivePicker.load(cat, layout),
-    },
 });
 const autoBoot = new Autoboot({
     model,
@@ -256,7 +249,7 @@ const sthPicker = new SthPicker({
     processor,
     autoboot: (image) => autoBoot.boot(image),
 });
-const hfePicker = new HfePicker({
+new HfePicker({
     media,
     drives,
     modals,
@@ -264,7 +257,7 @@ const hfePicker = new HfePicker({
     processor,
     autoboot: (image) => autoBoot.boot(image),
 });
-const drivePicker = new GoogleDrivePicker({ media, drives, modals, processor });
+new GoogleDrivePicker({ media, drives, modals, processor });
 const snapshots = new SnapshotUI({
     processor,
     model,

--- a/src/web/google-drive-picker.js
+++ b/src/web/google-drive-picker.js
@@ -16,6 +16,7 @@ export class GoogleDrivePicker {
         this.modals = modals;
         this.processor = processor;
         this.googleDrive = loader;
+        media.addSource("drive", (cat, layout) => this.load(cat, layout));
 
         this.authEl = document.getElementById("google-drive-auth");
         this.el = document.getElementById("google-drive");

--- a/src/web/hfe-picker.js
+++ b/src/web/hfe-picker.js
@@ -41,6 +41,7 @@ export class HfePicker {
                 showArchiveMessage("hfe", "hfe-list", "There was an error accessing the HFE archive");
             },
         );
+        media.addSource("hfe", (path) => this.archive.fetch(path));
 
         this.modal = new bootstrap.Modal(document.getElementById("hfe"));
         document.getElementById("hfe").addEventListener("shown.bs.modal", () => {

--- a/src/web/media-loader.js
+++ b/src/web/media-loader.js
@@ -53,19 +53,17 @@ function readFileAsBinaryString(file) {
 export class MediaLoader extends EventTarget {
     /**
      * @param {object} deps
-     * @param {object} deps.sources fetchers keyed by schema: sth, tapeSth and hfe
-     *   resolve an archive name to image data; drive loads a Google Drive file
      * @param {Function} deps.isSnapshotFile says whether a dropped file is a save state
      * @param {Function} deps.loadSnapshot restores a dropped save state
      */
-    constructor({ processor, model, drives, urlState, modals, sources, isSnapshotFile, loadSnapshot }) {
+    constructor({ processor, model, drives, urlState, modals, isSnapshotFile, loadSnapshot }) {
         super();
         this.processor = processor;
         this.model = model;
         this.drives = drives;
         this.urlState = urlState;
         this.modals = modals;
-        this.sources = sources;
+        this.sources = {};
 
         document.getElementById("disc_load").addEventListener("change", async (evt) => {
             if (evt.target.files.length === 0) return;
@@ -165,6 +163,11 @@ export class MediaLoader extends EventTarget {
 
     get params() {
         return this.urlState.params;
+    }
+
+    /** Register the fetcher behind an image schema; each picker calls this as it is constructed. */
+    addSource(schema, fetcher) {
+        this.sources[schema] = fetcher;
     }
 
     /** Route tape to the correct interface (ACIA for BBC, PPIA for Atom) */

--- a/src/web/sth-picker.js
+++ b/src/web/sth-picker.js
@@ -46,6 +46,8 @@ export class SthPicker {
             onError,
             true,
         );
+        media.addSource("sth", (name) => this.discs.fetch(name));
+        media.addSource("tapeSth", (name) => this.tapes.fetch(name));
 
         document.addEventListener("click", (e) => {
             const target = e.target.closest("a.sth");

--- a/tests/unit/test-google-drive-picker.js
+++ b/tests/unit/test-google-drive-picker.js
@@ -26,7 +26,7 @@ describe("GoogleDrivePicker", () => {
             create: vi.fn(),
         };
         deps = {
-            media: { setDisc1Image: vi.fn() },
+            media: { addSource: vi.fn(), setDisc1Image: vi.fn() },
             drives: { layoutForDrive: () => "auto", putDiscIn: vi.fn() },
             modals: { popupLoading: vi.fn(), loadingFinished: vi.fn() },
             processor: { fdc: { drives: [{ disc: null }, {}] } },
@@ -182,6 +182,18 @@ describe("GoogleDrivePicker", () => {
             make();
             submit();
             expect(deps.modals.popupLoading).not.toHaveBeenCalled();
+        });
+    });
+
+    describe("registering media sources", () => {
+        it("hands the loader its own load as the drive fetcher", async () => {
+            const picker = make();
+            const registered = Object.fromEntries(deps.media.addSource.mock.calls);
+            expect(Object.keys(registered)).toEqual(["drive"]);
+            const ssd = {};
+            vi.spyOn(picker, "load").mockResolvedValue(ssd);
+            await expect(registered.drive({ id: "abc", name: "mine.ssd" }, "auto")).resolves.toBe(ssd);
+            expect(picker.load).toHaveBeenCalledWith({ id: "abc", name: "mine.ssd" }, "auto");
         });
     });
 });

--- a/tests/unit/test-hfe-picker.js
+++ b/tests/unit/test-hfe-picker.js
@@ -31,7 +31,7 @@ describe("HfePicker", () => {
         vi.useFakeTimers();
         document.body.innerHTML = Markup;
         deps = {
-            media: { setDisc1Image: vi.fn(), loadDiscImage: vi.fn() },
+            media: { addSource: vi.fn(), setDisc1Image: vi.fn(), loadDiscImage: vi.fn() },
             drives: { layoutForDrive: () => "auto", putDiscIn: vi.fn() },
             modals: { popupLoading: vi.fn(), loadingFinished: vi.fn() },
             urlState: { params: {}, updateUrl: vi.fn() },
@@ -165,6 +165,17 @@ describe("HfePicker", () => {
             expect(deps.modals.loadingFinished).toHaveBeenCalledWith(
                 expect.stringContaining("Unable to load Elite from the HFE archive: 404"),
             );
+        });
+    });
+
+    describe("registering media sources", () => {
+        it("hands the loader a fetcher for the archive", async () => {
+            const picker = make();
+            const registered = Object.fromEntries(deps.media.addSource.mock.calls);
+            expect(Object.keys(registered)).toEqual(["hfe"]);
+            vi.spyOn(picker.archive, "fetch").mockResolvedValue("hfe bytes");
+            await expect(registered.hfe("Games/ELITE.hfe")).resolves.toBe("hfe bytes");
+            expect(picker.archive.fetch).toHaveBeenCalledWith("Games/ELITE.hfe");
         });
     });
 });

--- a/tests/unit/test-media-loader.js
+++ b/tests/unit/test-media-loader.js
@@ -33,6 +33,7 @@ async function pickFile(inputId, file) {
 
 describe("MediaLoader", () => {
     let deps;
+    let sources;
 
     beforeEach(() => {
         document.body.innerHTML = Markup;
@@ -48,10 +49,10 @@ describe("MediaLoader", () => {
             drives: { layoutForDrive: () => DiscLayout.auto, putDiscIn: vi.fn() },
             urlState: { params: {}, updateUrl: vi.fn() },
             modals: { hide: vi.fn() },
-            sources: { sth: vi.fn(), tapeSth: vi.fn(), hfe: vi.fn(), drive: vi.fn() },
             isSnapshotFile: (name) => name.endsWith(".snp"),
             loadSnapshot: vi.fn(),
         };
+        sources = { sth: vi.fn(), tapeSth: vi.fn(), hfe: vi.fn(), drive: vi.fn() };
     });
 
     afterEach(() => {
@@ -60,7 +61,11 @@ describe("MediaLoader", () => {
         window.localStorage.clear();
     });
 
-    const make = () => new MediaLoader(deps);
+    const make = () => {
+        const media = new MediaLoader(deps);
+        for (const [schema, fetcher] of Object.entries(sources)) media.addSource(schema, fetcher);
+        return media;
+    };
     const toasts = () =>
         [...document.querySelectorAll(".toast")].map((el) => el.textContent.replace(/\s+/g, " ").trim());
 
@@ -85,33 +90,30 @@ describe("MediaLoader", () => {
         });
 
         it("fetches an sth: reference and names the disc after what was in the archive", async () => {
-            deps.sources.sth.mockResolvedValue({ name: "ELITE.ssd", data: ssdImage(), ignored: [] });
+            sources.sth.mockResolvedValue({ name: "ELITE.ssd", data: ssdImage(), ignored: [] });
             const loaded = await make().loadDiscImage("sth:ELITE.zip");
-            expect(deps.sources.sth).toHaveBeenCalledWith("ELITE.zip");
+            expect(sources.sth).toHaveBeenCalledWith("ELITE.zip");
             expect(loaded.name).toBe("ELITE.ssd");
         });
 
         it("reports what an archive held besides the file it loaded", async () => {
-            deps.sources.sth.mockResolvedValue({ name: "side1.ssd", data: ssdImage(), ignored: ["side2.ssd"] });
+            sources.sth.mockResolvedValue({ name: "side1.ssd", data: ssdImage(), ignored: ["side2.ssd"] });
             await make().loadDiscImage("sth:Game.zip");
             expect(toasts()).toEqual([expect.stringContaining("side2.ssd")]);
         });
 
         it("fetches an hfe: reference from the archive", async () => {
-            deps.sources.hfe.mockResolvedValue(toHfe(discFor(null, "x.ssd", ssdImage())));
+            sources.hfe.mockResolvedValue(toHfe(discFor(null, "x.ssd", ssdImage())));
             const loaded = await make().loadDiscImage("hfe:3A1DAB83.hfe");
-            expect(deps.sources.hfe).toHaveBeenCalledWith("3A1DAB83.hfe");
+            expect(sources.hfe).toHaveBeenCalledWith("3A1DAB83.hfe");
             expect(loaded.name).toBe("3A1DAB83.hfe");
         });
 
         it("splits a gd: reference into the file id and name for the Drive source", async () => {
             const fromDrive = {};
-            deps.sources.drive.mockResolvedValue(fromDrive);
+            sources.drive.mockResolvedValue(fromDrive);
             const loaded = await make().loadDiscImage("gd:abc123/mydisc.ssd", DiscLayout.contiguous);
-            expect(deps.sources.drive).toHaveBeenCalledWith(
-                { id: "abc123", name: "mydisc.ssd" },
-                DiscLayout.contiguous,
-            );
+            expect(sources.drive).toHaveBeenCalledWith({ id: "abc123", name: "mydisc.ssd" }, DiscLayout.contiguous);
             expect(loaded).toBe(fromDrive);
         });
 

--- a/tests/unit/test-sth-picker.js
+++ b/tests/unit/test-sth-picker.js
@@ -18,6 +18,7 @@ describe("SthPicker", () => {
         document.body.innerHTML = Markup;
         deps = {
             media: {
+                addSource: vi.fn(),
                 setDisc1Image: vi.fn(),
                 setTapeImage: vi.fn(),
                 loadDiscImage: vi.fn(),
@@ -156,6 +157,20 @@ describe("SthPicker", () => {
             expect(deps.modals.loadingFinished).toHaveBeenCalledWith(
                 expect.stringContaining("Unable to load CHUCKIE.zip from the STH archive: 410"),
             );
+        });
+    });
+
+    describe("registering media sources", () => {
+        it("hands the loader a fetcher for each catalogue", async () => {
+            const picker = make();
+            const registered = Object.fromEntries(deps.media.addSource.mock.calls);
+            expect(Object.keys(registered).sort()).toEqual(["sth", "tapeSth"]);
+            vi.spyOn(picker.discs, "fetch").mockResolvedValue("disc bytes");
+            vi.spyOn(picker.tapes, "fetch").mockResolvedValue("tape bytes");
+            await expect(registered.sth("ELITE.zip")).resolves.toBe("disc bytes");
+            expect(picker.discs.fetch).toHaveBeenCalledWith("ELITE.zip");
+            await expect(registered.tapeSth("CHUCKIE.zip")).resolves.toBe("tape bytes");
+            expect(picker.tapes.fetch).toHaveBeenCalledWith("CHUCKIE.zip");
         });
     });
 });


### PR DESCRIPTION
Item 3 of #971, on top of #986.

`main.js` handed `MediaLoader` a `sources` bag of closures over the STH, HFE and Google Drive pickers, all constructed after the loader, with a comment explaining the forward references. The loader now starts with no sources and exposes `addSource(schema, fetcher)`; each picker registers its fetchers from its own constructor (`sth` and `tapeSth` from `SthPicker`, `hfe` from `HfePicker`, `drive` from `GoogleDrivePicker`). The bag, the forward references and the comment are gone, and the now-unused `hfePicker` and `drivePicker` bindings in `main.js` are dropped (matching the existing bare `new Layout(...)`).

No behaviour change: lookups happen at load time exactly as the closures did. `test-media-loader.js` registers its mock fetchers through `addSource`, and each picker test gains an assertion that the constructor registers fetchers that delegate to the right catalogue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
