### PR TITLE
fix: persist the picker autoboot tick into the URL

### DIFF
--- a/src/web/archive-list.js
+++ b/src/web/archive-list.js
@@ -29,7 +29,7 @@ export class AutobootTicks {
             check.addEventListener("click", () => {
                 this.show(check.checked);
                 if (check.checked) {
-                    urlState.params.autoboot = "";
+                    urlState.params.autoboot = true;
                 } else {
                     delete urlState.params.autoboot;
                 }

--- a/tests/unit/test-archive-list.js
+++ b/tests/unit/test-archive-list.js
@@ -2,6 +2,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { AutobootTicks, clearArchiveList, filterArchiveList, showArchiveMessage } from "../../src/web/archive-list.js";
+import { UrlState } from "../../src/web/url-state.js";
 
 const Markup = `
 <div id="sth" class="modal"><span class="loading" style="display: none"></span>
@@ -61,29 +62,32 @@ describe("archive lists", () => {
         const boxes = () => [...document.querySelectorAll(".autoboot")];
 
         beforeEach(() => {
-            urlState = { params: {}, updateUrl: vi.fn() };
+            urlState = new UrlState(
+                { origin: "https://bbc.example", pathname: "/", search: "", hash: "" },
+                { pushState: vi.fn() },
+            );
             new AutobootTicks({ urlState });
         });
 
         it("mirrors a tick into every picker and the URL", () => {
             boxes()[0].click();
             expect(boxes().map((box) => box.checked)).toEqual([true, true]);
-            expect(urlState.params.autoboot).toBe("");
-            expect(urlState.updateUrl).toHaveBeenCalledTimes(1);
+            expect(urlState.url()).toBe("https://bbc.example/?autoboot");
+            expect(urlState.history.pushState).toHaveBeenCalledTimes(1);
         });
 
         it("clears the URL when unticked from the other picker", () => {
             boxes()[0].click();
             boxes()[1].click();
             expect(boxes().map((box) => box.checked)).toEqual([false, false]);
-            expect(urlState.params.autoboot).toBeUndefined();
+            expect(urlState.url()).toBe("https://bbc.example/");
         });
 
         it("can be shown a state without touching the URL", () => {
             const ticks = new AutobootTicks({ urlState });
             ticks.show(true);
             expect(boxes().every((box) => box.checked)).toBe(true);
-            expect(urlState.updateUrl).not.toHaveBeenCalled();
+            expect(urlState.history.pushState).not.toHaveBeenCalled();
         });
     });
 });


### PR DESCRIPTION
Found by Copilot reviewing #990, which had faithfully preserved this pre-existing bug. `autoboot` is typed BOOL and `buildUrlFromParams` only serialises a BOOL when the value is exactly `true`, so the picker tick's `params.autoboot = ""` never reached the URL: tick autoboot, copy or reload the URL, and the tick is gone. Same class of bug as #942.

The fix sets `true`, which round-trips (`?autoboot` parses back to `true`, and every reader only checks the parameter is defined, so in-page behaviour is unchanged). The tests now build the real URL through `UrlState` instead of asserting the raw parameter value, which is the gap that let this escape.

#990 will pick this up via a merge from main once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019CJ9csHch7kjzF3DKzR5DP