### PR TITLE
feat: track executed instructions in the debugger disassembly

### DIFF
--- a/src/6502.opcodes.js
+++ b/src/6502.opcodes.js
@@ -1105,17 +1105,25 @@ class Disassemble6502 {
      * opcodes are discarded. The highest-scoring run's last instruction wins;
      * any run beats none, since a wrong parse resynchronises within a few
      * instructions and so nearly always shares the true stream's last one.
+     * When an execution map is supplied, a verified executed instruction
+     * ending exactly at the target is returned before any guessing.
      * Good test cases:
      *   Repton 2 @ 2cbb
      *   MOS @ cfc8, and the unrolled STA abs,X screen clear @ cc63
      * also, just starting from the back of ROM and going up...
      */
-    prevInstruction(address, pc) {
+    prevInstruction(address, pc, executionMap = null) {
         const commonInstructions =
             /(RTS|B..|JMP|JSR|LD[AXY]|ST[AXY]|TA[XY]|T[XY]A|AD[DC]|SUB|SBC|CLC|SEC|CMP|EOR|ORA|AND|INC|DEC).*/;
         const uncommonInstructions = /.*,\s*([XY]|X\))$/;
 
         address &= 0xffff;
+        if (executionMap) {
+            for (let length = 1; length <= 3; ++length) {
+                const addr = (address - length) & 0xffff;
+                if (executionMap.isVerified(addr) && (this.disassemble(addr)[1] & 0xffff) === address) return addr;
+            }
+        }
         let bestAddr = address - 1;
         let bestScore = -1;
         for (let startingPoint = address - PrevInstructionWindow; startingPoint !== address; startingPoint++) {

--- a/src/execution-map.js
+++ b/src/execution-map.js
@@ -1,0 +1,49 @@
+"use strict";
+
+const SidewaysStart = 0x8000;
+const SidewaysEnd = 0xc000;
+const SidewaysSize = SidewaysEnd - SidewaysStart;
+const NumBanks = 16;
+
+/**
+ * Records which addresses the CPU has fetched opcodes from. Each entry holds
+ * the opcode byte plus one (zero means never executed), so an entry vouches
+ * for itself: it is trustworthy exactly when the byte in memory still matches,
+ * which covers self-modifying code and overwritten RAM with no write hook.
+ * The sideways region is keyed by ROM bank as each bank has its own code at
+ * the same addresses; Master shadow and private RAM alias that keying, and
+ * the opcode check catches nearly all of it.
+ */
+export class ExecutionMap {
+    constructor(cpu) {
+        this._cpu = cpu;
+        this._main = new Uint16Array(0x10000);
+        this._sideways = new Array(NumBanks).fill(null);
+    }
+
+    record(addr, opcode) {
+        addr &= 0xffff;
+        if (addr >= SidewaysStart && addr < SidewaysEnd) {
+            const bank = this._cpu.romsel & 15;
+            let entries = this._sideways[bank];
+            if (!entries) entries = this._sideways[bank] = new Uint16Array(SidewaysSize);
+            entries[addr - SidewaysStart] = opcode + 1;
+        } else {
+            this._main[addr] = opcode + 1;
+        }
+    }
+
+    /** True when the instruction at addr was executed and its opcode byte is unchanged. */
+    isVerified(addr) {
+        addr &= 0xffff;
+        let entry;
+        if (addr >= SidewaysStart && addr < SidewaysEnd) {
+            const entries = this._sideways[this._cpu.romsel & 15];
+            if (!entries) return false;
+            entry = entries[addr - SidewaysStart];
+        } else {
+            entry = this._main[addr];
+        }
+        return entry !== 0 && entry === this._cpu.peekmem(addr) + 1;
+    }
+}

--- a/src/jsbeeb.css
+++ b/src/jsbeeb.css
@@ -406,6 +406,10 @@ div.modal-body > div:not(:first-child) {
   background-color: #227777;
 }
 
+.dis_elem.unexecuted {
+  opacity: 0.45;
+}
+
 .highlight {
   border: 1px solid #444;
 }

--- a/src/web/debug.js
+++ b/src/web/debug.js
@@ -1,6 +1,7 @@
 "use strict";
 import { hexbyte, hexword, noop, parseAddr } from "../utils.js";
 import { toggle } from "../dom-utils.js";
+import { ExecutionMap } from "../execution-map.js";
 
 const numToShow = 16;
 
@@ -102,6 +103,8 @@ export class Debugger {
         this.disassStack = [];
         this.uservia = this.sysvia = this.crtc = null;
         this.breakpoints = {};
+        this._executionMap = null;
+        this._executionHook = null;
 
         function setupGoto(form, func) {
             const addr = form.querySelector(".goto-addr");
@@ -143,6 +146,7 @@ export class Debugger {
 
     setCpu(cpu) {
         this.cpu = cpu;
+        this._executionMap = new ExecutionMap(cpu);
         this.sysvia = this.setupVia(document.getElementById("sysvia"), cpu.sysvia);
         this.uservia = this.setupVia(document.getElementById("uservia"), cpu.uservia);
         this.crtc = this.setupCrtc(document.getElementById("crtc_debug"), cpu.video);
@@ -332,6 +336,15 @@ export class Debugger {
             this.updatePrevMem();
         }
         this._enabled = e;
+        if (e && !this._executionHook && this.cpu) {
+            this._executionHook = this.cpu.debugInstruction.add((pc, opcode) => {
+                this._executionMap.record(pc, opcode);
+                return false;
+            });
+        } else if (!e && this._executionHook) {
+            this._executionHook.remove();
+            this._executionHook = null;
+        }
         for (const node of this.debugNodes) toggle(node, this._enabled);
     }
 
@@ -351,6 +364,7 @@ export class Debugger {
             elem.querySelector(".dis_addr").innerHTML = labelHtml(address);
             elem.classList.toggle("current", address === this.cpu.pc);
             elem.classList.toggle("highlight", address === this.disassPc);
+            elem.classList.toggle("unexecuted", !this._executionMap.isVerified(address));
             elem.querySelector(".instr_bytes").textContent = dump.hex.join(" ");
             elem.querySelector(".instr_asc").textContent = dump.asc.join("");
             const disNode = elem.querySelector(".disassembly");
@@ -382,7 +396,7 @@ export class Debugger {
     }
 
     prevInstruction(address) {
-        return this.cpu.disassembler.prevInstruction(address, this.cpu.pc);
+        return this.cpu.disassembler.prevInstruction(address, this.cpu.pc, this._executionMap);
     }
 
     updatePrevMem() {

--- a/tests/unit/test-6502-opcodes.js
+++ b/tests/unit/test-6502-opcodes.js
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it } from "vitest";
 
 import { Cpu6502 as cpu6502Opcodes, Cpu65c02 as cpu65c02Opcodes } from "../../src/6502.opcodes.js";
+import { ExecutionMap } from "../../src/execution-map.js";
 
 describe("Disassemble6502", () => {
     const mem = new Uint8Array(0x10000);
@@ -107,5 +108,31 @@ describe("Disassemble6502", () => {
         }
         mem[0x1fff] = 0xad;
         expect(disassembler.prevInstruction(0x2002, 0x2000)).toBe(0x2000);
+    });
+
+    describe("with an execution map", () => {
+        const makeMap = () => new ExecutionMap({ peekmem: (addr) => mem[addr & 0xffff], romsel: 0 });
+
+        it("returns the verified previous instruction ahead of the heuristic's guess", () => {
+            mem[0x1ffe] = 0xa9;
+            const map = makeMap();
+            map.record(0x1fff, mem[0x1fff]);
+            expect(disassembler.prevInstruction(0x2000, 0x0000)).toBe(0x1ffe);
+            expect(disassembler.prevInstruction(0x2000, 0x0000, map)).toBe(0x1fff);
+        });
+
+        it("ignores an entry whose byte has since been overwritten", () => {
+            const map = makeMap();
+            map.record(0x1fff, mem[0x1fff]);
+            mem[0x1ffe] = 0xa9;
+            mem[0x1fff] = 0x41;
+            expect(disassembler.prevInstruction(0x2000, 0x0000, map)).toBe(0x1ffe);
+        });
+
+        it("falls back to the heuristic when nothing before the target is verified", () => {
+            mem[0x1ffe] = 0xa9;
+            const map = makeMap();
+            expect(disassembler.prevInstruction(0x2000, 0x0000, map)).toBe(0x1ffe);
+        });
     });
 });

--- a/tests/unit/test-execution-map.js
+++ b/tests/unit/test-execution-map.js
@@ -1,0 +1,57 @@
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { ExecutionMap } from "../../src/execution-map.js";
+
+describe("ExecutionMap", () => {
+    const mem = new Uint8Array(0x10000);
+    const cpu = { peekmem: (addr) => mem[addr & 0xffff], romsel: 0 };
+    let map;
+
+    beforeEach(() => {
+        mem.fill(0xea);
+        cpu.romsel = 0;
+        map = new ExecutionMap(cpu);
+    });
+
+    it("verifies an address only once it has executed", () => {
+        expect(map.isVerified(0x2000)).toBe(false);
+        map.record(0x2000, mem[0x2000]);
+        expect(map.isVerified(0x2000)).toBe(true);
+        expect(map.isVerified(0x2001)).toBe(false);
+    });
+
+    it("distinguishes an executed 0xff opcode from never-executed", () => {
+        mem[0x2000] = 0xff;
+        map.record(0x2000, 0xff);
+        expect(map.isVerified(0x2000)).toBe(true);
+        mem[0x3000] = 0xff;
+        expect(map.isVerified(0x3000)).toBe(false);
+    });
+
+    it("invalidates an entry when the byte is overwritten, and trusts it again when restored", () => {
+        map.record(0x2000, mem[0x2000]);
+        mem[0x2000] = 0x60;
+        expect(map.isVerified(0x2000)).toBe(false);
+        mem[0x2000] = 0xea;
+        expect(map.isVerified(0x2000)).toBe(true);
+    });
+
+    it("keys the sideways region by the selected bank, ignoring the high romsel bits", () => {
+        cpu.romsel = 4;
+        map.record(0x9000, mem[0x9000]);
+        expect(map.isVerified(0x9000)).toBe(true);
+        cpu.romsel = 5;
+        expect(map.isVerified(0x9000)).toBe(false);
+        cpu.romsel = 0x84;
+        expect(map.isVerified(0x9000)).toBe(true);
+    });
+
+    it("keeps main-memory entries whatever bank is paged in", () => {
+        cpu.romsel = 4;
+        map.record(0x2000, mem[0x2000]);
+        map.record(0xd000, mem[0xd000]);
+        cpu.romsel = 9;
+        expect(map.isVerified(0x2000)).toBe(true);
+        expect(map.isVerified(0xd000)).toBe(true);
+    });
+});

--- a/tests/unit/test-web-debug.js
+++ b/tests/unit/test-web-debug.js
@@ -104,6 +104,43 @@ describe("Debugger", () => {
         });
     });
 
+    describe("execution tracking", () => {
+        const rowFor = (addr) => disRows().find((row) => row.dataset.addr === String(addr));
+        const dimmed = (addr) => rowFor(addr).classList.contains("unexecuted");
+
+        it("dims rows the CPU has not been seen to execute", () => {
+            dbgr.debug(cpu.pc);
+            expect(dimmed(0x2000)).toBe(true);
+            keyPress("n");
+            expect(dimmed(0x2000)).toBe(false);
+            expect(dimmed(0x2002)).toBe(true);
+        });
+
+        it("stops recording once hidden but remembers what it saw", () => {
+            cpu.writemem(0x2002, 0xea);
+            dbgr.debug(cpu.pc);
+            keyPress("n");
+            dbgr.hide();
+            while (cpu.pc === 0x2002) cpu.execute(1);
+            expect(cpu.pc).toBe(0x2003);
+            dbgr.debug(cpu.pc);
+            expect(dimmed(0x2000)).toBe(false);
+            expect(dimmed(0x2002)).toBe(true);
+        });
+
+        it("returns the CPU to the fast loop once hidden", () => {
+            dbgr.debug(cpu.pc);
+            const slow = vi.spyOn(cpu, "executeInternal");
+            const fast = vi.spyOn(cpu, "executeInternalFast");
+            cpu.execute(1);
+            expect(slow).toHaveBeenCalledTimes(1);
+            expect(fast).not.toHaveBeenCalled();
+            dbgr.hide();
+            cpu.execute(1);
+            expect(fast).toHaveBeenCalledTimes(1);
+        });
+    });
+
     describe("the memory window", () => {
         it("shows the bytes and text around the address the form asks for", () => {
             cpu.writemem(0x1234, 0x48);


### PR DESCRIPTION
Item 3 of #1016: the executed-opcode map, exact back-disassembly through executed code, and the Mesen-style presentation. Closes #1016.

## What it does

`ExecutionMap` (src/execution-map.js) records `opcode + 1` for every fetched instruction start, zero meaning never seen. Entries vouch for themselves: one is trusted exactly when `map[addr] === peekmem(addr) + 1`, so self-modifying code and overwritten RAM invalidate themselves with no write hook. The sideways region is keyed by `romsel & 15` as well, since each bank has its own code at the same addresses; Master shadow and private RAM alias that keying, and the opcode compare catches nearly all of it, as the issue sketched.

The recording hook is added in `Debugger.enable(true)` and removed in `enable(false)`. `Cpu6502.execute` picks the hooked loop only while a debug hook exists, so with the debugger closed the cost is exactly zero; a unit test asserts the CPU is back on `executeInternalFast` after the debugger is hidden.

`prevInstruction` gains an optional third argument: with a map, a verified executed instruction ending exactly at the target is returned before any guessing, and with no map nothing changes. The debugger passes its map through; that one optional parameter is the whole seam.

In the disassembly window, rows whose address is not a verified executed instruction start get an `unexecuted` class and render dimmed, so real code reads bright and junk parses read dim. Showing byte runs between executed instructions as explicit data rows is a possible follow-on; it needs realignment logic that did not fit a CSS-class-sized change.

## Repton 2: the comment's test case, finally checked after eleven years

The `prevInstruction` comment has named "Repton 2 @ 2cbb" as a good test case since 2015 (2ce54b1), and the issue's caveat was that game code was never measured. Measured now: `Superior/Repton2.zip` fetched at runtime from the STH mirror, booted headlessly (SHIFT+BREAK, real Video so the loader's vsync waits run), and played into the game via injected keys, with executed starts recorded through the same `debugInstruction` mechanism the debugger uses. Nothing is committed to the repository and no test touches the network.

- During the loader and title music, &2CBB holds `STA $FE40` in the sound-write routine (the same player soundchip.js's `@0x2caa` comment refers to). The heuristic alone answers &2CB9 `ORA #$08`, which is correct; with the map the same answer comes back verified rather than guessed.
- Once the main game loads over the title code, &2CBB holds data and the map self-invalidates: the verified count visibly dropped mid-load as the loader overwrote previously executed memory. The old test case turns out to be an overwritten-RAM case, exactly what the opcode compare is for.
- Accuracy against ground truth (executed starts with a single executed fall-through predecessor, pc outside the window): heuristic alone 529/530 (99.8%) on the loader/title corpus and 1440/1441 (99.9%) in-game; with the map, 100% on both. The one in-game miss is a junk parse `AND ($60,X)` at &087F chosen over the real `RTS` at &0880.

## Tests

Map recording, self-invalidation on overwrite and bank keying; hook install on enable and removal on disable, including the return to the fast execute loop; `prevInstruction` preferring a verified answer, ignoring a stale one, and falling back with nothing verified; the `unexecuted` class present on unexecuted rows and absent on executed ones.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
