### PR TITLE
fix: shift-N in the debugger stepped the CPU then threw

### DIFF
--- a/src/web/debug.js
+++ b/src/web/debug.js
@@ -544,7 +544,7 @@ export class Debugger {
             case "N":
                 this.updatePrevMem();
                 this.cpu.execute(1);
-                self.debug(this.cpu.pc);
+                this.debug(this.cpu.pc);
                 break;
             case "m":
                 this.stepOver();


### PR DESCRIPTION
Found while #997 put `web/debug.js` under test for the first time: the shift-N handler executes one instruction and then calls `self.debug(this.cpu.pc)`, where `self` is `window` and no such global exists, so the view never refreshes and the handler throws. A leftover from the pre-class `var self = this` idiom in the original Miracle port (the surrounding code was classified long ago; this call was missed).

Two characters: `this.debug`. No test here because the debugger's test harness arrives in #997; a shift-N case can join that suite once both land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019CJ9csHch7kjzF3DKzR5DP