### PR TITLE
refactor: tidy small web-layer indirections

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -192,7 +192,7 @@ const machine = new Machine({
 });
 const processor = machine.processor;
 
-const keys = new KeyboardSetup({
+const { keyboard } = new KeyboardSetup({
     actions: {
         enterDebugger: () => loop.stop(true),
         reload: () => window.location.reload(),
@@ -201,7 +201,7 @@ const keys = new KeyboardSetup({
         openPrinter: () => frontPanel.checkPrinterWindow(),
         pause: () => loop.stop(false),
         resume: () => loop.go(),
-        paste: (text) => keys.sendRawKeyboard(autoBoot.stringToMachineKeys(text), true),
+        paste: (text) => keyboard.sendRawKeyboard(autoBoot.stringToMachineKeys(text), true),
         onAnyKeyDown: () => {
             audioHandler.tryResume();
             inputs.ensureMicrophoneRunning();
@@ -220,7 +220,7 @@ const loop = new EmulationLoop({
     audioHandler,
     dbgr,
     gamepad,
-    keyboard: keys,
+    keyboard,
     syncLights: () => frontPanel.syncLights(),
     rewindBuffer,
     onRewindCaptured: () => rewindUI.updateButtonState(),
@@ -230,7 +230,7 @@ const loop = new EmulationLoop({
     audioStatsNode,
 });
 
-const runControls = new RunControls({ loop, dbgr, keys });
+const runControls = new RunControls({ loop, dbgr, keyboard });
 
 const modals = new Modals({ loop });
 
@@ -247,7 +247,7 @@ const media = new MediaLoader({
 const autoBoot = new Autoboot({
     model,
     processor,
-    sendKeys: (keysToSend, check) => keys.sendRawKeyboard(keysToSend, check),
+    sendKeys: (keysToSend, check) => keyboard.sendRawKeyboard(keysToSend, check),
 });
 const autobootTicks = new AutobootTicks({ urlState });
 const sthPicker = new SthPicker({
@@ -323,7 +323,7 @@ const layout = new Layout({
 });
 
 // Everything a setting can reach now exists.
-settings.wire({ audioHandler, display, layout, quickSettings, machine, keys, inputs, modals });
+settings.wire({ audioHandler, display, layout, quickSettings, machine, keyboard, inputs, modals });
 
 // ------------------------------------------------------------------------
 // The page's own handlers.
@@ -334,7 +334,7 @@ for (const el of document.querySelectorAll(".initially-hidden")) el.classList.re
 document.getElementById("paste-form").addEventListener("submit", (event) => event.preventDefault());
 
 window.addEventListener("blur", function () {
-    keys.clearKeys();
+    keyboard.clearKeys();
     loop.setEmulationLead(audioHandler.setWindowFocused(false));
 });
 window.addEventListener("focus", () => loop.setEmulationLead(audioHandler.setWindowFocused(true)));

--- a/src/web/google-drive-picker.js
+++ b/src/web/google-drive-picker.js
@@ -32,8 +32,12 @@ export class GoogleDrivePicker {
             else this.authReject?.(new Error("Unable to authorize Google Drive"));
         });
 
-        // Closing the loading dialog while the auth panel waits is a cancellation, not an error.
-        document.getElementById("loading-dialog").addEventListener("hidden.bs.modal", () => this.authResolve?.(false));
+        // Closing the loading dialog puts the auth panel away; while the panel
+        // waits, that close is a cancellation, not an error.
+        document.getElementById("loading-dialog").addEventListener("hidden.bs.modal", () => {
+            this.authEl.style.display = "none";
+            this.authResolve?.(false);
+        });
 
         // Loading the Google client holds the main thread for ~100ms, so it waits for
         // someone to ask for Drive.

--- a/src/web/hfe-picker.js
+++ b/src/web/hfe-picker.js
@@ -58,14 +58,15 @@ export class HfePicker {
 
     async pick(file) {
         utils.noteEvent("hfe", "click", file.path);
-        this.media.setDisc1Image("hfe:" + file.path);
+        const image = "hfe:" + file.path;
+        this.media.setDisc1Image(image);
         const needsAutoboot = this.urlState.params.autoboot !== undefined;
         if (needsAutoboot) this.processor.reset(true);
 
         const name = describeHfe(file).title;
         this.modals.popupLoading("Loading " + name);
         try {
-            const loaded = await this.media.loadDiscImage(this.urlState.params.disc1, this.drives.layoutForDrive(0));
+            const loaded = await this.media.loadDiscImage(image, this.drives.layoutForDrive(0));
             this.drives.putDiscIn(0, loaded);
             this.modals.loadingFinished();
             if (needsAutoboot) this.autoboot(name);

--- a/src/web/keyboard-setup.js
+++ b/src/web/keyboard-setup.js
@@ -5,7 +5,10 @@ import { showNotice } from "./reporting.js";
 const PasteBoxId = "paste-text";
 const TypingTargets = 'input, textarea, select, [contenteditable]:not([contenteditable="false"])';
 
-/** The page's keyboard: the emulated one and the browser shortcuts around it. */
+/**
+ * Builds the emulated keyboard and wires the browser's shortcuts around it,
+ * exposing it as `keyboard` for whoever needs the machine's keys.
+ */
 export class KeyboardSetup {
     /**
      * @param {object} opts
@@ -71,29 +74,5 @@ export class KeyboardSetup {
             const text = evt.clipboardData?.getData("text/plain");
             if (text) actions.paste(text);
         });
-    }
-
-    sendRawKeyboard(keysToSend, checkCapsAndShiftLocks) {
-        this.keyboard.sendRawKeyboard(keysToSend, checkCapsAndShiftLocks);
-    }
-
-    clearKeys() {
-        this.keyboard.clearKeys();
-    }
-
-    setKeyLayout(keyLayout) {
-        this.keyboard.setKeyLayout(keyLayout);
-    }
-
-    resumeEmulation() {
-        this.keyboard.resumeEmulation();
-    }
-
-    setRunning(running) {
-        this.keyboard.setRunning(running);
-    }
-
-    postFrameShouldPause() {
-        return this.keyboard.postFrameShouldPause();
     }
 }

--- a/src/web/modals.js
+++ b/src/web/modals.js
@@ -12,7 +12,6 @@ export class Modals {
         this.errorModal = new bootstrap.Modal(this.errorDialog);
         this.loadingDialog = document.getElementById("loading-dialog");
         this.loadingModal = new bootstrap.Modal(this.loadingDialog);
-        this.googleDriveAuth = document.getElementById("google-drive-auth");
         this.aysEl = document.getElementById("are-you-sure");
         this.aysModal = new bootstrap.Modal(this.aysEl);
 
@@ -48,12 +47,10 @@ export class Modals {
 
     popupLoading(msg) {
         this.loadingDialog.querySelector(".loading").textContent = msg;
-        this.googleDriveAuth.style.display = "none";
         this.loadingModal.show();
     }
 
     loadingFinished(message) {
-        this.googleDriveAuth.style.display = "none";
         this.loadingModal.hide();
         if (message) toast(message);
     }

--- a/src/web/run-controls.js
+++ b/src/web/run-controls.js
@@ -9,18 +9,18 @@ export class RunControls {
      * @param {object} options
      * @param {object} options.loop - the emulation loop
      * @param {object} options.dbgr - the debugger, hidden on resume
-     * @param {object} options.keys - the keyboard setup, told the running state
+     * @param {object} options.keyboard - the machine keyboard, told the running state
      */
-    constructor({ loop, dbgr, keys }) {
+    constructor({ loop, dbgr, keyboard }) {
         this.loop = loop;
         this.dbgr = dbgr;
-        this.keys = keys;
+        this.keyboard = keyboard;
         this.playButton = document.getElementById("debug-play");
         this.pauseButton = document.getElementById("debug-pause");
 
         loop.addEventListener("running", () => {
             const running = loop.isRunning();
-            keys.setRunning(running);
+            keyboard.setRunning(running);
             this.playButton.disabled = running;
             this.pauseButton.disabled = !running;
         });
@@ -36,6 +36,6 @@ export class RunControls {
     /** Hide the debugger; the keyboard's resume event restarts the loop. */
     resume() {
         this.dbgr.hide();
-        this.keys.resumeEmulation();
+        this.keyboard.resumeEmulation();
     }
 }

--- a/src/web/settings.js
+++ b/src/web/settings.js
@@ -1,13 +1,9 @@
-import * as utils from "../utils.js";
 import { Config } from "./config.js";
 import { DefaultModel, findModel } from "../models.js";
 import { DefaultAudioOutput, isAudioOutput } from "../audio-output.js";
 import { SpeechOutput } from "../speech-output.js";
 import { guessModelFromHostname } from "../url-params.js";
 import { toast } from "./toast.js";
-
-// A slider fires for every pixel of a drag, and each URL update is a history entry.
-const UrlSettleMs = 300;
 
 /**
  * The user's settings: resolved from the URL, browser storage and the
@@ -79,8 +75,6 @@ export class Settings {
             [parsedQuery.speakerAmount, parseFloat(window.localStorage.speakerAmount)].find(Number.isFinite) ?? 1;
         this.config.setAudioOutput(this.audioOutput);
         this.config.setSpeakerAmount(this.speakerAmount);
-
-        this.updateUrlOnceSettled = utils.debounce(() => urlState.updateUrl(), UrlSettleMs);
     }
 
     get model() {
@@ -115,8 +109,7 @@ export class Settings {
         this.config.setSpeakerAmount(amount);
         this.targets.quickSettings?.showSpeakerAmount(amount);
         window.localStorage.speakerAmount = amount;
-        this.urlState.params.speakerAmount = amount;
-        this.updateUrlOnceSettled();
+        this.urlState.set({ speakerAmount: amount }, { settle: true });
     }
 
     applyDisplayMode(mode) {
@@ -132,13 +125,13 @@ export class Settings {
 
     onDialogClosed(changed) {
         const { urlState } = this;
-        const { machine, keys, inputs } = this.targets;
+        const { machine, keyboard, inputs } = this.targets;
         const parsedQuery = urlState.params;
         urlState.set(changed);
         if (changed.keyLayout) {
             window.localStorage.keyLayout = changed.keyLayout;
             machine.emulationConfig.keyLayout = changed.keyLayout;
-            keys.setKeyLayout(changed.keyLayout);
+            keyboard.setKeyLayout(changed.keyLayout);
         }
         if (changed.mouseJoystickEnabled !== undefined || Object.hasOwn(changed, "microphoneChannel")) {
             inputs.updateAdcSources(parsedQuery.mouseJoystickEnabled, parsedQuery.microphoneChannel);

--- a/src/web/sth-picker.js
+++ b/src/web/sth-picker.js
@@ -70,7 +70,8 @@ export class SthPicker {
 
     async pickDisc(item) {
         utils.noteEvent("sth", "click", item);
-        this.media.setDisc1Image("sth:" + item);
+        const image = "sth:" + item;
+        this.media.setDisc1Image(image);
         const needsAutoboot = this.urlState.params.autoboot !== undefined;
         if (needsAutoboot) {
             this.processor.reset(true);
@@ -78,7 +79,7 @@ export class SthPicker {
 
         this.modals.popupLoading("Loading " + item);
         try {
-            const loaded = await this.media.loadDiscImage(this.urlState.params.disc1, this.drives.layoutForDrive(0));
+            const loaded = await this.media.loadDiscImage(image, this.drives.layoutForDrive(0));
             this.drives.putDiscIn(0, loaded);
             this.modals.loadingFinished();
 
@@ -93,11 +94,12 @@ export class SthPicker {
 
     async pickTape(item) {
         utils.noteEvent("sth", "clickTape", item);
-        this.media.setTapeImage("sth:" + item);
+        const image = "sth:" + item;
+        this.media.setTapeImage(image);
 
         this.modals.popupLoading("Loading " + item);
         try {
-            const tape = await this.media.loadTapeImage(this.urlState.params.tape);
+            const tape = await this.media.loadTapeImage(image);
             this.media.setProcessorTape(tape);
             this.modals.loadingFinished();
         } catch (err) {

--- a/src/web/url-state.js
+++ b/src/web/url-state.js
@@ -1,4 +1,8 @@
 import { buildUrlFromParams, ParamTypes, parseQueryString } from "../url-params.js";
+import { debounce } from "../utils.js";
+
+// A slider fires for every pixel of a drag, and each URL update is a history entry.
+const UrlSettleMs = 300;
 
 /** How each parameter the page understands is parsed and written back. */
 export const UrlParamTypes = {
@@ -67,6 +71,7 @@ export class UrlState {
         // Parameters may be given after the hash as well as in the query.
         const queryString = location.search.substring(1) + "&" + location.hash.substring(1);
         this.params = parseQueryString(queryString, paramTypes);
+        this.updateUrlOnceSettled = debounce(() => this.updateUrl(), UrlSettleMs);
     }
 
     /** The page's URL with the parameters as they are now. */
@@ -79,13 +84,18 @@ export class UrlState {
         return buildUrlFromParams(this.baseUrl, { ...this.params, ...overrides }, this.paramTypes);
     }
 
-    /** Apply `changes` to the parameters (undefined deletes a key) and push the new URL. */
-    set(changes) {
+    /**
+     * Apply `changes` to the parameters (undefined deletes a key) and push the
+     * new URL; `settle: true` lets a burst of changes finish before pushing one
+     * history entry for the lot.
+     */
+    set(changes, { settle = false } = {}) {
         for (const [key, value] of Object.entries(changes)) {
             if (value === undefined) delete this.params[key];
             else this.params[key] = value;
         }
-        this.updateUrl();
+        if (settle) this.updateUrlOnceSettled();
+        else this.updateUrl();
     }
 
     updateUrl() {

--- a/tests/unit/test-google-drive-picker.js
+++ b/tests/unit/test-google-drive-picker.js
@@ -66,6 +66,7 @@ describe("GoogleDrivePicker", () => {
             await vi.waitFor(() => expect(document.getElementById("google-drive-auth").style.display).toBe(""));
             document.getElementById("loading-dialog").dispatchEvent(new Event("hidden.bs.modal"));
             await expect(loading).resolves.toBeNull();
+            expect(document.getElementById("google-drive-auth").style.display).toBe("none");
             expect(deps.modals.loadingFinished).toHaveBeenCalledWith();
             expect(loader.load).not.toHaveBeenCalled();
             expect(toasts()).toEqual([]);

--- a/tests/unit/test-hfe-picker.js
+++ b/tests/unit/test-hfe-picker.js
@@ -118,7 +118,6 @@ describe("HfePicker", () => {
 
         it("names it in the URL, loads it and closes the loading dialog", async () => {
             const loaded = {};
-            deps.media.setDisc1Image.mockImplementation((name) => (deps.urlState.params.disc1 = name));
             deps.media.loadDiscImage.mockResolvedValue(loaded);
             await make().pick(entry("Games/ELITE.hfe", "Elite"));
             expect(deps.media.setDisc1Image).toHaveBeenCalledWith("hfe:Games/ELITE.hfe");

--- a/tests/unit/test-keyboard-setup.js
+++ b/tests/unit/test-keyboard-setup.js
@@ -59,7 +59,7 @@ describe("KeyboardSetup", () => {
             },
         };
         setup = new KeyboardSetup({ actions, accessibilitySwitches, processor, dbgr: {}, keyLayout: "physical" });
-        setup.setRunning(true);
+        setup.keyboard.setRunning(true);
     });
 
     afterEach(teardownDom);

--- a/tests/unit/test-modals.js
+++ b/tests/unit/test-modals.js
@@ -95,12 +95,9 @@ describe("Modals", () => {
     });
 
     describe("loading dialog", () => {
-        it("shows the message and hides the Drive sign-in", () => {
-            const auth = document.getElementById("google-drive-auth");
-            auth.style.display = "";
+        it("shows the message", () => {
             modals.popupLoading("Loading Elite");
             expect(document.querySelector("#loading-dialog .loading").textContent).toBe("Loading Elite");
-            expect(auth.style.display).toBe("none");
         });
 
         it("toasts a message on finishing when given one", () => {

--- a/tests/unit/test-run-controls.js
+++ b/tests/unit/test-run-controls.js
@@ -28,7 +28,7 @@ class FakeLoop extends EventTarget {
 describe("RunControls", () => {
     let loop;
     let dbgr;
-    let keys;
+    let keyboard;
     let controls;
 
     const playButton = () => document.getElementById("debug-play");
@@ -39,8 +39,8 @@ describe("RunControls", () => {
         loop = new FakeLoop();
         dbgr = { hide: vi.fn() };
         // In the app, resumeEmulation restarts the loop through the keyboard's resume event.
-        keys = { setRunning: vi.fn(), resumeEmulation: vi.fn(() => loop.go()) };
-        controls = new RunControls({ loop, dbgr, keys });
+        keyboard = { setRunning: vi.fn(), resumeEmulation: vi.fn(() => loop.go()) };
+        controls = new RunControls({ loop, dbgr, keyboard });
     });
 
     afterEach(teardownDom);
@@ -56,7 +56,7 @@ describe("RunControls", () => {
     it("play hides the debugger and resumes through the keyboard", () => {
         playButton().click();
         expect(dbgr.hide).toHaveBeenCalled();
-        expect(keys.resumeEmulation).toHaveBeenCalled();
+        expect(keyboard.resumeEmulation).toHaveBeenCalled();
         expect(loop.isRunning()).toBe(true);
     });
 
@@ -71,9 +71,9 @@ describe("RunControls", () => {
 
     it("tells the keyboard the running state", () => {
         loop.go();
-        expect(keys.setRunning).toHaveBeenLastCalledWith(true);
+        expect(keyboard.setRunning).toHaveBeenLastCalledWith(true);
         loop.stop();
-        expect(keys.setRunning).toHaveBeenLastCalledWith(false);
+        expect(keyboard.setRunning).toHaveBeenLastCalledWith(false);
     });
 
     it("pause and resume work without the buttons, for the desktop app's menu", () => {

--- a/tests/unit/test-settings.js
+++ b/tests/unit/test-settings.js
@@ -40,7 +40,7 @@ describe("Settings", () => {
             layout: { resize: vi.fn() },
             quickSettings: { showAudioOutput: vi.fn(), showSpeakerAmount: vi.fn(), showDisplayMode: vi.fn() },
             machine: { emulationConfig: {}, processor: { hasTube: false, tube: {} } },
-            keys: { setKeyLayout: vi.fn() },
+            keyboard: { setKeyLayout: vi.fn() },
             inputs: { updateAdcSources: vi.fn(), setupMicrophone: vi.fn() },
             modals: { confirm: vi.fn().mockResolvedValue(false) },
         };
@@ -153,7 +153,7 @@ describe("Settings", () => {
             settings.config.onClose({ keyLayout: "natural" });
             expect(window.localStorage.keyLayout).toBe("natural");
             expect(targets.machine.emulationConfig.keyLayout).toBe("natural");
-            expect(targets.keys.setKeyLayout).toHaveBeenCalledWith("natural");
+            expect(targets.keyboard.setKeyLayout).toHaveBeenCalledWith("natural");
         });
 
         it("reroutes the analogue channels when the mouse joystick or microphone change", () => {

--- a/tests/unit/test-sth-picker.js
+++ b/tests/unit/test-sth-picker.js
@@ -82,7 +82,6 @@ describe("SthPicker", () => {
     describe("picking a disc", () => {
         it("names it in the URL, loads it into drive 0 and closes the loading dialog", async () => {
             const loaded = {};
-            deps.media.setDisc1Image.mockImplementation((name) => (deps.urlState.params.disc1 = name));
             deps.media.loadDiscImage.mockResolvedValue(loaded);
             await make().pickDisc("ELITE.zip");
             expect(deps.media.setDisc1Image).toHaveBeenCalledWith("sth:ELITE.zip");

--- a/tests/unit/test-url-state.js
+++ b/tests/unit/test-url-state.js
@@ -46,6 +46,22 @@ describe("UrlState", () => {
         );
     });
 
+    it("lets a settling burst of changes finish before pushing one URL", () => {
+        vi.useFakeTimers();
+        try {
+            const state = new UrlState(location("?model=B"), history);
+            state.set({ speakerAmount: 0.5 }, { settle: true });
+            state.set({ speakerAmount: 0.3 }, { settle: true });
+            expect(state.params.speakerAmount).toBe(0.3);
+            expect(history.pushState).not.toHaveBeenCalled();
+            vi.runAllTimers();
+            expect(history.pushState).toHaveBeenCalledTimes(1);
+            expect(history.pushState).toHaveBeenCalledWith(null, null, expect.stringContaining("speakerAmount=0.3"));
+        } finally {
+            vi.useRealTimers();
+        }
+    });
+
     it("deletes a parameter set to undefined", () => {
         const state = new UrlState(location("?model=B&disc=elite.ssd"), history);
         state.set({ disc: undefined });


### PR DESCRIPTION
Part of #1002 (the cheap batch).

Four small web-layer tidies, each removing an indirection:

- The STH and HFE pickers wrote a disc or tape ref with `setDisc1Image`/`setTapeImage` and then read it back out of `urlState.params` to hand to the loader. They now pass the ref directly, the way google-drive-picker already did.
- `Modals` hard-coded the Google Drive auth panel and hid it on every unrelated `popupLoading`. The panel is now owned entirely by `GoogleDrivePicker`, which puts it away when the loading dialog closes (the same listener that treats that close as an auth cancellation).
- The speaker-volume slider updated `urlState.params` directly and kept its own debounce in `Settings`. `UrlState.set` now takes a `settle: true` option that debounces the history push, so the slider goes through the same entry point as every other setting.
- `KeyboardSetup` had six pure pass-through methods to `Keyboard`. It now exposes the keyboard it builds, and main.js, `RunControls` and `Settings` hold that directly.

One audit item skipped as stale: hfe-picker no longer re-implements `filterArchiveList`; its filter has since grown provenance checkboxes and matches on structured catalogue data rather than row text, so the shared text filter is not a fit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
