### PR TITLE
fix: record the default boot disc in save states and verify discs on restore

### DIFF
--- a/docs/snapshot-format.md
+++ b/docs/snapshot-format.md
@@ -41,13 +41,13 @@ jsbeeb saves emulator state as gzip-compressed JSON files with the extension `.j
 | `disc1Layout`    | string     | _(Optional)_ Track layout drive 0's disc was loaded with         |
 | `disc2Layout`    | string     | _(Optional)_ Track layout drive 1's disc was loaded with         |
 
-On restore, discs are reloaded from these source references before the FDC state is applied. The source string uses the same schema as URL query parameters (`sth:`, `http://`, `gd:`, etc.).
+On restore, discs are reloaded from these source references before the FDC state is applied. The source string uses the same schema as URL query parameters (`sth:`, `http://`, `gd:`, etc.); a bare filename names a built-in disc served from `discs/`, which is how a state saved from a default boot records its disc.
 
 `discNLayout` is `"contiguous"` (logical track N on physical track N) or `"expanded40"` (logical track N on physical track 2N, as a 40-track drive writes). It is recorded because the dirty track overlays below are indexed by physical track: reloading the disc pins it to the layout saved here rather than working the layout out again from the image. Absent means `"contiguous"`, which is what every snapshot written before layout detection existed holds.
 
 For locally-loaded files (via file input), the original disc image bytes are embedded in `discNImageData` so the disc can be reconstructed on restore without requiring the user to reload the file manually.
 
-When `discNCrc32` is present, it is compared against the CRC32 of the reloaded disc image. A mismatch shows an error dialog warning that the disc image may have changed since the snapshot was saved.
+When `discNCrc32` is present, it is compared against the CRC32 of the reloaded disc image. The restore fails with an error if the reloaded image does not match, or if the state carries a CRC but no source and the disc already in the drive does not match; the dirty track overlays below would otherwise be laid over the wrong disc.
 
 ### Version history
 

--- a/src/main.js
+++ b/src/main.js
@@ -50,6 +50,7 @@ let secondDiscImage = null;
 const { discImage: queryDiscImage, secondDiscImage: querySecondDisc, mmcImage } = parseMediaParams(parsedQuery);
 if (queryDiscImage) discImage = queryDiscImage;
 if (querySecondDisc) secondDiscImage = querySecondDisc;
+const defaultBootDisc = queryDiscImage ? undefined : discImage;
 const { settings: driveTracks, warnings: driveTrackWarnings } = processDriveTrackParams(parsedQuery);
 
 const extraRoms = [];
@@ -276,6 +277,7 @@ const snapshots = new SnapshotUI({
     urlState,
     modals,
     loop,
+    defaultBootDisc,
 });
 
 const inputs = new AnalogueInputs({

--- a/src/web/snapshot-ui.js
+++ b/src/web/snapshot-ui.js
@@ -200,12 +200,22 @@ export class SnapshotUI {
             if (!loadedDisc) {
                 if (savedMedia[crcKey] != null) {
                     // A state may name no source (older default-boot saves); the disc
-                    // already in the drive can still satisfy the CRC.
+                    // already in the drive can still satisfy the CRC, but only laid out
+                    // the way the state's dirty tracks expect.
                     const currentDisc = this.processor.fdc.drives[driveIndex].disc;
-                    if (currentDisc && currentDisc.originalImageCrc32 === savedMedia[crcKey]) continue;
+                    const currentLayout = currentDisc?.is40Track ? DiscLayout.expanded40 : DiscLayout.contiguous;
+                    if (
+                        currentDisc &&
+                        currentDisc.originalImageCrc32 === savedMedia[crcKey] &&
+                        currentLayout === layout
+                    )
+                        continue;
+                    const problem = savedMedia[discKey]
+                        ? `The disc for drive ${driveIndex} (${savedMedia[discKey]}) could not be reloaded`
+                        : `This state does not record where the disc in drive ${driveIndex} came from`;
                     throw new Error(
-                        `This state does not record where the disc in drive ${driveIndex} came from, and the ` +
-                            `drive does not hold a matching disc. Load the right disc, then load the state again.`,
+                        `${problem}, and the drive does not hold a matching disc. ` +
+                            `Load the right disc, then load the state again.`,
                     );
                 }
                 continue;

--- a/src/web/snapshot-ui.js
+++ b/src/web/snapshot-ui.js
@@ -1,7 +1,6 @@
 import * as disc from "../fdc.js";
 import { DiscLayout } from "../disc.js";
 import { downloadBlob } from "../dom-utils.js";
-import { toast } from "./toast.js";
 import {
     createSnapshot,
     restoreSnapshot,
@@ -58,9 +57,14 @@ async function readSnapshot(arrayBuffer) {
  * where they have one, the image bytes where they do not, and CRCs for
  * saying when a source has changed underneath a state.
  */
-export function snapshotMedia(fdcDrives, params) {
+export function snapshotMedia(fdcDrives, params, defaultBootDisc) {
     const manifest = {};
+    const drive0Disc = fdcDrives[0].disc;
     if (params.disc1 || params.disc) manifest.disc1 = params.disc1 || params.disc;
+    // A default boot loads the built-in disc without naming it in the URL; record it by
+    // name so the state can reload it, but only while that disc is still in the drive.
+    else if (defaultBootDisc && drive0Disc && drive0Disc.name === defaultBootDisc && !drive0Disc.originalImageData)
+        manifest.disc1 = defaultBootDisc;
     if (params.disc2) manifest.disc2 = params.disc2;
 
     // For each drive with a disc loaded, include CRC32 for verification
@@ -84,7 +88,7 @@ export function snapshotMedia(fdcDrives, params) {
 
 /** Saving and restoring states: the menu item, the file input and the reload across a model change. */
 export class SnapshotUI {
-    constructor({ processor, model, video, media, drives, urlState, modals, loop }) {
+    constructor({ processor, model, video, media, drives, urlState, modals, loop, defaultBootDisc }) {
         this.processor = processor;
         this.model = model;
         this.video = video;
@@ -93,6 +97,7 @@ export class SnapshotUI {
         this.urlState = urlState;
         this.modals = modals;
         this.loop = loop;
+        this.defaultBootDisc = defaultBootDisc;
 
         document.getElementById("save-state").addEventListener("click", async (event) => {
             event.preventDefault();
@@ -111,7 +116,7 @@ export class SnapshotUI {
         const wasRunning = this.loop.isRunning();
         if (wasRunning) this.loop.stop(false);
         try {
-            const manifest = snapshotMedia(this.processor.fdc.drives, this.urlState.params);
+            const manifest = snapshotMedia(this.processor.fdc.drives, this.urlState.params, this.defaultBootDisc);
             const snapshot = createSnapshot(this.processor, this.model, manifest);
             const json = snapshotToJSON(snapshot);
             const blob = await compressBlob(new Blob([json]));
@@ -192,16 +197,28 @@ export class SnapshotUI {
                 // Retain the image bytes so subsequent saves can re-embed them.
                 loadedDisc.setOriginalImage(imageData);
             }
-            if (!loadedDisc) continue;
-
-            // Verify CRC32 if present
-            if (savedMedia[crcKey] != null && loadedDisc.originalImageCrc32 != null) {
-                if (loadedDisc.originalImageCrc32 !== savedMedia[crcKey]) {
-                    toast(
-                        `${loadedDisc.name} has changed since this state was saved. The state has been restored anyway and may not run correctly.`,
-                        { title: "Restoring state" },
+            if (!loadedDisc) {
+                if (savedMedia[crcKey] != null) {
+                    // A state may name no source (older default-boot saves); the disc
+                    // already in the drive can still satisfy the CRC.
+                    const currentDisc = this.processor.fdc.drives[driveIndex].disc;
+                    if (currentDisc && currentDisc.originalImageCrc32 === savedMedia[crcKey]) continue;
+                    throw new Error(
+                        `This state does not record where the disc in drive ${driveIndex} came from, and the ` +
+                            `drive does not hold a matching disc. Load the right disc, then load the state again.`,
                     );
                 }
+                continue;
+            }
+
+            if (
+                savedMedia[crcKey] != null &&
+                loadedDisc.originalImageCrc32 != null &&
+                loadedDisc.originalImageCrc32 !== savedMedia[crcKey]
+            ) {
+                throw new Error(
+                    `${loadedDisc.name} has changed since this state was saved, so the state cannot be restored over it.`,
+                );
             }
 
             this.drives.putDiscIn(driveIndex, loadedDisc);

--- a/tests/unit/test-snapshot-ui.js
+++ b/tests/unit/test-snapshot-ui.js
@@ -200,6 +200,13 @@ describe("SnapshotUI", () => {
             expect(deps.drives.putDiscIn).not.toHaveBeenCalled();
         });
 
+        it("rejects a sourceless state when the matching disc is laid out differently", async () => {
+            deps.processor.fdc.drives[0].disc = { name: "elite.ssd", originalImageCrc32: 0x1234, is40Track: true };
+            await expect(
+                make().reloadSnapshotMedia({ disc1Crc32: 0x1234, disc1Layout: DiscLayout.contiguous }),
+            ).rejects.toThrow("does not hold a matching disc");
+        });
+
         it("round-trips the media of a default-boot session", async () => {
             const bootDisc = { name: "elite.ssd", originalImageCrc32: 0x1234, is40Track: false };
             deps.processor.fdc.drives[0].disc = bootDisc;

--- a/tests/unit/test-snapshot-ui.js
+++ b/tests/unit/test-snapshot-ui.js
@@ -45,6 +45,31 @@ describe("snapshot media manifest", () => {
         expect(manifest.disc2).toBe("b.ssd");
         expect(manifest.disc2Crc32).toBe(0x1234);
     });
+
+    const defaultBootDisc = { ...urlDisc, name: "elite.ssd" };
+
+    it("names the default built-in disc when the URL names none", () => {
+        const manifest = snapshotMedia([{ disc: defaultBootDisc }, { disc: null }], {}, "elite.ssd");
+        expect(manifest.disc1).toBe("elite.ssd");
+        expect(manifest.disc1Crc32).toBe(0x1234);
+    });
+
+    it("prefers the URL's disc over the default boot disc", () => {
+        const manifest = snapshotMedia([{ disc: urlDisc }, { disc: null }], { disc1: "sth:OTHER.zip" }, "elite.ssd");
+        expect(manifest.disc1).toBe("sth:OTHER.zip");
+    });
+
+    it("embeds a local disc rather than naming the default it replaced", () => {
+        const manifest = snapshotMedia([{ disc: localDisc }, { disc: null }], {}, "elite.ssd");
+        expect(manifest.disc1).toBeUndefined();
+        expect(manifest.disc1ImageData).toBe(localDisc.originalImageData);
+    });
+
+    it("does not name the default when the drive holds something else", () => {
+        const swappedIn = { ...urlDisc, name: "other.ssd" };
+        const manifest = snapshotMedia([{ disc: swappedIn }, { disc: null }], {}, "elite.ssd");
+        expect(manifest.disc1).toBeUndefined();
+    });
 });
 
 describe("isSnapshotFile", () => {
@@ -146,11 +171,45 @@ describe("SnapshotUI", () => {
             expect(toasts()).toEqual([]);
         });
 
-        it("warns when the source has changed under the state", async () => {
+        it("refuses to restore when the source has changed under the state", async () => {
             deps.media.loadDiscImage.mockResolvedValue({ name: "ELITE.ssd", originalImageCrc32: 0x9999 });
-            await make().reloadSnapshotMedia({ disc1: "sth:ELITE.zip", disc1Crc32: 0x1234 });
-            expect(toasts()).toEqual([expect.stringContaining("ELITE.ssd has changed since this state was saved")]);
-            expect(deps.drives.putDiscIn).toHaveBeenCalled();
+            await expect(make().reloadSnapshotMedia({ disc1: "sth:ELITE.zip", disc1Crc32: 0x1234 })).rejects.toThrow(
+                "ELITE.ssd has changed since this state was saved",
+            );
+            expect(deps.drives.putDiscIn).not.toHaveBeenCalled();
+        });
+
+        it("refuses to restore over an empty drive when the state has a CRC but no source", async () => {
+            await expect(make().reloadSnapshotMedia({ disc1Crc32: 0x1234 })).rejects.toThrow(
+                "does not record where the disc in drive 0 came from",
+            );
+            expect(deps.drives.putDiscIn).not.toHaveBeenCalled();
+        });
+
+        it("refuses to restore over a different disc when the state has a CRC but no source", async () => {
+            deps.processor.fdc.drives[0].disc = { name: "other.ssd", originalImageCrc32: 0x9999 };
+            await expect(make().reloadSnapshotMedia({ disc1Crc32: 0x1234 })).rejects.toThrow(
+                "does not hold a matching disc",
+            );
+            expect(deps.drives.putDiscIn).not.toHaveBeenCalled();
+        });
+
+        it("accepts a sourceless state when the drive already holds the matching disc", async () => {
+            deps.processor.fdc.drives[0].disc = { name: "elite.ssd", originalImageCrc32: 0x1234 };
+            await make().reloadSnapshotMedia({ disc1Crc32: 0x1234 });
+            expect(deps.drives.putDiscIn).not.toHaveBeenCalled();
+        });
+
+        it("round-trips the media of a default-boot session", async () => {
+            const bootDisc = { name: "elite.ssd", originalImageCrc32: 0x1234, is40Track: false };
+            deps.processor.fdc.drives[0].disc = bootDisc;
+            deps.defaultBootDisc = "elite.ssd";
+            const ui = make();
+            const manifest = snapshotMedia(deps.processor.fdc.drives, deps.urlState.params, deps.defaultBootDisc);
+            deps.media.loadDiscImage.mockResolvedValue(bootDisc);
+            await ui.reloadSnapshotMedia(manifest);
+            expect(deps.media.loadDiscImage).toHaveBeenCalledWith("elite.ssd", DiscLayout.contiguous);
+            expect(deps.drives.putDiscIn).toHaveBeenCalledWith(0, bootDisc);
         });
 
         it("rebuilds an embedded local disc and keeps it out of the URL", async () => {


### PR DESCRIPTION
## The bug

Booting with no `?disc1` loads the built-in disc (`BuiltInImages[0].file` in `src/main.js`) directly through `machine.start`, without the URL bookkeeping that `setDisc1Image` does, so `urlState.params.disc1` stays unset. When a state is saved, `snapshotMedia` writes `disc1Crc32` and `disc1Layout` into the media manifest but no `disc1` reference and no embedded image bytes (those are only kept for local-file loads). On restore, `reloadSnapshotMedia` found neither a reference nor image data, loaded nothing, skipped the CRC check entirely, and `restoreSnapshot` then laid the state's dirty track overlays over whatever was in drive 0. That worked by accident when the same default disc was already loaded, and silently corrupted drive 0 when the state was loaded into a session started with a different `?disc1`.

## The fix

Two parts, in order of importance:

- A restore never proceeds unverified any more. If the manifest carries a `discNCrc32` and the reloaded disc does not match it, or nothing could be reloaded and the disc already in the drive does not match, the restore fails with a clear error through the existing modal path instead of overlaying the wrong disc. The old behaviour for a mismatch was a toast saying the state had been restored anyway.
- A state saved from a default boot now records its disc. `main.js` passes the built-in disc name to `SnapshotUI` when the URL named no disc, and `snapshotMedia` records it as `disc1`, but only while that disc is still the one in drive 0 (a picker load sets the URL params, and a local-file load carries embedded bytes, so both take precedence). The visible URL stays clean on a default boot; nothing is written to the address bar.

Older sourceless states (saved before this fix) still restore when the drive already holds the matching disc, which is the situation where they previously worked correctly; otherwise they now error instead of corrupting.

No manifest fields were added and the format version is unchanged; `docs/snapshot-format.md` is updated to describe the default-boot reference and the restore-failure semantics.

Part of #1001 (item 3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)