### PR TITLE
test: open a picker in the smoke test and state what it covers (#971 item 12)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,7 +15,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 - `npm run test:integration` - Run integration tests
 - `npm run test:cpu` - Run CPU compatibility tests
 - `npm run test:smoke` - Build, then boot the built page in headless Chrome and check the things unit tests cannot
-  see (construction order, element ids, Bootstrap, the console surface). Part of `npm test`, and needs Chrome like the
+  see (construction order, Bootstrap, the console surface, the ids the checks reach). Part of `npm test`, and needs Chrome like the
   shader tests; `node tests/browser/smoke.js --url http://localhost:5173/` runs it against a server that is already up
 - `npm run ci-checks` - Run linting checks for CI
 - `vitest run tests/unit/test-gzip.js` - Run a single test file

--- a/tests/browser/smoke.js
+++ b/tests/browser/smoke.js
@@ -1,5 +1,7 @@
 // Boots the built page in headless Chrome and exercises the things unit tests
-// cannot see: construction order, element ids, Bootstrap, the console surface.
+// cannot see: construction order, Bootstrap, the console surface, and the ids
+// each check below reaches (the toolbar, the settings bar, the loaders, the
+// STH picker); an id nothing here touches is not covered.
 // Talks to Chrome over the DevTools protocol with Node's own WebSocket.
 //
 //   npm run test:smoke       build, serve dist/ and run every check
@@ -373,6 +375,46 @@ check("a disc from the built-in list goes into drive 0", async (page, base) => {
     await waitUntil(
         "the URL to name the disc",
         () => page.evaluate(`location.search.includes("disc1=elite.ssd")`),
+        StepTimeoutMs,
+    );
+});
+
+check("the STH disc picker opens, shows its list and closes again", async (page, base) => {
+    await page.goto(base);
+    await page.waitForScreenText(">");
+    // Bootstrap ignores a hide until the show transition is over, which is
+    // when it fires shown.bs.modal.
+    await page.evaluate(
+        `(() => { window.smokeSthShown = false; document.getElementById("sth").addEventListener("shown.bs.modal", () => { window.smokeSthShown = true; }, { once: true }); })()`,
+    );
+    await page.click('a.sth[data-id="discs"]');
+    await waitUntil("the STH modal to finish appearing", () => page.evaluate("window.smokeSthShown"), StepTimeoutMs);
+    if (!(await page.evaluate(`!!document.querySelector("#sth-list .template")`)))
+        throw new Error("The STH modal has no list to fill");
+    // The catalogue is fetched from the archive mirror, so a run cut off from
+    // it still has to open the modal and report the failure inside it.
+    const outcome = await waitUntil(
+        "the catalogue, or word that it could not be fetched",
+        () =>
+            page.evaluate(`(() => {
+                if (document.querySelector("#sth-list li:not(.template)")) return "catalogue";
+                const loading = document.querySelector("#sth .loading");
+                if (loading.style.display !== "none" && loading.textContent.includes("error")) return "failure";
+                return null;
+            })()`),
+        BootTimeoutMs,
+    );
+    if (outcome === "failure") {
+        const kept = page.takeProblems().filter((p) => !/catalog|manifest|Failed to load resource/.test(p));
+        page.problems.push(...kept);
+    }
+    await page.click("#sth .btn-close");
+    await waitUntil(
+        "the modal to close and the emulator to resume",
+        () =>
+            page.evaluate(
+                `!document.getElementById("sth").classList.contains("show") && !document.getElementById("debug-pause").disabled`,
+            ),
         StepTimeoutMs,
     );
 });


### PR DESCRIPTION
Item 12 of #971: the smoke test's header claimed it exercised "element ids" generally, but no check opened a picker, the tape menu, the drive-tracks switches, the downloads, rewind or fullscreen; an id rename there stayed green.

**New check**: opens the STH archive picker from the Discs menu (the `a.sth[data-id="discs"]` item, modal `#sth`), waits for `shown.bs.modal` (Bootstrap ignores a hide while the show transition runs, and the file's opacity heuristic left a window where the close click was swallowed), verifies the `#sth-list` container and its template row, then waits for either catalogue rows or the picker's own "error accessing the STH archive" message, so a run cut off from the mirror still proves the modal opens and reports the failure (on that path the fetch's console noise is dropped, nothing else). It closes via the modal's close button and waits for the modal to leave and the emulator to resume, so later checks are unaffected. Verified both ways: against the live mirror, and with `bbc.xania.org` mapped to an unreachable address.

**Header comment**: now says the suite covers construction order, Bootstrap, the console surface, and the ids each check reaches (the toolbar, the settings bar, the loaders, the STH picker), and that an id nothing touches is not covered. CLAUDE.md's one-line mirror of that claim is updated to match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
