### PR TITLE
fix: score the debugger's back-disassembly boost on the address, not the text

### DIFF
--- a/src/web/debug.js
+++ b/src/web/debug.js
@@ -89,6 +89,48 @@ class MemoryView {
     }
 }
 
+/**
+ * Guesses the address of the instruction before the given one by scoring each
+ * possible run of instructions leading up to it: a point per "common"
+ * instruction (loads, stores, branches, compares, arithmetic and
+ * carry-set/clear that avoid unusual indexing modes) and a large boost for a
+ * run that passes through the current program counter. The highest-scoring
+ * run wins and its last instruction is the answer.
+ * Good test cases:
+ *   Repton 2 @ 2cbb
+ *   MOS @ cfc8
+ * also, just starting from the back of ROM and going up...
+ */
+export function prevInstruction(disassemble, pc, address) {
+    const commonInstructions =
+        /(RTS|B..|JMP|JSR|LD[AXY]|ST[AXY]|TA[XY]|T[XY]A|AD[DC]|SUB|SBC|CLC|SEC|CMP|EOR|ORR|AND|INC|DEC).*/;
+    const uncommonInstrucions = /.*,\s*([XY]|X\))$/;
+
+    address &= 0xffff;
+    let bestAddr = address - 1;
+    let bestScore = 0;
+    for (let startingPoint = address - 20; startingPoint !== address; startingPoint++) {
+        let score = 0;
+        let addr = startingPoint & 0xffff;
+        while (addr < address) {
+            const result = disassemble(addr);
+            if (addr === pc) score += 10;
+            if (result[0].match(commonInstructions) && !result[0].match(uncommonInstrucions)) {
+                score++;
+            }
+            if (result[1] === address) {
+                if (score > bestScore) {
+                    bestScore = score;
+                    bestAddr = addr;
+                    break;
+                }
+            }
+            addr = result[1];
+        }
+    }
+    return bestAddr;
+}
+
 export class Debugger {
     constructor() {
         this.patchInstructions = new Map();
@@ -382,42 +424,7 @@ export class Debugger {
     }
 
     prevInstruction(address) {
-        // Some attempt at making prevInstruction more accurate; score the sequence of instructions leading
-        // up to the target by counting all "common" instructions as a point. The highest-scoring run of
-        // instructions is picked as the most likely, and the previous from that is used. Common instructions
-        // here mean loads, stores, branches, compares, arithmetic and carry-set/clear that don't use "unusual"
-        // indexing modes like abs,X, abs,Y and (zp,X).
-        // Good test cases:
-        //   Repton 2 @ 2cbb
-        //   MOS @ cfc8
-        // also, just starting from the back of ROM and going up...
-        const commonInstructions =
-            /(RTS|B..|JMP|JSR|LD[AXY]|ST[AXY]|TA[XY]|T[XY]A|AD[DC]|SUB|SBC|CLC|SEC|CMP|EOR|ORR|AND|INC|DEC).*/;
-        const uncommonInstrucions = /.*,\s*([XY]|X\))$/;
-
-        address &= 0xffff;
-        let bestAddr = address - 1;
-        let bestScore = 0;
-        for (let startingPoint = address - 20; startingPoint !== address; startingPoint++) {
-            let score = 0;
-            let addr = startingPoint & 0xffff;
-            while (addr < address) {
-                const result = this.disassemble(addr);
-                if (addr === this.cpu.pc) score += 10;
-                if (result[0].match(commonInstructions) && !result[0].match(uncommonInstrucions)) {
-                    score++;
-                }
-                if (result[1] === address) {
-                    if (score > bestScore) {
-                        bestScore = score;
-                        bestAddr = addr;
-                        break;
-                    }
-                }
-                addr = result[1];
-            }
-        }
-        return bestAddr;
+        return prevInstruction((addr) => this.disassemble(addr), this.cpu.pc, address);
     }
 
     updatePrevMem() {

--- a/src/web/debug.js
+++ b/src/web/debug.js
@@ -403,7 +403,7 @@ export class Debugger {
             let addr = startingPoint & 0xffff;
             while (addr < address) {
                 const result = this.disassemble(addr);
-                if (result[0] === this.cpu.pc) score += 10; // huge boost if this instruction was executed
+                if (addr === this.cpu.pc) score += 10;
                 if (result[0].match(commonInstructions) && !result[0].match(uncommonInstrucions)) {
                     score++;
                 }

--- a/tests/unit/test-web-debug.js
+++ b/tests/unit/test-web-debug.js
@@ -85,6 +85,21 @@ describe("Debugger", () => {
             expect(currentRow().querySelector(".dis_addr").textContent).toBe("2000");
         });
 
+        it("scrolls back to the instruction at the program counter despite an ambiguous prefix", () => {
+            // Five LDA $41 pairs then $ad give a misaligned parse whose LDA $41a9 swallows
+            // the real LDA #$41 at 2000; only the boost for a run through pc outscores it.
+            for (let i = 0; i < 5; i++) {
+                cpu.writemem(0x1ff5 + i * 2, 0xa5);
+                cpu.writemem(0x1ff6 + i * 2, 0x41);
+            }
+            cpu.writemem(0x1fff, 0xad);
+            dbgr.debug(cpu.pc);
+            keyPress("j");
+            expect(currentRow().querySelector(".dis_addr").textContent).toBe("2002");
+            keyPress("k");
+            expect(currentRow().querySelector(".dis_addr").textContent).toBe("2000");
+        });
+
         it("toggles a breakpoint from the gutter, keeping it across a re-render", () => {
             dbgr.debug(cpu.pc);
             const gutter = () => currentRow().querySelector(".bp_gutter");

--- a/tests/unit/test-web-debug.js
+++ b/tests/unit/test-web-debug.js
@@ -1,10 +1,38 @@
 // @vitest-environment jsdom
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { Debugger } from "../../src/web/debug.js";
+import { Debugger, prevInstruction } from "../../src/web/debug.js";
+import { Cpu6502 as cpu6502Opcodes } from "../../src/6502.opcodes.js";
 import { fake6502 } from "../../src/fake6502.js";
 import { FakeVideo } from "../../src/video.js";
 import { domFromIndexHtml, teardownDom } from "./helpers.js";
+
+describe("prevInstruction", () => {
+    const mem = new Uint8Array(0x10000);
+    const disassembler = cpu6502Opcodes({ peekmem: (addr) => mem[addr & 0xffff] }).disassembler;
+    const disassemble = (addr) => disassembler.disassemble(addr);
+
+    beforeEach(() => {
+        mem.fill(0xea);
+    });
+
+    it("returns the previous instruction in an unambiguous run", () => {
+        expect(prevInstruction(disassemble, 0x1000, 0x2002)).toBe(0x2001);
+    });
+
+    it("prefers the run of instructions that passes through the program counter", () => {
+        // Five LDA $41 pairs then $ad give a misaligned parse whose LDA $41a9 swallows
+        // the real LDA #$41 at 2000; only the boost for a run through pc outscores it.
+        mem[0x2000] = 0xa9;
+        mem[0x2001] = 0x41;
+        for (let i = 0; i < 5; i++) {
+            mem[0x1ff5 + i * 2] = 0xa5;
+            mem[0x1ff6 + i * 2] = 0x41;
+        }
+        mem[0x1fff] = 0xad;
+        expect(prevInstruction(disassemble, 0x2000, 0x2002)).toBe(0x2000);
+    });
+});
 
 describe("Debugger", () => {
     let cpu;
@@ -79,21 +107,6 @@ describe("Debugger", () => {
             expect(currentRow().querySelector(".dis_addr").textContent).toBe("2002");
             disass.dispatchEvent(new WheelEvent("wheel", { deltaY: -30, cancelable: true }));
             expect(currentRow().querySelector(".dis_addr").textContent).toBe("2000");
-            keyPress("j");
-            expect(currentRow().querySelector(".dis_addr").textContent).toBe("2002");
-            keyPress("k");
-            expect(currentRow().querySelector(".dis_addr").textContent).toBe("2000");
-        });
-
-        it("scrolls back to the instruction at the program counter despite an ambiguous prefix", () => {
-            // Five LDA $41 pairs then $ad give a misaligned parse whose LDA $41a9 swallows
-            // the real LDA #$41 at 2000; only the boost for a run through pc outscores it.
-            for (let i = 0; i < 5; i++) {
-                cpu.writemem(0x1ff5 + i * 2, 0xa5);
-                cpu.writemem(0x1ff6 + i * 2, 0x41);
-            }
-            cpu.writemem(0x1fff, 0xad);
-            dbgr.debug(cpu.pc);
             keyPress("j");
             expect(currentRow().querySelector(".dis_addr").textContent).toBe("2002");
             keyPress("k");


### PR DESCRIPTION
The debugger's back-disassembly heuristic scores candidate instruction runs leading up to the target address, with a large boost meant for any run that passes through the instruction the CPU actually executed. The boost compared `result[0]` (the disassembled HTML string) against `this.cpu.pc` (a number), so it never fired; back-scrolling relied only on the "common instruction" scoring and could land on a misaligned boundary.

The fix compares the candidate address itself against the program counter. The regression test builds a byte pattern where a misaligned parse (a run of `LDA $41` pairs whose final `LDA $41a9` swallows the real `LDA #$41` at the program counter) outscores the true run unless the boost fires, then checks that scrolling down and back up in the disassembly window returns to the instruction at pc.

Part of #1001 (item 9).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
