### PR TITLE
test: build test DOMs from the real index.html where they mirror it

### DIFF
--- a/tests/unit/helpers.js
+++ b/tests/unit/helpers.js
@@ -45,9 +45,6 @@ export function makeWebDeps() {
 export const fakeUrlState = (search = "") =>
     new UrlState({ origin: "https://bbc.example", pathname: "/", search, hash: "" }, { pushState: vi.fn() });
 
-export const modalMarkup = (id, body) =>
-    `<div id="${id}" class="modal"><div class="modal-dialog"><div class="modal-content"><div class="modal-body">${body}</div></div></div></div>`;
-
 export const toasts = () =>
     [...document.querySelectorAll(".toast")].map((el) => el.textContent.replace(/\s+/g, " ").trim());
 

--- a/tests/unit/test-analogue-inputs.js
+++ b/tests/unit/test-analogue-inputs.js
@@ -2,9 +2,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { AnalogueInputs } from "../../src/web/analogue-inputs.js";
-import { fakeUrlState, teardownDom } from "./helpers.js";
-
-const Markup = `<div id="cub-monitor"><canvas id="screen"></canvas></div><span id="micPermissionStatus"></span>`;
+import { domFromIndexHtml, fakeUrlState, teardownDom } from "./helpers.js";
 
 describe("AnalogueInputs", () => {
     let deps;
@@ -12,7 +10,7 @@ describe("AnalogueInputs", () => {
 
     beforeEach(() => {
         vi.useFakeTimers();
-        document.body.innerHTML = Markup;
+        domFromIndexHtml("cub-monitor", "micPermissionStatus");
         channels = {};
         deps = {
             processor: {

--- a/tests/unit/test-archive-list.js
+++ b/tests/unit/test-archive-list.js
@@ -2,17 +2,7 @@
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import { AutobootTicks, clearArchiveList, filterArchiveList, showArchiveMessage } from "../../src/web/archive-list.js";
-import { fakeUrlState, teardownDom } from "./helpers.js";
-
-const Markup = `
-<div id="sth" class="modal"><span class="loading" style="display: none"></span>
-  <ul id="sth-list"><li class="template"><span class="name"></span></li></ul>
-  <label><input type="checkbox" class="autoboot" /></label>
-</div>
-<div id="hfe" class="modal"><span class="loading"></span>
-  <ul id="hfe-list"><li class="template"><span class="name"></span></li></ul>
-  <label><input type="checkbox" class="autoboot" /></label>
-</div>`;
+import { domFromIndexHtml, fakeUrlState, teardownDom } from "./helpers.js";
 
 const addRow = (listId, text) => {
     const row = document.createElement("li");
@@ -23,7 +13,7 @@ const addRow = (listId, text) => {
 
 describe("archive lists", () => {
     beforeEach(() => {
-        document.body.innerHTML = Markup;
+        domFromIndexHtml("sth", "hfe");
     });
 
     afterEach(teardownDom);

--- a/tests/unit/test-audio-handler.js
+++ b/tests/unit/test-audio-handler.js
@@ -5,6 +5,7 @@ import * as bootstrap from "bootstrap";
 
 import { Scheduler } from "../../src/scheduler.js";
 import { AudioHandler } from "../../src/web/audio-handler.js";
+import { domFromIndexHtml } from "./helpers.js";
 
 const SuspendedText = "Your browser has suspended audio";
 
@@ -69,7 +70,7 @@ describe("AudioHandler", () => {
 
     beforeEach(() => {
         contexts = [];
-        document.body.innerHTML = `<div id="audio-warning">${SuspendedText}</div>`;
+        domFromIndexHtml("audio-warning");
         vi.stubGlobal("AudioContext", undefined);
         vi.stubGlobal("webkitAudioContext", undefined);
     });

--- a/tests/unit/test-disc-visualiser.js
+++ b/tests/unit/test-disc-visualiser.js
@@ -5,25 +5,7 @@ import { DiscVisualiser } from "../../src/web/disc-visualiser.js";
 import { DiscGeometry } from "../../src/disc-surface.js";
 import { IbmDiscFormat } from "../../src/disc.js";
 import { discFor } from "../../src/fdc.js";
-import { ssdImage, teardownDom } from "./helpers.js";
-
-const Markup = `
-<a href="#" id="disc-visualiser-open"></a>
-<div id="disc-panel" hidden>
-  <div class="disc-header"><span class="disc-title">Disc surface</span><span id="disc-name"></span>
-    <button id="disc-close"></button></div>
-  <div class="disc-controls">
-    <button data-drive="0"></button><button data-drive="1"></button>
-    <div id="disc-side-controls" hidden><button data-side="0"></button><button data-side="1"></button></div>
-    <button data-view="density"></button><button data-view="format"></button>
-  </div>
-  <canvas id="disc-surface"></canvas>
-  <canvas id="disc-overlay"></canvas>
-  <div id="disc-legend"></div>
-  <div id="disc-status"></div>
-  <div id="disc-hover-where"></div>
-  <div id="disc-hover-what"></div>
-</div>`;
+import { domFromIndexHtml, ssdImage, teardownDom } from "./helpers.js";
 
 const CanvasSize = 100;
 
@@ -42,7 +24,7 @@ describe("DiscVisualiser", () => {
     let rafCallbacks;
 
     beforeEach(() => {
-        document.body.innerHTML = Markup;
+        domFromIndexHtml("disc-visualiser-open", "disc-panel");
         const surface = document.getElementById("disc-surface");
         const overlay = document.getElementById("disc-overlay");
         Object.defineProperty(surface, "clientWidth", { value: CanvasSize });

--- a/tests/unit/test-display.js
+++ b/tests/unit/test-display.js
@@ -2,7 +2,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { Display } from "../../src/web/display.js";
-import { teardownDom } from "./helpers.js";
+import { domFromIndexHtml, teardownDom } from "./helpers.js";
 
 const FbWidth = 1024;
 
@@ -11,7 +11,7 @@ describe("Display", () => {
     let fakeCanvas;
 
     beforeEach(() => {
-        document.body.innerHTML = `<img id="cub-monitor-pic" /><canvas id="screen"></canvas>`;
+        domFromIndexHtml("cub-monitor");
         rafCallbacks = [];
         vi.spyOn(window, "requestAnimationFrame").mockImplementation((callback) => rafCallbacks.push(callback));
     });

--- a/tests/unit/test-drives.js
+++ b/tests/unit/test-drives.js
@@ -4,13 +4,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { Drives } from "../../src/web/drives.js";
 import { DiscLayout } from "../../src/disc.js";
 import { DriveTracks } from "../../src/url-params.js";
-import { teardownDom, toasts } from "./helpers.js";
-
-const Markup = `
-<div class="drive-tracks" data-drive="0"><button data-tracks="40">40</button><button data-tracks="80">80</button></div>
-<div class="drive-tracks" data-drive="1"><button data-tracks="40">40</button><button data-tracks="80">80</button></div>
-<a id="download-drive-link"></a>
-<a id="download-drive-hfe-link"></a>`;
+import { domFromIndexHtml, teardownDom, toasts } from "./helpers.js";
 
 /** Enough of an FDC for the page's side of putting a disc in. */
 function fakeFdc() {
@@ -39,7 +33,7 @@ describe("Drives", () => {
 
     beforeEach(() => {
         vi.useFakeTimers();
-        document.body.innerHTML = Markup;
+        domFromIndexHtml("navbarSupportedContent");
         fdc = fakeFdc();
         confirm = vi.fn().mockResolvedValue(false);
     });

--- a/tests/unit/test-emulation-loop.js
+++ b/tests/unit/test-emulation-loop.js
@@ -2,6 +2,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { EmulationLoop } from "../../src/web/emulation-loop.js";
+import { domFromIndexHtml } from "./helpers.js";
 
 const ClocksPerSecond = 2000000;
 
@@ -12,7 +13,7 @@ describe("EmulationLoop", () => {
         vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout", "Date", "performance"] });
         // Move off zero: the loop uses last === 0 to mean "first tick".
         vi.advanceTimersByTime(1000);
-        document.body.innerHTML = `<span class="virtualMHz"></span><span id="virtual-mhz-header"></span>`;
+        domFromIndexHtml("leds");
         deps = {
             processor: {
                 execute: vi.fn(() => true),

--- a/tests/unit/test-front-panel.js
+++ b/tests/unit/test-front-panel.js
@@ -2,21 +2,14 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { FrontPanel } from "../../src/web/front-panel.js";
-import { teardownDom } from "./helpers.js";
-
-const Markup = `
-<div id="tape-menu"><a data-id="rewind">Rewind</a><a data-id="archive">Archive</a></div>
-<table><tbody><tr><th id="tape-control-header"></th><td id="tape-control-cell"></td></tr></tbody></table>
-<button id="tape-play-stop"></button>
-<span id="motorlight"></span><span id="capslight" class="bbc-only"></span><span id="shiftlight" class="bbc-only"></span>
-<span id="drive0" class="bbc-only"></span><span id="drive1" class="bbc-only"></span><span id="networklight" class="bbc-only"></span>`;
+import { domFromIndexHtml, teardownDom } from "./helpers.js";
 
 describe("FrontPanel", () => {
     let processor;
 
     beforeEach(() => {
         vi.spyOn(console, "log").mockImplementation(() => {});
-        document.body.innerHTML = Markup;
+        domFromIndexHtml("tape-menu", "leds");
         processor = {
             sysvia: { capsLockLight: false, shiftLockLight: false },
             fdc: { motorOn: [false, false] },
@@ -62,13 +55,13 @@ describe("FrontPanel", () => {
     describe("what each machine shows", () => {
         it("hides the BBC lights and shows the tape control on an Atom", () => {
             make(true);
-            expect(document.getElementById("capslight").style.display).toBe("none");
+            expect(document.getElementById("capslight").closest(".bbc-only").style.display).toBe("none");
             expect(document.getElementById("tape-control-header").style.display).toBe("");
         });
 
         it("shows the BBC lights and hides the tape control on a BBC", () => {
             make(false);
-            expect(document.getElementById("capslight").style.display).toBe("");
+            expect(document.getElementById("capslight").closest(".bbc-only").style.display).toBe("");
             expect(document.getElementById("tape-control-header").style.display).toBe("none");
         });
     });
@@ -100,10 +93,12 @@ describe("FrontPanel", () => {
         });
 
         it("ignores menu links it does not handle", () => {
+            const link = document.getElementById("tape-menu").appendChild(document.createElement("a"));
+            link.dataset.id = "archive";
             make(false);
-            document.querySelector('#tape-menu a[data-id="archive"]').click();
+            link.click();
             expect(processor.acia.rewindTape).not.toHaveBeenCalled();
-            expect(console.log).not.toHaveBeenCalledWith("unknown type", "archive");
+            expect(console.log).not.toHaveBeenCalled();
         });
     });
 

--- a/tests/unit/test-google-drive-picker.js
+++ b/tests/unit/test-google-drive-picker.js
@@ -2,26 +2,14 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { GoogleDrivePicker } from "../../src/web/google-drive-picker.js";
-import { modalMarkup, teardownDom, toasts } from "./helpers.js";
-
-const Markup =
-    `
-<a id="open-drive-link"></a>
-<div id="google-drive-auth" style="display: none"><form></form></div>` +
-    modalMarkup(
-        "google-drive",
-        `
-  <span class="loading"></span>
-  <ul class="list"><li class="template"><span class="name"></span></li></ul>
-  <form><input class="disc-name" value="" /><input type="checkbox" class="create-from-existing" /></form>`,
-    );
+import { domFromIndexHtml, teardownDom, toasts } from "./helpers.js";
 
 describe("GoogleDrivePicker", () => {
     let deps;
     let loader;
 
     beforeEach(() => {
-        document.body.innerHTML = Markup;
+        domFromIndexHtml("open-drive-link", "google-drive", "loading-dialog");
         loader = {
             initialise: vi.fn().mockResolvedValue(true),
             authorize: vi.fn().mockResolvedValue(true),

--- a/tests/unit/test-hfe-picker.js
+++ b/tests/unit/test-hfe-picker.js
@@ -3,18 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { HfePicker } from "../../src/web/hfe-picker.js";
 import { Provenance } from "../../src/bbcdiscs.js";
-import { makeWebDeps, modalMarkup, teardownDom } from "./helpers.js";
-
-const Markup = modalMarkup(
-    "hfe",
-    `
-  <span class="loading"></span>
-  <input id="hfe-filter" value="" />
-  <div id="hfe-provenance"></div>
-  <ul id="hfe-list"><li class="template"><a href="#">
-    <span class="name"></span><span class="publisher"></span><span class="detail"></span><span class="provenance"></span>
-  </a></li></ul>`,
-);
+import { domFromIndexHtml, makeWebDeps, teardownDom } from "./helpers.js";
 
 const entry = (path, title, provenance = Provenance.Captured, extra = {}) => ({
     path,
@@ -31,7 +20,7 @@ describe("HfePicker", () => {
 
     beforeEach(() => {
         vi.useFakeTimers();
-        document.body.innerHTML = Markup;
+        domFromIndexHtml("hfe");
         deps = makeWebDeps();
     });
 

--- a/tests/unit/test-layout.js
+++ b/tests/unit/test-layout.js
@@ -2,7 +2,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { Layout, fitMonitor } from "../../src/web/layout.js";
-import { teardownDom, toasts } from "./helpers.js";
+import { domFromIndexHtml, teardownDom, toasts } from "./helpers.js";
 
 const Config = {
     imageWidth: 800,
@@ -98,23 +98,16 @@ describe("fitMonitor", () => {
     });
 });
 
-const LayoutMarkup = `
-<nav id="header-bar"></nav>
-<div id="cub-monitor">
-  <img id="cub-monitor-pic" />
-  <div class="sidebar left"><img /></div>
-  <canvas id="screen" width="800" height="600"></canvas>
-  <div class="sidebar right"><img /></div>
-  <div class="sidebar bottom"><img /></div>
-</div>
-<ul><li><a href="#" id="fs"></a></li></ul>`;
-
 describe("Layout", () => {
     let display;
 
     beforeEach(() => {
         vi.useFakeTimers();
-        document.body.innerHTML = LayoutMarkup;
+        domFromIndexHtml("header-bar", "cub-monitor");
+        // The drawing buffer is the display's to size; give it the mocked config's.
+        const canvas = document.getElementById("screen");
+        canvas.width = Config.canvasWidth;
+        canvas.height = Config.canvasHeight;
         display = { filterClass: { getDisplayConfig: vi.fn(() => Config) }, video: { paint: vi.fn() } };
     });
 

--- a/tests/unit/test-media-loader.js
+++ b/tests/unit/test-media-loader.js
@@ -5,14 +5,7 @@ import { BuiltInImages, MediaLoader, splitImage } from "../../src/web/media-load
 import { DiscLayout } from "../../src/disc.js";
 import { discFor } from "../../src/fdc.js";
 import { toHfe } from "../../src/disc-hfe.js";
-import { fakeUrlState, ssdImage, teardownDom, toasts } from "./helpers.js";
-
-const Markup = `
-<input type="file" id="disc_load" />
-<input type="file" id="fs_load" />
-<input type="file" id="tape_load" />
-<form><textarea id="paste-text"></textarea></form>
-<ul id="disc-list"><li class="template"><span class="name"></span><span class="description"></span></li></ul>`;
+import { domFromIndexHtml, fakeUrlState, ssdImage, teardownDom, toasts } from "./helpers.js";
 
 const fileFor = (name, bytes) => new File([bytes], name);
 
@@ -29,7 +22,7 @@ describe("MediaLoader", () => {
     let sources;
 
     beforeEach(() => {
-        document.body.innerHTML = Markup;
+        domFromIndexHtml("discs", "econetfs", "tapes", "paste-text");
         deps = {
             processor: {
                 fdc: null,

--- a/tests/unit/test-modals.js
+++ b/tests/unit/test-modals.js
@@ -2,18 +2,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { Modals } from "../../src/web/modals.js";
-import { modalMarkup, teardownDom } from "./helpers.js";
-
-const Markup = [
-    modalMarkup("error-dialog", '<span class="context"></span><span class="error"></span>'),
-    modalMarkup("loading-dialog", '<span class="loading"></span><div id="google-drive-auth"></div>'),
-    modalMarkup(
-        "are-you-sure",
-        '<span class="context"></span><button class="ays-yes"></button><button class="ays-no"></button>',
-    ),
-    modalMarkup("info", ""),
-    modalMarkup("discs", ""),
-].join("");
+import { domFromIndexHtml, teardownDom } from "./helpers.js";
 
 describe("Modals", () => {
     let emulator;
@@ -21,7 +10,7 @@ describe("Modals", () => {
 
     beforeEach(() => {
         vi.useFakeTimers();
-        document.body.innerHTML = Markup;
+        domFromIndexHtml("error-dialog", "loading-dialog", "are-you-sure", "info", "discs");
         emulator = { running: true, stop: vi.fn(), go: vi.fn() };
         modals = new Modals({
             loop: {
@@ -139,7 +128,11 @@ describe("Modals", () => {
 
         it("resolves true once the dialog has gone after yes", async () => {
             const answer = modals.confirm("Restart now?", "Restart", "Later");
+            await vi.runAllTimersAsync();
             dialog().querySelector(".ays-yes").click();
+            // The real dialog fades, so the hidden event waits on bootstrap's
+            // transition timers.
+            await vi.runAllTimersAsync();
             await expect(answer).resolves.toBe(true);
             expect(dialog().classList.contains("show")).toBe(false);
         });

--- a/tests/unit/test-quick-settings.js
+++ b/tests/unit/test-quick-settings.js
@@ -2,22 +2,13 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { QuickSettings } from "../../src/web/quick-settings.js";
-import { teardownDom } from "./helpers.js";
-
-const Markup = `
-<div id="audio-output">
-  <button data-output="speaker"><span>S</span></button><button data-output="board">B</button><button data-output="off">O</button>
-</div>
-<input id="speaker-amount" type="range" min="0" max="1" step="0.05" value="1" />
-<div id="display-mode">
-  <button data-mode="rgb">R</button><button data-mode="pal">P</button><button data-mode="xbr">X</button>
-</div>`;
+import { domFromIndexHtml, teardownDom } from "./helpers.js";
 
 describe("QuickSettings", () => {
     let callbacks;
 
     beforeEach(() => {
-        document.body.innerHTML = Markup;
+        domFromIndexHtml("quick-settings");
         callbacks = { onAudioOutput: vi.fn(), onSpeakerAmount: vi.fn(), onDisplayMode: vi.fn() };
     });
 
@@ -42,9 +33,10 @@ describe("QuickSettings", () => {
 
     it("reports a chosen sound output, from a click anywhere on its button, without showing it itself", () => {
         make();
-        document.querySelector('[data-output="off"] ').click();
+        document.querySelector('[data-output="off"]').click();
         expect(callbacks.onAudioOutput).toHaveBeenCalledWith("off");
-        document.querySelector('[data-output="speaker"] span').click();
+        const inner = document.querySelector('[data-output="speaker"]').appendChild(document.createElement("span"));
+        inner.click();
         expect(callbacks.onAudioOutput).toHaveBeenLastCalledWith("speaker");
         expect(pressed("[data-output]")).toEqual(["speaker"]);
     });

--- a/tests/unit/test-rewind-ui.js
+++ b/tests/unit/test-rewind-ui.js
@@ -3,14 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { RewindUI } from "../../src/web/rewind-ui.js";
 import { RewindBuffer } from "../../src/rewind.js";
-import { teardownDom } from "./helpers.js";
-
-const Markup = `
-<a href="#" id="rewind-open"></a>
-<div id="rewind-panel" hidden>
-  <button id="rewind-close"></button>
-  <div id="rewind-filmstrip"></div>
-</div>`;
+import { domFromIndexHtml, teardownDom } from "./helpers.js";
 
 const FakeContext = {
     createImageData: () => ({ data: new Uint8Array(1024 * 625 * 4) }),
@@ -26,7 +19,7 @@ describe("RewindUI", () => {
     let loop;
 
     beforeEach(() => {
-        document.body.innerHTML = Markup;
+        domFromIndexHtml("rewind-open", "rewind-panel");
         Element.prototype.scrollIntoView = vi.fn();
         const realCreateElement = document.createElement.bind(document);
         vi.spyOn(document, "createElement").mockImplementation((tag) => {

--- a/tests/unit/test-snapshot-ui.js
+++ b/tests/unit/test-snapshot-ui.js
@@ -3,9 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { SnapshotUI, isSnapshotFile, snapshotMedia } from "../../src/web/snapshot-ui.js";
 import { DiscLayout } from "../../src/disc.js";
-import { ssdImage, teardownDom, toasts } from "./helpers.js";
-
-const Markup = `<a id="save-state"></a><input type="file" id="load-state" />`;
+import { domFromIndexHtml, ssdImage, teardownDom, toasts } from "./helpers.js";
 
 describe("snapshot media manifest", () => {
     const urlDisc = { originalImageCrc32: 0x1234, is40Track: false, originalImageData: null };
@@ -66,7 +64,7 @@ describe("SnapshotUI", () => {
     let deps;
 
     beforeEach(() => {
-        document.body.innerHTML = Markup;
+        domFromIndexHtml("save-state", "load-state");
         deps = {
             processor: { fdc: { drives: [{ disc: null }, { disc: null }] }, hasTube: false, execute: vi.fn() },
             model: { name: "B-DFS1.2" },

--- a/tests/unit/test-sth-picker.js
+++ b/tests/unit/test-sth-picker.js
@@ -2,22 +2,14 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { SthPicker } from "../../src/web/sth-picker.js";
-import { makeWebDeps, modalMarkup, teardownDom } from "./helpers.js";
-
-const Markup = modalMarkup(
-    "sth",
-    `
-  <span class="loading"></span>
-  <input id="sth-filter" value="" />
-  <ul id="sth-list"><li class="template"><span class="name"></span></li></ul>`,
-);
+import { domFromIndexHtml, makeWebDeps, teardownDom } from "./helpers.js";
 
 describe("SthPicker", () => {
     let deps;
 
     beforeEach(() => {
         vi.useFakeTimers();
-        document.body.innerHTML = Markup;
+        domFromIndexHtml("sth");
         deps = makeWebDeps();
     });
 
@@ -44,7 +36,7 @@ describe("SthPicker", () => {
             vi.runAllTimers();
             expect(rows()).toHaveLength(151);
             const shown = rows().filter((row) => row.style.display !== "none");
-            expect(shown.map((row) => row.textContent)).toEqual(["ELITE.zip"]);
+            expect(shown.map((row) => row.textContent.trim())).toEqual(["ELITE.zip"]);
         });
 
         it("re-filters what is already on screen as the user types", () => {
@@ -53,7 +45,7 @@ describe("SthPicker", () => {
             filter.value = "chuckie";
             filter.dispatchEvent(new Event("keyup"));
             const shown = rows().filter((row) => row.style.display !== "none");
-            expect(shown.map((row) => row.textContent)).toEqual(["CHUCKIE.zip"]);
+            expect(shown.map((row) => row.textContent.trim())).toEqual(["CHUCKIE.zip"]);
         });
 
         it("hides the loading text once the catalogue is up", () => {

--- a/tests/unit/test-web-machine.js
+++ b/tests/unit/test-web-machine.js
@@ -2,7 +2,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { Machine, buildEmulationConfig } from "../../src/web/machine.js";
-import { teardownDom, toasts } from "./helpers.js";
+import { domFromIndexHtml, teardownDom, toasts } from "./helpers.js";
 
 const config = (overrides = {}) => ({
     tubeCpuMultiplier: 1,
@@ -49,7 +49,7 @@ describe("Machine", () => {
     let fakeProcessor;
 
     beforeEach(() => {
-        document.body.innerHTML = `<span id="fsmenuitem"></span>`;
+        domFromIndexHtml("fsmenuitem");
         fakeProcessor = {
             uservia: {},
             acia: { addEventListener: vi.fn(), setRs423Handler: vi.fn() },


### PR DESCRIPTION
A hand-copied replica of the page's markup lets index.html changes break the page while the tests stay green. Every web UI test whose fixture mirrored real index.html structure now builds its DOM from the page itself via `domFromIndexHtml`, following test-web-debug from #997.

## Converted (ids pulled from index.html)

- `test-archive-list.js`: `sth`, `hfe`
- `test-sth-picker.js`: `sth`
- `test-hfe-picker.js`: `hfe`
- `test-modals.js`: `error-dialog`, `loading-dialog`, `are-you-sure`, `info`, `discs`
- `test-google-drive-picker.js`: `open-drive-link`, `google-drive`, `loading-dialog` (the real `#google-drive-auth` lives inside the loading dialog)
- `test-media-loader.js`: `discs`, `econetfs`, `tapes`, `paste-text`
- `test-quick-settings.js`: `quick-settings`
- `test-drives.js`: `navbarSupportedContent` (the drive-tracks switches sit in the discs dropdown, which has no id of its own)
- `test-front-panel.js`: `tape-menu`, `leds`
- `test-rewind-ui.js`: `rewind-open`, `rewind-panel`
- `test-disc-visualiser.js`: `disc-visualiser-open`, `disc-panel`
- `test-analogue-inputs.js`: `cub-monitor`, `micPermissionStatus`
- `test-audio-handler.js`: `audio-warning`
- `test-display.js`: `cub-monitor`
- `test-emulation-loop.js`: `leds`
- `test-layout.js`: `header-bar`, `cub-monitor`
- `test-snapshot-ui.js`: `save-state`, `load-state`
- `test-web-machine.js`: `fsmenuitem`

## Adjusted to what the real page actually is

- **front-panel**: the `bbc-only` class is on the `td`/`th`, not the light `div`s, so the Atom/BBC visibility tests assert through `closest(".bbc-only")`; the replica had moved the class onto the lights. The "ignores unhandled links" test adds a synthetic `data-id="archive"` link to the real menu, since every real non-rewind link is a bootstrap modal toggle whose delegate would chase a target modal the test does not build.
- **modals**: the real `are-you-sure` dialog has `fade`, so the confirm test advances bootstrap's transition timers before expecting the hidden event.
- **quick-settings**: the real buttons hold bare text, so the click-on-a-descendant test appends the span it clicks.
- **sth-picker**: the real list template wraps the name in whitespace; the two textContent assertions trim.
- **layout**: the real canvas is 896x600 where the replica pre-sized it to the mocked display config's 800x600; the test now sets the drawing buffer explicitly, which is the display's job in production.

## Deliberately left as synthetic fixtures

- `test-keyboard-setup.js`: builds no markup (only clears the body); the component works on document-level events.
- `test-toast.js`: the toast container is the component's own creation, not page markup.

`modalMarkup` in helpers.js lost all its users and is deleted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
