### PR TITLE
fix: stop a failed Google Drive load reaching the drive as undefined

### DIFF
--- a/src/web/google-drive-picker.js
+++ b/src/web/google-drive-picker.js
@@ -28,9 +28,12 @@ export class GoogleDrivePicker {
             this.authEl.style.display = "none";
             e.preventDefault();
             const authed = await this.auth(false);
-            if (authed) this.authResolve();
-            else this.authReject(new Error("Unable to authorize Google Drive"));
+            if (authed) this.authResolve?.(true);
+            else this.authReject?.(new Error("Unable to authorize Google Drive"));
         });
+
+        // Closing the loading dialog while the auth panel waits is a cancellation, not an error.
+        document.getElementById("loading-dialog").addEventListener("hidden.bs.modal", () => this.authResolve?.(false));
 
         // Loading the Google client holds the main thread for ~100ms, so it waits for
         // someone to ask for Drive.
@@ -74,11 +77,21 @@ export class GoogleDrivePicker {
             console.log("Google Drive authed=", authed);
 
             if (!authed) {
-                await new Promise((resolve, reject) => {
-                    this.authResolve = resolve;
-                    this.authReject = reject;
-                    this.authEl.style.display = "";
-                });
+                let granted;
+                try {
+                    granted = await new Promise((resolve, reject) => {
+                        this.authResolve = resolve;
+                        this.authReject = reject;
+                        this.authEl.style.display = "";
+                    });
+                } finally {
+                    this.authResolve = this.authReject = null;
+                }
+                if (!granted) {
+                    console.log("Google Drive authorization dismissed");
+                    this.modals.loadingFinished();
+                    return null;
+                }
             }
 
             const ssd = await this.googleDrive.load(this.processor.fdc, cat.id, layout);
@@ -93,7 +106,8 @@ export class GoogleDrivePicker {
             return ssd;
         } catch (error) {
             console.error("Google Drive loading error:", error);
-            this.modals.loadingFinished(`Unable to load ${cat.name} from Google Drive: ${errorText(error)}`);
+            this.modals.loadingFinished();
+            throw error;
         }
     }
 
@@ -122,8 +136,14 @@ export class GoogleDrivePicker {
                 utils.noteEvent("google-drive", "click", item.name);
                 this.media.setDisc1Image(`gd:${item.id}/${item.name}`);
                 this.modal.hide();
-                const ssd = await this.load(item, this.drives.layoutForDrive(0));
-                if (ssd) this.drives.putDiscIn(0, ssd);
+                try {
+                    const ssd = await this.load(item, this.drives.layoutForDrive(0));
+                    if (ssd) this.drives.putDiscIn(0, ssd);
+                } catch (error) {
+                    toast(`Unable to load ${item.name} from Google Drive: ${errorText(error)}`, {
+                        title: "Google Drive",
+                    });
+                }
             });
         }
     }

--- a/src/web/machine.js
+++ b/src/web/machine.js
@@ -162,15 +162,17 @@ export class Machine {
         }
 
         if (discImage) {
-            startImageLoad(`disc ${discImage}`, async () =>
-                drives.putDiscIn(0, await media.loadDiscImage(discImage, drives.layoutForDrive(0))),
-            );
+            startImageLoad(`disc ${discImage}`, async () => {
+                const loadedDisc = await media.loadDiscImage(discImage, drives.layoutForDrive(0));
+                if (loadedDisc) drives.putDiscIn(0, loadedDisc);
+            });
         }
 
         if (secondDiscImage) {
-            startImageLoad(`disc ${secondDiscImage}`, async () =>
-                drives.putDiscIn(1, await media.loadDiscImage(secondDiscImage, drives.layoutForDrive(1))),
-            );
+            startImageLoad(`disc ${secondDiscImage}`, async () => {
+                const loadedDisc = await media.loadDiscImage(secondDiscImage, drives.layoutForDrive(1));
+                if (loadedDisc) drives.putDiscIn(1, loadedDisc);
+            });
         }
 
         if (tape) {

--- a/tests/unit/test-google-drive-picker.js
+++ b/tests/unit/test-google-drive-picker.js
@@ -50,13 +50,25 @@ describe("GoogleDrivePicker", () => {
             expect(toasts()).toEqual([expect.stringContaining("mine.ssd is read only on Google Drive")]);
         });
 
-        it("reports Drive being unavailable through the loading dialog", async () => {
+        it("rejects when Drive is unavailable, closing the loading dialog without a report of its own", async () => {
             loader.initialise.mockResolvedValue(false);
-            const got = await make().load({ id: "abc", name: "mine.ssd" }, "auto");
-            expect(got).toBeUndefined();
-            expect(deps.modals.loadingFinished).toHaveBeenCalledWith(
-                expect.stringContaining("Unable to load mine.ssd from Google Drive"),
+            await expect(make().load({ id: "abc", name: "mine.ssd" }, "auto")).rejects.toThrow(
+                "Google Drive is not available",
             );
+            expect(deps.modals.loadingFinished).toHaveBeenCalledWith();
+            expect(toasts()).toEqual([]);
+        });
+
+        it("cancels quietly when the loading dialog is dismissed at the sign-in", async () => {
+            loader.authorize.mockResolvedValue(false);
+            const picker = make();
+            const loading = picker.load({ id: "abc", name: "mine.ssd" }, "auto");
+            await vi.waitFor(() => expect(document.getElementById("google-drive-auth").style.display).toBe(""));
+            document.getElementById("loading-dialog").dispatchEvent(new Event("hidden.bs.modal"));
+            await expect(loading).resolves.toBeNull();
+            expect(deps.modals.loadingFinished).toHaveBeenCalledWith();
+            expect(loader.load).not.toHaveBeenCalled();
+            expect(toasts()).toEqual([]);
         });
 
         it("shows the sign-in and carries on once the form is submitted", async () => {
@@ -107,6 +119,22 @@ describe("GoogleDrivePicker", () => {
             document.querySelector("#google-drive li:not(.template)").click();
             await vi.waitFor(() => expect(deps.drives.putDiscIn).toHaveBeenCalledWith(0, ssd));
             expect(deps.media.setDisc1Image).toHaveBeenCalledWith("gd:abc/mine.ssd");
+        });
+
+        it("reports a failed load once and leaves the drive alone", async () => {
+            loader.listFiles.mockResolvedValue([{ id: "abc", name: "mine.ssd" }]);
+            loader.load.mockRejectedValue(new Error("boom"));
+            const picker = make();
+            vi.spyOn(picker.modal, "hide").mockImplementation(() => {});
+            document.getElementById("google-drive").dispatchEvent(new Event("show.bs.modal"));
+            await vi.waitFor(() =>
+                expect(document.querySelectorAll("#google-drive li:not(.template)")).toHaveLength(1),
+            );
+            document.querySelector("#google-drive li:not(.template)").click();
+            await vi.waitFor(() =>
+                expect(toasts()).toEqual([expect.stringContaining("Unable to load mine.ssd from Google Drive: boom")]),
+            );
+            expect(deps.drives.putDiscIn).not.toHaveBeenCalled();
         });
 
         it("says when the list cannot be fetched", async () => {

--- a/tests/unit/test-web-machine.js
+++ b/tests/unit/test-web-machine.js
@@ -151,6 +151,15 @@ describe("Machine", () => {
             expect(started.media.setProcessorTape).toHaveBeenCalled();
         });
 
+        it("skips a drive whose image load resolves to nothing", async () => {
+            const machine = make();
+            const started = startDeps();
+            started.media.loadDiscImage.mockResolvedValue(null);
+            await machine.start({ ...started, discImage: "gd:abc/mine.ssd" });
+            expect(started.drives.putDiscIn).not.toHaveBeenCalled();
+            expect(toasts()).toEqual([]);
+        });
+
         it("only loads an MMC image on an Atom", async () => {
             const machine = make();
             await machine.start({ ...startDeps(), mmcImage: "sd.img" });


### PR DESCRIPTION
Two related bugs in the Google Drive load path.

**A failed load reported twice and put undefined in the drive.** `GoogleDrivePicker.load()` caught any failure, toasted it, and fell off the end returning undefined. The file-list click path guarded against that, but the `gd:` URL source did not: the undefined flowed through `media.loadDiscImage` into `drives.putDiscIn(0, undefined)`, which threw a TypeError in `noteUnsavedWrites`, and `startImageLoad` then reported that TypeError on top of Google's own message. `load()` now closes the loading dialog and rethrows, leaving each caller's existing error path as the single report: `reportLoadFailure` on the URL path (consistent with every other disc source), a toast on the file-list path.

**A dismissed auth prompt hung the load forever.** The pending sign-in promise was only ever settled by the auth form's submit handler; closing the loading dialog (which hosts the auth panel) left `load()` awaiting it with the modal state stuck. The picker now listens for `hidden.bs.modal` on the loading dialog and resolves the pending sign-in as a cancellation. The user deliberately closed it, so this is quiet: no toast, `load()` resolves null, and `Machine.start` skips `putDiscIn` for a nullish disc (which `media.loadDiscImage` could already return for an empty image name).

Part of #1001 (items 6 and 7).

🤖 Generated with [Claude Code](https://claude.com/claude-code)