### PR TITLE
fix: guard filestore access when Econet is not fitted

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -392,6 +392,7 @@ document.getElementById("soft-reset").addEventListener("click", function (event)
 });
 
 document.getElementById("download-filestore-link").addEventListener("click", function () {
+    if (!processor.filestore) return;
     downloadDriveData(processor.filestore.scsi, "scsi", ".dat");
 });
 

--- a/src/web/media-loader.js
+++ b/src/web/media-loader.js
@@ -210,8 +210,9 @@ export class MediaLoader extends EventTarget {
     }
 
     async loadSCSIFile(file) {
-        const binaryData = await readFileAsBinaryString(file);
         const { processor } = this;
+        if (!processor.filestore) return;
+        const binaryData = await readFileAsBinaryString(file);
         processor.filestore.scsi = utils.stringToUint8Array(binaryData);
 
         processor.filestore.PC = 0x400;

--- a/tests/unit/test-media-loader.js
+++ b/tests/unit/test-media-loader.js
@@ -182,6 +182,12 @@ describe("MediaLoader", () => {
             expect(deps.processor.filestore.PC).toBe(0x400);
             expect(deps.processor.econet.receiveBlocks).toEqual([]);
         });
+
+        it("quietly ignores a SCSI image when no filestore is fitted", async () => {
+            deps.processor.filestore = undefined;
+            await make().loadSCSIFile(fileFor("scsi.dat", new Uint8Array([1, 2, 3])));
+            expect(deps.modals.hide).not.toHaveBeenCalled();
+        });
     });
 
     describe("the drop zone", () => {


### PR DESCRIPTION
`processor.filestore` only exists when the machine is fitted with Econet (`src/6502.js` creates it behind `if (this.econet)`), but two places dereferenced it unconditionally:

- the `download-filestore-link` click handler in `src/main.js` read `processor.filestore.scsi`, so a click threw a TypeError on machines without Econet; only the CSS-hidden menu item masked it
- `loadSCSIFile` in `src/web/media-loader.js` wrote to `processor.filestore.scsi` and friends with the same failure mode

Both now return early when there is no filestore; a quiet no-op is right since the UI for these paths is hidden on such machines. The new test drives `loadSCSIFile` without a filestore and checks it neither throws nor closes the modal.

Part of #1001 (item 10).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
