### PR TITLE
test: shared unit-test helpers (#971 item 10)

### DIFF
--- a/tests/unit/helpers.js
+++ b/tests/unit/helpers.js
@@ -1,0 +1,56 @@
+import { vi } from "vitest";
+
+import { UrlState } from "../../src/web/url-state.js";
+
+/** The dependency bag the archive pickers take, every callback a mock. */
+export function makeWebDeps() {
+    return {
+        media: {
+            addSource: vi.fn(),
+            setDisc1Image: vi.fn(),
+            setTapeImage: vi.fn(),
+            loadDiscImage: vi.fn(),
+            loadTapeImage: vi.fn(),
+            setProcessorTape: vi.fn(),
+        },
+        drives: { layoutForDrive: () => "auto", putDiscIn: vi.fn() },
+        modals: { popupLoading: vi.fn(), loadingFinished: vi.fn() },
+        urlState: { params: {}, updateUrl: vi.fn() },
+        processor: { reset: vi.fn() },
+        autoboot: vi.fn(),
+    };
+}
+
+/** A real UrlState on a fake origin, with history that goes nowhere. */
+export const fakeUrlState = (search = "") =>
+    new UrlState({ origin: "https://bbc.example", pathname: "/", search, hash: "" }, { pushState: vi.fn() });
+
+export const modalMarkup = (id, body) =>
+    `<div id="${id}" class="modal"><div class="modal-dialog"><div class="modal-content"><div class="modal-body">${body}</div></div></div></div>`;
+
+export const toasts = () =>
+    [...document.querySelectorAll(".toast")].map((el) => el.textContent.replace(/\s+/g, " ").trim());
+
+/** A catalogued single-density image, the smallest thing discFor accepts. */
+export function ssdImage(sectors = 800) {
+    const data = new Uint8Array(80 * 10 * 256);
+    data[0x106] = (sectors >>> 8) & 3;
+    data[0x107] = sectors & 0xff;
+    return data;
+}
+
+/**
+ * For afterEach. Fake timers left running would outlive the file's jsdom
+ * window and fail the run from outside any test when they fire, so they are
+ * flushed before the clock goes back to real.
+ */
+export function teardownDom() {
+    if (vi.isFakeTimers()) {
+        vi.runAllTimers();
+        vi.useRealTimers();
+    }
+    vi.restoreAllMocks();
+    document.body.innerHTML = "";
+    window.localStorage.clear();
+    window.sessionStorage.clear();
+}

--- a/tests/unit/test-analogue-inputs.js
+++ b/tests/unit/test-analogue-inputs.js
@@ -2,7 +2,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { AnalogueInputs } from "../../src/web/analogue-inputs.js";
-import { UrlState } from "../../src/web/url-state.js";
+import { fakeUrlState, teardownDom } from "./helpers.js";
 
 const Markup = `<div id="cub-monitor"><canvas id="screen"></canvas></div><span id="micPermissionStatus"></span>`;
 
@@ -22,24 +22,14 @@ describe("AnalogueInputs", () => {
             },
             screenCanvas: document.getElementById("screen"),
             getGamepads: () => [],
-            urlState: new UrlState(
-                { origin: "https://bbc.example", pathname: "/", search: "", hash: "" },
-                {
-                    pushState: () => {},
-                },
-            ),
+            urlState: fakeUrlState(),
             config: { setMicrophoneChannel: vi.fn() },
             audioHandler: { tryResume: vi.fn() },
         };
         vi.spyOn(deps.urlState, "updateUrl");
     });
 
-    afterEach(() => {
-        vi.runAllTimers();
-        vi.useRealTimers();
-        vi.restoreAllMocks();
-        document.body.innerHTML = "";
-    });
+    afterEach(teardownDom);
 
     const make = () => new AnalogueInputs(deps);
 

--- a/tests/unit/test-archive-list.js
+++ b/tests/unit/test-archive-list.js
@@ -1,8 +1,8 @@
 // @vitest-environment jsdom
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import { AutobootTicks, clearArchiveList, filterArchiveList, showArchiveMessage } from "../../src/web/archive-list.js";
-import { UrlState } from "../../src/web/url-state.js";
+import { fakeUrlState, teardownDom } from "./helpers.js";
 
 const Markup = `
 <div id="sth" class="modal"><span class="loading" style="display: none"></span>
@@ -26,9 +26,7 @@ describe("archive lists", () => {
         document.body.innerHTML = Markup;
     });
 
-    afterEach(() => {
-        document.body.innerHTML = "";
-    });
+    afterEach(teardownDom);
 
     it("clears every row but the template", () => {
         addRow("sth-list", "Elite");
@@ -62,10 +60,7 @@ describe("archive lists", () => {
         const boxes = () => [...document.querySelectorAll(".autoboot")];
 
         beforeEach(() => {
-            urlState = new UrlState(
-                { origin: "https://bbc.example", pathname: "/", search: "", hash: "" },
-                { pushState: vi.fn() },
-            );
+            urlState = fakeUrlState();
             new AutobootTicks({ urlState });
         });
 

--- a/tests/unit/test-display.js
+++ b/tests/unit/test-display.js
@@ -2,6 +2,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { Display } from "../../src/web/display.js";
+import { teardownDom } from "./helpers.js";
 
 const FbWidth = 1024;
 
@@ -15,11 +16,7 @@ describe("Display", () => {
         vi.spyOn(window, "requestAnimationFrame").mockImplementation((callback) => rafCallbacks.push(callback));
     });
 
-    afterEach(() => {
-        vi.restoreAllMocks();
-        document.body.innerHTML = "";
-        window.localStorage.clear();
-    });
+    afterEach(teardownDom);
 
     const make = (options = {}) => {
         const screenCanvas = document.getElementById("screen");

--- a/tests/unit/test-drives.js
+++ b/tests/unit/test-drives.js
@@ -4,6 +4,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { Drives } from "../../src/web/drives.js";
 import { DiscLayout } from "../../src/disc.js";
 import { DriveTracks } from "../../src/url-params.js";
+import { teardownDom, toasts } from "./helpers.js";
 
 const Markup = `
 <div class="drive-tracks" data-drive="0"><button data-tracks="40">40</button><button data-tracks="80">80</button></div>
@@ -43,16 +44,9 @@ describe("Drives", () => {
         confirm = vi.fn().mockResolvedValue(false);
     });
 
-    afterEach(() => {
-        vi.runAllTimers();
-        vi.useRealTimers();
-        document.body.innerHTML = "";
-        window.localStorage.clear();
-    });
+    afterEach(teardownDom);
 
     const make = (driveTracks = [DriveTracks.auto, DriveTracks.auto]) => new Drives({ fdc, driveTracks, confirm });
-    const toasts = () =>
-        [...document.querySelectorAll(".toast")].map((el) => el.textContent.replace(/\s+/g, " ").trim());
     const activeTracks = (driveIndex) =>
         [...document.querySelectorAll(`.drive-tracks[data-drive="${driveIndex}"] .active`)].map(
             (b) => b.dataset.tracks,

--- a/tests/unit/test-front-panel.js
+++ b/tests/unit/test-front-panel.js
@@ -2,6 +2,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { FrontPanel } from "../../src/web/front-panel.js";
+import { teardownDom } from "./helpers.js";
 
 const Markup = `
 <div id="tape-menu"><a data-id="rewind">Rewind</a><a data-id="archive">Archive</a></div>
@@ -25,11 +26,7 @@ describe("FrontPanel", () => {
         };
     });
 
-    afterEach(() => {
-        vi.restoreAllMocks();
-        document.body.innerHTML = "";
-        window.localStorage.clear();
-    });
+    afterEach(teardownDom);
 
     const make = (isAtom = false, printer = { text: "" }) => new FrontPanel({ processor, model: { isAtom }, printer });
     const lit = (id) => document.getElementById(id).classList.contains("on");

--- a/tests/unit/test-google-drive-picker.js
+++ b/tests/unit/test-google-drive-picker.js
@@ -2,15 +2,19 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { GoogleDrivePicker } from "../../src/web/google-drive-picker.js";
+import { modalMarkup, teardownDom, toasts } from "./helpers.js";
 
-const Markup = `
+const Markup =
+    `
 <a id="open-drive-link"></a>
-<div id="google-drive-auth" style="display: none"><form></form></div>
-<div id="google-drive" class="modal"><div class="modal-dialog"><div class="modal-content"><div class="modal-body">
+<div id="google-drive-auth" style="display: none"><form></form></div>` +
+    modalMarkup(
+        "google-drive",
+        `
   <span class="loading"></span>
   <ul class="list"><li class="template"><span class="name"></span></li></ul>
-  <form><input class="disc-name" value="" /><input type="checkbox" class="create-from-existing" /></form>
-</div></div></div></div>`;
+  <form><input class="disc-name" value="" /><input type="checkbox" class="create-from-existing" /></form>`,
+    );
 
 describe("GoogleDrivePicker", () => {
     let deps;
@@ -36,15 +40,9 @@ describe("GoogleDrivePicker", () => {
         vi.spyOn(console, "error").mockImplementation(() => {});
     });
 
-    afterEach(() => {
-        vi.restoreAllMocks();
-        document.body.innerHTML = "";
-        window.localStorage.clear();
-    });
+    afterEach(teardownDom);
 
     const make = () => new GoogleDrivePicker(deps);
-    const toasts = () =>
-        [...document.querySelectorAll(".toast")].map((el) => el.textContent.replace(/\s+/g, " ").trim());
 
     describe("load", () => {
         it("loads a file once signed in, through the loading dialog", async () => {

--- a/tests/unit/test-google-drive.js
+++ b/tests/unit/test-google-drive.js
@@ -2,14 +2,12 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { GoogleDriveLoader } from "../../src/google-drive.js";
+import { teardownDom } from "./helpers.js";
 
 describe("GoogleDriveLoader", () => {
     beforeEach(() => vi.spyOn(console, "log").mockImplementation(() => {}));
 
-    afterEach(() => {
-        vi.restoreAllMocks();
-        document.body.innerHTML = "";
-    });
+    afterEach(teardownDom);
 
     it("gives up when the Google script cannot be fetched", async () => {
         const loader = new GoogleDriveLoader();

--- a/tests/unit/test-hfe-picker.js
+++ b/tests/unit/test-hfe-picker.js
@@ -3,16 +3,18 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { HfePicker } from "../../src/web/hfe-picker.js";
 import { Provenance } from "../../src/bbcdiscs.js";
+import { makeWebDeps, modalMarkup, teardownDom } from "./helpers.js";
 
-const Markup = `
-<div id="hfe" class="modal"><div class="modal-dialog"><div class="modal-content"><div class="modal-body">
+const Markup = modalMarkup(
+    "hfe",
+    `
   <span class="loading"></span>
   <input id="hfe-filter" value="" />
   <div id="hfe-provenance"></div>
   <ul id="hfe-list"><li class="template"><a href="#">
     <span class="name"></span><span class="publisher"></span><span class="detail"></span><span class="provenance"></span>
-  </a></li></ul>
-</div></div></div></div>`;
+  </a></li></ul>`,
+);
 
 const entry = (path, title, provenance = Provenance.Captured, extra = {}) => ({
     path,
@@ -30,23 +32,10 @@ describe("HfePicker", () => {
     beforeEach(() => {
         vi.useFakeTimers();
         document.body.innerHTML = Markup;
-        deps = {
-            media: { addSource: vi.fn(), setDisc1Image: vi.fn(), loadDiscImage: vi.fn() },
-            drives: { layoutForDrive: () => "auto", putDiscIn: vi.fn() },
-            modals: { popupLoading: vi.fn(), loadingFinished: vi.fn() },
-            urlState: { params: {}, updateUrl: vi.fn() },
-            processor: { reset: vi.fn() },
-            autoboot: vi.fn(),
-        };
+        deps = makeWebDeps();
     });
 
-    afterEach(() => {
-        vi.runAllTimers();
-        vi.useRealTimers();
-        vi.restoreAllMocks();
-        document.body.innerHTML = "";
-        window.localStorage.clear();
-    });
+    afterEach(teardownDom);
 
     const make = () => new HfePicker(deps);
     const rows = () => [...document.querySelectorAll("#hfe-list li:not(.template)")];

--- a/tests/unit/test-keyboard-setup.js
+++ b/tests/unit/test-keyboard-setup.js
@@ -4,6 +4,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { AccessibilitySwitches } from "../../src/web/accessibility-switches.js";
 import { KeyboardSetup } from "../../src/web/keyboard-setup.js";
 import * as utils from "../../src/utils.js";
+import { teardownDom } from "./helpers.js";
 
 const keyEvent = (type, which, { alt = false, ctrl = false } = {}) => {
     const event = new KeyboardEvent(type, { altKey: alt, ctrlKey: ctrl, cancelable: true });
@@ -54,10 +55,7 @@ describe("KeyboardSetup", () => {
         setup.setRunning(true);
     });
 
-    afterEach(() => {
-        vi.restoreAllMocks();
-        document.body.innerHTML = "";
-    });
+    afterEach(teardownDom);
 
     describe("the accessibility switches", () => {
         it("clears a bit while its switch is held, keys and function keys alike", () => {

--- a/tests/unit/test-media-loader.js
+++ b/tests/unit/test-media-loader.js
@@ -2,10 +2,10 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { BuiltInImages, MediaLoader, splitImage } from "../../src/web/media-loader.js";
-import { UrlState } from "../../src/web/url-state.js";
 import { DiscLayout } from "../../src/disc.js";
 import { discFor } from "../../src/fdc.js";
 import { toHfe } from "../../src/disc-hfe.js";
+import { fakeUrlState, ssdImage, teardownDom, toasts } from "./helpers.js";
 
 const Markup = `
 <input type="file" id="disc_load" />
@@ -13,14 +13,6 @@ const Markup = `
 <input type="file" id="tape_load" />
 <form><textarea id="paste-text"></textarea></form>
 <ul id="disc-list"><li class="template"><span class="name"></span><span class="description"></span></li></ul>`;
-
-/** A catalogued single-density image, the smallest thing discFor accepts. */
-function ssdImage(sectors = 800) {
-    const data = new Uint8Array(80 * 10 * 256);
-    data[0x106] = (sectors >>> 8) & 3;
-    data[0x107] = sectors & 0xff;
-    return data;
-}
 
 const fileFor = (name, bytes) => new File([bytes], name);
 
@@ -48,12 +40,7 @@ describe("MediaLoader", () => {
             },
             model: { isAtom: false },
             drives: { layoutForDrive: () => DiscLayout.auto, putDiscIn: vi.fn() },
-            urlState: new UrlState(
-                { origin: "https://bbc.example", pathname: "/", search: "", hash: "" },
-                {
-                    pushState: () => {},
-                },
-            ),
+            urlState: fakeUrlState(),
             modals: { hide: vi.fn() },
             isSnapshotFile: (name) => name.endsWith(".snp"),
             loadSnapshot: vi.fn(),
@@ -62,19 +49,13 @@ describe("MediaLoader", () => {
         sources = { sth: vi.fn(), tapeSth: vi.fn(), hfe: vi.fn(), drive: vi.fn() };
     });
 
-    afterEach(() => {
-        vi.restoreAllMocks();
-        document.body.innerHTML = "";
-        window.localStorage.clear();
-    });
+    afterEach(teardownDom);
 
     const make = () => {
         const media = new MediaLoader(deps);
         for (const [schema, fetcher] of Object.entries(sources)) media.addSource(schema, fetcher);
         return media;
     };
-    const toasts = () =>
-        [...document.querySelectorAll(".toast")].map((el) => el.textContent.replace(/\s+/g, " ").trim());
 
     describe("splitImage", () => {
         it.each([

--- a/tests/unit/test-modals.js
+++ b/tests/unit/test-modals.js
@@ -2,19 +2,17 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { Modals } from "../../src/web/modals.js";
-
-const modal = (id, body) =>
-    `<div id="${id}" class="modal"><div class="modal-dialog"><div class="modal-content"><div class="modal-body">${body}</div></div></div></div>`;
+import { modalMarkup, teardownDom } from "./helpers.js";
 
 const Markup = [
-    modal("error-dialog", '<span class="context"></span><span class="error"></span>'),
-    modal("loading-dialog", '<span class="loading"></span><div id="google-drive-auth"></div>'),
-    modal(
+    modalMarkup("error-dialog", '<span class="context"></span><span class="error"></span>'),
+    modalMarkup("loading-dialog", '<span class="loading"></span><div id="google-drive-auth"></div>'),
+    modalMarkup(
         "are-you-sure",
         '<span class="context"></span><button class="ays-yes"></button><button class="ays-no"></button>',
     ),
-    modal("info", ""),
-    modal("discs", ""),
+    modalMarkup("info", ""),
+    modalMarkup("discs", ""),
 ].join("");
 
 describe("Modals", () => {
@@ -40,12 +38,7 @@ describe("Modals", () => {
         });
     });
 
-    afterEach(() => {
-        vi.runAllTimers();
-        vi.useRealTimers();
-        document.body.innerHTML = "";
-        window.localStorage.clear();
-    });
+    afterEach(teardownDom);
 
     // What Bootstrap does around a modal: the events bubble up to the
     // document, and the element carries "show" while it is up.

--- a/tests/unit/test-quick-settings.js
+++ b/tests/unit/test-quick-settings.js
@@ -2,6 +2,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { QuickSettings } from "../../src/web/quick-settings.js";
+import { teardownDom } from "./helpers.js";
 
 const Markup = `
 <div id="audio-output">
@@ -20,9 +21,7 @@ describe("QuickSettings", () => {
         callbacks = { onAudioOutput: vi.fn(), onSpeakerAmount: vi.fn(), onDisplayMode: vi.fn() };
     });
 
-    afterEach(() => {
-        document.body.innerHTML = "";
-    });
+    afterEach(teardownDom);
 
     const make = (initial = { audioOutput: "speaker", speakerAmount: 1, displayMode: "rgb" }) =>
         new QuickSettings(callbacks, initial);

--- a/tests/unit/test-reporting.js
+++ b/tests/unit/test-reporting.js
@@ -11,6 +11,7 @@ import {
     showNotice,
     unzipAndReport,
 } from "../../src/web/reporting.js";
+import { teardownDom, toasts } from "./helpers.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const readZip = (name) => new Uint8Array(fs.readFileSync(join(__dirname, "zip", name)));
@@ -21,16 +22,7 @@ describe("reporting", () => {
         vi.spyOn(console, "error").mockImplementation(() => {});
     });
 
-    afterEach(() => {
-        vi.runAllTimers();
-        vi.useRealTimers();
-        vi.restoreAllMocks();
-        document.body.innerHTML = "";
-        window.localStorage.clear();
-    });
-
-    const toasts = () =>
-        [...document.querySelectorAll(".toast")].map((el) => el.textContent.replace(/\s+/g, " ").trim());
+    afterEach(teardownDom);
 
     describe("errorText", () => {
         it("uses an error's message", () => {

--- a/tests/unit/test-settings.js
+++ b/tests/unit/test-settings.js
@@ -2,8 +2,8 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { Settings } from "../../src/web/settings.js";
-import { UrlState } from "../../src/web/url-state.js";
 import { DefaultModel, findModel } from "../../src/models.js";
+import { fakeUrlState, teardownDom } from "./helpers.js";
 
 /** Stands in for the Config dialog: remembers what it was told and hands back the callbacks. */
 function fakeConfig(onChange, onClose, onRestartRequired) {
@@ -32,12 +32,7 @@ describe("Settings", () => {
 
     beforeEach(() => {
         vi.useFakeTimers();
-        urlState = new UrlState(
-            { origin: "https://bbc.example", pathname: "/", search: "", hash: "" },
-            {
-                pushState: () => {},
-            },
-        );
+        urlState = fakeUrlState();
         vi.spyOn(urlState, "updateUrl");
         targets = {
             audioHandler: { setAudioOutput: vi.fn(), setSpeakerAmount: vi.fn() },
@@ -51,13 +46,7 @@ describe("Settings", () => {
         };
     });
 
-    afterEach(() => {
-        vi.runAllTimers();
-        vi.useRealTimers();
-        vi.restoreAllMocks();
-        document.body.innerHTML = "";
-        window.localStorage.clear();
-    });
+    afterEach(teardownDom);
 
     const make = () => {
         const settings = new Settings({ urlState, makeConfig: (...handlers) => fakeConfig(...handlers) });

--- a/tests/unit/test-snapshot-ui.js
+++ b/tests/unit/test-snapshot-ui.js
@@ -3,16 +3,9 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { SnapshotUI, isSnapshotFile, snapshotMedia } from "../../src/web/snapshot-ui.js";
 import { DiscLayout } from "../../src/disc.js";
+import { ssdImage, teardownDom, toasts } from "./helpers.js";
 
 const Markup = `<a id="save-state"></a><input type="file" id="load-state" />`;
-
-/** A catalogued single-density image, the smallest thing discFor accepts. */
-function ssdImage(sectors = 800) {
-    const data = new Uint8Array(80 * 10 * 256);
-    data[0x106] = (sectors >>> 8) & 3;
-    data[0x107] = sectors & 0xff;
-    return data;
-}
 
 describe("snapshot media manifest", () => {
     const urlDisc = { originalImageCrc32: 0x1234, is40Track: false, originalImageData: null };
@@ -86,16 +79,9 @@ describe("SnapshotUI", () => {
         };
     });
 
-    afterEach(() => {
-        vi.restoreAllMocks();
-        document.body.innerHTML = "";
-        window.localStorage.clear();
-        window.sessionStorage.clear();
-    });
+    afterEach(teardownDom);
 
     const make = () => new SnapshotUI(deps);
-    const toasts = () =>
-        [...document.querySelectorAll(".toast")].map((el) => el.textContent.replace(/\s+/g, " ").trim());
 
     describe("loading a state", () => {
         it("stops the emulator, reports a file it cannot read, and runs on", async () => {

--- a/tests/unit/test-sth-picker.js
+++ b/tests/unit/test-sth-picker.js
@@ -2,13 +2,15 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { SthPicker } from "../../src/web/sth-picker.js";
+import { makeWebDeps, modalMarkup, teardownDom } from "./helpers.js";
 
-const Markup = `
-<div id="sth" class="modal"><div class="modal-dialog"><div class="modal-content"><div class="modal-body">
+const Markup = modalMarkup(
+    "sth",
+    `
   <span class="loading"></span>
   <input id="sth-filter" value="" />
-  <ul id="sth-list"><li class="template"><span class="name"></span></li></ul>
-</div></div></div></div>`;
+  <ul id="sth-list"><li class="template"><span class="name"></span></li></ul>`,
+);
 
 describe("SthPicker", () => {
     let deps;
@@ -16,30 +18,10 @@ describe("SthPicker", () => {
     beforeEach(() => {
         vi.useFakeTimers();
         document.body.innerHTML = Markup;
-        deps = {
-            media: {
-                addSource: vi.fn(),
-                setDisc1Image: vi.fn(),
-                setTapeImage: vi.fn(),
-                loadDiscImage: vi.fn(),
-                loadTapeImage: vi.fn(),
-                setProcessorTape: vi.fn(),
-            },
-            drives: { layoutForDrive: () => "auto", putDiscIn: vi.fn() },
-            modals: { popupLoading: vi.fn(), loadingFinished: vi.fn() },
-            urlState: { params: {}, updateUrl: vi.fn() },
-            processor: { reset: vi.fn() },
-            autoboot: vi.fn(),
-        };
+        deps = makeWebDeps();
     });
 
-    afterEach(() => {
-        vi.runAllTimers();
-        vi.useRealTimers();
-        vi.restoreAllMocks();
-        document.body.innerHTML = "";
-        window.localStorage.clear();
-    });
+    afterEach(teardownDom);
 
     const make = () => new SthPicker(deps);
     const rows = () => [...document.querySelectorAll("#sth-list li:not(.template)")];

--- a/tests/unit/test-toast.js
+++ b/tests/unit/test-toast.js
@@ -4,20 +4,14 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import * as bootstrap from "bootstrap";
 
 import { toast } from "../../src/web/toast.js";
+import { teardownDom } from "./helpers.js";
 
 describe("toast", () => {
     beforeEach(() => {
         vi.useFakeTimers();
     });
 
-    // A toast's timers left on the real clock outlive this file's jsdom
-    // window, and fail the run from outside any test when they fire.
-    afterEach(() => {
-        vi.runAllTimers();
-        vi.useRealTimers();
-        document.body.innerHTML = "";
-        window.localStorage.clear();
-    });
+    afterEach(teardownDom);
 
     const toasts = () => [...document.querySelectorAll(".toast")];
 

--- a/tests/unit/test-web-machine.js
+++ b/tests/unit/test-web-machine.js
@@ -2,6 +2,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { Machine, buildEmulationConfig } from "../../src/web/machine.js";
+import { teardownDom, toasts } from "./helpers.js";
 
 const config = (overrides = {}) => ({
     tubeCpuMultiplier: 1,
@@ -75,15 +76,9 @@ describe("Machine", () => {
         };
     });
 
-    afterEach(() => {
-        vi.restoreAllMocks();
-        document.body.innerHTML = "";
-        window.localStorage.clear();
-    });
+    afterEach(teardownDom);
 
     const make = () => new Machine(deps);
-    const toasts = () =>
-        [...document.querySelectorAll(".toast")].map((el) => el.textContent.replace(/\s+/g, " ").trim());
 
     it("builds the processor with everything bolted on and attaches the printer", () => {
         const machine = make();

--- a/vite.config.js
+++ b/vite.config.js
@@ -15,7 +15,7 @@ export default defineConfig({
     test: {
         include: [
             ...configDefaults.include,
-            "tests/unit/**/*.js",
+            "tests/unit/**/test-*.js",
             "tests/integration/**/*.js",
             "tests/shader/test-*.js",
         ],


### PR DESCRIPTION
Item 10 of #971: pull the unit tests' repeated fixtures into `tests/unit/helpers.js`.

What moved there:

- `makeWebDeps()`: the mock dependency bag the STH and HFE picker tests each built by hand (the HFE one used a subset; both now take the superset).
- `toasts()`: the whitespace-normalising toast reader, previously copied into six files.
- `ssdImage()`: the smallest catalogued single-density image `discFor` accepts, previously in the media-loader and snapshot-ui tests.
- `modalMarkup(id, body)`: the Bootstrap modal wrapper, previously a builder in test-modals and inlined in the three picker tests.
- `fakeUrlState(search)`: a real `UrlState` on `https://bbc.example` with a `vi.fn()` history, previously built inline in four files.
- `teardownDom()`: the standard afterEach ritual (flush and drop fake timers when active, restore mocks, clear the DOM and both storages). Files whose ritual was a subset adopted it too.

Judgement calls:

- The vitest include glob narrows from `tests/unit/**/*.js` to `tests/unit/**/test-*.js` so helpers.js is not collected as an empty test file.
- test-toast keeps its own `toasts()`: it asserts on the elements, not their text.
- test-url-state keeps building `UrlState` by hand: it is the unit under test there, with its own pathname and an asserted history.
- test-emulation-loop keeps its own teardown (it deliberately clears rather than runs pending timers) and test-audio-handler keeps its `unstubAllGlobals` variant.

A pure test refactor: no production code changes, no assertion touched, no test added or removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
