### PR TITLE
test: read the smoke test's DevTools port from Chrome instead of guessing it

### DIFF
--- a/tests/browser/smoke.js
+++ b/tests/browser/smoke.js
@@ -13,22 +13,17 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 
+import { findChrome } from "../find-chrome.js";
+
 const Args = parseArgs(process.argv.slice(2));
 const PreviewHost = "127.0.0.1";
 const PreviewPort = 5199;
-const DebugPort = 9229 + Math.floor(Math.random() * 1000);
-const ChromeCandidates = [
-    process.env.CHROME_PATH,
-    "google-chrome",
-    "google-chrome-stable",
-    "chromium",
-    "chromium-browser",
-];
 const ScreenBase = 0x7c00;
 const ScreenBytes = 1000;
 const BootTimeoutMs = 30000;
 const StepTimeoutMs = 10000;
 const ServerTimeoutMs = 30000;
+const ChromeStartTimeoutMs = 30000;
 const KeyHoldMs = 120;
 const ConsoleSurface = [
     "processor",
@@ -95,45 +90,67 @@ async function startPreview() {
 }
 
 async function startChrome(width) {
+    const chrome = findChrome();
+    const profile = fs.mkdtempSync(path.join(os.tmpdir(), "jsbeeb-smoke-profile-"));
     const args = [
         "--headless=new",
         "--no-sandbox",
+        // Chrome puts its shared memory in /dev/shm, which containers make tiny.
+        "--disable-dev-shm-usage",
+        "--no-first-run",
+        `--user-data-dir=${profile}`,
         "--use-gl=angle",
         "--use-angle=swiftshader",
         "--autoplay-policy=no-user-gesture-required",
-        `--remote-debugging-port=${DebugPort}`,
+        "--remote-debugging-port=0",
         `--window-size=${width},900`,
         "about:blank",
     ];
-    const candidates = ChromeCandidates.filter(Boolean);
-    for (const candidate of candidates) {
-        const child = spawn(candidate, args, { stdio: "ignore" });
-        // A candidate that is not there fails to spawn; one that is there but
-        // cannot run exits straight away. Either way, try the next.
-        const gone = new Promise((resolve) => {
-            child.once("error", () => resolve(true));
-            child.once("exit", () => resolve(true));
+    const child = spawn(chrome, args, { stdio: ["ignore", "ignore", "pipe"] });
+    let stderr = "";
+    child.stderr.on("data", (chunk) => (stderr += chunk));
+    const exited = new Promise((resolve) => {
+        child.once("exit", resolve);
+        child.once("error", resolve);
+    });
+    const stop = async () => {
+        if (child.pid && child.exitCode === null && child.signalCode === null) {
+            child.kill();
+            await exited;
+        }
+        fs.rmSync(profile, { recursive: true, force: true });
+    };
+    const failure = (what) => new Error(`${chrome} ${what}${stderr ? `; it said:\n${stderr.trim()}` : ""}`);
+    // With port 0 Chrome picks a free port and the only way to learn it is the
+    // line it prints to stderr.
+    const devtoolsHost = new Promise((resolve, reject) => {
+        const timer = setTimeout(
+            () => reject(failure(`did not announce its DevTools port within ${ChromeStartTimeoutMs}ms`)),
+            ChromeStartTimeoutMs,
+        );
+        child.stderr.on("data", () => {
+            const host = /DevTools listening on ws:\/\/([^/\s]+)/.exec(stderr)?.[1];
+            if (!host) return;
+            clearTimeout(timer);
+            resolve(host);
         });
-        const target = await Promise.race([gone, debugTarget()]);
-        if (target !== true) return { child, target };
+        child.once("error", (error) => reject(failure(`could not be started: ${error.message}`)));
+        child.once("exit", (code, signal) =>
+            reject(failure(`exited (${signal ?? `code ${code}`}) before announcing its DevTools port`)),
+        );
+    });
+    try {
+        const host = await devtoolsHost;
+        const target = await waitUntil(
+            "Chrome's page target",
+            async () => (await (await fetch(`http://${host}/json/list`)).json()).find((t) => t.type === "page"),
+            StepTimeoutMs,
+        );
+        return { host, target, stop };
+    } catch (error) {
+        await stop();
+        throw error;
     }
-    throw new Error(`No Chrome would start; tried ${candidates.join(", ")}`);
-}
-
-/** The page target of the Chrome listening on the debug port, once it is. */
-function debugTarget() {
-    return waitUntil(
-        "Chrome's debugging port",
-        async () => {
-            try {
-                const list = await (await fetch(`http://127.0.0.1:${DebugPort}/json/list`)).json();
-                return list.find((t) => t.type === "page");
-            } catch (_e) {
-                return null;
-            }
-        },
-        StepTimeoutMs,
-    );
 }
 
 class Page {
@@ -519,9 +536,8 @@ async function main() {
     let chrome = null;
     let failures = 0;
     try {
-        const started = await startChrome(1400);
-        chrome = started.child;
-        const page = await Page.connect(started.target);
+        chrome = await startChrome(1400);
+        const page = await Page.connect(chrome.target);
         const selected = checks.filter((c) => !Args.only || c.name.includes(Args.only));
         for (const { name, run } of selected) {
             try {
@@ -537,11 +553,11 @@ async function main() {
             }
         }
         if (Args.keep) {
-            console.log(`Chrome left running on port ${DebugPort}; base ${base}`);
+            console.log(`Chrome left running with DevTools at ${chrome.host}; base ${base}`);
             await new Promise(() => {});
         }
     } finally {
-        chrome?.kill();
+        await chrome?.stop();
         server?.stop();
     }
     process.exit(failures ? 1 : 0);

--- a/tests/find-chrome.js
+++ b/tests/find-chrome.js
@@ -1,0 +1,32 @@
+// Where the browser tests find a Chrome to drive: CHROME_PATH, else PATH.
+
+import { existsSync } from "node:fs";
+import path from "node:path";
+
+const ChromeCandidates = ["google-chrome", "google-chrome-stable", "chrome", "chromium", "chromium-browser"];
+
+let chromePath = null;
+
+/** Look a command up on PATH, as a shell would, without spawning one. */
+function onPath(command) {
+    // Windows needs the extension supplying; everywhere else the name is whole.
+    const suffixes = process.platform === "win32" ? [".exe", ".cmd", ""] : [""];
+    for (const dir of (process.env.PATH ?? "").split(path.delimiter)) {
+        for (const suffix of suffixes) {
+            const candidate = path.join(dir, command + suffix);
+            if (existsSync(candidate)) return candidate;
+        }
+    }
+    return null;
+}
+
+export function findChrome() {
+    if (chromePath) return chromePath;
+    chromePath = process.env.CHROME_PATH || ChromeCandidates.map(onPath).find(Boolean);
+    if (!chromePath)
+        throw new Error(
+            `No Chrome found on PATH (looked for ${ChromeCandidates.join(", ")}). Install Chrome or ` +
+                `Chromium, or set CHROME_PATH to the browser's executable.`,
+        );
+    return chromePath;
+}

--- a/tests/shader/render.js
+++ b/tests/shader/render.js
@@ -8,42 +8,16 @@
 // launching one costs far more than drawing into it.
 
 import { execFileSync } from "child_process";
-import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "fs";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "fs";
 import { tmpdir } from "os";
 import path from "path";
+
+import { findChrome } from "../find-chrome.js";
 
 /** Framebuffer stride, and the size of the square GL texture it is uploaded into. */
 export const TextureSize = 1024;
 
 const ShaderDir = new URL("../../src/video-filters/shaders/", import.meta.url);
-
-const ChromeCandidates = ["google-chrome", "google-chrome-stable", "chrome", "chromium", "chromium-browser"];
-
-let chromePath = null;
-
-/** Look a command up on PATH, as a shell would, without spawning one. */
-function onPath(command) {
-    // Windows needs the extension supplying; everywhere else the name is whole.
-    const suffixes = process.platform === "win32" ? [".exe", ".cmd", ""] : [""];
-    for (const dir of (process.env.PATH ?? "").split(path.delimiter)) {
-        for (const suffix of suffixes) {
-            const candidate = path.join(dir, command + suffix);
-            if (existsSync(candidate)) return candidate;
-        }
-    }
-    return null;
-}
-
-function findChrome() {
-    if (chromePath) return chromePath;
-    chromePath = process.env.CHROME_PATH || ChromeCandidates.map(onPath).find(Boolean);
-    if (!chromePath)
-        throw new Error(
-            `No Chrome found on PATH (looked for ${ChromeCandidates.join(", ")}). Install Chrome or ` +
-                `Chromium, or set CHROME_PATH to the browser's executable.`,
-        );
-    return chromePath;
-}
 
 /**
  * How to draw through one of the project's filters. The `setup` and `bind`


### PR DESCRIPTION
## The failure

Run [33523834306](https://github.com/mattgodbolt/jsbeeb/actions/runs/33523834306) (a push to `claude/fix-prev-instruction-scoring`) failed its Smoke test step with

```
Error: Timed out after 10000ms waiting for Chrome's debugging port
```

exactly 10 s after `vite build` finished, with no other output. The same commit's shader tests had just driven headless Chrome on the same runner without trouble.

## Root cause

`startChrome` picked a port at random in 9229..10228, passed it as `--remote-debugging-port`, and polled `http://127.0.0.1:<port>/json/list` for 10 s. Chrome's stderr was `ignore`d. That handshake conflates every way Chrome can be alive without answering on that address:

- **The port is already taken.** Chrome does not exit: it logs `bind() failed: Address already in use` and listens on `[::1]` instead (verified locally against Chrome 151 with a listener parked on the chosen port), so the IPv4 poll never sees it and the test times out with Chrome still running.
- **Chrome takes longer than 10 s to come up** on a loaded shared runner. Cold start here is about 230 ms, but the preview server in the same file is already given 30 s.

Because nothing from Chrome reached the log, the two cannot be told apart from the failed runs, which is itself the bug this fixes.

## How often

I pulled the build-and-test job log of every run of the tests workflow since the smoke step was added (3e3d65b, 2026-08-30), about 150 runs across main and every branch. The Chrome start-up timeout occurred twice, both on branches: [33408599725](https://github.com/mattgodbolt/jsbeeb/actions/runs/33408599725) on 2026-08-31 (passed silently, since until #1003 the step could not fail) and the run above. Never on main.

## The fix

- `--remote-debugging-port=0`: Chrome picks a free port and announces it as `DevTools listening on ws://127.0.0.1:<port>/...` on stderr; the test reads the address from that line. No guessed port, nothing to collide with.
- Chrome's stderr is captured and included in the error if it exits before announcing or does not announce within 30 s (`ChromeStartTimeoutMs`, matching `ServerTimeoutMs`), so the next occurrence explains itself.
- A fresh `--user-data-dir` per run (removed on exit) with `--no-first-run`, and `--disable-dev-shm-usage` for anyone running the suite in a container.
- The binary is resolved once with the shader tests' `CHROME_PATH`-then-`PATH` lookup, now shared in `tests/find-chrome.js` (moved out of `tests/shader/render.js` verbatim), instead of spawning each candidate and racing its exit against the poll. The GL flags the smoke test relies on are unchanged.

## Verification

- `npm run test:smoke` twice locally, all checks pass, no profile directories left in `/tmp`.
- `npm run test:shader` passes with the shared lookup.
- `CHROME_PATH=/nonexistent/chrome`: `Error: /nonexistent/chrome could not be started: spawn /nonexistent/chrome ENOENT`, exit 2 immediately.
- `CHROME_PATH=/bin/false`: `Error: /bin/false exited (code 1) before announcing its DevTools port`.
- `CHROME_PATH` pointing at a script that prints to stderr and sleeps: fails after 30 s with `did not announce its DevTools port within 30000ms; it said: ...` followed by the script's output, and the child is killed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
