### PR TITLE
feat: trim the top bar so it fits one row on laptop screens

### DIFF
--- a/index.html
+++ b/index.html
@@ -40,7 +40,9 @@
   <body>
     <nav id="header-bar" class="navbar navbar-dark bg-dark navbar-expand-lg not-electron" role="navigation">
       <div class="container-fluid">
-        <a class="navbar-brand" href="https://bbc.xania.org/" target="_top">jsbeeb</a>
+        <a class="navbar-brand" href="https://bbc.xania.org/" target="_top" title="jsbeeb">
+          <img src="/jsbeeb-icon.png" alt="jsbeeb" width="28" height="28" />
+        </a>
         <button
           class="navbar-toggler"
           type="button"
@@ -55,8 +57,14 @@
         <div class="collapse navbar-collapse" id="navbarSupportedContent">
           <ul class="navbar-nav nav mb-2 mb-lg-0">
             <li class="nav-item">
-              <a href="#configuration" class="nav-link" data-bs-toggle="modal" data-bs-target="#configuration">
-                <span class="bbc-model">BBC B</span></a
+              <a
+                href="#configuration"
+                class="nav-link"
+                id="model-settings"
+                data-bs-toggle="modal"
+                data-bs-target="#configuration"
+                title="Emulation settings"
+                >&#x2699;&#xfe0f; <span class="bbc-model-short">BBC B</span></a
               >
             </li>
             <li class="nav-item dropdown embed-hide">
@@ -204,6 +212,11 @@
                 <li><a href="#" id="fs" class="dropdown-item">Fullscreen</a></li>
                 <li><a href="#help" class="dropdown-item" data-bs-toggle="modal" data-bs-target="#help">Help</a></li>
                 <li>
+                  <a href="https://bbcmic.ro/" class="dropdown-item" target="_blank" rel="noopener"
+                    >Edit BBC BASIC with Owlet (bbcmic.ro)</a
+                  >
+                </li>
+                <li>
                   <a href="#pp-tos" class="dropdown-item" data-bs-toggle="modal" data-bs-target="#pp-tos"
                     >Privacy Policy &amp; ToS</a
                   >
@@ -222,11 +235,11 @@
               </ul>
             </li>
           </ul>
-          <span class="navbar-text m-auto">
+          <span class="navbar-text ms-auto px-3 d-none d-xxl-inline">
             Edit BBC BASIC interactively with Owlet at
             <a href="https://bbcmic.ro/" target="_blank">bbcmic.ro</a>!
           </span>
-          <div class="d-flex align-items-center me-3" id="quick-settings">
+          <div class="d-flex align-items-center ms-auto me-3" id="quick-settings">
             <div class="btn-group btn-group-sm" role="group" aria-label="Sound output" id="audio-output">
               <button
                 type="button"
@@ -298,14 +311,14 @@
               &#x23f8;
             </button>
           </div>
-          <form class="d-flex">
+          <form class="d-flex" id="paste-form">
             <input
               id="paste-text"
-              class="form-control me-2"
+              class="form-control"
               type="text"
               maxlength="0"
-              placeholder="Paste text or drop files here..."
-              aria-label="Search"
+              placeholder="Paste / drop here"
+              aria-label="Paste text or drop files here"
             />
           </form>
         </div>
@@ -975,7 +988,7 @@
       <div class="modal-dialog modal-dialog-scrollable">
         <div class="modal-content">
           <div class="modal-header">
-            <h5 class="modal-title" id="configurationModalLabel">Emulation Configuration</h5>
+            <h5 class="modal-title" id="configurationModalLabel"><span class="bbc-model"></span> settings</h5>
             <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal" aria-label="Close"></button>
           </div>
           <div class="modal-body">

--- a/index.html
+++ b/index.html
@@ -237,7 +237,7 @@
           </ul>
           <span class="navbar-text ms-auto px-3 d-none d-xxl-inline">
             Edit BBC BASIC with Owlet at
-            <a href="https://bbcmic.ro/" target="_blank">bbcmic.ro</a>!
+            <a href="https://bbcmic.ro/" target="_blank" rel="noopener">bbcmic.ro</a>!
           </span>
           <div class="d-flex align-items-center ms-auto me-3" id="quick-settings">
             <div class="btn-group btn-group-sm" role="group" aria-label="Sound output" id="audio-output">

--- a/index.html
+++ b/index.html
@@ -236,7 +236,7 @@
             </li>
           </ul>
           <span class="navbar-text ms-auto px-3 d-none d-xxl-inline">
-            Edit BBC BASIC interactively with Owlet at
+            Edit BBC BASIC with Owlet at
             <a href="https://bbcmic.ro/" target="_blank">bbcmic.ro</a>!
           </span>
           <div class="d-flex align-items-center ms-auto me-3" id="quick-settings">

--- a/src/jsbeeb.css
+++ b/src/jsbeeb.css
@@ -564,8 +564,21 @@ small {
   display: block;
 }
 
+/* Shrunk, the menu list wraps onto a second row; the promo yields instead, by truncating. */
+#header-bar .navbar-nav {
+  flex-shrink: 0;
+}
+
+#header-bar .navbar-text {
+  flex: 0 1 auto;
+  min-width: 0;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
 #paste-form {
-  flex: 1 1 6rem;
+  flex: 1 0 6rem;
   min-width: 0;
   max-width: 14rem;
 }

--- a/src/jsbeeb.css
+++ b/src/jsbeeb.css
@@ -560,6 +560,20 @@ small {
   flex: none;
 }
 
+#header-bar .navbar-brand img {
+  display: block;
+}
+
+#paste-form {
+  flex: 1 1 6rem;
+  min-width: 0;
+  max-width: 14rem;
+}
+
+#paste-text {
+  min-width: 0;
+}
+
 /* The only item in the header with no bound on its width, so it is the one that yields. */
 #disc-name {
   flex: 1;

--- a/src/main.js
+++ b/src/main.js
@@ -196,6 +196,7 @@ const keys = new KeyboardSetup({
         openPrinter: () => frontPanel.checkPrinterWindow(),
         pause: () => loop.stop(false),
         resume: () => loop.go(),
+        paste: (text) => keys.sendRawKeyboard(autoBoot.stringToMachineKeys(text), true),
         onAnyKeyDown: () => {
             audioHandler.tryResume();
             inputs.ensureMicrophoneRunning();
@@ -332,12 +333,7 @@ settings.wire({ audioHandler, display, layout, quickSettings, machine, keys, inp
 
 for (const el of document.querySelectorAll(".initially-hidden")) el.classList.remove("initially-hidden");
 
-const pastetext = document.getElementById("paste-text");
-pastetext.closest("form").addEventListener("submit", (event) => event.preventDefault());
-pastetext.addEventListener("paste", function (event) {
-    const text = event.clipboardData.getData("text/plain");
-    keys.sendRawKeyboard(autoBoot.stringToMachineKeys(text), true);
-});
+document.getElementById("paste-form").addEventListener("submit", (event) => event.preventDefault());
 
 window.addEventListener("blur", function () {
     keys.clearKeys();

--- a/src/models.js
+++ b/src/models.js
@@ -19,9 +19,23 @@ const CpuModel = Object.freeze({
  * to any number of machines without one session's settings leaking into the next.
  */
 class Model {
-    constructor({ name, synonyms, os, cpuModel, isMaster, isAtom, swram, fdc, cmosOverride, banks, clockMhz } = {}) {
+    constructor({
+        name,
+        shortName = name,
+        synonyms,
+        os,
+        cpuModel,
+        isMaster,
+        isAtom,
+        swram,
+        fdc,
+        cmosOverride,
+        banks,
+        clockMhz,
+    } = {}) {
         if (!(clockMhz > 0)) throw new Error(`Model ${name} has no clock speed`);
         this.name = name;
+        this.shortName = shortName;
         this.synonyms = synonyms;
         this.os = os;
         this.clockMhz = clockMhz;
@@ -79,6 +93,7 @@ function pickDfs(cmos) {
 function atomModel({ name, synonyms, os, banks }) {
     return new Model({
         name,
+        shortName: "Atom",
         synonyms,
         os,
         cpuModel: CpuModel.MOS6502,
@@ -132,6 +147,7 @@ const masterSwram = [
 export const allModels = [
     new Model({
         name: "BBC B with 8271 (DFS 1.2)",
+        shortName: "BBC B",
         synonyms: ["B-DFS1.2", "BBC B with DFS 1.2"],
         os: ["os.rom", "BASIC.ROM", "b/DFS-1.2.rom"],
         cpuModel: CpuModel.MOS6502,
@@ -142,6 +158,7 @@ export const allModels = [
     }),
     new Model({
         name: "BBC B with 8271 (DFS 0.9)",
+        shortName: "BBC B",
         synonyms: ["B-DFS0.9", "B", "BBC B with DFS 0.9"],
         os: ["os.rom", "BASIC.ROM", "b/DFS-0.9.rom"],
         cpuModel: CpuModel.MOS6502,
@@ -152,6 +169,7 @@ export const allModels = [
     }),
     new Model({
         name: "BBC B with 1770 (DFS)",
+        shortName: "BBC B",
         synonyms: ["B1770"],
         os: ["os.rom", "BASIC.ROM", "b1770/dfs1770.rom", "b1770/zADFS.ROM"],
         cpuModel: CpuModel.MOS6502,
@@ -163,6 +181,7 @@ export const allModels = [
     // putting ADFS in a higher ROM slot gives it priority
     new Model({
         name: "BBC B with 1770 (ADFS)",
+        shortName: "BBC B",
         synonyms: ["B1770A"],
         os: ["os.rom", "BASIC.ROM", "b1770/zADFS.ROM", "b1770/dfs1770.rom"],
         cpuModel: CpuModel.MOS6502,
@@ -173,6 +192,7 @@ export const allModels = [
     }),
     new Model({
         name: "BBC Master 128 (DFS)",
+        shortName: "Master 128",
         synonyms: ["Master"],
         os: ["master/mos3.20"],
         cpuModel: CpuModel.CMOS65C12,
@@ -184,6 +204,7 @@ export const allModels = [
     }),
     new Model({
         name: "BBC Master 128 (ADFS)",
+        shortName: "Master 128",
         synonyms: ["MasterADFS"],
         os: ["master/mos3.20"],
         cpuModel: CpuModel.CMOS65C12,
@@ -195,6 +216,7 @@ export const allModels = [
     }),
     new Model({
         name: "BBC Master 128 (ANFS)",
+        shortName: "Master 128",
         synonyms: ["MasterANFS"],
         os: ["master/mos3.20"],
         cpuModel: CpuModel.CMOS65C12,

--- a/src/web/config.js
+++ b/src/web/config.js
@@ -216,6 +216,9 @@ export class Config extends EventTarget {
     setModel(modelName) {
         this.model = findModel(modelName);
         for (const el of document.querySelectorAll(".bbc-model")) el.textContent = this.model.name;
+        for (const el of document.querySelectorAll(".bbc-model-short")) el.textContent = this.model.shortName;
+        const settingsLink = document.getElementById("model-settings");
+        if (settingsLink) settingsLink.title = `${this.model.name}: emulation settings`;
     }
 
     setKeyLayout(keyLayout) {

--- a/src/web/keyboard-setup.js
+++ b/src/web/keyboard-setup.js
@@ -68,7 +68,8 @@ export class KeyboardSetup {
         document.addEventListener("paste", (evt) => {
             const target = document.activeElement;
             if (target && target.id !== PasteBoxId && target.matches(TypingTargets)) return;
-            actions.paste(evt.clipboardData.getData("text/plain"));
+            const text = evt.clipboardData?.getData("text/plain");
+            if (text) actions.paste(text);
         });
     }
 

--- a/src/web/keyboard-setup.js
+++ b/src/web/keyboard-setup.js
@@ -2,19 +2,22 @@ import * as utils from "../utils.js";
 import { Keyboard } from "../keyboard.js";
 import { showNotice } from "./reporting.js";
 
+const PasteBoxId = "paste-text";
+const TypingTargets = 'input, textarea, select, [contenteditable]:not([contenteditable="false"])';
+
 /** The page's keyboard: the emulated one and the browser shortcuts around it. */
 export class KeyboardSetup {
     /**
      * @param {object} opts
      * @param {object} opts.actions what each shortcut does, supplied late-bound:
      *   enterDebugger, reload, toggleFast, openRewind, openPrinter,
-     *   pause, resume, onAnyKeyDown
+     *   pause, resume, paste, onAnyKeyDown
      * @param {import("./accessibility-switches.js").AccessibilitySwitches} opts.accessibilitySwitches
      */
     constructor({ actions, accessibilitySwitches, processor, dbgr, keyLayout }) {
         const keyboard = (this.keyboard = new Keyboard({
             processor,
-            inputEnabledFunction: () => document.activeElement && document.activeElement.id === "paste-text",
+            inputEnabledFunction: () => document.activeElement && document.activeElement.id === PasteBoxId,
             keyLayout,
             dbgr,
         }));
@@ -62,6 +65,11 @@ export class KeyboardSetup {
         });
         document.addEventListener("keypress", (evt) => keyboard.keyPress(evt));
         document.addEventListener("keyup", (evt) => keyboard.keyUp(evt));
+        document.addEventListener("paste", (evt) => {
+            const target = document.activeElement;
+            if (target && target.id !== PasteBoxId && target.matches(TypingTargets)) return;
+            actions.paste(evt.clipboardData.getData("text/plain"));
+        });
     }
 
     sendRawKeyboard(keysToSend, checkCapsAndShiftLocks) {

--- a/tests/browser/smoke.js
+++ b/tests/browser/smoke.js
@@ -31,8 +31,8 @@ const BootTimeoutMs = 30000;
 const StepTimeoutMs = 10000;
 const ServerTimeoutMs = 30000;
 const KeyHoldMs = 120;
-const OneRowWidth = 2000;
-const LaptopWidths = [1280, 1440];
+const OneRowWidth = 4000;
+const LaptopWidths = [1024, 1280, 1400, 1440, 1512, 1536, 1600];
 const ConsoleSurface = [
     "processor",
     "video",
@@ -254,7 +254,18 @@ class Page {
         return this.evaluate(`(() => {
             const bar = document.getElementById("header-bar");
             const paste = document.getElementById("paste-text").getBoundingClientRect();
-            return { height: bar.offsetHeight, pasteFits: paste.width > 0 && paste.right <= innerWidth };
+            const promo = bar.querySelector(".navbar-text");
+            const promoState = () => {
+                if (getComputedStyle(promo).display === "none") return "hidden";
+                if (promo.getBoundingClientRect().right > promo.nextElementSibling.getBoundingClientRect().left)
+                    return "overflowing";
+                return promo.scrollWidth > promo.clientWidth ? "truncated" : "fits";
+            };
+            return {
+                height: bar.offsetHeight,
+                pasteFits: paste.width > 0 && paste.right <= innerWidth,
+                promo: promoState(),
+            };
         })()`);
     }
 }
@@ -279,11 +290,14 @@ check("the top bar is one row at laptop widths", async (page, base) => {
     await page.waitForScreenText(">");
     try {
         const oneRow = await page.headerBar(OneRowWidth);
+        if (oneRow.promo !== "fits") throw new Error(`At ${OneRowWidth}px the Owlet promo is ${oneRow.promo}`);
         for (const width of LaptopWidths) {
             const bar = await page.headerBar(width);
             if (bar.height !== oneRow.height)
                 throw new Error(`At ${width}px the bar is ${bar.height}px tall, not ${oneRow.height}px`);
             if (!bar.pasteFits) throw new Error(`At ${width}px the paste box is off the right edge`);
+            // A wider fallback font truncates the promo near 1400, which is allowed; spilling over the controls is not.
+            if (bar.promo === "overflowing") throw new Error(`At ${width}px the Owlet promo runs into the controls`);
         }
     } finally {
         await page.send("Emulation.clearDeviceMetricsOverride");

--- a/tests/browser/smoke.js
+++ b/tests/browser/smoke.js
@@ -1,7 +1,8 @@
 // Boots the built page in headless Chrome and exercises the things unit tests
-// cannot see: construction order, Bootstrap, the console surface, and the ids
-// each check below reaches (the toolbar, the settings bar, the loaders, the
-// STH picker); an id nothing here touches is not covered.
+// cannot see: construction order, Bootstrap, the console surface, the top
+// bar's layout at laptop widths, and the ids each check below reaches (the
+// toolbar, the settings bar, the loaders, the STH picker); an id nothing here
+// touches is not covered.
 // Talks to Chrome over the DevTools protocol with Node's own WebSocket.
 //
 //   npm run test:smoke       build, serve dist/ and run every check
@@ -30,6 +31,8 @@ const BootTimeoutMs = 30000;
 const StepTimeoutMs = 10000;
 const ServerTimeoutMs = 30000;
 const KeyHoldMs = 120;
+const OneRowWidth = 2000;
+const LaptopWidths = [1280, 1440];
 const ConsoleSurface = [
     "processor",
     "video",
@@ -236,6 +239,24 @@ class Page {
         this.problems.length = 0;
         return problems;
     }
+
+    setViewportWidth(width) {
+        return this.send("Emulation.setDeviceMetricsOverride", {
+            width,
+            height: 900,
+            deviceScaleFactor: 1,
+            mobile: false,
+        });
+    }
+
+    async headerBar(width) {
+        await this.setViewportWidth(width);
+        return this.evaluate(`(() => {
+            const bar = document.getElementById("header-bar");
+            const paste = document.getElementById("paste-text").getBoundingClientRect();
+            return { height: bar.offsetHeight, pasteFits: paste.width > 0 && paste.right <= innerWidth };
+        })()`);
+    }
 }
 
 const checks = [];
@@ -251,6 +272,22 @@ check("boots to the BASIC prompt with a working console surface", async (page, b
     }
     const byte = await page.evaluate("processor.readmem(0)");
     if (typeof byte !== "number") throw new Error(`processor.readmem(0) gave ${byte}`);
+});
+
+check("the top bar is one row at laptop widths", async (page, base) => {
+    await page.goto(base);
+    await page.waitForScreenText(">");
+    try {
+        const oneRow = await page.headerBar(OneRowWidth);
+        for (const width of LaptopWidths) {
+            const bar = await page.headerBar(width);
+            if (bar.height !== oneRow.height)
+                throw new Error(`At ${width}px the bar is ${bar.height}px tall, not ${oneRow.height}px`);
+            if (!bar.pasteFits) throw new Error(`At ${width}px the paste box is off the right edge`);
+        }
+    } finally {
+        await page.send("Emulation.clearDeviceMetricsOverride");
+    }
 });
 
 check("typing at the keyboard reaches the machine", async (page, base) => {

--- a/tests/unit/test-keyboard-setup.js
+++ b/tests/unit/test-keyboard-setup.js
@@ -4,11 +4,17 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { AccessibilitySwitches } from "../../src/web/accessibility-switches.js";
 import { KeyboardSetup } from "../../src/web/keyboard-setup.js";
 import * as utils from "../../src/utils.js";
-import { teardownDom } from "./helpers.js";
+import { domFromIndexHtml, teardownDom } from "./helpers.js";
 
 const keyEvent = (type, which, { alt = false, ctrl = false } = {}) => {
     const event = new KeyboardEvent(type, { altKey: alt, ctrlKey: ctrl, cancelable: true });
     Object.defineProperty(event, "which", { value: which });
+    return event;
+};
+
+const pasteEvent = (text) => {
+    const event = new Event("paste", { bubbles: true, cancelable: true });
+    Object.defineProperty(event, "clipboardData", { value: { getData: () => text } });
     return event;
 };
 
@@ -28,6 +34,7 @@ describe("KeyboardSetup", () => {
             openPrinter: vi.fn(),
             pause: vi.fn(),
             resume: vi.fn(),
+            paste: vi.fn(),
             onAnyKeyDown: vi.fn(),
         };
         accessibilitySwitches = new AccessibilitySwitches();
@@ -93,6 +100,29 @@ describe("KeyboardSetup", () => {
         it("tells the page about every key on the way down", () => {
             document.dispatchEvent(keyEvent("keydown", utils.keyCodes.A));
             expect(actions.onAnyKeyDown).toHaveBeenCalledTimes(1);
+        });
+    });
+
+    describe("pasting", () => {
+        beforeEach(() => domFromIndexHtml("paste-form"));
+
+        it("goes to the machine when nothing on the page has focus", () => {
+            document.body.dispatchEvent(pasteEvent("PRINT 1\n"));
+            expect(actions.paste).toHaveBeenCalledWith("PRINT 1\n");
+        });
+
+        it("goes to the machine from the paste box", () => {
+            const box = document.getElementById("paste-text");
+            box.focus();
+            box.dispatchEvent(pasteEvent("*CAT"));
+            expect(actions.paste).toHaveBeenCalledWith("*CAT");
+        });
+
+        it("is left to any other field being typed into", () => {
+            const field = document.body.appendChild(document.createElement("input"));
+            field.focus();
+            field.dispatchEvent(pasteEvent("not for the Beeb"));
+            expect(actions.paste).not.toHaveBeenCalled();
         });
     });
 

--- a/tests/unit/test-keyboard-setup.js
+++ b/tests/unit/test-keyboard-setup.js
@@ -118,6 +118,11 @@ describe("KeyboardSetup", () => {
             expect(actions.paste).toHaveBeenCalledWith("*CAT");
         });
 
+        it("ignores a paste event that carries no clipboard", () => {
+            document.body.dispatchEvent(new Event("paste", { bubbles: true, cancelable: true }));
+            expect(actions.paste).not.toHaveBeenCalled();
+        });
+
         it("is left to any other field being typed into", () => {
             const field = document.body.appendChild(document.createElement("input"));
             field.focus();

--- a/tests/unit/test-models.js
+++ b/tests/unit/test-models.js
@@ -23,6 +23,25 @@ describe("Model", () => {
         expect(findModel("Atom").cyclesPerSecond).toBe(1 * 1000 * 1000);
     });
 
+    it("has a short name for the top bar, and every selectable model has one", () => {
+        const shortNames = Object.fromEntries(allModels.map((model) => [model.name, model.shortName]));
+        expect(shortNames).toEqual({
+            "BBC B with 8271 (DFS 1.2)": "BBC B",
+            "BBC B with 8271 (DFS 0.9)": "BBC B",
+            "BBC B with 1770 (DFS)": "BBC B",
+            "BBC B with 1770 (ADFS)": "BBC B",
+            "BBC Master 128 (DFS)": "Master 128",
+            "BBC Master 128 (ADFS)": "Master 128",
+            "BBC Master 128 (ANFS)": "Master 128",
+            "Acorn Atom (MMC)": "Atom",
+            "Acorn Atom (Tape)": "Atom",
+            "Acorn Atom (Tape with FP)": "Atom",
+            "Acorn Atom (DOS)": "Atom",
+            Tube65C02: "Tube65C02",
+            Tube65C102: "Tube65C102",
+        });
+    });
+
     it("carries no per-session settings", () => {
         const master = findModel("Master");
 


### PR DESCRIPTION
The top bar needed 1614 CSS px to sit on one row, so every laptop viewport got a second row (#1014). This is the first of three stacked PRs and carries most of the width saving; the tiers and the icon set follow on top of it.

## What changed

- **Model label is a settings control.** A gear plus the short model name (BBC B, Master 128, Atom), the full name as the link's tooltip, and the settings dialog's heading now reads `<full model name> settings`. `Model` gains an explicit `shortName` (defaulting to `name`, which is what the unselectable Tube models keep), and a unit test pins the short name of every model in `allModels`. The nav span's class is now `bbc-model-short`; `.bbc-model` still means the full name everywhere else, including the Electron title observer.
- **Brand is the icon.** The `jsbeeb` text becomes `public/jsbeeb-icon.png` at 28px with `title="jsbeeb"`; the link and `target="_top"` are unchanged.
- **Paste box flexes.** `flex: 1 1 6rem; max-width: 14rem` with the placeholder "Paste / drop here". The paste handler moves to document level in `KeyboardSetup`: a paste reaches the machine unless focus is in some other input, textarea, select or contenteditable, so the box is now a hint and a drop target rather than the mechanism. Keys typed with the box focused still go to the box, not the Beeb. As the issue notes, Ctrl+V while the emulator has focus is a Beeb keypress, so page-level paste arrives through the browser's Edit menu.
- **Owlet promo** is shown only from `xxl` (1400px), with a permanent link in the More menu so it is always reachable. It is the one item on the bar that is not a control, so it is the one that yields: it shrinks and truncates with an ellipsis when the row is short of room, while the menu list and the paste box (never below 6rem) no longer shrink. The copy drops "interactively" so that it still fits untruncated at 1400 in a wider fallback font.
- **Smoke guard.** A new check measures `#header-bar` at 4000px (where the promo must show untruncated) and asserts the same height, with the paste box inside the viewport and the promo not running into the controls, at 1024, 1280, 1400, 1440, 1512, 1536 and 1600.

## Measurements

Headless Chrome, `deviceScaleFactor` 1, measured with the same script as the issue:

| | before | after |
|---|---|---|
| natural width of the row | 1614 | 1099 (1509 with the promo showing) |
| fits on one row from | 1614 px | 993 px (every width above the `lg` collapse) |

Below 1400 the box takes the slack; at 1400 (promo showing, tightest point) it is about 135px wide. In DejaVu Sans, which is what the CI runner renders when it has no Lato, the promo still fits untruncated at 1400 with the box at its 6rem minimum plus 40px; anything wider truncates the promo rather than wrapping the bar.

## Decisions the issue left open

- The dialog heading reads "BBC B with 8271 (DFS 1.2) settings" rather than the bare model name, so the dialog still says what it is.
- `shortName` is an explicit field rather than derived from `name`: the names the issue asked for (Master 128, Atom) are not a prefix of the full names.
- The paste input's `aria-label` was "Search"; it now describes the box.

Part of #1014

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

