### PR TITLE
refactor: extract RunControls and the console surface from main.js

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -22,6 +22,8 @@ import { Autoboot } from "./web/autoboot.js";
 import { Display } from "./web/display.js";
 import { Layout } from "./web/layout.js";
 import { EmulationLoop, RewindCaptureInterval } from "./web/emulation-loop.js";
+import { RunControls } from "./web/run-controls.js";
+import { exposeConsoleSurface } from "./web/console-surface.js";
 import { KeyboardSetup } from "./web/keyboard-setup.js";
 import { AccessibilitySwitches } from "./web/accessibility-switches.js";
 import { AnalogueInputs } from "./web/analogue-inputs.js";
@@ -228,14 +230,7 @@ const loop = new EmulationLoop({
     audioStatsNode,
 });
 
-const debugPause = document.getElementById("debug-pause");
-const debugPlay = document.getElementById("debug-play");
-loop.addEventListener("running", () => {
-    const running = loop.isRunning();
-    keys.setRunning(running);
-    debugPlay.disabled = running;
-    debugPause.disabled = !running;
-});
+const runControls = new RunControls({ loop, dbgr, keys });
 
 const modals = new Modals({ loop });
 
@@ -344,18 +339,6 @@ window.addEventListener("blur", function () {
 });
 window.addEventListener("focus", () => loop.setEmulationLead(audioHandler.setWindowFocused(true)));
 
-function pauseIntoDebugger() {
-    loop.stop(true);
-}
-
-function resumeFromDebugger() {
-    dbgr.hide();
-    keys.resumeEmulation();
-}
-
-debugPause.addEventListener("click", pauseIntoDebugger);
-debugPlay.addEventListener("click", resumeFromDebugger);
-
 // To lower chance of data loss, only accept drop events in the drop
 // zone in the menu bar.
 document.addEventListener("dragover", function (event) {
@@ -460,40 +443,7 @@ const startPromise = machine.start({
 // The console surface the wiki documents, and the desktop app's hooks.
 // ------------------------------------------------------------------------
 
-// Handy shortcuts. bench/profile stuff is delayed so that they can be
-// safely run from the JS console in firefox.
-window.benchmarkCpu = utils.debounce((numCycles) => loop.benchmarkCpu(numCycles), 1);
-window.profileCpu = utils.debounce((arg) => loop.profileCpu(arg), 1);
-window.benchmarkVideo = utils.debounce((numCycles) => loop.benchmarkVideo(numCycles), 1);
-window.profileVideo = utils.debounce((arg) => loop.profileVideo(arg), 1);
-window.go = () => loop.go();
-window.stop = (debug) => loop.stop(debug);
-window.soundChip = audioHandler.soundChip;
-window.processor = processor;
-window.video = video;
-window.hd = function (start, end) {
-    console.log(
-        utils.hd(
-            function (x) {
-                return processor.readmem(x);
-            },
-            start,
-            end,
-        ),
-    );
-};
-window.m7dump = function () {
-    console.log(
-        utils.hd(
-            function (x) {
-                return processor.readmem(x) & 0x7f;
-            },
-            0x7c00,
-            0x7fe8,
-            { width: 40, gap: false },
-        ),
-    );
-};
+exposeConsoleSurface(window, { loop, processor, video, audioHandler });
 
 // Hooks for electron.
 electron({
@@ -517,8 +467,8 @@ electron({
         "hard-reset": hardReset,
         "save-state": () => snapshots.saveState(),
         rewind: () => rewindUI.open(),
-        pause: pauseIntoDebugger,
-        resume: resumeFromDebugger,
+        pause: () => runControls.pause(),
+        resume: () => runControls.resume(),
     },
 });
 

--- a/src/web/console-surface.js
+++ b/src/web/console-surface.js
@@ -1,6 +1,6 @@
 "use strict";
 
-import * as utils from "./../utils.js";
+import * as utils from "../utils.js";
 
 /**
  * The debugging surface the wiki documents, put on `target` (window in the

--- a/src/web/console-surface.js
+++ b/src/web/console-surface.js
@@ -1,0 +1,26 @@
+"use strict";
+
+import * as utils from "./../utils.js";
+
+/**
+ * The debugging surface the wiki documents, put on `target` (window in the
+ * app). The bench/profile calls are debounced so that they can be safely run
+ * from the JS console in firefox.
+ */
+export function exposeConsoleSurface(target, { loop, processor, video, audioHandler }) {
+    target.benchmarkCpu = utils.debounce((numCycles) => loop.benchmarkCpu(numCycles), 1);
+    target.profileCpu = utils.debounce((arg) => loop.profileCpu(arg), 1);
+    target.benchmarkVideo = utils.debounce((numCycles) => loop.benchmarkVideo(numCycles), 1);
+    target.profileVideo = utils.debounce((arg) => loop.profileVideo(arg), 1);
+    target.go = () => loop.go();
+    target.stop = (debug) => loop.stop(debug);
+    target.soundChip = audioHandler.soundChip;
+    target.processor = processor;
+    target.video = video;
+    target.hd = (start, end) => {
+        console.log(utils.hd((x) => processor.readmem(x), start, end));
+    };
+    target.m7dump = () => {
+        console.log(utils.hd((x) => processor.readmem(x) & 0x7f, 0x7c00, 0x7fe8, { width: 40, gap: false }));
+    };
+}

--- a/src/web/run-controls.js
+++ b/src/web/run-controls.js
@@ -1,0 +1,41 @@
+"use strict";
+
+/**
+ * The play and pause buttons on the top bar, kept in step with the loop's
+ * running state. pause() and resume() are also the desktop app's menu actions.
+ */
+export class RunControls {
+    /**
+     * @param {object} options
+     * @param {object} options.loop - the emulation loop
+     * @param {object} options.dbgr - the debugger, hidden on resume
+     * @param {object} options.keys - the keyboard setup, told the running state
+     */
+    constructor({ loop, dbgr, keys }) {
+        this.loop = loop;
+        this.dbgr = dbgr;
+        this.keys = keys;
+        this.playButton = document.getElementById("debug-play");
+        this.pauseButton = document.getElementById("debug-pause");
+
+        loop.addEventListener("running", () => {
+            const running = loop.isRunning();
+            keys.setRunning(running);
+            this.playButton.disabled = running;
+            this.pauseButton.disabled = !running;
+        });
+        this.pauseButton.addEventListener("click", () => this.pause());
+        this.playButton.addEventListener("click", () => this.resume());
+    }
+
+    /** Stop the loop into the debugger. */
+    pause() {
+        this.loop.stop(true);
+    }
+
+    /** Hide the debugger; the keyboard's resume event restarts the loop. */
+    resume() {
+        this.dbgr.hide();
+        this.keys.resumeEmulation();
+    }
+}

--- a/tests/unit/test-console-surface.js
+++ b/tests/unit/test-console-surface.js
@@ -1,0 +1,88 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { exposeConsoleSurface } from "../../src/web/console-surface.js";
+import * as utils from "../../src/utils.js";
+
+// Mirrors the ConsoleSurface list in tests/browser/smoke.js.
+const ExpectedNames = [
+    "processor",
+    "video",
+    "soundChip",
+    "go",
+    "stop",
+    "hd",
+    "m7dump",
+    "benchmarkCpu",
+    "profileCpu",
+    "benchmarkVideo",
+    "profileVideo",
+];
+
+function make() {
+    const target = {};
+    const deps = {
+        loop: {
+            go: vi.fn(),
+            stop: vi.fn(),
+            benchmarkCpu: vi.fn(),
+            profileCpu: vi.fn(),
+            benchmarkVideo: vi.fn(),
+            profileVideo: vi.fn(),
+        },
+        processor: { readmem: (addr) => addr & 0xff },
+        video: {},
+        audioHandler: { soundChip: {} },
+    };
+    exposeConsoleSurface(target, deps);
+    return { target, ...deps };
+}
+
+describe("exposeConsoleSurface", () => {
+    afterEach(() => {
+        vi.restoreAllMocks();
+        if (vi.isFakeTimers()) vi.useRealTimers();
+    });
+
+    it("defines every name the smoke test checks for", () => {
+        const { target } = make();
+        for (const name of ExpectedNames) expect(target[name], name).toBeDefined();
+    });
+
+    it("go and stop drive the loop", () => {
+        const { target, loop } = make();
+        target.go();
+        expect(loop.go).toHaveBeenCalled();
+        target.stop(true);
+        expect(loop.stop).toHaveBeenCalledWith(true);
+    });
+
+    it("exposes the machine's parts", () => {
+        const { target, processor, video, audioHandler } = make();
+        expect(target.processor).toBe(processor);
+        expect(target.video).toBe(video);
+        expect(target.soundChip).toBe(audioHandler.soundChip);
+    });
+
+    it("hd logs a hex dump of memory", () => {
+        const { target } = make();
+        const log = vi.spyOn(console, "log").mockImplementation(() => {});
+        target.hd(0, 16);
+        expect(log).toHaveBeenCalledWith(utils.hd((x) => x & 0xff, 0, 16));
+    });
+
+    it("m7dump logs the mode 7 screen with the top bit stripped", () => {
+        const { target } = make();
+        const log = vi.spyOn(console, "log").mockImplementation(() => {});
+        target.m7dump();
+        expect(log).toHaveBeenCalledWith(utils.hd((x) => x & 0x7f, 0x7c00, 0x7fe8, { width: 40, gap: false }));
+    });
+
+    it("the benchmark and profile calls are debounced onto the loop", () => {
+        vi.useFakeTimers();
+        const { target, loop } = make();
+        target.benchmarkCpu(1000);
+        expect(loop.benchmarkCpu).not.toHaveBeenCalled();
+        vi.advanceTimersByTime(2);
+        expect(loop.benchmarkCpu).toHaveBeenCalledWith(1000);
+    });
+});

--- a/tests/unit/test-run-controls.js
+++ b/tests/unit/test-run-controls.js
@@ -1,0 +1,87 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { RunControls } from "../../src/web/run-controls.js";
+import { domFromIndexHtml, teardownDom } from "./helpers.js";
+
+class FakeLoop extends EventTarget {
+    constructor() {
+        super();
+        this.running = false;
+    }
+
+    isRunning() {
+        return this.running;
+    }
+
+    go() {
+        this.running = true;
+        this.dispatchEvent(new Event("running"));
+    }
+
+    stop() {
+        this.running = false;
+        this.dispatchEvent(new Event("running"));
+    }
+}
+
+describe("RunControls", () => {
+    let loop;
+    let dbgr;
+    let keys;
+    let controls;
+
+    const playButton = () => document.getElementById("debug-play");
+    const pauseButton = () => document.getElementById("debug-pause");
+
+    beforeEach(() => {
+        domFromIndexHtml("debug-pause", "debug-play");
+        loop = new FakeLoop();
+        dbgr = { hide: vi.fn() };
+        // In the app, resumeEmulation restarts the loop through the keyboard's resume event.
+        keys = { setRunning: vi.fn(), resumeEmulation: vi.fn(() => loop.go()) };
+        controls = new RunControls({ loop, dbgr, keys });
+    });
+
+    afterEach(teardownDom);
+
+    it("pause stops the loop into the debugger", () => {
+        loop.go();
+        const stop = vi.spyOn(loop, "stop");
+        pauseButton().click();
+        expect(stop).toHaveBeenCalledWith(true);
+        expect(loop.isRunning()).toBe(false);
+    });
+
+    it("play hides the debugger and resumes through the keyboard", () => {
+        playButton().click();
+        expect(dbgr.hide).toHaveBeenCalled();
+        expect(keys.resumeEmulation).toHaveBeenCalled();
+        expect(loop.isRunning()).toBe(true);
+    });
+
+    it("the buttons' disabled states track the loop's running state", () => {
+        loop.go();
+        expect(playButton().disabled).toBe(true);
+        expect(pauseButton().disabled).toBe(false);
+        loop.stop();
+        expect(playButton().disabled).toBe(false);
+        expect(pauseButton().disabled).toBe(true);
+    });
+
+    it("tells the keyboard the running state", () => {
+        loop.go();
+        expect(keys.setRunning).toHaveBeenLastCalledWith(true);
+        loop.stop();
+        expect(keys.setRunning).toHaveBeenLastCalledWith(false);
+    });
+
+    it("pause and resume work without the buttons, for the desktop app's menu", () => {
+        const stop = vi.spyOn(loop, "stop");
+        controls.pause();
+        expect(stop).toHaveBeenCalledWith(true);
+        controls.resume();
+        expect(dbgr.hide).toHaveBeenCalled();
+        expect(loop.isRunning()).toBe(true);
+    });
+});


### PR DESCRIPTION
Step 2 of the browser-test migration plan from #1025: the two extractions its audit marked (b), pulling browser-only wiring out of `main.js` behind small interfaces so unit tests can reach it. No behaviour change; the smoke test still passes untouched.

## RunControls (`src/web/run-controls.js`)

Owns the `#debug-play`/`#debug-pause` buttons, in the style of the other `src/web` modules (elements via `getElementById` in the constructor). Takes `{ loop, dbgr, keys }`:

- subscribes to the loop's `running` event, keeping the buttons' disabled states and `keys.setRunning` in step
- `pause()` stops the loop into the debugger; `resume()` hides the debugger and resumes through `keys.resumeEmulation()`, exactly what the old `pauseIntoDebugger`/`resumeFromDebugger` closures did
- the electron menu actions in `main.js` now call `runControls.pause()`/`resume()` instead of those closures

`tests/unit/test-run-controls.js` builds the real buttons with `domFromIndexHtml("debug-pause", "debug-play")` and covers the same ground as the smoke check "the pause and play buttons stop and start the emulator", plus the menu-action path.

## exposeConsoleSurface (`src/web/console-surface.js`)

The `window` surface the wiki documents (`processor`, `video`, `soundChip`, `go`, `stop`, `hd`, `m7dump`, and the debounced bench/profile calls) becomes `exposeConsoleSurface(target, { loop, processor, video, audioHandler })`; `main.js` calls it with `window`.

`tests/unit/test-console-surface.js` runs it against a plain object, asserts every name on the smoke test's `ConsoleSurface` list is defined, and spot-checks the behaviours: `go`/`stop` delegate to the loop, `hd`/`m7dump` format memory through `utils.hd`, and the benchmark calls are debounced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
