### PR TITLE
test: scale local e2e workers to the machine

### DIFF
--- a/playwright.config.js
+++ b/playwright.config.js
@@ -1,4 +1,5 @@
 import { defineConfig } from "@playwright/test";
+import os from "node:os";
 
 // The preview of dist/ the tests drive, on a port of its own so a dev server
 // can run alongside. BASE_URL points the suite at a server that is already
@@ -14,10 +15,11 @@ export default defineConfig({
     forbidOnly: !!process.env.CI,
     // Deliberately none, anywhere: a flake is a bug to root-cause.
     retries: 0,
-    // Each page runs the machine in real time, so the checks that watch it
-    // stop and start need CPU of their own: with one worker per core they
-    // starve each other and keys auto-repeat.
-    workers: process.env.CI ? 2 : 4,
+    // Each worker is a whole Chrome running the machine in real time, and
+    // starved emulators time out rather than slow down; a 15GB laptop showed
+    // four of them paging each other to death. One worker per eight hardware
+    // threads keeps small machines serial and big ones parallel.
+    workers: process.env.CI ? 2 : Math.max(1, Math.min(4, Math.floor(os.availableParallelism() / 8))),
     reporter: process.env.CI ? [["list"], ["github"], ["html", { open: "never" }]] : "list",
     timeout: 60000,
     expect: { timeout: 10000 },


### PR DESCRIPTION
The first `npm test` on a laptop had four of the six e2e tests time out at the full 60s while the last two (running alone after the others died) passed. `top` during the run showed why: the local default of four workers is four whole Chrome instances each running a Beeb in real time, on a 4-core-class machine with 15GB of RAM that was already deep in swap; 87% user CPU, 3% idle, five Chrome main threads fighting for ~3.5 cores. A starved emulator does not run slower, it fails: emulated time stops advancing and every boot-and-wait check times out.

The worker count now scales with the machine: one worker per eight hardware threads, at least one, at most four. That laptop runs the suite serially (the whole suite is ~36s at one worker on a big machine, so still cheap), a 16-thread machine gets two, and only genuinely big machines keep four. CI keeps its explicit two.

Verified the arithmetic across 4 to 36 threads and the suite green at the computed count here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
