### PR TITLE
test: push browser-covered behaviour down into unit and integration tests

### DIFF
--- a/tests/integration/media-loader.js
+++ b/tests/integration/media-loader.js
@@ -11,7 +11,7 @@ import { domFromIndexHtml, fakeUrlState, teardownDom } from "../unit/helpers.js"
 // jsdom makes utils.loadData take the browser branch, so back XMLHttpRequest
 // with the files the dev server would serve.
 class FileBackedXhr {
-    open(method, url) {
+    open(_method, url) {
         this._url = url;
     }
 
@@ -63,8 +63,9 @@ describe("the built-in disc list", { timeout: 60000 }, () => {
         media.addEventListener("media-changed", (e) => mediaEvents.push(e.detail));
 
         const elite = [...document.querySelectorAll("#disc-list li:not(.template)")].find(
-            (li) => li.querySelector(".name").textContent === "Elite",
+            (li) => li.querySelector(".name")?.textContent === "Elite",
         );
+        expect(elite).toBeDefined();
         elite.click();
 
         await vi.waitFor(() => expect(machine.processor.fdc.drives[0].disc?.name).toBe("elite.ssd"));

--- a/tests/integration/media-loader.js
+++ b/tests/integration/media-loader.js
@@ -1,0 +1,85 @@
+// @vitest-environment jsdom
+import { existsSync, readFileSync } from "node:fs";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { MediaLoader } from "../../src/web/media-loader.js";
+import { Drives } from "../../src/web/drives.js";
+import { DriveTracks } from "../../src/url-params.js";
+import { TestMachine } from "../test-machine.js";
+import { domFromIndexHtml, fakeUrlState, teardownDom } from "../unit/helpers.js";
+
+// jsdom makes utils.loadData take the browser branch, so back XMLHttpRequest
+// with the files the dev server would serve.
+class FileBackedXhr {
+    open(method, url) {
+        this._url = url;
+    }
+
+    overrideMimeType() {}
+
+    send() {
+        const path = existsSync(`public/${this._url}`) ? `public/${this._url}` : this._url;
+        try {
+            this.response = new Uint8Array(readFileSync(path));
+            this.status = 200;
+        } catch {
+            this.status = 404;
+        }
+        this.onload();
+    }
+}
+
+describe("the built-in disc list", { timeout: 60000 }, () => {
+    beforeEach(() => {
+        domFromIndexHtml("header-bar", "discs", "econetfs", "tapes", "paste-text");
+        vi.stubGlobal("XMLHttpRequest", FileBackedXhr);
+    });
+
+    afterEach(() => {
+        vi.unstubAllGlobals();
+        teardownDom();
+    });
+
+    it("clicks Elite into drive 0, names it in the URL and catalogues it", async () => {
+        const machine = new TestMachine();
+        await machine.initialise();
+        const urlState = fakeUrlState();
+        const modals = { hide: vi.fn() };
+        const drives = new Drives({
+            fdc: machine.processor.fdc,
+            driveTracks: [DriveTracks.auto, DriveTracks.auto],
+            confirm: async () => false,
+        });
+        const media = new MediaLoader({
+            processor: machine.processor,
+            model: machine.model,
+            drives,
+            urlState,
+            modals,
+            isSnapshotFile: () => false,
+            loadSnapshot: () => {},
+        });
+        const mediaEvents = [];
+        media.addEventListener("media-changed", (e) => mediaEvents.push(e.detail));
+
+        const elite = [...document.querySelectorAll("#disc-list li:not(.template)")].find(
+            (li) => li.querySelector(".name").textContent === "Elite",
+        );
+        elite.click();
+
+        await vi.waitFor(() => expect(machine.processor.fdc.drives[0].disc?.name).toBe("elite.ssd"));
+        expect(urlState.params.disc1).toBe("elite.ssd");
+        expect(mediaEvents).toEqual([{ disc1: "elite.ssd" }]);
+        expect(modals.hide).toHaveBeenCalledWith("discs");
+
+        await machine.runUntilInput();
+        const seen = [];
+        machine.captureText((element) => seen.push(element.text));
+        await machine.type("*CAT");
+        await machine.runUntilInput();
+
+        const catalogue = seen.join("\n");
+        expect(catalogue).toContain("Elite");
+        expect(catalogue).toContain("LOAD");
+    });
+});

--- a/tests/integration/snapshot.js
+++ b/tests/integration/snapshot.js
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+
+import { createSnapshot, restoreSnapshot, snapshotFromJSON, snapshotToJSON } from "../../src/snapshot.js";
+import { TestMachine } from "../test-machine.js";
+
+const Mode7ScreenStart = 0x7c00;
+const Mode7ScreenEnd = 0x8000;
+
+function screenText(machine) {
+    let text = "";
+    for (let addr = Mode7ScreenStart; addr < Mode7ScreenEnd; addr++) {
+        const c = machine.readbyte(addr);
+        text += c >= 0x20 && c < 0x7f ? String.fromCharCode(c) : " ";
+    }
+    return text;
+}
+
+describe("save state round trip", { timeout: 60000 }, () => {
+    it("continues identically in a fresh machine restored through the gzipped file format", async () => {
+        const original = new TestMachine();
+        await original.initialise();
+        await original.runUntilInput();
+        await original.type('PRINT "SNAPSHOT"');
+        await original.runUntilInput();
+        expect(screenText(original)).toContain("SNAPSHOT");
+
+        const json = snapshotToJSON(createSnapshot(original.processor, original.model));
+        const compressed = await new Response(
+            new Blob([json]).stream().pipeThrough(new CompressionStream("gzip")),
+        ).blob();
+        const compressedBytes = new Uint8Array(await compressed.arrayBuffer());
+        expect([compressedBytes[0], compressedBytes[1]]).toEqual([0x1f, 0x8b]);
+        const decompressed = await new Response(
+            compressed.stream().pipeThrough(new DecompressionStream("gzip")),
+        ).text();
+        const snapshot = snapshotFromJSON(decompressed);
+
+        const restored = new TestMachine();
+        await restored.initialise();
+        restoreSnapshot(restored.processor, restored.model, snapshot);
+
+        expect(screenText(restored)).toContain("SNAPSHOT");
+        expect(restored.processor.pc).toBe(original.processor.pc);
+
+        const cycles = 4 * 1000 * 1000;
+        await original.runFor(cycles);
+        await restored.runFor(cycles);
+
+        for (const reg of ["pc", "a", "x", "y", "s"]) expect(restored.processor[reg]).toBe(original.processor[reg]);
+        expect(screenText(restored)).toBe(screenText(original));
+        expect(screenText(restored)).toContain("SNAPSHOT");
+    });
+});

--- a/tests/unit/test-media-loader.js
+++ b/tests/unit/test-media-loader.js
@@ -190,6 +190,32 @@ describe("MediaLoader", () => {
         });
     });
 
+    describe("the local tape input", () => {
+        // "UEF File!" header, then one data chunk, the least loadTapeFromData accepts.
+        const uefImage = () =>
+            new Uint8Array([
+                0x55, 0x45, 0x46, 0x20, 0x46, 0x69, 0x6c, 0x65, 0x21, 0x00, 0x06, 0x00, 0x00, 0x01, 0x01, 0x00, 0x00,
+                0x00, 0x41,
+            ]);
+
+        it("routes the file to the cassette interface and takes the tape out of the URL", async () => {
+            deps.urlState.params.tape = "old.uef";
+            make();
+            await pickFile("tape_load", fileFor("mine.uef", uefImage()));
+            await vi.waitFor(() => expect(deps.processor.acia.setTape).toHaveBeenCalled());
+            expect(deps.processor.acia.setTape.mock.calls[0][0]).toBeTruthy();
+            expect(deps.urlState.params.tape).toBeUndefined();
+            expect(deps.modals.hide).toHaveBeenCalledWith("tapes");
+        });
+
+        it("reports a file the tape code cannot take", async () => {
+            make();
+            await pickFile("tape_load", fileFor("noise.uef", new Uint8Array(12)));
+            await vi.waitFor(() => expect(toasts()).toEqual([expect.stringContaining("Could not load noise.uef")]));
+            expect(deps.processor.acia.setTape).not.toHaveBeenCalled();
+        });
+    });
+
     describe("the drop zone", () => {
         const drop = (file) => {
             const event = new Event("drop", { bubbles: true, cancelable: true });


### PR DESCRIPTION
Step 1 of the migration plan from #1025: the smoke checks whose behaviour needs no browser now have headless homes, as pure test additions. Nothing in `tests/browser/` or the checks themselves changes here.

## What moved down

**The local tape file input** (`tests/unit/test-media-loader.js`). The disc input already had unit coverage; the `#tape_load` change handler now has the matching cases: a picked UEF reaches the cassette interface, the `tape` URL parameter is cleared and the Tapes dialog closed, and an unreadable file is reported by name without touching the ACIA.

**The built-in disc list, end to end** (`tests/integration/media-loader.js`). A real `MediaLoader` and `Drives` built from the real `index.html` markup, wired to a `TestMachine`; clicking the Elite entry loads the real `public/discs/elite.ssd` into drive 0 through the same code path the page uses, names it in the URL state and fires the media-changed event, and the booted machine then catalogues the disc with `*CAT`. That matches what the smoke check asserts (disc name in drive 0, `disc1` in the URL) and goes further by proving DFS can read the catalogue.

One audit claim did not survive contact: the plan said the test could ride `utils.loadData`'s Node branch, but that branch is chosen by `typeof window`, and the click needs jsdom, so the window exists and the browser branch runs. The test instead backs `XMLHttpRequest` with the files the dev server would serve, which still exercises the app's own fetch path over the real disc and ROM images.

**The save/load state round trip** (`tests/integration/snapshot.js`). A running `TestMachine` is snapshotted with the same `createSnapshot`/`snapshotToJSON` the UI calls, compressed and decompressed through `CompressionStream("gzip")` exactly as `snapshot-ui.js` does (including checking the gzip magic the loader sniffs for), restored into a fresh machine, and both machines then run on identically: same registers and the same mode 7 screen, still showing the text typed before the save.

## Why

Each of these was only proven in headless Chrome via `tests/browser/smoke.js`; per the #1025 audit they are unit- or integration-testable today, so the browser suite can later shrink to the checks that genuinely need a browser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)