### PR TITLE
test: cover what the main.js split left untested (#971 item 11)

### DIFF
--- a/tests/unit/helpers.js
+++ b/tests/unit/helpers.js
@@ -1,6 +1,22 @@
+import { readFileSync } from "node:fs";
 import { vi } from "vitest";
 
 import { UrlState } from "../../src/web/url-state.js";
+
+let indexHtmlDoc = null;
+
+/**
+ * Builds the test DOM from the named elements of the real index.html, so a
+ * rename or restructure there fails the unit tests instead of only the page.
+ */
+export function domFromIndexHtml(...ids) {
+    if (!indexHtmlDoc) indexHtmlDoc = new DOMParser().parseFromString(readFileSync("index.html", "utf8"), "text/html");
+    for (const id of ids) {
+        const el = indexHtmlDoc.getElementById(id);
+        if (!el) throw new Error(`index.html has no #${id}`);
+        document.body.appendChild(document.importNode(el, true));
+    }
+}
 
 /** The dependency bag the archive pickers take, every callback a mock. */
 export function makeWebDeps() {

--- a/tests/unit/helpers.js
+++ b/tests/unit/helpers.js
@@ -1,5 +1,6 @@
 import { readFileSync } from "node:fs";
-import { vi } from "vitest";
+import { dirname, resolve } from "node:path";
+import { expect, vi } from "vitest";
 
 import { UrlState } from "../../src/web/url-state.js";
 
@@ -10,7 +11,10 @@ let indexHtmlDoc = null;
  * rename or restructure there fails the unit tests instead of only the page.
  */
 export function domFromIndexHtml(...ids) {
-    if (!indexHtmlDoc) indexHtmlDoc = new DOMParser().parseFromString(readFileSync("index.html", "utf8"), "text/html");
+    if (!indexHtmlDoc) {
+        const indexHtml = resolve(dirname(expect.getState().testPath), "../../index.html");
+        indexHtmlDoc = new DOMParser().parseFromString(readFileSync(indexHtml, "utf8"), "text/html");
+    }
     for (const id of ids) {
         const el = indexHtmlDoc.getElementById(id);
         if (!el) throw new Error(`index.html has no #${id}`);

--- a/tests/unit/test-disc-visualiser.js
+++ b/tests/unit/test-disc-visualiser.js
@@ -1,0 +1,195 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { DiscVisualiser } from "../../src/web/disc-visualiser.js";
+import { DiscGeometry } from "../../src/disc-surface.js";
+import { IbmDiscFormat } from "../../src/disc.js";
+import { discFor } from "../../src/fdc.js";
+import { ssdImage, teardownDom } from "./helpers.js";
+
+const Markup = `
+<a href="#" id="disc-visualiser-open"></a>
+<div id="disc-panel" hidden>
+  <div class="disc-header"><span class="disc-title">Disc surface</span><span id="disc-name"></span>
+    <button id="disc-close"></button></div>
+  <div class="disc-controls">
+    <button data-drive="0"></button><button data-drive="1"></button>
+    <div id="disc-side-controls" hidden><button data-side="0"></button><button data-side="1"></button></div>
+    <button data-view="density"></button><button data-view="format"></button>
+  </div>
+  <canvas id="disc-surface"></canvas>
+  <canvas id="disc-overlay"></canvas>
+  <div id="disc-legend"></div>
+  <div id="disc-status"></div>
+  <div id="disc-hover-where"></div>
+  <div id="disc-hover-what"></div>
+</div>`;
+
+const CanvasSize = 100;
+
+const overlayContext = () => ({
+    clearRect: vi.fn(),
+    beginPath: vi.fn(),
+    arc: vi.fn(),
+    moveTo: vi.fn(),
+    lineTo: vi.fn(),
+    stroke: vi.fn(),
+    fill: vi.fn(),
+});
+
+describe("DiscVisualiser", () => {
+    let fdc;
+    let rafCallbacks;
+
+    beforeEach(() => {
+        document.body.innerHTML = Markup;
+        const surface = document.getElementById("disc-surface");
+        const overlay = document.getElementById("disc-overlay");
+        Object.defineProperty(surface, "clientWidth", { value: CanvasSize });
+        surface.getContext = () => ({
+            createImageData: (width, height) => ({ data: new Uint8Array(width * height * 4) }),
+            putImageData: vi.fn(),
+        });
+        overlay.getContext = overlayContext;
+        overlay.getBoundingClientRect = () => ({ left: 0, top: 0, width: CanvasSize, height: CanvasSize });
+        document.querySelector(".disc-header").setPointerCapture = () => {};
+
+        rafCallbacks = new Map();
+        let nextHandle = 1;
+        vi.spyOn(window, "requestAnimationFrame").mockImplementation((callback) => {
+            rafCallbacks.set(nextHandle, callback);
+            return nextHandle++;
+        });
+        vi.spyOn(window, "cancelAnimationFrame").mockImplementation((handle) => rafCallbacks.delete(handle));
+
+        fdc = {
+            drives: [
+                { disc: null, track: 0, positionFraction: 0, spinning: false, isSideUpper: false },
+                { disc: null, track: 0, positionFraction: 0, spinning: false, isSideUpper: false },
+            ],
+        };
+    });
+
+    afterEach(teardownDom);
+
+    const make = () => new DiscVisualiser({ fdc });
+    const panel = () => document.getElementById("disc-panel");
+    const status = () => document.getElementById("disc-status").textContent;
+    const pumpFrame = () => {
+        const callbacks = [...rafCallbacks.values()];
+        rafCallbacks.clear();
+        for (const callback of callbacks) callback();
+    };
+    const pumpUntilScanned = () => {
+        for (let i = 0; i < 500 && status().includes("reading surface"); ++i) pumpFrame();
+    };
+
+    describe("the panel", () => {
+        it("opens from the menu item and closes from its button", () => {
+            make();
+            document.getElementById("disc-visualiser-open").click();
+            expect(panel().hidden).toBe(false);
+            expect(status()).toBe("Drive 0: no disc");
+            document.getElementById("disc-close").click();
+            expect(panel().hidden).toBe(true);
+        });
+
+        it("toggles from the same menu item", () => {
+            make();
+            document.getElementById("disc-visualiser-open").click();
+            document.getElementById("disc-visualiser-open").click();
+            expect(panel().hidden).toBe(true);
+        });
+
+        it("stops animating once closed", () => {
+            make();
+            document.getElementById("disc-visualiser-open").click();
+            pumpFrame();
+            document.getElementById("disc-close").click();
+            expect(rafCallbacks.size).toBe(0);
+        });
+
+        it("can be dragged around by its header, clamped to the window", () => {
+            make();
+            const header = document.querySelector(".disc-header");
+            header.dispatchEvent(new MouseEvent("pointerdown", { button: 0, clientX: 10, clientY: 10 }));
+            header.dispatchEvent(new MouseEvent("pointermove", { clientX: 30, clientY: 25 }));
+            expect(panel().style.left).toBe("20px");
+            expect(panel().style.top).toBe("15px");
+            expect(panel().style.right).toBe("auto");
+            header.dispatchEvent(new MouseEvent("pointermove", { clientX: 2, clientY: 2 }));
+            expect(panel().style.left).toBe("0px");
+            expect(panel().style.top).toBe("0px");
+        });
+    });
+
+    describe("the views", () => {
+        it("starts on the pulse density legend and swaps for the format one", () => {
+            make();
+            const legend = document.getElementById("disc-legend");
+            expect(legend.textContent).toContain("pulses per 64");
+            document.querySelector("[data-view='format']").click();
+            expect(legend.textContent).toContain("CRC error");
+        });
+
+        it("marks the drive, side and view in use once open", () => {
+            make();
+            document.getElementById("disc-visualiser-open").click();
+            const active = [...panel().querySelectorAll(".active")];
+            expect(active.map((button) => button.dataset)).toEqual([
+                expect.objectContaining({ drive: "0" }),
+                expect.objectContaining({ side: "0" }),
+                expect.objectContaining({ view: "density" }),
+            ]);
+            document.querySelector("[data-drive='1']").click();
+            expect(panel().querySelector("[data-drive='1']").classList.contains("active")).toBe(true);
+            expect(status()).toBe("Drive 1: no disc");
+        });
+    });
+
+    describe("with a disc in the drive", () => {
+        beforeEach(() => {
+            vi.spyOn(console, "log").mockImplementation(() => {});
+            fdc.drives[0].disc = discFor(null, "elite.ssd", ssdImage());
+            fdc.drives[0].spinning = true;
+        });
+
+        it("scans the surface, then names the disc and reports the head", () => {
+            make();
+            document.getElementById("disc-visualiser-open").click();
+            pumpUntilScanned();
+            expect(status()).toBe("spinning · head track 0 · 0.0 ms");
+            expect(document.getElementById("disc-name").textContent).toBe("elite.ssd");
+            expect(document.getElementById("disc-side-controls").hidden).toBe(true);
+        });
+
+        it("reads the surface under the pointer", () => {
+            make();
+            document.getElementById("disc-visualiser-open").click();
+            pumpUntilScanned();
+            const geometry = new DiscGeometry(CanvasSize, IbmDiscFormat.tracksPerDisc);
+            const { x, y } = geometry.pointAt(0, 0.25);
+            const overlay = document.getElementById("disc-overlay");
+            overlay.dispatchEvent(new MouseEvent("mousemove", { clientX: x, clientY: y }));
+            pumpFrame();
+            expect(document.getElementById("disc-hover-where").textContent).toMatch(/^Track 0 · word \d+/);
+            expect(document.getElementById("disc-hover-what").textContent).toMatch(/pulses|no flux/);
+            overlay.dispatchEvent(new MouseEvent("mouseleave"));
+            pumpFrame();
+            expect(document.getElementById("disc-hover-where").textContent).toBe("Point at the surface to read it");
+        });
+
+        it("zooms with the wheel and says so, and a double click resets", () => {
+            make();
+            document.getElementById("disc-visualiser-open").click();
+            pumpUntilScanned();
+            const overlay = document.getElementById("disc-overlay");
+            overlay.dispatchEvent(new WheelEvent("wheel", { deltaY: -100, clientX: 50, clientY: 50 }));
+            pumpFrame();
+            expect(status()).toContain("1.3x");
+            overlay.dispatchEvent(new MouseEvent("dblclick"));
+            pumpFrame();
+            expect(status()).not.toContain("x");
+        });
+    });
+});

--- a/tests/unit/test-layout.js
+++ b/tests/unit/test-layout.js
@@ -232,9 +232,9 @@ describe("Layout", () => {
                 screenCanvas().requestFullscreen = vi.fn().mockRejectedValue(new Error("denied"));
                 make();
                 document.getElementById("fs").click();
-                await null;
-                await null;
-                expect(toasts()).toEqual([expect.stringContaining("Could not go fullscreen: denied")]);
+                await vi.waitFor(() =>
+                    expect(toasts()).toEqual([expect.stringContaining("Could not go fullscreen: denied")]),
+                );
             });
         });
     });

--- a/tests/unit/test-layout.js
+++ b/tests/unit/test-layout.js
@@ -1,7 +1,8 @@
 // @vitest-environment jsdom
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { fitMonitor } from "../../src/web/layout.js";
+import { Layout, fitMonitor } from "../../src/web/layout.js";
+import { teardownDom, toasts } from "./helpers.js";
 
 const Config = {
     imageWidth: 800,
@@ -94,5 +95,147 @@ describe("fitMonitor", () => {
         );
         expect(fitted.monitor.width).toBe(800);
         expect(fitted.monitor.height).toBe(600);
+    });
+});
+
+const LayoutMarkup = `
+<nav id="header-bar"></nav>
+<div id="cub-monitor">
+  <img id="cub-monitor-pic" />
+  <div class="sidebar left"><img /></div>
+  <canvas id="screen" width="800" height="600"></canvas>
+  <div class="sidebar right"><img /></div>
+  <div class="sidebar bottom"><img /></div>
+</div>
+<ul><li><a href="#" id="fs"></a></li></ul>`;
+
+describe("Layout", () => {
+    let display;
+
+    beforeEach(() => {
+        vi.useFakeTimers();
+        document.body.innerHTML = LayoutMarkup;
+        display = { filterClass: { getDisplayConfig: vi.fn(() => Config) }, video: { paint: vi.fn() } };
+    });
+
+    afterEach(teardownDom);
+
+    const screenCanvas = () => document.getElementById("screen");
+    const make = (overrides = {}) => new Layout({ screenCanvas: screenCanvas(), display, embed: true, ...overrides });
+    const resize = () => window.dispatchEvent(new Event("resize"));
+
+    describe("fitting the window", () => {
+        it("places the monitor and canvas on a window resize", () => {
+            make();
+            resize();
+            const monitor = document.getElementById("cub-monitor");
+            expect(monitor.style.width).toBe("1024px");
+            expect(monitor.style.height).toBe("768px");
+            expect(document.getElementById("cub-monitor-pic").style.width).toBe("1024px");
+            const canvas = screenCanvas();
+            expect(canvas.style.width).toBe("768px");
+            expect(canvas.style.height).toBe("576px");
+            expect(canvas.style.left).toBe("128px");
+            expect(canvas.style.top).toBe("64px");
+        });
+
+        it("reserves room for the page furniture when not embedded", () => {
+            make({ embed: false });
+            resize();
+            const monitor = document.getElementById("cub-monitor");
+            expect(monitor.style.width).toBe("824px");
+            expect(monitor.style.height).toBe("618px");
+        });
+
+        it("takes two more looks shortly after load, when the page has settled", () => {
+            make();
+            expect(display.filterClass.getDisplayConfig).not.toHaveBeenCalled();
+            vi.advanceTimersByTime(1);
+            expect(display.filterClass.getDisplayConfig).toHaveBeenCalledTimes(1);
+            vi.advanceTimersByTime(499);
+            expect(display.filterClass.getDisplayConfig).toHaveBeenCalledTimes(2);
+        });
+    });
+
+    describe("the drawing buffer", () => {
+        beforeEach(() => {
+            display.filterClass.getDisplayConfig = () => ({ ...Config, maxCanvasScale: 3 });
+            Object.defineProperty(window, "devicePixelRatio", { value: 2, configurable: true });
+        });
+
+        afterEach(() => {
+            delete window.devicePixelRatio;
+        });
+
+        it("is reallocated and repainted when a mode asks for a new size", () => {
+            make();
+            resize();
+            expect(screenCanvas().width).toBe(1600);
+            expect(screenCanvas().height).toBe(1200);
+            expect(display.video.paint).toHaveBeenCalledTimes(1);
+        });
+
+        it("is left alone when the fitted size has not changed", () => {
+            make();
+            resize();
+            resize();
+            expect(display.video.paint).toHaveBeenCalledTimes(1);
+        });
+    });
+
+    describe("the sidebars", () => {
+        it("keeps the art hidden when there is none to show", () => {
+            make();
+            for (const img of document.querySelectorAll(".sidebar img")) expect(img.style.display).toBe("none");
+        });
+
+        it("hangs a loaded image off its edge of the monitor", () => {
+            make({ sidebars: { left: "left.png", bottom: "strip.png" } });
+            const left = document.querySelector(".sidebar.left img");
+            expect(left.src).toContain("left.png");
+            Object.defineProperty(left, "naturalWidth", { value: 60 });
+            left.dispatchEvent(new Event("load"));
+            expect(left.parentElement.style.left).toBe("-65px");
+            expect(left.style.display).toBe("");
+
+            const bottom = document.querySelector(".sidebar.bottom img");
+            Object.defineProperty(bottom, "naturalHeight", { value: 40 });
+            bottom.dispatchEvent(new Event("load"));
+            expect(bottom.parentElement.style.bottom).toBe("-40px");
+            expect(document.querySelector(".sidebar.right img").style.display).toBe("none");
+        });
+    });
+
+    describe("the fullscreen menu item", () => {
+        it("is hidden where the API is missing", () => {
+            make();
+            expect(document.getElementById("fs").closest("li").hidden).toBe(true);
+        });
+
+        describe("with the API present", () => {
+            beforeEach(() => {
+                Object.defineProperty(document, "fullscreenEnabled", { value: true, configurable: true });
+            });
+
+            afterEach(() => {
+                delete document.fullscreenEnabled;
+            });
+
+            it("asks for fullscreen on the canvas", () => {
+                screenCanvas().requestFullscreen = vi.fn().mockResolvedValue();
+                make();
+                document.getElementById("fs").click();
+                expect(screenCanvas().requestFullscreen).toHaveBeenCalledTimes(1);
+            });
+
+            it("toasts when the browser refuses", async () => {
+                screenCanvas().requestFullscreen = vi.fn().mockRejectedValue(new Error("denied"));
+                make();
+                document.getElementById("fs").click();
+                await null;
+                await null;
+                expect(toasts()).toEqual([expect.stringContaining("Could not go fullscreen: denied")]);
+            });
+        });
     });
 });

--- a/tests/unit/test-rewind-ui.js
+++ b/tests/unit/test-rewind-ui.js
@@ -1,0 +1,201 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { RewindUI } from "../../src/web/rewind-ui.js";
+import { RewindBuffer } from "../../src/rewind.js";
+import { teardownDom } from "./helpers.js";
+
+const Markup = `
+<a href="#" id="rewind-open"></a>
+<div id="rewind-panel" hidden>
+  <button id="rewind-close"></button>
+  <div id="rewind-filmstrip"></div>
+</div>`;
+
+const FakeContext = {
+    createImageData: () => ({ data: new Uint8Array(1024 * 625 * 4) }),
+    putImageData: () => {},
+    drawImage: () => {},
+};
+
+describe("RewindUI", () => {
+    let rewindBuffer;
+    let video;
+    let processor;
+    let running;
+    let loop;
+
+    beforeEach(() => {
+        document.body.innerHTML = Markup;
+        Element.prototype.scrollIntoView = vi.fn();
+        const realCreateElement = document.createElement.bind(document);
+        vi.spyOn(document, "createElement").mockImplementation((tag) => {
+            const element = realCreateElement(tag);
+            if (tag === "canvas") element.getContext = () => FakeContext;
+            return element;
+        });
+        rewindBuffer = new RewindBuffer(5);
+        video = { fb32: new Uint32Array(1024 * 625), frameCount: 0, clearPaintBuffer: () => {}, paint: vi.fn() };
+        processor = {
+            snapshotState: vi.fn(() => ({ live: true })),
+            restoreState: vi.fn(),
+            execute: vi.fn(() => {
+                video.frameCount++;
+            }),
+        };
+        running = true;
+        loop = { isRunning: () => running, stop: vi.fn(() => (running = false)), go: vi.fn(() => (running = true)) };
+    });
+
+    afterEach(teardownDom);
+
+    const make = () => new RewindUI({ rewindBuffer, processor, video, captureInterval: 50, loop });
+    const panel = () => document.getElementById("rewind-panel");
+    const thumbs = () => [...document.querySelectorAll(".rewind-thumb")];
+    const selectedIndex = () => Number(document.querySelector(".rewind-thumb.selected").dataset.index);
+    const lastRestored = () => processor.restoreState.mock.calls.at(-1)[0];
+    const key = (name) => document.dispatchEvent(new KeyboardEvent("keydown", { key: name, cancelable: true }));
+
+    const captured = (count) => {
+        const snapshots = Array.from({ length: count }, (_, i) => ({ snapshot: i }));
+        for (const snapshot of snapshots) rewindBuffer.push(snapshot);
+        return snapshots;
+    };
+
+    describe("opening", () => {
+        it("does nothing when nothing has been captured", () => {
+            make().open();
+            expect(panel().hidden).toBe(true);
+            expect(loop.stop).not.toHaveBeenCalled();
+        });
+
+        it("pauses, fills the filmstrip with ages, and lands on now", () => {
+            const snapshots = captured(3);
+            make();
+            document.getElementById("rewind-open").click();
+            expect(loop.stop).toHaveBeenCalledWith(false);
+            expect(panel().hidden).toBe(false);
+            expect(thumbs().map((thumb) => thumb.querySelector(".rewind-thumb-label").textContent)).toEqual([
+                "-2s",
+                "-1s",
+                "now",
+            ]);
+            expect(selectedIndex()).toBe(2);
+            expect(lastRestored()).toBe(snapshots[2]);
+            expect(video.paint).toHaveBeenCalled();
+        });
+
+        it("opens once no matter how often it is asked", () => {
+            captured(1);
+            const ui = make();
+            ui.open();
+            ui.open();
+            expect(loop.stop).toHaveBeenCalledTimes(1);
+            expect(thumbs()).toHaveLength(1);
+        });
+    });
+
+    describe("choosing a snapshot", () => {
+        it("previews a clicked thumbnail without moving the machine on", () => {
+            const snapshots = captured(3);
+            make().open();
+            thumbs()[0].click();
+            expect(selectedIndex()).toBe(0);
+            expect(lastRestored()).toBe(snapshots[0]);
+        });
+
+        it("walks the filmstrip with the arrow keys, stopping at the ends", () => {
+            captured(2);
+            make().open();
+            key("ArrowLeft");
+            expect(selectedIndex()).toBe(0);
+            key("ArrowLeft");
+            expect(selectedIndex()).toBe(0);
+            key("ArrowRight");
+            key("ArrowRight");
+            expect(selectedIndex()).toBe(1);
+        });
+
+        it("keeps every key from reaching the emulator while open", () => {
+            captured(1);
+            make().open();
+            const leaked = vi.fn();
+            document.addEventListener("keydown", leaked);
+            key("a");
+            expect(leaked).not.toHaveBeenCalled();
+            document.removeEventListener("keydown", leaked);
+        });
+    });
+
+    describe("closing", () => {
+        it("commits the chosen snapshot on Enter and runs on from it", () => {
+            const snapshots = captured(2);
+            make().open();
+            key("ArrowLeft");
+            key("Enter");
+            expect(lastRestored()).toBe(snapshots[0]);
+            expect(panel().hidden).toBe(true);
+            expect(thumbs()).toHaveLength(0);
+            expect(loop.go).toHaveBeenCalledTimes(1);
+        });
+
+        it("cancels back to the state from before it opened on Escape", () => {
+            captured(2);
+            make().open();
+            key("ArrowLeft");
+            key("Escape");
+            expect(lastRestored()).toEqual({ live: true });
+            expect(panel().hidden).toBe(true);
+            expect(loop.go).toHaveBeenCalledTimes(1);
+        });
+
+        it("cancels from the close button", () => {
+            captured(1);
+            make().open();
+            document.getElementById("rewind-close").click();
+            expect(panel().hidden).toBe(true);
+        });
+
+        it("stops listening for keys once closed", () => {
+            captured(2);
+            make().open();
+            key("Escape");
+            processor.restoreState.mockClear();
+            key("ArrowLeft");
+            expect(processor.restoreState).not.toHaveBeenCalled();
+        });
+
+        it("leaves a machine that was paused before opening paused", () => {
+            captured(1);
+            running = false;
+            const ui = make();
+            ui.open();
+            ui.commit();
+            expect(loop.stop).not.toHaveBeenCalled();
+            expect(loop.go).not.toHaveBeenCalled();
+        });
+    });
+
+    describe("the menu item", () => {
+        it("is disabled until something has been captured", () => {
+            const ui = make();
+            ui.updateButtonState();
+            expect(document.getElementById("rewind-open").classList.contains("disabled")).toBe(true);
+            captured(1);
+            ui.updateButtonState();
+            expect(document.getElementById("rewind-open").classList.contains("disabled")).toBe(false);
+        });
+    });
+
+    describe("reset", () => {
+        it("closes the panel and forgets everything captured", () => {
+            captured(3);
+            const ui = make();
+            ui.open();
+            ui.reset();
+            expect(panel().hidden).toBe(true);
+            expect(rewindBuffer.length).toBe(0);
+            expect(document.getElementById("rewind-open").classList.contains("disabled")).toBe(true);
+        });
+    });
+});

--- a/tests/unit/test-snapshot-ui.js
+++ b/tests/unit/test-snapshot-ui.js
@@ -97,6 +97,39 @@ describe("SnapshotUI", () => {
             expect(deps.loop.stop).not.toHaveBeenCalled();
             expect(deps.loop.go).not.toHaveBeenCalled();
         });
+
+        const snapshotBuffer = (snapshot) =>
+            new TextEncoder().encode(JSON.stringify({ format: "jsbeeb-snapshot", version: 3, state: {}, ...snapshot }))
+                .buffer;
+
+        it("stashes a state for another model and navigates to a matching machine", async () => {
+            deps.urlState.urlWith.mockReturnValue(`${window.location.href}#stashed`);
+            await make().loadStateFromFile(null, snapshotBuffer({ model: "Master", coProcessor: false }));
+            expect(deps.urlState.urlWith).toHaveBeenCalledWith({ model: "Master", coProcessor: false });
+            expect(window.location.hash).toBe("#stashed");
+            expect(JSON.parse(sessionStorage.getItem("jsbeeb-pending-state")).model).toBe("Master");
+            expect(deps.video.paint).not.toHaveBeenCalled();
+            expect(deps.loop.go).not.toHaveBeenCalled();
+            window.location.hash = "";
+        });
+
+        it("treats a co-processor mismatch as a machine change too", async () => {
+            deps.urlState.urlWith.mockReturnValue(`${window.location.href}#stashed`);
+            await make().loadStateFromFile(null, snapshotBuffer({ model: "B-DFS1.2", coProcessor: true }));
+            expect(deps.urlState.urlWith).toHaveBeenCalledWith({ model: "B-DFS1.2", coProcessor: true });
+            expect(sessionStorage.getItem("jsbeeb-pending-state")).not.toBeNull();
+            window.location.hash = "";
+        });
+
+        it("restores a matching state in place and repaints", async () => {
+            deps.processor.restoreState = vi.fn();
+            await make().loadStateFromFile(null, snapshotBuffer({ model: "B-DFS1.2", coProcessor: false }));
+            expect(deps.processor.restoreState).toHaveBeenCalledWith({});
+            expect(deps.video.paint).toHaveBeenCalledTimes(1);
+            expect(deps.modals.showError).not.toHaveBeenCalled();
+            expect(sessionStorage.getItem("jsbeeb-pending-state")).toBeNull();
+            expect(deps.loop.go).toHaveBeenCalledTimes(1);
+        });
     });
 
     describe("reloading a snapshot's media", () => {
@@ -159,6 +192,25 @@ describe("SnapshotUI", () => {
             await make().restorePendingState();
             expect(deps.modals.showError).not.toHaveBeenCalled();
             expect(deps.processor.execute).not.toHaveBeenCalled();
+        });
+
+        it("picks up a stashed state, settles the machine, and forgets the stash", async () => {
+            deps.processor.restoreState = vi.fn();
+            sessionStorage.setItem(
+                "jsbeeb-pending-state",
+                JSON.stringify({
+                    format: "jsbeeb-snapshot",
+                    version: 3,
+                    model: "B-DFS1.2",
+                    coProcessor: false,
+                    state: { stashed: true },
+                }),
+            );
+            await make().restorePendingState();
+            expect(deps.processor.restoreState).toHaveBeenCalledWith({ stashed: true });
+            expect(deps.processor.execute).toHaveBeenCalledWith(40000);
+            expect(deps.modals.showError).not.toHaveBeenCalled();
+            expect(sessionStorage.getItem("jsbeeb-pending-state")).toBeNull();
         });
 
         it("consumes a stashed state even when it cannot be restored", async () => {

--- a/tests/unit/test-web-debug.js
+++ b/tests/unit/test-web-debug.js
@@ -1,0 +1,247 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { Debugger } from "../../src/web/debug.js";
+import { fake6502 } from "../../src/fake6502.js";
+import { FakeVideo } from "../../src/video.js";
+import { teardownDom } from "./helpers.js";
+
+const templateRow = '<tr class="template"><th><span class="register"></span>:</th><td class="value"></td></tr>';
+const Markup = `
+<div id="crtc_debug">
+  <div class="crtc_state"><table><tbody>${templateRow}</tbody></table></div>
+  <div class="crtc_regs"><table><tbody>${templateRow}</tbody></table></div>
+</div>
+<div id="debug">
+  <form id="goto-mem-addr-form"><input class="goto-addr" /></form>
+  <div id="memory">
+    <div class="template">
+      <span class="dis_addr"></span>
+      <span class="mem_bytes">${"<span></span>".repeat(8)}</span>
+      <span class="mem_asc">${"<span></span>".repeat(8)}</span>
+    </div>
+  </div>
+  <form id="goto-dis-addr-form"><input class="goto-addr" /></form>
+  <div id="disassembly">
+    <div class="template dis_elem">
+      <span class="bp_gutter"></span><span class="dis_addr"></span><span class="instr_bytes"></span
+      ><span class="instr_asc"></span><span class="disassembly"></span>
+    </div>
+  </div>
+  <span id="cpu6502_a"></span><span id="cpu6502_x"></span><span id="cpu6502_y"></span>
+  <span id="cpu6502_s"></span><span id="cpu6502_pc"></span>
+  <span id="cpu6502_flag_c"></span><span id="cpu6502_flag_z"></span><span id="cpu6502_flag_i"></span>
+  <span id="cpu6502_flag_d"></span><span id="cpu6502_flag_v"></span><span id="cpu6502_flag_n"></span>
+</div>
+<div id="hardware_debug">
+  <div id="sysvia"><table><tbody>${templateRow}</tbody></table></div>
+  <div id="uservia"><table><tbody>${templateRow}</tbody></table></div>
+</div>`;
+
+describe("Debugger", () => {
+    let cpu;
+    let video;
+    let dbgr;
+
+    beforeEach(async () => {
+        vi.spyOn(console, "log").mockImplementation(() => {});
+        document.body.innerHTML = Markup;
+        video = new FakeVideo();
+        video.debugPaint = vi.fn();
+        cpu = fake6502(null, { video });
+        await cpu.initialise();
+        cpu.writemem(0x2000, 0xa9);
+        cpu.writemem(0x2001, 0x41);
+        cpu.pc = 0x2000;
+        dbgr = new Debugger();
+        dbgr.setCpu(cpu);
+    });
+
+    afterEach(teardownDom);
+
+    const visible = (id) => document.getElementById(id).style.display !== "none";
+    const disRows = () => [...document.querySelectorAll("#disassembly .dis_elem:not(.template)")];
+    const currentRow = () => document.querySelector("#disassembly .highlight");
+    const memHighlight = () => document.querySelector("#memory .highlight");
+    const keyPress = (char) => dbgr.keyPress(char.charCodeAt(0));
+
+    describe("the panels", () => {
+        it("start hidden and show when the debugger is entered", () => {
+            expect(visible("debug")).toBe(false);
+            expect(visible("hardware_debug")).toBe(false);
+            expect(visible("crtc_debug")).toBe(false);
+            dbgr.debug(cpu.pc);
+            expect(dbgr.enabled()).toBe(true);
+            expect(visible("debug")).toBe(true);
+            expect(visible("hardware_debug")).toBe(true);
+        });
+
+        it("hide again on leaving", () => {
+            dbgr.debug(cpu.pc);
+            dbgr.hide();
+            expect(dbgr.enabled()).toBe(false);
+            expect(visible("debug")).toBe(false);
+        });
+    });
+
+    describe("the disassembly window", () => {
+        it("centres on the program counter with the instruction decoded", () => {
+            dbgr.debug(cpu.pc);
+            expect(disRows()).toHaveLength(16);
+            const row = currentRow();
+            expect(row.classList.contains("current")).toBe(true);
+            expect(row.querySelector(".dis_addr").textContent).toBe("2000");
+            expect(row.querySelector(".instr_bytes").textContent).toBe("a9 41");
+            expect(row.querySelector(".disassembly").textContent).toBe("LDA #$41");
+            expect(video.debugPaint).toHaveBeenCalled();
+        });
+
+        it("goes where the address form asks", () => {
+            dbgr.debug(cpu.pc);
+            const form = document.getElementById("goto-dis-addr-form");
+            form.querySelector(".goto-addr").value = "$3000";
+            form.dispatchEvent(new Event("submit", { cancelable: true }));
+            expect(currentRow().querySelector(".dis_addr").textContent).toBe("3000");
+        });
+
+        it("walks instructions with the wheel and the j and k keys", () => {
+            dbgr.debug(cpu.pc);
+            const disass = document.getElementById("disassembly");
+            disass.dispatchEvent(new WheelEvent("wheel", { deltaY: 30, cancelable: true }));
+            expect(currentRow().querySelector(".dis_addr").textContent).toBe("2002");
+            disass.dispatchEvent(new WheelEvent("wheel", { deltaY: -30, cancelable: true }));
+            expect(currentRow().querySelector(".dis_addr").textContent).toBe("2000");
+            keyPress("j");
+            expect(currentRow().querySelector(".dis_addr").textContent).toBe("2002");
+            keyPress("k");
+            expect(currentRow().querySelector(".dis_addr").textContent).toBe("2000");
+        });
+
+        it("toggles a breakpoint from the gutter, keeping it across a re-render", () => {
+            dbgr.debug(cpu.pc);
+            const gutter = () => currentRow().querySelector(".bp_gutter");
+            gutter().dispatchEvent(new MouseEvent("click", { bubbles: true }));
+            expect(gutter().classList.contains("active")).toBe(true);
+            keyPress("j");
+            keyPress("k");
+            expect(gutter().classList.contains("active")).toBe(true);
+            gutter().dispatchEvent(new MouseEvent("click", { bubbles: true }));
+            expect(gutter().classList.contains("active")).toBe(false);
+        });
+
+        it("toggles a breakpoint at the cursor with the t key", () => {
+            dbgr.debug(cpu.pc);
+            keyPress("t");
+            expect(currentRow().querySelector(".bp_gutter").classList.contains("active")).toBe(true);
+        });
+    });
+
+    describe("the memory window", () => {
+        it("shows the bytes and text around the address the form asks for", () => {
+            cpu.writemem(0x1234, 0x48);
+            dbgr.debug(cpu.pc);
+            const form = document.getElementById("goto-mem-addr-form");
+            form.querySelector(".goto-addr").value = "$1234";
+            form.dispatchEvent(new Event("submit", { cancelable: true }));
+            const row = memHighlight();
+            expect(row.querySelector(".dis_addr").textContent).toBe("1234");
+            expect(row.querySelector(".mem_bytes span").textContent).toBe("48");
+            expect(row.querySelector(".mem_asc span").textContent).toBe("H");
+        });
+
+        it("marks bytes changed since the last debugger visit, forgetting them on leaving", () => {
+            const gotoMem = (value) => {
+                const form = document.getElementById("goto-mem-addr-form");
+                form.querySelector(".goto-addr").value = value;
+                form.dispatchEvent(new Event("submit", { cancelable: true }));
+            };
+            const changed = () => memHighlight().querySelector(".mem_bytes span").classList.contains("changed");
+            dbgr.debug(cpu.pc);
+            dbgr.hide();
+            dbgr.debug(cpu.pc);
+            gotoMem("$1234");
+            expect(changed()).toBe(false);
+            cpu.writemem(0x1234, 0x48);
+            gotoMem("$1234");
+            expect(changed()).toBe(true);
+            dbgr.hide();
+            dbgr.debug(cpu.pc);
+            gotoMem("$1234");
+            expect(changed()).toBe(false);
+        });
+
+        it("scrolls a row per wheel notch and a screenful on U", () => {
+            dbgr.debug(cpu.pc);
+            const form = document.getElementById("goto-mem-addr-form");
+            form.querySelector(".goto-addr").value = "$1000";
+            form.dispatchEvent(new Event("submit", { cancelable: true }));
+            document.getElementById("memory").dispatchEvent(new WheelEvent("wheel", { deltaY: 20, cancelable: true }));
+            expect(memHighlight().querySelector(".dis_addr").textContent).toBe("1008");
+            keyPress("u");
+            expect(memHighlight().querySelector(".dis_addr").textContent).toBe("1010");
+            keyPress("I");
+            expect(memHighlight().querySelector(".dis_addr").textContent).toBe("0fd0");
+        });
+    });
+
+    describe("the keyboard", () => {
+        it("steps one instruction on n and shows its effect", () => {
+            dbgr.debug(cpu.pc);
+            keyPress("n");
+            expect(document.getElementById("cpu6502_a").textContent).toBe("41");
+            expect(document.getElementById("cpu6502_pc").textContent).toBe("2002");
+            expect(currentRow().querySelector(".dis_addr").textContent).toBe("2002");
+        });
+
+        it("leaves the keys alone while a form field has focus", () => {
+            dbgr.debug(cpu.pc);
+            document.querySelector("#goto-dis-addr-form .goto-addr").focus();
+            expect(keyPress("j")).toBe(false);
+            expect(currentRow().querySelector(".dis_addr").textContent).toBe("2000");
+        });
+    });
+
+    describe("the hardware panels", () => {
+        it("lists the VIA registers with their values", () => {
+            const rows = [...document.querySelectorAll("#sysvia tr:not(.template)")];
+            const named = Object.fromEntries(
+                rows.map((row) => [row.querySelector(".register").textContent, row.querySelector(".value")]),
+            );
+            expect(Object.keys(named)).toContain("ORA");
+            expect(Object.keys(named)).toContain("IC32");
+            expect(named.ORA.textContent).toBe("00");
+            expect(named.T1C.textContent).toHaveLength(6);
+        });
+
+        it("lists the CRTC registers and state", () => {
+            const regRows = [...document.querySelectorAll("#crtc_debug .crtc_regs tr:not(.template)")];
+            expect(regRows.map((row) => row.querySelector(".register").textContent)).toHaveLength(16);
+            expect(regRows[0].querySelector(".register").textContent).toBe("R0");
+            expect(regRows[0].querySelector(".value").textContent).toBe("00");
+            const stateRows = [...document.querySelectorAll("#crtc_debug .crtc_state tr:not(.template)")];
+            expect(stateRows.map((row) => row.querySelector(".register").textContent)).toContain("vertCounter");
+        });
+    });
+
+    describe("patches", () => {
+        it("pokes bytes from a patch string", () => {
+            dbgr.execPatch("3000:ea4c");
+            expect(cpu.peekmem(0x3000)).toBe(0xea);
+            expect(cpu.peekmem(0x3001)).toBe(0x4c);
+        });
+
+        it("applies an unconditional patch immediately", () => {
+            dbgr.setPatch("3000:ea;3010:60");
+            expect(cpu.peekmem(0x3000)).toBe(0xea);
+            expect(cpu.peekmem(0x3010)).toBe(0x60);
+        });
+
+        it("holds an @-patch until the program counter arrives", () => {
+            dbgr.setPatch("@20003000:ea");
+            expect(cpu.peekmem(0x3000)).toBe(0xff);
+            dbgr.debug(cpu.pc);
+            keyPress("n");
+            expect(cpu.peekmem(0x3000)).toBe(0xea);
+        });
+    });
+});

--- a/tests/unit/test-web-debug.js
+++ b/tests/unit/test-web-debug.js
@@ -4,39 +4,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { Debugger } from "../../src/web/debug.js";
 import { fake6502 } from "../../src/fake6502.js";
 import { FakeVideo } from "../../src/video.js";
-import { teardownDom } from "./helpers.js";
-
-const templateRow = '<tr class="template"><th><span class="register"></span>:</th><td class="value"></td></tr>';
-const Markup = `
-<div id="crtc_debug">
-  <div class="crtc_state"><table><tbody>${templateRow}</tbody></table></div>
-  <div class="crtc_regs"><table><tbody>${templateRow}</tbody></table></div>
-</div>
-<div id="debug">
-  <form id="goto-mem-addr-form"><input class="goto-addr" /></form>
-  <div id="memory">
-    <div class="template">
-      <span class="dis_addr"></span>
-      <span class="mem_bytes">${"<span></span>".repeat(8)}</span>
-      <span class="mem_asc">${"<span></span>".repeat(8)}</span>
-    </div>
-  </div>
-  <form id="goto-dis-addr-form"><input class="goto-addr" /></form>
-  <div id="disassembly">
-    <div class="template dis_elem">
-      <span class="bp_gutter"></span><span class="dis_addr"></span><span class="instr_bytes"></span
-      ><span class="instr_asc"></span><span class="disassembly"></span>
-    </div>
-  </div>
-  <span id="cpu6502_a"></span><span id="cpu6502_x"></span><span id="cpu6502_y"></span>
-  <span id="cpu6502_s"></span><span id="cpu6502_pc"></span>
-  <span id="cpu6502_flag_c"></span><span id="cpu6502_flag_z"></span><span id="cpu6502_flag_i"></span>
-  <span id="cpu6502_flag_d"></span><span id="cpu6502_flag_v"></span><span id="cpu6502_flag_n"></span>
-</div>
-<div id="hardware_debug">
-  <div id="sysvia"><table><tbody>${templateRow}</tbody></table></div>
-  <div id="uservia"><table><tbody>${templateRow}</tbody></table></div>
-</div>`;
+import { domFromIndexHtml, teardownDom } from "./helpers.js";
 
 describe("Debugger", () => {
     let cpu;
@@ -45,7 +13,7 @@ describe("Debugger", () => {
 
     beforeEach(async () => {
         vi.spyOn(console, "log").mockImplementation(() => {});
-        document.body.innerHTML = Markup;
+        domFromIndexHtml("crtc_debug", "debug", "hardware_debug");
         video = new FakeVideo();
         video.debugPaint = vi.fn();
         cpu = fake6502(null, { video });


### PR DESCRIPTION
Item 11 of #971: tests for what the main.js split exposed as untested in `src/web`. Stacked on #996 and written with its helpers.

- **test-layout.js**: the `Layout` class joins the existing `fitMonitor` coverage: the window resize wiring and the two deferred looks after load, the quantised drawing-buffer reallocation with its repaint (and that an unchanged fit leaves the buffer alone), sidebar image binding, and the fullscreen menu item with the API present and missing.
- **test-snapshot-ui.js**: the cross-model branch: a snapshot for another model, or with a different co-processor fitting, is stashed in sessionStorage and the page navigates to `urlWith`'s machine; a matching one restores in place and repaints; `restorePendingState` picks the stash up, settles the machine and forgets it.
- **test-rewind-ui.js** (new): open, commit and cancel around a real `RewindBuffer`: filmstrip thumbnails and their ages, arrow-key walking, key capture while open, pause and resume bookkeeping, the disabled menu item and reset.
- **test-disc-visualiser.js** (new): the panel lifecycle under a hand-driven requestAnimationFrame, header dragging with clamping, the two views' legends and active markings, and, with a real disc image in the drive, the surface scan, the status line, the hover readout and wheel zoom.
- **test-web-debug.js** (new): the `Debugger` against a real 6502 via `fake6502`: panel visibility, the disassembly window (centred on the pc, the goto form, wheel and j/k walking, breakpoints from the gutter and the t key), the memory window (goto, changed-byte markers, wheel and u/I scrolling), a single step on n, the VIA and CRTC panels, and memory patches including a deferred @-patch.

Judgement calls:

- Canvas 2D contexts are stubbed per element (jsdom has none); geometry, track analysis and surface rendering run for real.
- The cross-model navigation is asserted through a hash-only location change, the one navigation jsdom implements.
- `web/debug.js` was indeed wholly untested, as the issue said.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
