### PR TITLE
feat: give the top bar's menus an icon tier below xl

### DIFF
--- a/index.html
+++ b/index.html
@@ -64,7 +64,8 @@
                 data-bs-toggle="modal"
                 data-bs-target="#configuration"
                 title="Emulation settings"
-                >&#x2699;&#xfe0f; <span class="bbc-model-short">BBC B</span></a
+                ><span class="nav-icon me-1" aria-hidden="true">&#x2699;&#xfe0f;</span
+                ><span class="nav-word bbc-model-short">BBC B</span></a
               >
             </li>
             <li class="nav-item dropdown embed-hide">
@@ -75,7 +76,10 @@
                 role="button"
                 data-bs-toggle="dropdown"
                 aria-expanded="false"
-                >Discs</a
+                aria-label="Discs"
+                title="Discs"
+                ><span class="nav-icon d-xl-none me-1" aria-hidden="true">&#x1f4be;</span
+                ><span class="nav-word">Discs</span></a
               >
               <ul class="dropdown-menu dropdown-menu-dark" aria-labelledby="navbarDiscs">
                 <li>
@@ -142,7 +146,10 @@
                 role="button"
                 data-bs-toggle="dropdown"
                 aria-expanded="false"
-                >Cassettes</a
+                aria-label="Cassettes"
+                title="Cassettes"
+                ><span class="nav-icon d-xl-none me-1" aria-hidden="true">&#x1f4fc;</span
+                ><span class="nav-word d-none d-xl-inline">Cassettes</span></a
               >
               <ul class="dropdown-menu dropdown-menu-dark" id="tape-menu" aria-labelledby="navbarCassettes">
                 <li>
@@ -166,7 +173,10 @@
                 role="button"
                 data-bs-toggle="dropdown"
                 aria-expanded="false"
-                >Reset</a
+                aria-label="Reset"
+                title="Reset"
+                ><span class="nav-icon d-xl-none me-1" aria-hidden="true">&#x21bb;</span
+                ><span class="nav-word d-none d-xl-inline">Reset</span></a
               >
               <ul class="dropdown-menu dropdown-menu-dark" aria-labelledby="navbarReset">
                 <li><a href="#" id="soft-reset" class="dropdown-item">Soft reset</a></li>
@@ -181,7 +191,10 @@
                 role="button"
                 data-bs-toggle="dropdown"
                 aria-expanded="false"
-                >State</a
+                aria-label="State"
+                title="State"
+                ><span class="nav-icon d-xl-none me-1" aria-hidden="true">&#x1f4f7;</span
+                ><span class="nav-word d-none d-xl-inline">State</span></a
               >
               <ul class="dropdown-menu dropdown-menu-dark" aria-labelledby="navbarState">
                 <li><a href="#" id="save-state" class="dropdown-item">Save state</a></li>
@@ -206,7 +219,10 @@
                 role="button"
                 data-bs-toggle="dropdown"
                 aria-expanded="false"
-                >More</a
+                aria-label="More"
+                title="More"
+                ><span class="nav-icon d-xl-none me-1" aria-hidden="true">&#x22ef;</span
+                ><span class="nav-word d-none d-xl-inline">More</span></a
               >
               <ul class="dropdown-menu dropdown-menu-dark" aria-labelledby="navbarMore">
                 <li><a href="#" id="fs" class="dropdown-item">Fullscreen</a></li>

--- a/tests/browser/smoke.js
+++ b/tests/browser/smoke.js
@@ -32,7 +32,7 @@ const StepTimeoutMs = 10000;
 const ServerTimeoutMs = 30000;
 const KeyHoldMs = 120;
 const OneRowWidth = 2000;
-const LaptopWidths = [1280, 1440];
+const LaptopWidths = [1024, 1280, 1400, 1440];
 const ConsoleSurface = [
     "processor",
     "video",


### PR DESCRIPTION
Second of the three-PR stack for #1014, on top of the trims. The bar now collapses in a chosen order instead of wrapping, with Bootstrap display utilities only.

## Collapse order

1. Owlet promo (below `xxl`, from the previous PR)
2. Brand text (already the icon)
3. Menu words give way to icons with tooltips below `xl` (1200px). Discs is the exception: below `xl` it shows its icon and its word, and keeps the word down to the `lg` hamburger, so it is the last word standing. It is the primary entry point, and a labelled item in a row of icons anchors the row; the icon costs 24px, which at 1024 comes out of the auto margins rather than the paste box
4. The gear and short model name stay at every width

Each dropdown toggle now carries `aria-label` and `title` with the menu's name, so the icon-only form is still named for tooltips and screen readers. The icons are placeholder emoji here; the next PR in the stack replaces them with the proper icon set.

Apart from Discs, words and icons are never shown together, so the bar is no wider at `xl` and above than after the trims; below `xl` the menus need 75px less (372px against 447px), which leaves the paste box its full 14rem down to about 1000px and 12rem at the collapse.

`navbar-expand-xl` was not needed: after the trims nothing in the 992 to 1200 range wraps, and with the icon tier the paste box is not squeezed there either. The paste placeholder did not need a shorter form at `lg` for the same reason; the one place the box is narrower than 14rem is from 1400 with the promo showing, where it is about 205px in Lato and never below its 6rem minimum in a wider font (the promo truncates first).

## Measurements

Fits from 993px, as after the trims; no width in the expanded range gives two rows, in Lato or in the DejaVu Sans the CI runner falls back to. The smoke check covers 1024 (the icon tier) and 1400 (the promo's narrowest showing) among the laptop widths.

Part of #1014

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

