### PR TITLE
ci: fail the smoke test step when the smoke test fails

### DIFF
--- a/.github/workflows/test-and-deploy.yml
+++ b/.github/workflows/test-and-deploy.yml
@@ -58,6 +58,9 @@ jobs:
           echo "# Shader tests" >> "$GITHUB_STEP_SUMMARY"
           npm run test:shader
       - name: Smoke test
+        # An explicit shell makes Actions add -o pipefail, so the step fails on
+        # the smoke test's exit code rather than tee's.
+        shell: bash
         run: |
           echo "# Smoke test" >> "$GITHUB_STEP_SUMMARY"
           npm run test:smoke | tee >(sed 's/^/- /' >> "$GITHUB_STEP_SUMMARY")


### PR DESCRIPTION
The smoke test step in CI piped its output through `tee` with no explicit `shell:` key, so it ran under plain `bash -e` with no pipefail; the step's exit status was `tee`'s, which is always zero. Every smoke check has been advisory-only since the suite landed in #995: `FAIL` lines went into the step summary while the job stayed green.

An explicit `shell: bash` makes Actions run the step with `-o pipefail`, so the smoke test's own exit code now decides the step. Verified locally that `bash -e -c 'false | tee /dev/null'` exits 0 while `bash -eo pipefail` exits 1 on the same pipeline.

Part of #1001 (item 1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
