### PR TITLE
test: give the display mode clicks a shader compile budget

### DIFF
--- a/tests/playwright/smoke.spec.js
+++ b/tests/playwright/smoke.spec.js
@@ -118,7 +118,9 @@ test("every display mode and sound output on the bar can be picked", async ({ be
     expect(modes).not.toEqual([]);
     expect(outputs).not.toEqual([]);
     for (const mode of modes) {
-        await page.click(`#display-mode [data-mode="${mode}"]`);
+        // Picking a mode compiles its shaders under software GL, which blocks
+        // the page well past the action default on a slow machine.
+        await page.click(`#display-mode [data-mode="${mode}"]`, { timeout: 30000 });
         await expect(page.locator("#display-mode .active")).toHaveAttribute("data-mode", mode);
     }
     for (const output of outputs) {


### PR DESCRIPTION
Found on the same laptop that motivated #1032, running the e2e suite serially: five tests green, then "every display mode and sound output on the bar can be picked" timed out with the click log showing "click action done" followed by the 10s action timeout expiring. The click succeeded; the page main thread then stalled, because picking PAL compiles the composite filter's 21 and 31 tap FIR shaders under software GL on first use, and on a loaded machine that outlives the action default. The mode-picking clicks get an explicit 30s budget with a comment saying why; the sound output clicks stay on the default, since they compile nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
