### PR TITLE
refactor: split AccessibilitySwitches out of KeyboardSetup (#971 item 6)

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -22,6 +22,7 @@ import { Display } from "./web/display.js";
 import { Layout } from "./web/layout.js";
 import { EmulationLoop, RewindCaptureInterval } from "./web/emulation-loop.js";
 import { KeyboardSetup } from "./web/keyboard-setup.js";
+import { AccessibilitySwitches } from "./web/accessibility-switches.js";
 import { AnalogueInputs } from "./web/analogue-inputs.js";
 import { FrontPanel } from "./web/front-panel.js";
 import { Machine } from "./web/machine.js";
@@ -92,19 +93,7 @@ const printer = new Printer({
         }),
 });
 
-const keys = new KeyboardSetup({
-    enterDebugger: () => loop.stop(true),
-    reload: () => window.location.reload(),
-    toggleFast: () => loop.toggleFastAsPossible(),
-    openRewind: () => rewindUI.open(),
-    openPrinter: () => frontPanel.checkPrinterWindow(),
-    pause: () => loop.stop(false),
-    resume: () => loop.go(),
-    onAnyKeyDown: () => {
-        audioHandler.tryResume();
-        inputs.ensureMicrophoneRunning();
-    },
-});
+const accessibilitySwitches = new AccessibilitySwitches();
 
 const settings = new Settings({ urlState });
 const { config, speechOutput, keyLayout, displayMode, audioOutput, speakerAmount } = settings;
@@ -188,7 +177,7 @@ const machine = new Machine({
     cpuMultiplier,
     extraRoms,
     stationId,
-    userPort: keys.userPort,
+    userPort: accessibilitySwitches.userPort,
     printer,
     speechOutput,
     video,
@@ -196,6 +185,26 @@ const machine = new Machine({
     dbgr,
 });
 const processor = machine.processor;
+
+const keys = new KeyboardSetup({
+    actions: {
+        enterDebugger: () => loop.stop(true),
+        reload: () => window.location.reload(),
+        toggleFast: () => loop.toggleFastAsPossible(),
+        openRewind: () => rewindUI.open(),
+        openPrinter: () => frontPanel.checkPrinterWindow(),
+        pause: () => loop.stop(false),
+        resume: () => loop.go(),
+        onAnyKeyDown: () => {
+            audioHandler.tryResume();
+            inputs.ensureMicrophoneRunning();
+        },
+    },
+    accessibilitySwitches,
+    processor,
+    dbgr,
+    keyLayout,
+});
 
 const rewindBuffer = new RewindBuffer(30);
 const loop = new EmulationLoop({
@@ -294,8 +303,6 @@ if (parsedQuery.microphoneChannel !== undefined) {
 }
 // Apply ADC source settings from URL parameters
 inputs.updateAdcSources(parsedQuery.mouseJoystickEnabled, parsedQuery.microphoneChannel);
-
-keys.attach({ processor, dbgr, keyLayout });
 
 const frontPanel = new FrontPanel({ processor, model, printer });
 

--- a/src/web/accessibility-switches.js
+++ b/src/web/accessibility-switches.js
@@ -1,0 +1,26 @@
+/**
+ * The accessibility switches on the user port. Bits 0-7 correspond to switches
+ * 1-8, active low: 0xff = no switches pressed; a clear bit = that switch held.
+ *
+ * On real hardware, the Brilliant Computing switch interface box and special-ed
+ * joystick connect to the User Port only; they do not touch the analogue port
+ * or the System VIA fire buttons (PB4/PB5), which belong to the standard
+ * analogue joystick connector.
+ */
+export class AccessibilitySwitches {
+    constructor() {
+        this.switchState = 0xff;
+        const switches = this;
+        this.userPort = {
+            write() {},
+            read() {
+                return switches.switchState;
+            },
+        };
+    }
+
+    setSwitch(index, held) {
+        if (held) this.switchState &= ~(1 << index);
+        else this.switchState |= 1 << index;
+    }
+}

--- a/src/web/keyboard-setup.js
+++ b/src/web/keyboard-setup.js
@@ -2,36 +2,16 @@ import * as utils from "../utils.js";
 import { Keyboard } from "../keyboard.js";
 import { showNotice } from "./reporting.js";
 
-/**
- * The page's keyboard: the emulated one, the browser shortcuts around it, and
- * the accessibility switches on the user port. Built in two steps because the
- * user port has to exist before the processor does, and the keyboard after.
- */
+/** The page's keyboard: the emulated one and the browser shortcuts around it. */
 export class KeyboardSetup {
     /**
-     * @param {object} actions what each shortcut does, supplied late-bound:
+     * @param {object} opts
+     * @param {object} opts.actions what each shortcut does, supplied late-bound:
      *   enterDebugger, reload, toggleFast, openRewind, openPrinter,
      *   pause, resume, onAnyKeyDown
+     * @param {import("./accessibility-switches.js").AccessibilitySwitches} opts.accessibilitySwitches
      */
-    constructor(actions) {
-        this.actions = actions;
-        this.keyboard = null;
-
-        // Accessibility switch state: bits 0-7 correspond to switches 1-8.
-        // Active low: 0xff = no switches pressed; clearing a bit = that switch is pressed.
-        this.switchState = 0xff;
-        const setup = this;
-        this.userPort = {
-            write() {},
-            read() {
-                return setup.switchState;
-            },
-        };
-    }
-
-    /** Initialise keyboard now that processor exists */
-    attach({ processor, dbgr, keyLayout }) {
-        const { actions } = this;
+    constructor({ actions, accessibilitySwitches, processor, dbgr, keyLayout }) {
         const keyboard = (this.keyboard = new Keyboard({
             processor,
             inputEnabledFunction: () => document.activeElement && document.activeElement.id === "paste-text",
@@ -66,22 +46,11 @@ export class KeyboardSetup {
         keyboard.registerKeyHandler(utils.keyCodes.PAGEDOWN, onDown("pagedown", actions.openRewind), alt);
         keyboard.registerKeyHandler(utils.keyCodes.B, onDown(null, actions.openPrinter), ctrl);
 
-        // Register accessibility switch key handlers.
-        // Keys 1-8 (K1-K8) and function keys F1-F8 both map to user port bits 0-7
-        // (active low: pressing the key clears the corresponding bit in &FE60).
-        //
-        // On real hardware, the Brilliant Computing switch interface box and special-ed
-        // joystick connect to the User Port only; they do not touch the analogue port
-        // or the System VIA fire buttons (PB4/PB5), which belong to the standard
-        // analogue joystick connector.  So we only update switchState here.
-        const handleSwitch = (bit) => (down) => {
-            if (down) this.switchState &= ~(1 << bit);
-            else this.switchState |= 1 << bit;
-        };
-
-        // Alt+1-8 and Alt+F1-F8 trigger the switches.  Using Alt means the underlying
-        // key is never forwarded to the BBC Micro (keyboard.js bails out early when a
-        // handler fires), so typing numbers or using function keys works normally.
+        // Alt+1-8 and Alt+F1-F8 trigger the accessibility switches. Using Alt means
+        // the underlying key is never forwarded to the BBC Micro (keyboard.js bails
+        // out early when a handler fires), so typing numbers or using function keys
+        // works normally.
+        const handleSwitch = (index) => (down) => accessibilitySwitches.setSwitch(index, down);
         for (let i = 0; i < 8; i++) {
             keyboard.registerKeyHandler(utils.keyCodes.K1 + i, handleSwitch(i), alt);
             keyboard.registerKeyHandler(utils.keyCodes.F1 + i, handleSwitch(i), alt);
@@ -96,11 +65,7 @@ export class KeyboardSetup {
     }
 
     sendRawKeyboard(keysToSend, checkCapsAndShiftLocks) {
-        if (this.keyboard) {
-            this.keyboard.sendRawKeyboard(keysToSend, checkCapsAndShiftLocks);
-        } else {
-            console.warn("Tried to send keys before keyboard was initialised");
-        }
+        this.keyboard.sendRawKeyboard(keysToSend, checkCapsAndShiftLocks);
     }
 
     clearKeys() {

--- a/tests/unit/test-accessibility-switches.js
+++ b/tests/unit/test-accessibility-switches.js
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+
+import { AccessibilitySwitches } from "../../src/web/accessibility-switches.js";
+
+describe("AccessibilitySwitches", () => {
+    it("reads as no switches pressed to begin with", () => {
+        expect(new AccessibilitySwitches().userPort.read()).toBe(0xff);
+    });
+
+    it("clears a switch's bit while held and restores it on release", () => {
+        const switches = new AccessibilitySwitches();
+        switches.setSwitch(0, true);
+        expect(switches.userPort.read()).toBe(0xfe);
+        switches.setSwitch(7, true);
+        expect(switches.userPort.read()).toBe(0x7e);
+        switches.setSwitch(0, false);
+        expect(switches.userPort.read()).toBe(0x7f);
+        switches.setSwitch(7, false);
+        expect(switches.userPort.read()).toBe(0xff);
+    });
+
+    it("ignores writes from the user port", () => {
+        const switches = new AccessibilitySwitches();
+        switches.userPort.write(0x00);
+        expect(switches.userPort.read()).toBe(0xff);
+    });
+});

--- a/tests/unit/test-keyboard-setup.js
+++ b/tests/unit/test-keyboard-setup.js
@@ -1,6 +1,7 @@
 // @vitest-environment jsdom
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+import { AccessibilitySwitches } from "../../src/web/accessibility-switches.js";
 import { KeyboardSetup } from "../../src/web/keyboard-setup.js";
 import * as utils from "../../src/utils.js";
 
@@ -12,10 +13,11 @@ const keyEvent = (type, which, { alt = false, ctrl = false } = {}) => {
 
 describe("KeyboardSetup", () => {
     let actions;
+    let accessibilitySwitches;
+    let processor;
     let setup;
 
     beforeEach(() => {
-        vi.spyOn(console, "warn").mockImplementation(() => {});
         document.body.innerHTML = "";
         actions = {
             enterDebugger: vi.fn(),
@@ -27,16 +29,8 @@ describe("KeyboardSetup", () => {
             resume: vi.fn(),
             onAnyKeyDown: vi.fn(),
         };
-        setup = new KeyboardSetup(actions);
-    });
-
-    afterEach(() => {
-        vi.restoreAllMocks();
-        document.body.innerHTML = "";
-    });
-
-    const attach = () => {
-        const processor = {
+        accessibilitySwitches = new AccessibilitySwitches();
+        processor = {
             model: { isAtom: false },
             scheduler: {
                 newTask: () => ({
@@ -56,25 +50,24 @@ describe("KeyboardSetup", () => {
                 keyboardEnabled: true,
             },
         };
-        setup.attach({ processor, dbgr: {}, keyLayout: "physical" });
+        setup = new KeyboardSetup({ actions, accessibilitySwitches, processor, dbgr: {}, keyLayout: "physical" });
         setup.setRunning(true);
-        return processor;
-    };
+    });
 
-    describe("the user port", () => {
-        it("reads as no switches pressed to begin with", () => {
-            expect(setup.userPort.read()).toBe(0xff);
-        });
+    afterEach(() => {
+        vi.restoreAllMocks();
+        document.body.innerHTML = "";
+    });
 
+    describe("the accessibility switches", () => {
         it("clears a bit while its switch is held, keys and function keys alike", () => {
-            attach();
             document.dispatchEvent(keyEvent("keydown", utils.keyCodes.K1, { alt: true }));
-            expect(setup.userPort.read()).toBe(0xfe);
+            expect(accessibilitySwitches.userPort.read()).toBe(0xfe);
             document.dispatchEvent(keyEvent("keyup", utils.keyCodes.K1, { alt: true }));
-            expect(setup.userPort.read()).toBe(0xff);
+            expect(accessibilitySwitches.userPort.read()).toBe(0xff);
 
             document.dispatchEvent(keyEvent("keydown", utils.keyCodes.F8, { alt: true }));
-            expect(setup.userPort.read()).toBe(0x7f);
+            expect(accessibilitySwitches.userPort.read()).toBe(0x7f);
         });
     });
 
@@ -87,7 +80,6 @@ describe("KeyboardSetup", () => {
             ["Alt-PageDown", utils.keyCodes.PAGEDOWN, { alt: true }, "openRewind"],
             ["Ctrl-B", utils.keyCodes.B, { ctrl: true }, "openPrinter"],
         ])("%s fires %s on the way down only", (name, which, modifiers, action) => {
-            attach();
             document.dispatchEvent(keyEvent("keydown", which, modifiers));
             expect(actions[action]).toHaveBeenCalledTimes(1);
             document.dispatchEvent(keyEvent("keyup", which, modifiers));
@@ -95,14 +87,12 @@ describe("KeyboardSetup", () => {
         });
 
         it("does nothing without the modifier", () => {
-            const processor = attach();
             document.dispatchEvent(keyEvent("keydown", utils.keyCodes.S));
             expect(actions.enterDebugger).not.toHaveBeenCalled();
             expect(processor.sysvia.keyDown).toHaveBeenCalled();
         });
 
         it("tells the page about every key on the way down", () => {
-            attach();
             document.dispatchEvent(keyEvent("keydown", utils.keyCodes.A));
             expect(actions.onAnyKeyDown).toHaveBeenCalledTimes(1);
         });
@@ -110,18 +100,10 @@ describe("KeyboardSetup", () => {
 
     describe("the keyboard's own events", () => {
         it("routes pause and resume to the loop's actions", () => {
-            attach();
             setup.keyboard.dispatchEvent(new CustomEvent("pause"));
             setup.keyboard.dispatchEvent(new CustomEvent("resume"));
             expect(actions.pause).toHaveBeenCalledTimes(1);
             expect(actions.resume).toHaveBeenCalledTimes(1);
-        });
-    });
-
-    describe("before the keyboard exists", () => {
-        it("swallows raw keys with a warning rather than throwing", () => {
-            expect(() => setup.sendRawKeyboard([1000], false)).not.toThrow();
-            expect(console.warn).toHaveBeenCalled();
         });
     });
 });


### PR DESCRIPTION
Part of #971 (item 6).

## What moved

- New `src/web/accessibility-switches.js`: `AccessibilitySwitches` owns `switchState` and the `userPort` object (active-low read, no-op write) plus a `setSwitch(index, held)` method. The hardware note about the Brilliant Computing switch box moved onto this class, where the state now lives.
- `KeyboardSetup` is single-phase. Its constructor takes `{ actions, accessibilitySwitches, processor, dbgr, keyLayout }` and does everything `attach` used to; `attach` is gone. The Alt+1-8 / Alt+F1-F8 handlers now call `accessibilitySwitches.setSwitch` instead of poking their own bits. With the keyboard created in the constructor, the keyboard-is-null guard (and its console warning) in `sendRawKeyboard` is dead and removed.
- `main.js` builds `AccessibilitySwitches` early (where `KeyboardSetup` used to be built), hands its `userPort` to `Machine`, and constructs `KeyboardSetup` right after the processor exists, in place of the old `keys.attach(...)` call. `Machine`'s own `userPort` parameter is unchanged, so it stays generic over any user port peripheral.

## Why behaviour is unchanged

- The user port object read by the UserVia is byte-for-byte the same shape and semantics; only its owner changed.
- Every shortcut, switch mapping and document listener registers exactly as before; construction of `KeyboardSetup` moved from before the machine to just after `machine.processor` exists, which is between two points at which no key events can yet have been delivered (the only other document keydown listener, RewindUI's, uses the capture phase, so relative order is irrelevant anyway).
- The removed null-keyboard guard protected a window (construction to attach) that no longer exists; no caller could reach `sendRawKeyboard` before construction, before or after.

Tests: unit suite updated to the single-phase shape (the "before the keyboard exists" case dies with the two-phase split), plus a small new `test-accessibility-switches.js`. `npm run lint`, `npm run test:unit` (1495 passing) and the browser smoke suite (all 12 checks) are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)