### PR TITLE
fix: throw when extra ROMs exceed the free sideways banks

### DIFF
--- a/src/6502.js
+++ b/src/6502.js
@@ -1195,6 +1195,7 @@ export class Cpu6502 extends Base6502 {
             while (this.model.swram[romIndex]) {
                 romIndex--;
             }
+            if (romIndex < 0) throw new Error("Too many extra ROMs (no free sideways ROM banks)");
 
             awaiting.push(this.loadRom(extraRoms[i_2], this.romOffset + romIndex * 16384));
         }

--- a/tests/unit/test-rom-loading.js
+++ b/tests/unit/test-rom-loading.js
@@ -1,0 +1,37 @@
+import { describe, it, expect } from "vitest";
+import { Cpu6502 } from "../../src/6502.js";
+import { TEST_6502 } from "../../src/models.js";
+import { FakeVideo } from "../../src/video.js";
+import { FakeSoundChip } from "../../src/soundchip.js";
+import { FakeDdNoise } from "../../src/ddnoise.js";
+import { FakeMusic5000 } from "../../src/music5000.js";
+import { Cmos } from "../../src/cmos.js";
+
+function makeCpu() {
+    return new Cpu6502(TEST_6502, {
+        dbgr: { setCpu: () => {} },
+        video: new FakeVideo(),
+        soundChip: new FakeSoundChip(),
+        ddNoise: new FakeDdNoise(),
+        music5000: new FakeMusic5000(),
+        cmos: new Cmos(),
+        config: { extraRoms: [] },
+    });
+}
+
+// TEST_6502 has eight sideways RAM banks, leaving eight for extra ROMs.
+const NumFreeRomBanks = 8;
+
+describe("Cpu6502 extra ROM loading", () => {
+    it("loads extra ROMs into every free sideways bank", async () => {
+        const cpu = makeCpu();
+        await cpu.loadOs("os.rom", ...Array(NumFreeRomBanks).fill("BASIC.ROM"));
+    });
+
+    it("throws when extra ROMs exceed the free sideways banks", async () => {
+        const cpu = makeCpu();
+        await expect(cpu.loadOs("os.rom", ...Array(NumFreeRomBanks + 1).fill("BASIC.ROM"))).rejects.toThrow(
+            "Too many extra ROMs",
+        );
+    });
+});


### PR DESCRIPTION
## The bug

The BBC extra-ROM loop in `loadOs` decrements `romIndex` for each extra ROM with no bank-exhaustion check. Once every free sideways bank is in use (reachable with repeated `?rom=` URL parameters; the sideways RAM skip makes it as few as nine on a model B), `romIndex` goes negative and the swram skip loop exits on the undefined entry, so the next ROM is written at `romOffset - 16384`, inside the RAM region of `ramRomOs`, silently corrupting 16KB of emulated memory.

## The fix

Throw a clear error when the banks run out, matching the Atom path's existing "Too many extra ROMs" behaviour. Adds a regression test that loads one ROM more than the free banks and expects the rejection, plus a test that filling every free bank still works.

Part of #1001 (item 5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)