### PR TITLE
fix: keep the emulator paused behind a save or load state error dialog

### DIFF
--- a/src/web/snapshot-ui.js
+++ b/src/web/snapshot-ui.js
@@ -110,6 +110,7 @@ export class SnapshotUI {
     async saveState() {
         const wasRunning = this.loop.isRunning();
         if (wasRunning) this.loop.stop(false);
+        let failure = null;
         try {
             const manifest = snapshotMedia(this.processor.fdc.drives, this.urlState.params);
             const snapshot = createSnapshot(this.processor, this.model, manifest);
@@ -118,14 +119,18 @@ export class SnapshotUI {
             const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
             downloadBlob(blob, `jsbeeb-${this.model.name}-${timestamp}.json.gz`);
         } catch (e) {
-            this.modals.showError("saving state", e);
+            failure = e;
         }
+        // Resume before reporting failure: the error dialog pauses a running
+        // loop itself, and resumes it on close.
         if (wasRunning) this.loop.go();
+        if (failure) this.modals.showError("saving state", failure);
     }
 
     async loadStateFromFile(file, preReadBuffer) {
         const wasRunning = this.loop.isRunning();
         if (wasRunning) this.loop.stop(false);
+        let failure = null;
         try {
             const arrayBuffer = preReadBuffer || (await file.arrayBuffer());
             const snapshot = await readSnapshot(arrayBuffer);
@@ -142,9 +147,10 @@ export class SnapshotUI {
             // Force a repaint so the display updates even while paused
             this.video.paint();
         } catch (e) {
-            this.modals.showError("loading state", e);
+            failure = e;
         }
         if (wasRunning) this.loop.go();
+        if (failure) this.modals.showError("loading state", failure);
     }
 
     /** Picks up the state a cross-model reload stashed, once the matching machine is up. */

--- a/tests/unit/test-snapshot-ui.js
+++ b/tests/unit/test-snapshot-ui.js
@@ -2,6 +2,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { SnapshotUI, isSnapshotFile, snapshotMedia } from "../../src/web/snapshot-ui.js";
+import { Modals } from "../../src/web/modals.js";
 import { DiscLayout } from "../../src/disc.js";
 import { domFromIndexHtml, ssdImage, teardownDom, toasts } from "./helpers.js";
 
@@ -127,6 +128,70 @@ describe("SnapshotUI", () => {
             expect(deps.modals.showError).not.toHaveBeenCalled();
             expect(sessionStorage.getItem("jsbeeb-pending-state")).toBeNull();
             expect(deps.loop.go).toHaveBeenCalledTimes(1);
+        });
+    });
+
+    describe("failure with the real error dialog", () => {
+        let loop;
+        let modals;
+
+        const makeWithModals = () => {
+            domFromIndexHtml("error-dialog", "loading-dialog", "are-you-sure");
+            vi.useFakeTimers();
+            loop = {
+                running: true,
+                isRunning() {
+                    return this.running;
+                },
+                stop() {
+                    this.running = false;
+                },
+                go() {
+                    this.running = true;
+                },
+            };
+            modals = new Modals({ loop });
+            deps.loop = loop;
+            deps.modals = modals;
+            return new SnapshotUI(deps);
+        };
+
+        const expectPausedBehindDialogThenResumedOnClose = async () => {
+            expect(loop.isRunning()).toBe(false);
+            await vi.runAllTimersAsync();
+            expect(modals.anyVisible()).toBe(true);
+            expect(loop.isRunning()).toBe(false);
+            modals.hide("error-dialog");
+            await vi.runAllTimersAsync();
+            expect(modals.anyVisible()).toBe(false);
+            expect(loop.isRunning()).toBe(true);
+        };
+
+        it("keeps the emulator paused while the save error shows, resuming on close", async () => {
+            const ui = makeWithModals();
+            deps.processor.snapshotState = vi.fn(() => {
+                throw new Error("saving went wrong");
+            });
+            await ui.saveState();
+            await expectPausedBehindDialogThenResumedOnClose();
+        });
+
+        it("keeps the emulator paused while the load error shows, resuming on close", async () => {
+            const ui = makeWithModals();
+            await ui.loadStateFromFile(null, new Uint8Array([0x00, 0x01, 0x02]).buffer);
+            await expectPausedBehindDialogThenResumedOnClose();
+        });
+
+        it("leaves a stopped emulator stopped after the error dialog closes", async () => {
+            const ui = makeWithModals();
+            loop.running = false;
+            await ui.loadStateFromFile(null, new Uint8Array([0x00, 0x01, 0x02]).buffer);
+            await vi.runAllTimersAsync();
+            expect(modals.anyVisible()).toBe(true);
+            expect(loop.isRunning()).toBe(false);
+            modals.hide("error-dialog");
+            await vi.runAllTimersAsync();
+            expect(loop.isRunning()).toBe(false);
         });
     });
 


### PR DESCRIPTION
## The bug

Two independent latches held the one piece of "was the emulator running" state, and they collided. `SnapshotUI.saveState` (and `loadStateFromFile`) records `wasRunning`, stops the loop, and does its work. On failure it calls `modals.showError`, which opens a Bootstrap modal; `Modals`' document-level `show.bs.modal` handler samples `loop.isRunning()` for the first modal up, but the loop is already stopped, so its latch records false. `saveState` then reaches its `if (wasRunning) this.loop.go()` and the emulator resumes behind the error dialog; closing the dialog does nothing because `Modals`' latch says there is nothing to resume.

## The fix

`SnapshotUI` now captures the failure, restores the loop to its prior state first, and only then shows the error dialog. The dialog therefore opens on a loop in its true pre-save state, and `Modals`' existing pause-and-resume handling is the single authority while any dialog is up: it stops the running loop as the dialog opens and restarts it when the last dialog closes. The success path, the already-stopped path, and a failure while another dialog is already up (loop stopped, `wasRunning` false, `Modals`' latch untouched because a modal is visible) all come out right.

`RewindUI` has its own stop/go pair but does not collide: its panel is a plain hidden div, not a Bootstrap modal, so opening it fires no `show.bs.modal` and never touches `Modals`' latch; it never opens a dialog while it holds the loop stopped.

## Tests

New regression tests wire `SnapshotUI` to a real `Modals` over a shared loop: a failing save (and load) must leave the loop stopped while the error dialog shows and running again once it closes, and a loop that was already stopped must stay stopped. The save and load failure tests fail on main.

Part of #1001 (item 2). This is a stopgap at the colliding call sites; the pause-depth mechanism on `EmulationLoop` (#1002, theme B) is the durable shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)