### PR TITLE
spike: Playwright for the smoke checks, and what to push down into unit tests

### DIFF
--- a/.github/workflows/test-and-deploy.yml
+++ b/.github/workflows/test-and-deploy.yml
@@ -64,6 +64,29 @@ jobs:
         run: |
           echo "# Smoke test" >> "$GITHUB_STEP_SUMMARY"
           npm run test:smoke | tee >(sed 's/^/- /' >> "$GITHUB_STEP_SUMMARY")
+      # The Playwright spike: the same checks, once in the runner's Chrome and
+      # once in the browser Playwright pins, each timed as its own step.
+      - name: Playwright smoke (system Chrome)
+        run: npx playwright test --project chrome
+      - name: Playwright browser version
+        id: playwright
+        run: echo "version=$(node -p "require('@playwright/test/package.json').version")" >> "$GITHUB_OUTPUT"
+      - name: Cache Playwright's Chromium
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-chromium-${{ runner.os }}-${{ steps.playwright.outputs.version }}
+      - name: Install Playwright's Chromium
+        run: npx playwright install --with-deps --only-shell chromium
+      - name: Playwright smoke (bundled Chromium)
+        run: npx playwright test --project chromium
+      - name: Keep the Playwright traces of any failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-traces
+          path: test-results/
+          if-no-files-found: ignore
 
   cpu-test:
     runs-on: ubuntu-24.04

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@ coverage
 
 **/.claude/settings.local.json
 **/.claude/worktrees/
+/test-results
+/playwright-report

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
+        "@playwright/test": "^1.62.1",
         "@vitest/coverage-v8": "^4.0.18",
         "eslint": "^10.7.0",
         "eslint-config-prettier": "^10.1.8",
@@ -1563,6 +1564,22 @@
       },
       "funding": {
         "url": "https://opencollective.com/pkgr"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.62.1.tgz",
+      "integrity": "sha512-DTcUc8qii+cpHvtOwggMtBRMjKZHXYWdw8syRYu2vtzuq4Wxphqq4NfCs5Zt44L6mA8rfDfj+PHnxFc/FeK6mQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.62.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@popperjs/core": {
@@ -5834,6 +5851,53 @@
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.1.tgz",
+      "integrity": "sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.62.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.1.tgz",
+      "integrity": "sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/plist": {

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
+    "@playwright/test": "^1.62.1",
     "@vitest/coverage-v8": "^4.0.18",
     "eslint": "^10.7.0",
     "eslint-config-prettier": "^10.1.8",
@@ -115,7 +116,8 @@
     "mirror-bbcdiscs:upload:index": "aws s3 cp .bbcdiscs-mirror/hfe/manifest.json s3://bbc.xania.org/archive/bbcdiscs/hfe/manifest.json --cache-control 'public, max-age=300' && aws s3 cp .bbcdiscs-mirror/manifest.json s3://bbc.xania.org/archive/bbcdiscs/manifest.json --cache-control 'public, max-age=300'",
     "electron": "npm run build && ELECTRON_DISABLE_SANDBOX=1 electron .",
     "electron:build": "electron-builder",
-    "test:smoke": "npm run build && node tests/browser/smoke.js"
+    "test:smoke": "npm run build && node tests/browser/smoke.js",
+    "e2e": "npm run build && playwright test"
   },
   "lint-staged": {
     "*.js": [

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -1,0 +1,42 @@
+import { defineConfig } from "@playwright/test";
+
+// The preview of dist/ the tests drive. A port of its own, so this and
+// tests/browser/smoke.js can run side by side.
+const PreviewHost = "127.0.0.1";
+const PreviewPort = 5198;
+const PreviewUrl = `http://${PreviewHost}:${PreviewPort}/`;
+
+export default defineConfig({
+    testDir: "tests/playwright",
+    fullyParallel: true,
+    forbidOnly: !!process.env.CI,
+    workers: process.env.CI ? 2 : undefined,
+    reporter: process.env.CI ? [["list"], ["github"]] : "list",
+    timeout: 60000,
+    expect: { timeout: 10000 },
+    use: {
+        // Without this a click on a selector that matches nothing waits out
+        // the whole test timeout.
+        actionTimeout: 10000,
+        baseURL: PreviewUrl,
+        viewport: { width: 1400, height: 900 },
+        trace: "retain-on-failure",
+        launchOptions: {
+            // Playwright's own headless switches already mute audio and keep
+            // shared memory out of /dev/shm; these are what the app needs on top.
+            args: ["--use-gl=angle", "--use-angle=swiftshader", "--autoplay-policy=no-user-gesture-required"],
+        },
+    },
+    projects: [
+        // The system Chrome, as the CDP harness and CI use today.
+        { name: "chrome", use: { channel: "chrome" } },
+        // The build Playwright ships and pins to its own version.
+        { name: "chromium" },
+    ],
+    webServer: {
+        // vite's own entry point, not npx, so the kill reaches the server itself.
+        command: `node node_modules/vite/bin/vite.js preview --host ${PreviewHost} --port ${PreviewPort} --strictPort`,
+        url: PreviewUrl,
+        reuseExistingServer: !process.env.CI,
+    },
+});

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -10,7 +10,10 @@ export default defineConfig({
     testDir: "tests/playwright",
     fullyParallel: true,
     forbidOnly: !!process.env.CI,
-    workers: process.env.CI ? 2 : undefined,
+    // Each page runs the machine in real time, so the checks that watch it
+    // stop and start need CPU of their own: with one worker per core they
+    // starve each other and keys auto-repeat.
+    workers: process.env.CI ? 2 : 4,
     reporter: process.env.CI ? [["list"], ["github"]] : "list",
     timeout: 60000,
     expect: { timeout: 10000 },

--- a/tests/playwright/fixtures.js
+++ b/tests/playwright/fixtures.js
@@ -44,8 +44,12 @@ class Beeb {
             .not.toContain(text);
     }
 
+    // currentCycles wraps every emulated second; the seconds term keeps this monotonic.
     cycles() {
-        return this.page.evaluate(() => window.processor.currentCycles);
+        return this.page.evaluate(
+            () =>
+                window.processor.cycleSeconds * window.processor.model.cyclesPerSecond + window.processor.currentCycles,
+        );
     }
 
     /** Checks the emulator stays where it is for a while, and returns where that is. */

--- a/tests/playwright/fixtures.js
+++ b/tests/playwright/fixtures.js
@@ -1,0 +1,105 @@
+import { expect, test as base } from "@playwright/test";
+
+const ScreenBase = 0x7c00;
+const ScreenBytes = 1000;
+const BootTimeoutMs = 30000;
+const KeyHoldMs = 120;
+
+/** The page with jsbeeb on it, reached through the console surface main.js exposes. */
+class Beeb {
+    constructor(page) {
+        this.page = page;
+        this.problems = [];
+        page.on("pageerror", (error) => this.problems.push(`exception: ${error.message}`));
+        page.on("console", (message) => {
+            if (message.type() === "error") this.problems.push(`console error: ${message.text()}`);
+        });
+    }
+
+    open(query = "") {
+        return this.page.goto(`/${query}`);
+    }
+
+    /** Mode 7 screen memory as text, which is what the machine shows at the prompt. */
+    screenText() {
+        return this.page.evaluate(
+            ([base, bytes]) => {
+                const cpu = window.processor;
+                if (!cpu) return "";
+                return Array.from({ length: bytes }, (_, i) => String.fromCharCode(cpu.readmem(base + i) & 0x7f)).join(
+                    "",
+                );
+            },
+            [ScreenBase, ScreenBytes],
+        );
+    }
+
+    async expectScreenText(text, timeout = BootTimeoutMs) {
+        await expect.poll(() => this.screenText(), { message: `"${text}" on the screen`, timeout }).toContain(text);
+    }
+
+    async expectNotOnScreen(text, timeout = BootTimeoutMs) {
+        await expect
+            .poll(() => this.screenText(), { message: `"${text}" to leave the screen`, timeout })
+            .not.toContain(text);
+    }
+
+    cycles() {
+        return this.page.evaluate(() => window.processor.currentCycles);
+    }
+
+    /** Checks the emulator stays where it is for a while, and returns where that is. */
+    async expectHeld(ms = 300) {
+        const before = await this.cycles();
+        await this.page.waitForTimeout(ms);
+        expect(await this.cycles(), "cycles run while the emulator should be stopped").toBe(before);
+        return before;
+    }
+
+    async expectRunningPast(cycles) {
+        await expect.poll(() => this.cycles(), { message: "the emulator to run again" }).toBeGreaterThan(cycles);
+    }
+
+    /** Held long enough for the OS to scan the matrix and see it down. */
+    async pressKey(key) {
+        await this.page.keyboard.down(key);
+        await this.page.waitForTimeout(KeyHoldMs);
+        await this.page.keyboard.up(key);
+    }
+
+    drive0() {
+        return this.page.evaluate(() => window.processor.fdc.drives[0].disc?.name ?? null);
+    }
+
+    async expectDrive0(name, timeout = BootTimeoutMs) {
+        await expect.poll(() => this.drive0(), { message: `${name} to be in drive 0`, timeout }).toBe(name);
+    }
+
+    /**
+     * Bootstrap ignores a hide while its show transition is still running, and
+     * says when that is over. Call before the click that opens the modal.
+     */
+    modalShown(id) {
+        return this.page.evaluate(
+            (modalId) =>
+                new Promise((resolve) =>
+                    document.getElementById(modalId).addEventListener("shown.bs.modal", resolve, { once: true }),
+                ),
+            id,
+        );
+    }
+
+    forgiveProblems(pattern) {
+        this.problems = this.problems.filter((problem) => !pattern.test(problem));
+    }
+}
+
+export const test = base.extend({
+    beeb: async ({ page }, use) => {
+        const beeb = new Beeb(page);
+        await use(beeb);
+        expect(beeb.problems, "errors the page logged").toEqual([]);
+    },
+});
+
+export { expect };

--- a/tests/playwright/smoke.spec.js
+++ b/tests/playwright/smoke.spec.js
@@ -1,0 +1,230 @@
+// The checks of tests/browser/smoke.js, on Playwright: what only the built
+// page in a real browser can show. Each test gets a page of its own.
+//
+//   npm run e2e                       build, then run every check in the system Chrome
+//   npx playwright test --project chromium   in the browser Playwright ships
+//   npx playwright test -g modal             checks whose name matches
+//   npx playwright show-trace test-results/**/trace.zip
+
+import path from "node:path";
+
+import { expect, test } from "./fixtures.js";
+
+const ConsoleSurface = [
+    "processor",
+    "video",
+    "soundChip",
+    "go",
+    "stop",
+    "hd",
+    "m7dump",
+    "benchmarkCpu",
+    "profileCpu",
+    "benchmarkVideo",
+    "profileVideo",
+];
+
+const OneRowWidth = 4000;
+const LaptopWidths = [1024, 1280, 1400, 1440, 1512, 1536, 1600];
+
+test("boots to the BASIC prompt with a working console surface", async ({ beeb, page }) => {
+    await beeb.open();
+    await beeb.expectScreenText("BASIC");
+    await beeb.expectScreenText(">");
+    const missing = await page.evaluate(
+        (names) => names.filter((name) => typeof window[name] === "undefined"),
+        ConsoleSurface,
+    );
+    expect(missing, "names missing from window").toEqual([]);
+    expect(typeof (await page.evaluate(() => window.processor.readmem(0)))).toBe("number");
+});
+
+test("the top bar is one row at laptop widths", async ({ beeb, page }) => {
+    test.fixme(true, "main's bar wraps below 1400px; the fix is on claude/toolbar-tiers, whose smoke check this ports");
+    const headerBar = async (width) => {
+        await page.setViewportSize({ width, height: 900 });
+        return page.evaluate(() => {
+            const bar = document.getElementById("header-bar");
+            const paste = document.getElementById("paste-text").getBoundingClientRect();
+            const promo = bar.querySelector(".navbar-text");
+            const promoState = () => {
+                if (getComputedStyle(promo).display === "none") return "hidden";
+                if (promo.getBoundingClientRect().right > promo.nextElementSibling.getBoundingClientRect().left)
+                    return "overflowing";
+                return promo.scrollWidth > promo.clientWidth ? "truncated" : "fits";
+            };
+            return {
+                height: bar.offsetHeight,
+                pasteFits: paste.width > 0 && paste.right <= innerWidth,
+                promo: promoState(),
+            };
+        });
+    };
+    await beeb.open();
+    await beeb.expectScreenText(">");
+    const oneRow = await headerBar(OneRowWidth);
+    expect(oneRow.promo, `the Owlet promo at ${OneRowWidth}px`).toBe("fits");
+    for (const width of LaptopWidths) {
+        const bar = await headerBar(width);
+        expect(bar, `the bar at ${width}px`).toEqual({
+            height: oneRow.height,
+            pasteFits: true,
+            promo: expect.not.stringMatching(/overflowing/),
+        });
+    }
+});
+
+test("typing at the keyboard reaches the machine", async ({ beeb }) => {
+    await beeb.open();
+    await beeb.expectScreenText(">");
+    await beeb.pressKey("a");
+    await beeb.expectScreenText(">A");
+});
+
+test("a disc named in the URL is loaded and autobooted", async ({ beeb }) => {
+    await beeb.open("?disc=elite.ssd&autoboot");
+    await beeb.expectDrive0("elite.ssd");
+    // Elite's loader leaves mode 7, so the prompt text goes away.
+    await beeb.expectNotOnScreen("BASIC");
+});
+
+test("a modal pauses the emulator and closing it resumes", async ({ beeb, page }) => {
+    await beeb.open();
+    await beeb.expectScreenText(">");
+    const shown = beeb.modalShown("configuration");
+    await page.click('a[data-bs-target="#configuration"]');
+    await expect(page.locator("#debug-pause")).toBeDisabled();
+    await shown;
+    const during = await beeb.expectHeld();
+    await page.click("#configuration .btn-close");
+    await expect(page.locator("#debug-pause")).toBeEnabled();
+    await beeb.expectRunningPast(during);
+});
+
+test("every display mode and sound output on the bar can be picked", async ({ beeb, page }) => {
+    await beeb.open();
+    await beeb.expectScreenText(">");
+    const modes = await page
+        .locator("#display-mode [data-mode]")
+        .evaluateAll((els) => els.map((el) => el.dataset.mode));
+    const outputs = await page
+        .locator("#audio-output [data-output]")
+        .evaluateAll((els) => els.map((el) => el.dataset.output));
+    expect(modes).not.toEqual([]);
+    expect(outputs).not.toEqual([]);
+    for (const mode of modes) {
+        await page.click(`#display-mode [data-mode="${mode}"]`);
+        await expect(page.locator("#display-mode .active")).toHaveAttribute("data-mode", mode);
+    }
+    for (const output of outputs) {
+        await page.click(`#audio-output [data-output="${output}"]`);
+        await expect(page.locator("#audio-output .active")).toHaveAttribute("data-output", output);
+    }
+    await beeb.expectScreenText(">");
+});
+
+test("the pause and play buttons stop and start the emulator", async ({ beeb, page }) => {
+    await beeb.open();
+    await beeb.expectScreenText(">");
+    await page.click("#debug-pause");
+    await expect(page.locator("#debug-play")).toBeEnabled();
+    const stopped = await beeb.expectHeld();
+    await page.click("#debug-play");
+    await beeb.expectRunningPast(stopped);
+});
+
+test("Ctrl-Home stops into the debugger", async ({ beeb, page }) => {
+    await beeb.open();
+    await beeb.expectScreenText(">");
+    await page.keyboard.down("Control");
+    await beeb.pressKey("Home");
+    await page.keyboard.up("Control");
+    await expect(page.locator("#debug-pause")).toBeDisabled();
+    const stopped = await beeb.expectHeld(200);
+    await page.click("#debug-play");
+    await beeb.expectRunningPast(stopped);
+});
+
+test("a disc from the built-in list goes into drive 0", async ({ beeb, page }) => {
+    await beeb.open("?disc=");
+    await beeb.expectScreenText(">");
+    const shown = beeb.modalShown("discs");
+    await page.click("#navbarDiscs");
+    await page.click('a[data-bs-target="#discs"]');
+    await shown;
+    const first = page.locator("#disc-list li:not(.template)").first();
+    await expect(first.locator(".name")).toHaveText("Elite");
+    await first.click();
+    await beeb.expectDrive0("elite.ssd");
+    await expect(page).toHaveURL(/disc1=elite\.ssd/);
+});
+
+test("the STH disc picker opens, shows its list and closes again", async ({ beeb, page }) => {
+    await beeb.open();
+    await beeb.expectScreenText(">");
+    const shown = beeb.modalShown("sth");
+    await page.click("#navbarDiscs");
+    await page.click('a.sth[data-id="discs"]');
+    await shown;
+    await expect(page.locator("#sth-list .template")).toHaveCount(1);
+    // The catalogue is fetched from the archive mirror, so a run cut off from
+    // it still has to open the modal and report the failure inside it.
+    const outcome = () =>
+        page.evaluate(() => {
+            if (document.querySelector("#sth-list li:not(.template)")) return "catalogue";
+            const loading = document.querySelector("#sth .loading");
+            if (loading.style.display !== "none" && loading.textContent.includes("error")) return "failure";
+            return null;
+        });
+    await expect
+        .poll(outcome, { message: "the catalogue, or word that it could not be fetched", timeout: 30000 })
+        .not.toBeNull();
+    if ((await outcome()) === "failure") beeb.forgiveProblems(/catalog|manifest|Failed to load resource/);
+    await page.click("#sth .btn-close");
+    await expect(page.locator("#sth")).not.toHaveClass(/show/);
+    await expect(page.locator("#debug-pause")).toBeEnabled();
+});
+
+test("a local disc file goes into drive 0 and out of the URL", async ({ beeb, page }) => {
+    await beeb.open("?disc=elite.ssd");
+    await beeb.expectScreenText(">");
+    await page.setInputFiles("#disc_load", path.resolve("dist/discs/Welcome.ssd"));
+    await beeb.expectDrive0("Welcome.ssd");
+    await expect(page, "a local disc cannot be named in the URL, yet").not.toHaveURL(/disc/);
+});
+
+test("a local tape file reaches the cassette interface", async ({ beeb, page }) => {
+    await beeb.open();
+    await beeb.expectScreenText(">");
+    await page.setInputFiles("#tape_load", path.resolve("dist/tapes/Welcome.uef"));
+    await expect.poll(() => page.evaluate(() => !!window.processor.acia.tape), { message: "the tape" }).toBe(true);
+});
+
+test("a disc dropped on the paste box goes into drive 0", async ({ beeb, page }) => {
+    await beeb.open();
+    await beeb.expectScreenText(">");
+    const dataTransfer = await page.evaluateHandle(async () => {
+        const bytes = await (await fetch("discs/Welcome.ssd")).arrayBuffer();
+        const transfer = new DataTransfer();
+        transfer.items.add(new File([bytes], "dropped.ssd"));
+        return transfer;
+    });
+    await page.dispatchEvent("#paste-text", "drop", { dataTransfer });
+    await beeb.expectDrive0("dropped.ssd");
+});
+
+test("a saved state can be loaded back", async ({ beeb, page }) => {
+    // A URL-named disc, so restoring goes back through the media loader.
+    await beeb.open("?disc=elite.ssd");
+    await beeb.expectScreenText(">");
+    await beeb.pressKey("a");
+    await beeb.expectScreenText(">A");
+    const download = page.waitForEvent("download");
+    await page.click("#navbarState");
+    await page.click("#save-state");
+    const saved = await (await download).path();
+    await beeb.pressKey("b");
+    await beeb.expectScreenText(">AB");
+    await page.setInputFiles("#load-state", saved);
+    await expect.poll(() => beeb.screenText(), { message: "the saved screen to come back" }).toMatch(/>A(?!B)/);
+});

--- a/tests/shader/render.js
+++ b/tests/shader/render.js
@@ -7,12 +7,9 @@
 // browser. Every pattern in a run is drawn by a single Chrome invocation:
 // launching one costs far more than drawing into it.
 
-import { execFileSync } from "child_process";
-import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "fs";
-import { tmpdir } from "os";
-import path from "path";
+import { readFileSync } from "fs";
 
-import { findChrome } from "../find-chrome.js";
+import { chromium } from "@playwright/test";
 
 /** Framebuffer stride, and the size of the square GL texture it is uploaded into. */
 export const TextureSize = 1024;
@@ -137,8 +134,8 @@ export function buildPattern({
 /**
  * Build a self-contained page that sets WebGL up as GlCanvas does, hands the
  * filter-specific part to the filter, draws every job, and reads the pixels
- * back. It has to be self-contained because it is loaded over file://: no
- * module imports, no dev server.
+ * back. It has to be self-contained because it is handed to the page as
+ * content: no module imports, no dev server.
  */
 function buildHarness(filter, jobs) {
     const vert = readFileSync(new URL(filter.vert, ShaderDir), "utf8");
@@ -192,10 +189,10 @@ function toBase64(bytes) {
 }
 
 function fail(message) {
-    document.title = "FAIL: " + message;
+    window.failure = message;
     throw new Error(message);
 }
-window.onerror = (message) => { document.title = "FAIL: " + message; };
+window.onerror = (message) => { window.failure = message; };
 
 const canvas = document.getElementById("c");
 // Unlike the app this does not set failIfMajorPerformanceCaveat: headless
@@ -281,12 +278,7 @@ for (const job of jobs) {
     results[job.name] = toBase64(pixels);
 }
 
-const out = document.createElement("script");
-out.type = "application/json";
-out.id = "results";
-out.textContent = JSON.stringify(results);
-document.body.appendChild(out);
-document.title = "OK";
+window.results = results;
 </script>
 </body>
 </html>`;
@@ -297,47 +289,23 @@ document.title = "OK";
  *
  * @param {FilterHarness} filter
  * @param {object[]} jobs from {@link buildPattern}
- * @returns {Object<string, {width: number, height: number, data: Uint8Array}>}
+ * @returns {Promise<Object<string, {width: number, height: number, data: Uint8Array}>>}
  *     RGBA rows, top row first
  */
-export function renderJobs(filter, jobs) {
-    const chrome = findChrome();
-    const dir = mkdtempSync(path.join(tmpdir(), "jsbeeb-shader-"));
-    const pageFile = path.join(dir, "harness.html");
-    writeFileSync(pageFile, buildHarness(filter, jobs));
+export async function renderJobs(filter, jobs) {
+    // The system Chrome, as the smoke test's "chrome" project drives.
+    const browser = await chromium.launch({
+        channel: "chrome",
+        // Software WebGL; newer Chrome hides it behind this flag.
+        args: ["--disable-gpu", "--enable-unsafe-swiftshader"],
+    });
     try {
-        // --dump-dom comes back on stdout, and the harness puts any WebGL
-        // failure in the title, so a shader that will not compile says so
-        // rather than quietly producing no pixels.
-        const dom = execFileSync(
-            chrome,
-            [
-                "--headless",
-                "--disable-gpu",
-                // Chrome cannot set up its sandbox in most CI containers.
-                "--no-sandbox",
-                // Software WebGL; newer Chrome hides it behind this flag.
-                "--enable-unsafe-swiftshader",
-                "--hide-scrollbars",
-                "--force-device-scale-factor=1",
-                "--dump-dom",
-                "--virtual-time-budget=10000",
-                pageFile,
-            ],
-            {
-                encoding: "utf8",
-                stdio: ["ignore", "pipe", "pipe"],
-                timeout: 120000,
-                // The page carries every pattern's pixels back in its DOM.
-                maxBuffer: 256 * 1024 * 1024,
-            },
-        );
-        const failure = /<title>FAIL: ([^<]*)<\/title>/.exec(dom);
-        if (failure) throw new Error(`WebGL harness failed: ${failure[1]}`);
-        const json = /<script type="application\/json" id="results">(.*?)<\/script>/s.exec(dom);
-        if (!json) throw new Error("WebGL harness did not finish; no results in the page");
+        const page = await browser.newPage();
+        await page.setContent(buildHarness(filter, jobs));
+        const { failure, raw } = await page.evaluate(() => ({ failure: window.failure, raw: window.results }));
+        if (failure) throw new Error(`WebGL harness failed: ${failure}`);
+        if (!raw) throw new Error("WebGL harness did not finish; no results in the page");
 
-        const raw = JSON.parse(json[1]);
         const images = {};
         for (const job of jobs) {
             if (!(job.name in raw)) throw new Error(`WebGL harness returned no pixels for "${job.name}"`);
@@ -346,7 +314,7 @@ export function renderJobs(filter, jobs) {
         }
         return images;
     } finally {
-        rmSync(dir, { recursive: true, force: true });
+        await browser.close();
     }
 }
 

--- a/tests/shader/test-pal-composite.js
+++ b/tests/shader/test-pal-composite.js
@@ -298,10 +298,10 @@ describe("PAL composite shader", () => {
     let rendered;
     let renderedNearest;
 
-    beforeAll(() => {
+    beforeAll(async () => {
         jobs = buildJobs();
-        rendered = renderJobs(PalHarness, jobs);
-        renderedNearest = renderJobs({ ...PalHarness, nearestSampling: true }, buildNearestJobs());
+        rendered = await renderJobs(PalHarness, jobs);
+        renderedNearest = await renderJobs({ ...PalHarness, nearestSampling: true }, buildNearestJobs());
     }, 180000);
 
     it("renders every job at the size asked for", () => {

--- a/tests/shader/test-xbr.js
+++ b/tests/shader/test-xbr.js
@@ -143,8 +143,8 @@ const intermediates = (image, ...words) => [...eachPixel(image)].filter((p) => !
 describe("xBR shader", () => {
     let rendered;
 
-    beforeAll(() => {
-        rendered = renderJobs(XbrHarness, Patterns.map(xbrPattern));
+    beforeAll(async () => {
+        rendered = await renderJobs(XbrHarness, Patterns.map(xbrPattern));
     }, 180000);
 
     it("renders every pattern at the size asked for", () => {

--- a/vite.config.js
+++ b/vite.config.js
@@ -19,6 +19,8 @@ export default defineConfig({
             "tests/integration/**/*.js",
             "tests/shader/test-*.js",
         ],
+        // Playwright's runner owns these; vitest's default globs would take the spec files.
+        exclude: [...configDefaults.exclude, "tests/playwright/**"],
         testTimeout: 15000,
         slowTestThreshold: 1000,
         coverage: {


### PR DESCRIPTION
A spike, not a proposal to merge as is. It answers three questions: how much of what `tests/browser/smoke.js` checks belongs in unit tests, what the minimal browser suite is, and whether Playwright should own that suite instead of our own CDP harness. `smoke.js` is untouched and still runs; the Playwright port runs beside it.

## What is on the branch

- `playwright.config.js`, `tests/playwright/fixtures.js`, `tests/playwright/smoke.spec.js`: every `smoke.js` check on `@playwright/test`, plus the top-bar width check from `claude/toolbar-tiers` (marked `fixme` until that lands; main's bar wraps at 1024px). Two projects: `chrome` (the system Chrome, what CI drives today) and `chromium` (the headless shell Playwright pins). `trace: "retain-on-failure"`. The `webServer` is the same `vite preview` of `dist/` on a port of its own. Not part of `npm test`: `npm run e2e`.
- `tests/shader/render.js`: the shader harness hands Chrome to Playwright's library. The `--dump-dom` of the whole document, the regex over it, the title as an error channel and the 256MB stdout buffer go; `page.setContent` and one `page.evaluate` replace them. 32 lines shorter, 6.05s to 4.97s.
- CI: four extra steps (chrome run; cache, shell-only install, chromium run) and a trace upload on failure. Existing steps untouched.

## Part 1: the audit

For each check: (a) unit-testable today with `domFromIndexHtml` and the real modules, (b) unit-testable after a small extraction, (c) needs a real browser. "Already" means the unit test exists on main.

| Check | Class | Seam or extraction | What only the browser catches |
| --- | --- | --- | --- |
| Boots to the BASIC prompt, console surface present | (c), surface (b) | Surface: `exposeConsoleSurface(target, { loop, processor, video, audioHandler })` in `src/web/`, tested against a plain object; the name list then lives at one site. | main.js constructing everything in order against the built bundle, ROMs fetched over HTTP, the machine reaching the prompt. Every other check reuses this. |
| Top bar one row at laptop widths | (c) | none | Layout: Bootstrap CSS, fonts, viewport widths. jsdom does no layout. The CI font fallback (Lato missing) is exactly the kind of thing only this sees. |
| Typing reaches the machine | (a) logic, (c) event shape | Already: `test-keyboard.js`, `test-keyboard-setup.js`. An integration test can dispatch `KeyboardEvent` on `document` with `TestMachine` and read the screen. | The fields Chrome puts on a real `KeyboardEvent` (`keyCode`, `location`) and that main.js wires `KeyboardSetup` at all. |
| Disc named in the URL autoboots | (a) parts, (c) wiring | Already: `test-url-params.js`, `test-web-machine.js`, `test-autoboot.js`. | Only main.js's wiring of those three. Fold into the boot check (boot with `?disc=elite.ssd&autoboot`) rather than keep a page load of its own. |
| A modal pauses and resumes | (a) | Already: `test-modals.js` with synthesised events. Probed here: with `domFromIndexHtml("configuration", "header-bar", ...)`, a click on the nav link opens the real Bootstrap modal through its data API, all four `*.bs.modal` events fire in order, and `Modals` stops and restarts the loop, in jsdom. | The fade transition's timing (`shown.bs.modal` after the CSS transition, hide ignored before it). Keep one modal in the browser for that. |
| Every display mode and sound output picked | (a) bar, (c) effects | Already: `test-quick-settings.js`. | Each mode building a `GlCanvas` and compiling its shader in a real GL context inside the app (the shader tests compile them in a harness, not through `Display`); each output touching WebAudio. Keep. |
| Pause and play buttons | (b) | The `debug-pause`/`debug-play` listeners and the `running` handler in main.js become `RunControls({ loop, dbgr, keys })` in `src/web/`, tested with `domFromIndexHtml("debug-pause", "debug-play")`. | Nothing once extracted. |
| Ctrl-Home into the debugger | (a) | Already: `test-keyboard-setup.js` covers Ctrl-Home to `enterDebugger`. | Nothing. |
| Built-in list into drive 0 | (a) | Already: `test-media-loader.js` lists the images. `utils.loadData` has a Node branch, so an integration test can click the entry and load the real `discs/elite.ssd` into a `TestMachine`'s FDC, then check `urlState`. | Nothing. |
| STH picker opens, lists, closes | (a) | Already: `test-sth-picker.js`. Open and close are the same real-Bootstrap path as the modal probe. The catalogue fetch is external and the check already tolerates its failure, so it proves little. | Nothing the modal check does not. |
| Local disc file | (a) | Already: `test-media-loader.js`, "puts the file in drive 0 and takes the disc out of the URL". | Nothing. |
| Local tape file | (a) | Add the `#tape_load` case to `test-media-loader.js`; the tape parsing is in `test-tapes.js`. | Nothing. |
| Drop on the paste box | (a) | Already: `test-media-loader.js`, "puts a dropped disc in drive 0". The smoke check fakes the `DataTransfer` too, so it is no more real than the unit test. (The Playwright port uses a real `DataTransfer`.) | Nothing. |
| Save state, load it back | (a) | Already: `test-snapshot-ui.js` for the UI; `test-snapshot.js` for the format. Add an integration round trip on `TestMachine`: create, gzip (`CompressionStream` exists in Node), read back, compare screen memory. | `downloadBlob`'s anchor click and the file input, both browser trivia. |
| Shader pixel tests (PAL composite, xBR) | (c) | none | WebGL output. The question is only which harness. |

Minimal browser suite, then: boot with autoboot and the console surface; one real keystroke; one Bootstrap modal; every display mode and sound output; the top bar widths once `toolbar-tiers` lands. Five tests, plus the shaders. Everything else has a headless home.

## Part 2: measurements

Machine: 36 cores, `dist/` already built (a build is 1.7s).

| Harness | Lines | Wall | Notes |
| --- | --- | --- | --- |
| `smoke.js` + `find-chrome.js` (CDP) | 569 + 32 | 17.8s | 13 checks, serial, one Chrome, one page reused. About 190 of those lines are the Chrome launch, the DevTools handshake, the CDP client and the preview server. |
| Playwright, `chrome` project | 39 config + 105 fixtures + 230 spec = 374 | 36.0s / 22.5s / 18.3s at 1 / 2 / 4 workers | 13 checks + 1 fixme. A page and context per test, so each pays a boot. |
| Playwright, `chromium` project | same | 26.5s / 16.2s / 11.8s at 1 / 2 / 4 workers | The headless shell is lighter than Chrome. |
| Playwright, unbounded workers (18) | same | 46s and 3 failures | Real-time emulators starve each other: a held key auto-repeated (`>AAAAB`), cycle counts moved while "paused". The config bounds workers to 4 locally and 2 on CI's 4 vCPUs. |
| Shader suite, `--dump-dom` | render.js 383 | 6.05s | 32 tests, two Chrome invocations |
| Shader suite, Playwright library | render.js 351 | 4.97s | same |

`npx playwright install chromium` took 19.5s here and fetched both the full browser (389MB on disk) and the headless shell (262MB); `--only-shell` fetches the 115MB shell alone, which is all headless runs use. CI step timings are in the section below.

### Diagnosability: the same break on both

I misspelt one selector (`#debug-pause` to `#debug-pausee`) in the pause/play check of each harness.

`smoke.js` (instant):

```
FAIL the pause and play buttons stop and start the emulator
  evaluate failed: Error: No element matches #debug-pausee
```

That is everything. For the CI font failure the whole record was `At 1400px the bar is 152px tall, not 72px`, and finding out why took a font hunt.

Playwright (after the 10s action timeout; before I set `actionTimeout` its auto-waiting burned the whole 60s test timeout, a real cost of the model):

```
TimeoutError: page.click: Timeout 10000ms exceeded.
  - waiting for locator('#debug-pausee')
  > 129 |     await page.click("#debug-pausee");
```

plus `error-context.md` (an accessibility-tree snapshot of the page at the moment of failure, 295 lines, the bar's buttons listed with their labels) and `trace.zip` (626KB): 36 titled steps with parameters and durations (`Navigate to "/"`, `">" on the screen` polls, `Click locator('#debug-pausee')`), 303 screencast frames, 9 DOM snapshots you can hover in the viewer, the 7 console lines, and 26 network exchanges with bodies, the two `woff2` font files among them. Open with `npx playwright show-trace` or trace.playwright.dev; CI uploads `test-results/` on failure. The top-bar failure on main gave the same: the trace shows the wrapped bar at 1024px, which is the picture the font hunt needed.

## Part 3: recommendation

Ranked.

1. **Push down first, whatever happens to the browser layer.** Nine of the fourteen checks are unit-testable today, most already are; the browser copies add only a page load each. Additions: the tape input case; a built-in-list integration test; a save/load round trip on `TestMachine`. Two extractions in the `prevInstruction` spirit: `RunControls` and `exposeConsoleSurface` out of main.js, each a class or function behind a tiny interface, tested against `domFromIndexHtml` or a plain object.
2. **Shrink the browser suite to five tests** (above). This is independent of the harness choice and halves either harness's wall time.
3. **Playwright over the CDP harness for what remains.** Evidence: 374 lines against 601 for the same checks, with no Chrome launch, port handshake, WebSocket client, download interception or file-input plumbing of our own (the day spent on #1022 was on exactly that layer); a trace per failure against one line; real `DataTransfer`, real downloads, real clicks that need the dropdown open (the port opens the Discs and State menus, which `el.click()` via evaluate skipped). Costs, measured: a page per test costs a boot each (18s at 4 workers against 17.8s serial, before the suite shrinks); auto-waiting turns a wrong selector into a timeout, so `actionTimeout` is not optional; a dependency with its own release cadence; the emulator's real-time nature forces a worker bound. Keeping the harness means keeping 200 lines of browser plumbing that have failed twice this month and give nothing when they do.
4. **System Chrome (`channel: "chrome"`) in CI to start.** It needs nothing new: no download, no cache, no `--with-deps`, and it is the browser CI runs now. Switch to the pinned `chromium` project only if a Chrome auto-update on the runner breaks a run; the config already has both, and `--only-shell` keeps the install small. (The font problem is the runner's, not the browser's; either bundle the webfont or keep the check's tolerance for a wider fallback, as `toolbar-tiers` does.)
5. **Cypress: not run here, and not recommended, for reasons I can point at rather than the earlier assessment.** Cypress runs the spec inside the browser beside the app and drives it with synthetic DOM events (its `type()` dispatches `keydown`/`keypress`/`keyup` from script; this is documented, not a guess). For jsbeeb the two checks that justify a browser at all are a real key reaching the matrix and layout at real widths; the first is exactly what synthetic events cannot show, and is what jsdom already gives us. Downloads and `DataTransfer` need plugins or workarounds there; here they are two lines. A one-spec Cypress trial to confirm would need its ~250MB binary and a config; I judged that not worth the spike's budget given the decisive fact is architectural. If you want it run anyway, the keyboard test is the one to run.
6. **vitest browser mode for the shader tests: yes, later, and only that.** The shader harness exists because the tests run in Node: it serialises setup and bind with `Function.prototype.toString` into an HTML string and reads pixels back through base64. In browser mode (`@vitest/browser` with the Playwright provider) the test file itself runs in Chromium, calls WebGL directly, and imports the `.glsl` through vite, so `firShaderPlugin` applies the coefficients the way the app gets them and the manual `applyFirCoefficients` call goes. That is a bigger move than the 32-line change on this branch (a browser project in the vitest config, two more packages, `tools/` stays Node-only), and it is not the right home for the smoke suite: page-level tests want Playwright's own runner (traces, per-test pages, `webServer`). Do it after the smoke suite settles.
7. **CI cost:** see below. The chrome project adds one step and no install; the chromium project adds the install (cached after the first run) and the run.

### Migration, in PRs that each touch one thing

1. `test:` add the tape input unit case, the built-in-list integration test, the save/load round trip. Pure additions.
2. `refactor:` extract `RunControls` and `exposeConsoleSurface` from main.js with unit tests; index.html ids unchanged.
3. `build:` add `@playwright/test`, the config, fixtures and the five-test suite; CI step on `channel: "chrome"`; `smoke.js` stays. (This branch minus the nine redundant tests.)
4. `test:` shader harness onto Playwright's library (second commit here), or straight to vitest browser mode if 6 is wanted now.
5. `test:` remove `smoke.js`, `find-chrome.js`, the smoke CI step and the `test:smoke` script; update CLAUDE.md; add the e2e script to `npm test`.
6. When `toolbar-tiers` lands: un-fixme the top-bar test.

### CI timings

Two runs on ubuntu-24.04 (4 vCPU), step durations from the workflow. The smoke step includes its `npm run build`.

| Step | Run 1 (cold cache) | Run 2 (cache hit) |
| --- | --- | --- |
| Shader tests (`--dump-dom` harness in run 1, Playwright library in both; both commits were in both runs) | 12s | 11s |
| Smoke test (`smoke.js`, build included) | 22s | 24s |
| Playwright smoke, system Chrome (2 workers) | 46s | 44s |
| Cache Playwright's Chromium | miss, 0s | restored, 3s |
| Install Playwright's Chromium (`--with-deps --only-shell`) | 19s | 16s |
| Playwright smoke, bundled Chromium (2 workers) | 28s | 29s |

Two things to read off that. The Playwright port is slower than `smoke.js` on the runner (44s against 24s) because every test boots its own page and 2 workers is all 4 vCPUs will bear; the five-test suite would cut that roughly in proportion, and the bundled headless shell runs the same tests in 29s. And `--with-deps` costs 16s even on a cache hit, since it is apt that takes the time, not the download: on this runner the smoke step already proves Chrome's libraries are present, so the bundled project should install with `--only-shell` alone, or only on a cache miss.
