### PR TITLE
fix: let the back-disassembly heuristic accept a run scoring nothing

### DIFF
--- a/src/6502.opcodes.js
+++ b/src/6502.opcodes.js
@@ -990,10 +990,28 @@ const opcodes65c02 = {
     0xff: "BBS7 zp,branch",
 };
 
+const LegalMnemonics = new Set(
+    (
+        "ADC AND ASL BCC BCS BEQ BIT BMI BNE BPL BRK BVC BVS CLC CLD CLI CLV CMP CPX CPY DEC DEX DEY EOR INC INX " +
+        "INY JMP JSR LDA LDX LDY LSR NOP ORA PHA PHP PLA PLP ROL ROR RTI RTS SBC SEC SED SEI STA STX STY TAX TAY " +
+        "TSX TXA TXS TYA BRA PHX PHY PLX PLY STZ TRB TSB"
+    ).split(" "),
+);
+const PrevInstructionWindow = 64;
+
 class Disassemble6502 {
     constructor(cpu, opcodes) {
         this.cpu = cpu;
         this.opcodes = opcodes;
+        // Only $EA is a documented NOP; the table's other NOPs are the undocumented slots.
+        this.legalOpcodes = new Set(
+            Object.entries(opcodes)
+                .filter(([op, text]) => {
+                    const mnemonic = text.split(" ")[0];
+                    return LegalMnemonics.has(mnemonic) && (mnemonic !== "NOP" || Number(op) === 0xea);
+                })
+                .map(([op]) => Number(op)),
+        );
     }
 
     disassemble(addr, plain) {
@@ -1065,14 +1083,16 @@ class Disassemble6502 {
 
     /**
      * Guesses the address of the instruction before the given one by scoring
-     * each possible run of instructions leading up to it: a point per "common"
-     * instruction (loads, stores, branches, compares, arithmetic and
-     * carry-set/clear that avoid unusual indexing modes) and a large boost for
-     * a run that passes through pc. The highest-scoring run wins and its last
-     * instruction is the answer.
+     * each run of instructions in the preceding window that lands exactly on
+     * it: a point per "common" instruction (loads, stores, branches, compares,
+     * arithmetic and carry-set/clear that avoid unusual indexing modes) and a
+     * large boost for a run that passes through pc. Runs through undocumented
+     * opcodes are discarded. The highest-scoring run's last instruction wins;
+     * any run beats none, since a wrong parse resynchronises within a few
+     * instructions and so nearly always shares the true stream's last one.
      * Good test cases:
      *   Repton 2 @ 2cbb
-     *   MOS @ cfc8
+     *   MOS @ cfc8, and the unrolled STA abs,X screen clear @ cc63
      * also, just starting from the back of ROM and going up...
      */
     prevInstruction(address, pc) {
@@ -1082,11 +1102,12 @@ class Disassemble6502 {
 
         address &= 0xffff;
         let bestAddr = address - 1;
-        let bestScore = 0;
-        for (let startingPoint = address - 20; startingPoint !== address; startingPoint++) {
+        let bestScore = -1;
+        for (let startingPoint = address - PrevInstructionWindow; startingPoint !== address; startingPoint++) {
             let score = 0;
             let addr = startingPoint & 0xffff;
             while (addr < address) {
+                if (!this.legalOpcodes.has(this.cpu.peekmem(addr))) break;
                 const result = this.disassemble(addr);
                 if (addr === pc) score += 10;
                 if (result[0].match(commonInstructions) && !result[0].match(uncommonInstructions)) {
@@ -1096,8 +1117,8 @@ class Disassemble6502 {
                     if (score > bestScore) {
                         bestScore = score;
                         bestAddr = addr;
-                        break;
                     }
+                    break;
                 }
                 addr = result[1];
             }

--- a/src/6502.opcodes.js
+++ b/src/6502.opcodes.js
@@ -525,254 +525,269 @@ function getOp(op, arg) {
     throw new Error(`Unrecognised operation '${op}'`);
 }
 
-const opcodes6502 = {
+// Undocumented opcodes carry a leading "*", as 6502 listings conventionally show them.
+function splitUndocumented(markedOpcodes) {
+    const opcodes = {};
+    const undocumented = new Set();
+    for (const [op, text] of Object.entries(markedOpcodes)) {
+        if (text.startsWith("*")) {
+            undocumented.add(Number(op));
+            opcodes[op] = text.slice(1);
+        } else {
+            opcodes[op] = text;
+        }
+    }
+    return { opcodes, undocumented };
+}
+
+const { opcodes: opcodes6502, undocumented: undocumented6502 } = splitUndocumented({
     0x00: "BRK",
     0x01: "ORA (,x)",
-    0x03: "SLO (,x)",
-    0x04: "NOP zp",
+    0x03: "*SLO (,x)",
+    0x04: "*NOP zp",
     0x05: "ORA zp",
     0x06: "ASL zp",
-    0x07: "SLO zp",
+    0x07: "*SLO zp",
     0x08: "PHP",
     0x09: "ORA imm",
     0x0a: "ASL A",
-    0x0b: "ANC imm",
-    0x0c: "NOP abs",
+    0x0b: "*ANC imm",
+    0x0c: "*NOP abs",
     0x0d: "ORA abs",
     0x0e: "ASL abs",
-    0x0f: "SLO abs",
+    0x0f: "*SLO abs",
     0x10: "BPL branch",
     0x11: "ORA (),y",
-    0x13: "SLO (),y",
-    0x14: "NOP zp,x",
+    0x13: "*SLO (),y",
+    0x14: "*NOP zp,x",
     0x15: "ORA zp,x",
     0x16: "ASL zp,x",
-    0x17: "SLO zp,x",
+    0x17: "*SLO zp,x",
     0x18: "CLC",
     0x19: "ORA abs,y",
-    0x1a: "NOP",
-    0x1b: "SLO abs,y",
-    0x1c: "NOP abs,x",
+    0x1a: "*NOP",
+    0x1b: "*SLO abs,y",
+    0x1c: "*NOP abs,x",
     0x1d: "ORA abs,x",
     0x1e: "ASL abs,x",
-    0x1f: "SLO abs,x",
+    0x1f: "*SLO abs,x",
     0x20: "JSR abs",
     0x21: "AND (,x)",
-    0x23: "RLA (,x)",
+    0x23: "*RLA (,x)",
     0x24: "BIT zp",
     0x25: "AND zp",
     0x26: "ROL zp",
-    0x27: "RLA zp",
+    0x27: "*RLA zp",
     0x28: "PLP",
     0x29: "AND imm",
     0x2a: "ROL A",
-    0x2b: "ANC imm",
+    0x2b: "*ANC imm",
     0x2c: "BIT abs",
     0x2d: "AND abs",
     0x2e: "ROL abs",
-    0x2f: "RLA abs",
+    0x2f: "*RLA abs",
     0x30: "BMI branch",
     0x31: "AND (),y",
-    0x33: "RLA (),y",
-    0x34: "NOP zp,x",
+    0x33: "*RLA (),y",
+    0x34: "*NOP zp,x",
     0x35: "AND zp,x",
     0x36: "ROL zp,x",
-    0x37: "RLA zp,x",
+    0x37: "*RLA zp,x",
     0x38: "SEC",
     0x39: "AND abs,y",
-    0x3a: "NOP",
-    0x3b: "RLA abs,y",
-    0x3c: "NOP abs,x",
+    0x3a: "*NOP",
+    0x3b: "*RLA abs,y",
+    0x3c: "*NOP abs,x",
     0x3d: "AND abs,x",
     0x3e: "ROL abs,x",
-    0x3f: "RLA abs,x",
+    0x3f: "*RLA abs,x",
     0x40: "RTI",
     0x41: "EOR (,x)",
-    0x43: "SRE (,x)",
-    0x44: "NOP zp",
+    0x43: "*SRE (,x)",
+    0x44: "*NOP zp",
     0x45: "EOR zp",
     0x46: "LSR zp",
-    0x47: "SRE zp",
+    0x47: "*SRE zp",
     0x48: "PHA",
     0x49: "EOR imm",
     0x4a: "LSR A",
-    0x4b: "ASR imm",
+    0x4b: "*ASR imm",
     0x4c: "JMP abs",
     0x4d: "EOR abs",
     0x4e: "LSR abs",
-    0x4f: "SRE abs",
+    0x4f: "*SRE abs",
     0x50: "BVC branch",
     0x51: "EOR (),y",
-    0x53: "SRE (),y",
-    0x54: "NOP zp,x",
+    0x53: "*SRE (),y",
+    0x54: "*NOP zp,x",
     0x55: "EOR zp,x",
     0x56: "LSR zp,x",
-    0x57: "SRE zp,x",
+    0x57: "*SRE zp,x",
     0x58: "CLI",
     0x59: "EOR abs,y",
-    0x5a: "NOP",
-    0x5b: "SRE abs,y",
-    0x5c: "NOP abs,x",
+    0x5a: "*NOP",
+    0x5b: "*SRE abs,y",
+    0x5c: "*NOP abs,x",
     0x5d: "EOR abs,x",
     0x5e: "LSR abs,x",
-    0x5f: "SRE abs,x",
+    0x5f: "*SRE abs,x",
     0x60: "RTS",
     0x61: "ADC (,x)",
-    0x63: "RRA (,x)",
-    0x64: "NOP zp",
+    0x63: "*RRA (,x)",
+    0x64: "*NOP zp",
     0x65: "ADC zp",
     0x66: "ROR zp",
-    0x67: "RRA zp",
+    0x67: "*RRA zp",
     0x68: "PLA",
     0x69: "ADC imm",
     0x6a: "ROR A",
-    0x6b: "ARR imm",
+    0x6b: "*ARR imm",
     0x6c: "JMP (abs)",
     0x6d: "ADC abs",
     0x6e: "ROR abs",
-    0x6f: "RRA abs",
+    0x6f: "*RRA abs",
     0x70: "BVS branch",
     0x71: "ADC (),y",
-    0x73: "RRA (),y",
-    0x74: "NOP zp,x",
+    0x73: "*RRA (),y",
+    0x74: "*NOP zp,x",
     0x75: "ADC zp,x",
     0x76: "ROR zp,x",
-    0x77: "RRA zp,x",
+    0x77: "*RRA zp,x",
     0x78: "SEI",
     0x79: "ADC abs,y",
-    0x7a: "NOP",
-    0x7b: "RRA abs,y",
-    0x7c: "NOP abs,x",
+    0x7a: "*NOP",
+    0x7b: "*RRA abs,y",
+    0x7c: "*NOP abs,x",
     0x7d: "ADC abs,x",
     0x7e: "ROR abs,x",
-    0x7f: "RRA abs,x",
-    0x80: "NOP imm",
+    0x7f: "*RRA abs,x",
+    0x80: "*NOP imm",
     0x81: "STA (,x)",
-    0x82: "NOP imm",
-    0x83: "SAX (,x)",
+    0x82: "*NOP imm",
+    0x83: "*SAX (,x)",
     0x84: "STY zp",
     0x85: "STA zp",
     0x86: "STX zp",
-    0x87: "SAX zp",
+    0x87: "*SAX zp",
     0x88: "DEY",
-    0x89: "NOP imm",
+    0x89: "*NOP imm",
     0x8a: "TXA",
-    0x8b: "ANE imm",
+    0x8b: "*ANE imm",
     0x8c: "STY abs",
     0x8d: "STA abs",
     0x8e: "STX abs",
-    0x8f: "SAX abs",
+    0x8f: "*SAX abs",
     0x90: "BCC branch",
     0x91: "STA (),y",
-    0x93: "SHA (),y",
+    0x93: "*SHA (),y",
     0x94: "STY zp,x",
     0x95: "STA zp,x",
     0x96: "STX zp,y",
-    0x97: "SAX zp,y",
+    0x97: "*SAX zp,y",
     0x98: "TYA",
     0x99: "STA abs,y",
     0x9a: "TXS",
-    0x9b: "SHS abs,y",
-    0x9c: "SHY abs,x",
+    0x9b: "*SHS abs,y",
+    0x9c: "*SHY abs,x",
     0x9d: "STA abs,x",
-    0x9e: "SHX abs,y",
-    0x9f: "SHA abs,y",
+    0x9e: "*SHX abs,y",
+    0x9f: "*SHA abs,y",
     0xa0: "LDY imm",
     0xa1: "LDA (,x)",
     0xa2: "LDX imm",
-    0xa3: "LAX (,x)",
+    0xa3: "*LAX (,x)",
     0xa4: "LDY zp",
     0xa5: "LDA zp",
     0xa6: "LDX zp",
-    0xa7: "LAX zp",
+    0xa7: "*LAX zp",
     0xa8: "TAY",
     0xa9: "LDA imm",
     0xaa: "TAX",
-    0xab: "LXA imm",
+    0xab: "*LXA imm",
     0xac: "LDY abs",
     0xad: "LDA abs",
     0xae: "LDX abs",
-    0xaf: "LAX abs",
+    0xaf: "*LAX abs",
     0xb0: "BCS branch",
     0xb1: "LDA (),y",
-    0xb3: "LAX (),y",
+    0xb3: "*LAX (),y",
     0xb4: "LDY zp,x",
     0xb5: "LDA zp,x",
     0xb6: "LDX zp,y",
-    0xb7: "LAX zp,y",
+    0xb7: "*LAX zp,y",
     0xb8: "CLV",
     0xb9: "LDA abs,y",
     0xba: "TSX",
-    0xbb: "LAS abs,y",
+    0xbb: "*LAS abs,y",
     0xbc: "LDY abs,x",
     0xbd: "LDA abs,x",
     0xbe: "LDX abs,y",
-    0xbf: "LAX abs,y",
+    0xbf: "*LAX abs,y",
     0xc0: "CPY imm",
     0xc1: "CMP (,x)",
-    0xc2: "NOP imm",
-    0xc3: "DCP (,x)",
+    0xc2: "*NOP imm",
+    0xc3: "*DCP (,x)",
     0xc4: "CPY zp",
     0xc5: "CMP zp",
     0xc6: "DEC zp",
-    0xc7: "DCP zp",
+    0xc7: "*DCP zp",
     0xc8: "INY",
     0xc9: "CMP imm",
     0xca: "DEX",
-    0xcb: "SBX imm",
+    0xcb: "*SBX imm",
     0xcc: "CPY abs",
     0xcd: "CMP abs",
     0xce: "DEC abs",
-    0xcf: "DCP abs",
+    0xcf: "*DCP abs",
     0xd0: "BNE branch",
     0xd1: "CMP (),y",
-    0xd3: "DCP (),y",
-    0xd4: "NOP zp,x",
+    0xd3: "*DCP (),y",
+    0xd4: "*NOP zp,x",
     0xd5: "CMP zp,x",
     0xd6: "DEC zp,x",
-    0xd7: "DCP zp,x",
+    0xd7: "*DCP zp,x",
     0xd8: "CLD",
     0xd9: "CMP abs,y",
-    0xda: "NOP",
-    0xdb: "DCP abs,y",
-    0xdc: "NOP abs,x",
+    0xda: "*NOP",
+    0xdb: "*DCP abs,y",
+    0xdc: "*NOP abs,x",
     0xdd: "CMP abs,x",
     0xde: "DEC abs,x",
-    0xdf: "DCP abs,x",
+    0xdf: "*DCP abs,x",
     0xe0: "CPX imm",
     0xe1: "SBC (,x)",
-    0xe2: "NOP imm",
-    0xe3: "ISB (,x)",
+    0xe2: "*NOP imm",
+    0xe3: "*ISB (,x)",
     0xe4: "CPX zp",
     0xe5: "SBC zp",
     0xe6: "INC zp",
-    0xe7: "ISB zp",
+    0xe7: "*ISB zp",
     0xe8: "INX",
     0xe9: "SBC imm",
     0xea: "NOP",
-    0xeb: "SBC imm",
+    0xeb: "*SBC imm",
     0xec: "CPX abs",
     0xed: "SBC abs",
     0xee: "INC abs",
-    0xef: "ISB abs",
+    0xef: "*ISB abs",
     0xf0: "BEQ branch",
     0xf1: "SBC (),y",
-    0xf3: "ISB (),y",
-    0xf4: "NOP zpx",
+    0xf3: "*ISB (),y",
+    0xf4: "*NOP zpx",
     0xf5: "SBC zp,x",
     0xf6: "INC zp,x",
-    0xf7: "ISB zp,x",
+    0xf7: "*ISB zp,x",
     0xf8: "SED",
     0xf9: "SBC abs,y",
-    0xfa: "NOP",
-    0xfb: "ISB abs,y",
-    0xfc: "NOP abs,x",
+    0xfa: "*NOP",
+    0xfb: "*ISB abs,y",
+    0xfc: "*NOP abs,x",
     0xfd: "SBC abs,x",
     0xfe: "INC abs,x",
-    0xff: "ISB abs,x",
-};
+    0xff: "*ISB abs,x",
+});
 
-const opcodes65c12 = {
+const { opcodes: opcodes65c12, undocumented: undocumented65c12 } = splitUndocumented({
     0x00: "BRK",
     0x01: "ORA (,x)",
     0x04: "TSB zp",
@@ -952,9 +967,9 @@ const opcodes65c12 = {
     0xfa: "PLX",
     0xfd: "SBC abs,x",
     0xfe: "INC abs,x",
-};
+});
 
-const opcodes65c02 = {
+const { opcodes: opcodes65c02, undocumented: undocumented65c02 } = splitUndocumented({
     ...opcodes65c12,
     0x07: "RMB0 zp",
     0x17: "RMB1 zp",
@@ -988,30 +1003,20 @@ const opcodes65c02 = {
     0xdf: "BBS5 zp,branch",
     0xef: "BBS6 zp,branch",
     0xff: "BBS7 zp,branch",
-};
+});
 
-const LegalMnemonics = new Set(
-    (
-        "ADC AND ASL BCC BCS BEQ BIT BMI BNE BPL BRK BVC BVS CLC CLD CLI CLV CMP CPX CPY DEC DEX DEY EOR INC INX " +
-        "INY JMP JSR LDA LDX LDY LSR NOP ORA PHA PHP PLA PLP ROL ROR RTI RTS SBC SEC SED SEI STA STX STY TAX TAY " +
-        "TSX TXA TXS TYA BRA PHX PHY PLX PLY STZ TRB TSB BBR BBS RMB SMB"
-    ).split(" "),
-);
 const PrevInstructionWindow = 64;
 
 class Disassemble6502 {
-    constructor(cpu, opcodes) {
+    constructor(cpu, opcodes, undocumented) {
         this.cpu = cpu;
         this.opcodes = opcodes;
-        // Only $EA is a documented NOP; the table's other NOPs are the undocumented slots.
-        this.legalOpcodes = new Set(
-            Object.entries(opcodes)
-                .filter(([op, text]) => {
-                    const mnemonic = text.split(" ")[0].replace(/\d$/, "");
-                    return LegalMnemonics.has(mnemonic) && (mnemonic !== "NOP" || Number(op) === 0xea);
-                })
-                .map(([op]) => Number(op)),
-        );
+        this.undocumented = undocumented;
+    }
+
+    isDocumented(addr) {
+        const op = this.cpu.peekmem(addr);
+        return op in this.opcodes && !this.undocumented.has(op);
     }
 
     disassemble(addr, plain) {
@@ -1021,11 +1026,13 @@ class Disassemble6502 {
             formatAddr = hexword;
             formatJumpAddr = hexword;
         }
-        const opcode = this.opcodes[this.cpu.peekmem(addr)];
+        const opcodeByte = this.cpu.peekmem(addr);
+        const opcode = this.opcodes[opcodeByte];
         if (!opcode) {
             return ["???", addr + 1];
         }
-        const split = opcode.split(" ");
+        const [mnemonic, ...rest] = opcode.split(" ");
+        const split = [(this.undocumented.has(opcodeByte) ? "*" : "") + mnemonic, ...rest];
         if (!split[1]) {
             return [opcode, addr + 1];
         }
@@ -1107,7 +1114,7 @@ class Disassemble6502 {
             let score = 0;
             let addr = startingPoint & 0xffff;
             while (addr < address) {
-                if (!this.legalOpcodes.has(this.cpu.peekmem(addr))) break;
+                if (!this.isDocumented(addr)) break;
                 const result = this.disassemble(addr);
                 if (addr === pc) score += 10;
                 if (result[0].match(commonInstructions) && !result[0].match(uncommonInstructions)) {
@@ -1127,7 +1134,7 @@ class Disassemble6502 {
     }
 }
 
-function makeCpuFunctions(cpu, opcodes, is65c12, cycleAccurate = true) {
+function makeCpuFunctions(cpu, opcodes, undocumented, is65c12, cycleAccurate = true) {
     function getInstruction(opcodeString, needsReg) {
         const split = opcodeString.split(" ");
         const opcode = split[0];
@@ -1476,7 +1483,7 @@ ${indent}`)
     Runner.prototype.run = generate6502JumpTable();
 
     return {
-        disassembler: new Disassemble6502(cpu, opcodes),
+        disassembler: new Disassemble6502(cpu, opcodes, undocumented),
         runInstruction: new Runner(),
         opcodes: opcodes,
         getInstruction: getInstruction,
@@ -1484,13 +1491,13 @@ ${indent}`)
 }
 
 export function Cpu6502(cpu, { cycleAccurate = true } = {}) {
-    return makeCpuFunctions(cpu, opcodes6502, false, cycleAccurate);
+    return makeCpuFunctions(cpu, opcodes6502, undocumented6502, false, cycleAccurate);
 }
 
 export function Cpu65c12(cpu, { cycleAccurate = true } = {}) {
-    return makeCpuFunctions(cpu, opcodes65c12, true, cycleAccurate);
+    return makeCpuFunctions(cpu, opcodes65c12, undocumented65c12, true, cycleAccurate);
 }
 
 export function Cpu65c02(cpu, { cycleAccurate = true } = {}) {
-    return makeCpuFunctions(cpu, opcodes65c02, true, cycleAccurate);
+    return makeCpuFunctions(cpu, opcodes65c02, undocumented65c02, true, cycleAccurate);
 }

--- a/src/6502.opcodes.js
+++ b/src/6502.opcodes.js
@@ -773,7 +773,7 @@ const { opcodes: opcodes6502, undocumented: undocumented6502 } = splitUndocument
     0xf0: "BEQ branch",
     0xf1: "SBC (),y",
     0xf3: "*ISB (),y",
-    0xf4: "*NOP zpx",
+    0xf4: "*NOP zp,x",
     0xf5: "SBC zp,x",
     0xf6: "INC zp,x",
     0xf7: "*ISB zp,x",
@@ -1034,7 +1034,7 @@ class Disassemble6502 {
         const [mnemonic, ...rest] = opcode.split(" ");
         const split = [(this.undocumented.has(opcodeByte) ? "*" : "") + mnemonic, ...rest];
         if (!split[1]) {
-            return [opcode, addr + 1];
+            return [split[0], addr + 1];
         }
         let param = split[1] || "";
         let suffix = "";
@@ -1059,6 +1059,14 @@ class Disassemble6502 {
             }
             case "zp":
                 return [`${split[0]} $${hexbyte(this.cpu.peekmem(addr + 1))}${suffix}`, addr + 2];
+            case "zp,branch": {
+                const destAddr = addr + signExtend(this.cpu.peekmem(addr + 2)) + 3;
+                return [
+                    `${split[0]} $${hexbyte(this.cpu.peekmem(addr + 1))}, $${formatJumpAddr(destAddr)}`,
+                    addr + 3,
+                    destAddr,
+                ];
+            }
             case "(,x)":
                 return [`${split[0]} ($${hexbyte(this.cpu.peekmem(addr + 1))}, X)${suffix}`, addr + 2];
             case "()": {
@@ -1081,7 +1089,7 @@ class Disassemble6502 {
                 return [`${split[0]} ($${formatJumpAddr(destAddr)},x)${suffix}`, addr + 3, indDest];
             }
         }
-        return [opcode, addr + 1];
+        return [split.join(" "), addr + 1];
     }
 
     nextInstruction(address) {
@@ -1171,7 +1179,6 @@ function makeCpuFunctions(cpu, opcodes, undocumented, is65c12, cycleAccurate = t
                 return ig.render();
 
             case "zp":
-            case "zpx": // Seems to be enough to keep tests happy, but needs investigation.
             case "zp,x":
             case "zp,y":
                 if (arg === "zp") {

--- a/src/6502.opcodes.js
+++ b/src/6502.opcodes.js
@@ -994,7 +994,7 @@ const LegalMnemonics = new Set(
     (
         "ADC AND ASL BCC BCS BEQ BIT BMI BNE BPL BRK BVC BVS CLC CLD CLI CLV CMP CPX CPY DEC DEX DEY EOR INC INX " +
         "INY JMP JSR LDA LDX LDY LSR NOP ORA PHA PHP PLA PLP ROL ROR RTI RTS SBC SEC SED SEI STA STX STY TAX TAY " +
-        "TSX TXA TXS TYA BRA PHX PHY PLX PLY STZ TRB TSB"
+        "TSX TXA TXS TYA BRA PHX PHY PLX PLY STZ TRB TSB BBR BBS RMB SMB"
     ).split(" "),
 );
 const PrevInstructionWindow = 64;
@@ -1007,7 +1007,7 @@ class Disassemble6502 {
         this.legalOpcodes = new Set(
             Object.entries(opcodes)
                 .filter(([op, text]) => {
-                    const mnemonic = text.split(" ")[0];
+                    const mnemonic = text.split(" ")[0].replace(/\d$/, "");
                     return LegalMnemonics.has(mnemonic) && (mnemonic !== "NOP" || Number(op) === 0xea);
                 })
                 .map(([op]) => Number(op)),

--- a/tests/unit/test-6502-opcodes.js
+++ b/tests/unit/test-6502-opcodes.js
@@ -38,11 +38,46 @@ describe("Disassemble6502", () => {
         expect(disassembler.prevInstruction(0x2000, 0x0000)).toBe(0x1ffe);
     });
 
-    it("treats the 65C02's bit instructions as documented", () => {
+    it("keeps a run ending in a documented 65C02 instruction", () => {
         const disassembler65c02 = cpu65c02Opcodes({ peekmem: (addr) => mem[addr & 0xffff] }).disassembler;
         mem.set([0x07, 0x41], 0x1ffe);
         expect(disassembler65c02.disassemble(0x1ffe)[0]).toMatch(/^RMB0/);
         expect(disassembler65c02.prevInstruction(0x2000, 0x0000)).toBe(0x1ffe);
+    });
+
+    describe("documented and undocumented opcodes", () => {
+        const countDocumented = (dis) => {
+            let count = 0;
+            for (let op = 0; op < 256; op++) {
+                mem[0] = op;
+                if (dis.isDocumented(0)) count++;
+            }
+            return count;
+        };
+
+        it("marks the NMOS part's undocumented instructions in the listing", () => {
+            mem.set([0x03, 0x41], 0x2000);
+            expect(disassembler.disassemble(0x2000)[0]).toMatch(/^\*SLO/);
+            mem.set([0xeb, 0x41], 0x2000);
+            expect(disassembler.disassemble(0x2000)[0]).toMatch(/^\*SBC/);
+            mem.set([0xe9, 0x41], 0x2000);
+            expect(disassembler.disassemble(0x2000)[0]).toMatch(/^SBC/);
+        });
+
+        it("knows the NMOS part has 151 documented opcodes", () => {
+            expect(countDocumented(disassembler)).toBe(151);
+            mem[0] = 0x02;
+            expect(disassembler.isDocumented(0)).toBe(false);
+        });
+
+        it("treats every listed 65C02 opcode as documented", () => {
+            const disassembler65c02 = cpu65c02Opcodes({ peekmem: (addr) => mem[addr & 0xffff] }).disassembler;
+            for (let op = 0; op < 256; op++) {
+                mem[0] = op;
+                const text = disassembler65c02.disassemble(0)[0];
+                expect(disassembler65c02.isDocumented(0)).toBe(text !== "???");
+            }
+        });
     });
 
     it("returns the previous instruction in an unambiguous run", () => {

--- a/tests/unit/test-6502-opcodes.js
+++ b/tests/unit/test-6502-opcodes.js
@@ -64,10 +64,22 @@ describe("Disassemble6502", () => {
             expect(disassembler.disassemble(0x2000)[0]).toMatch(/^SBC/);
         });
 
+        it("marks one-byte and zero-page,X undocumented NOPs and sizes them correctly", () => {
+            mem.set([0x1a, 0xf4, 0x41], 0x2000);
+            expect(disassembler.disassemble(0x2000)).toEqual(["*NOP", 0x2001]);
+            expect(disassembler.disassemble(0x2001, true)).toEqual(["*NOP $41,X", 0x2003]);
+        });
+
         it("knows the NMOS part has 151 documented opcodes", () => {
             expect(countDocumented(disassembler)).toBe(151);
             mem[0] = 0x02;
             expect(disassembler.isDocumented(0)).toBe(false);
+        });
+
+        it("disassembles the 65C02 bit branches as three bytes", () => {
+            const disassembler65c02 = cpu65c02Opcodes({ peekmem: (addr) => mem[addr & 0xffff] }).disassembler;
+            mem.set([0x0f, 0x41, 0x10], 0x2000);
+            expect(disassembler65c02.disassemble(0x2000, true)).toEqual(["BBR0 $41, $2013", 0x2003, 0x2013]);
         });
 
         it("treats every listed 65C02 opcode as documented", () => {

--- a/tests/unit/test-6502-opcodes.js
+++ b/tests/unit/test-6502-opcodes.js
@@ -28,6 +28,16 @@ describe("Disassemble6502", () => {
         expect(disassembler.prevInstruction(0x2000, 0x0000)).toBe(0x1ffe);
     });
 
+    it("prefers any run that lands on the target over none, even one scoring nothing", () => {
+        for (let i = 0; i < 8; i++) mem.set([0x9d, 0x00, 0x30], 0x1fe8 + i * 3);
+        expect(disassembler.prevInstruction(0x2000, 0x0000)).toBe(0x1ffd);
+    });
+
+    it("discards runs through undocumented opcodes", () => {
+        mem.set([0xa5, 0x41, 0xa5, 0xa9, 0x0f, 0xa9, 0x41], 0x1ff9);
+        expect(disassembler.prevInstruction(0x2000, 0x0000)).toBe(0x1ffe);
+    });
+
     it("returns the previous instruction in an unambiguous run", () => {
         expect(disassembler.prevInstruction(0x2002, 0x1000)).toBe(0x2001);
     });

--- a/tests/unit/test-6502-opcodes.js
+++ b/tests/unit/test-6502-opcodes.js
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it } from "vitest";
 
-import { Cpu6502 as cpu6502Opcodes } from "../../src/6502.opcodes.js";
+import { Cpu6502 as cpu6502Opcodes, Cpu65c02 as cpu65c02Opcodes } from "../../src/6502.opcodes.js";
 
 describe("Disassemble6502", () => {
     const mem = new Uint8Array(0x10000);
@@ -36,6 +36,13 @@ describe("Disassemble6502", () => {
     it("discards runs through undocumented opcodes", () => {
         mem.set([0xa5, 0x41, 0xa5, 0xa9, 0x0f, 0xa9, 0x41], 0x1ff9);
         expect(disassembler.prevInstruction(0x2000, 0x0000)).toBe(0x1ffe);
+    });
+
+    it("treats the 65C02's bit instructions as documented", () => {
+        const disassembler65c02 = cpu65c02Opcodes({ peekmem: (addr) => mem[addr & 0xffff] }).disassembler;
+        mem.set([0x07, 0x41], 0x1ffe);
+        expect(disassembler65c02.disassemble(0x1ffe)[0]).toMatch(/^RMB0/);
+        expect(disassembler65c02.prevInstruction(0x2000, 0x0000)).toBe(0x1ffe);
     });
 
     it("returns the previous instruction in an unambiguous run", () => {


### PR DESCRIPTION
Items 1 and 2 of #1016.

`prevInstruction` initialised `bestScore` to 0 and only replaced the default (`address - 1`) on a strictly higher score, so a run that landed on the target but contained only instructions the scoring treats as uncommon could never win. The MOS screen clear at &CC63 is an unrolled run of `STA $xx00,X`, all excluded by the indexed-mode rule, and scrolling back through it produced bogus instructions made from the address high bytes. That single behaviour was 16 of the 22 misses measured against executed-instruction ground truth from a Model B boot.

Changes:

- any run that lands on the target beats none (`bestScore` starts at -1);
- runs through undocumented opcodes are discarded;
- the search window grows from 20 to 64 bytes, where a misaligned parse has almost always resynchronised with the true stream.

Which opcodes are undocumented is now the opcode table's knowledge rather than the heuristic's: the NMOS table marks its 93 undocumented entries with the leading `*` that 6502 listings conventionally use (including `$EB`, the undocumented `SBC #imm` twin that a mnemonic-based rule cannot see). One splitter strips the marker for the code generator and gives the disassembler the set; the disassembler shows `*SLO`, `*SBC` and so on in its listing (the debugger and the MCP disassemble tool inherit that) and exposes `isDocumented(addr)`, which the heuristic asks. The 65C12 and 65C02 tables carry no markers, so every listed opcode there is documented and the Rockwell bit instructions need no special case.

Re-running the ground-truth evaluation against the real function: 22 misses of 5689 before, 5 after (99.91%). Tests cover the all-uncommon run, a junk parse through an undocumented opcode that would otherwise tie and win, a 65C02 run ending in `RMB0`, the listing marker, and that the NMOS table yields exactly 151 documented opcodes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
