### PR TITLE
chore: delete verified-dead code

### DIFF
--- a/src/6502.js
+++ b/src/6502.js
@@ -1,4 +1,3 @@
-"use strict";
 import * as utils from "./utils.js";
 import * as via from "./via.js";
 import { Acia } from "./acia.js";

--- a/src/6502.opcodes.js
+++ b/src/6502.opcodes.js
@@ -1,4 +1,3 @@
-"use strict";
 import * as utils from "./utils.js";
 
 const hexword = utils.hexword;

--- a/src/6847.js
+++ b/src/6847.js
@@ -1,4 +1,3 @@
-"use strict";
 import * as utils from "./utils.js";
 import * as fontData from "./6847_fontdata.js";
 import { encodeLineGrid } from "./video-filters/pixel-grid.js";

--- a/src/6847_fontdata.js
+++ b/src/6847_fontdata.js
@@ -1,5 +1,3 @@
-"use strict";
-
 // MC6847 internal character ROM data (PAL square pixel variant, 8x12).
 // Derived from the MAME project's MC6847 VDG emulation:
 //   https://github.com/mamedev/mame/blob/master/src/devices/video/mc6847.cpp

--- a/src/acia.js
+++ b/src/acia.js
@@ -1,4 +1,3 @@
-"use strict";
 // Some info:
 // http://www.playvectrex.com/designit/lecture/UP12.HTM
 // https://books.google.com/books?id=wUecAQAAQBAJ&pg=PA431&lpg=PA431&dq=acia+tdre&source=bl&ots=mp-yF-mK-P&sig=e6aXkFRfiIOb57WZmrvdIGsCooI&hl=en&sa=X&ei=0g2fVdDyFIXT-QG8-JD4BA&ved=0CCwQ6AEwAw#v=onepage&q=acia%20tdre&f=false

--- a/src/app-bench.js
+++ b/src/app-bench.js
@@ -1,5 +1,3 @@
-"use strict";
-
 import { fake6502 } from "./fake6502.js";
 import * as models from "./models.js";
 import * as disc from "./fdc.js";

--- a/src/app/app.js
+++ b/src/app/app.js
@@ -1,4 +1,3 @@
-"use strict";
 import { app, BrowserWindow, dialog, ipcMain, Menu, shell, nativeImage } from "electron";
 import Store from "electron-store";
 import * as fs from "fs";

--- a/src/app/args.js
+++ b/src/app/args.js
@@ -1,5 +1,3 @@
-"use strict";
-
 /**
  * Returns the command-line arguments the user actually passed to jsbeeb, with
  * the Electron binary path(s) and known runtime-injected flags stripped.

--- a/src/app/electron.js
+++ b/src/app/electron.js
@@ -1,5 +1,3 @@
-"use strict";
-
 // Electron integration for jsbeeb desktop application.
 // Handles IPC communication for loading disc/tape images and showing modals from Electron's main process.
 

--- a/src/audio-utils.js
+++ b/src/audio-utils.js
@@ -1,5 +1,3 @@
-"use strict";
-
 /**
  * Create an AudioContext with a fallback for older WebKit browsers.
  * @param {AudioContextOptions} [options] - passed to the AudioContext constructor

--- a/src/basic-loader.js
+++ b/src/basic-loader.js
@@ -1,5 +1,3 @@
-"use strict";
-
 /** Where the OS sits waiting for a keypress, per machine: the place to interrupt with a program. */
 export function basicIdleAddr(model) {
     return model.isMaster ? 0xe7e6 : 0xe581;

--- a/src/basic-tokenise.js
+++ b/src/basic-tokenise.js
@@ -1,4 +1,3 @@
-"use strict";
 import * as utils from "./utils.js";
 import * as models from "./models.js";
 import { fake6502 } from "./fake6502.js";

--- a/src/bbc-palette.js
+++ b/src/bbc-palette.js
@@ -1,5 +1,3 @@
-"use strict";
-
 // The 16 standard BBC Micro colours in ABGR format (0xffBBGGRR, little-endian canvas RGBA).
 // Colours 0-7 are the primary palette; 8-15 duplicate them as the default solid/non-flash set.
 // Imported by both video.js (NulaDefaultPalette) and teletext.js (BbcDefaultCollook) to avoid

--- a/src/bbcdiscs.js
+++ b/src/bbcdiscs.js
@@ -1,5 +1,3 @@
-"use strict";
-
 const mirrorBase = "https://bbc.xania.org/archive/bbcdiscs";
 
 /** How a disc came to be an image, which is the difference between the archives it came from. */

--- a/src/bem-snapshot.js
+++ b/src/bem-snapshot.js
@@ -1,4 +1,3 @@
-"use strict";
 import { inflate } from "./utils.js";
 
 // B-em snapshot format parser (versions 1 and 3).

--- a/src/canvas.js
+++ b/src/canvas.js
@@ -1,4 +1,3 @@
-"use strict";
 import webglDebug from "./lib/webgl-debug.js";
 import { PALCompositeFilter } from "./video-filters/pal-composite.js";
 import { PassthroughFilter } from "./video-filters/passthrough-filter.js";

--- a/src/cmos.js
+++ b/src/cmos.js
@@ -1,5 +1,3 @@
-"use strict";
-
 // CMOS layout: bytes 0-13 are RTC internal registers; bytes 14-63 are the 50
 // bytes of user storage.  Storage byte 11 (= CMOS address 25 = 0x19) holds
 // the BBC Master DFS configuration byte whose bits [1:0] are the WD1770 step

--- a/src/ddnoise.js
+++ b/src/ddnoise.js
@@ -1,4 +1,3 @@
-"use strict";
 import { SamplePlayer } from "./sample-player.js";
 
 const Idle = 0;

--- a/src/disc-surface.js
+++ b/src/disc-surface.js
@@ -1,5 +1,3 @@
-"use strict";
-
 // Pure geometry and colour mapping, free of the DOM; disc-visualiser.js owns the canvases.
 
 import { IbmDiscFormat } from "./disc.js";

--- a/src/dom-utils.js
+++ b/src/dom-utils.js
@@ -1,16 +1,6 @@
-"use strict";
-
 import { replaceOrAddExtension } from "./utils.js";
 
 // Minimal DOM helpers to replace jQuery usage.
-
-export function show(el) {
-    el.style.display = "";
-}
-
-export function hide(el) {
-    el.style.display = "none";
-}
 
 export function toggle(el, visible) {
     el.style.display = visible ? "" : "none";

--- a/src/fake6502.js
+++ b/src/fake6502.js
@@ -1,5 +1,4 @@
 // Fakes out various 6502s for testing purposes.
-"use strict";
 
 import { FakeVideo } from "./video.js";
 import { FakeSoundChip } from "./soundchip.js";

--- a/src/filestore.js
+++ b/src/filestore.js
@@ -1,8 +1,6 @@
 // Level-3 file server emulator ported from FSEM2
 // https://github.com/mmbeeb/FSEM
 
-"use strict";
-
 import { ReceiveBlock, EconetPacket } from "./econet.js";
 import * as utils from "./utils.js";
 

--- a/src/gamepads.js
+++ b/src/gamepads.js
@@ -1,4 +1,3 @@
-"use strict";
 import * as utils from "./utils.js";
 
 const BBC = utils.BBC;

--- a/src/google-drive.js
+++ b/src/google-drive.js
@@ -1,5 +1,3 @@
-"use strict";
-
 import { debounce, uint8ArrayToString } from "./utils.js";
 import { discFor } from "./fdc.js";
 

--- a/src/keyboard.js
+++ b/src/keyboard.js
@@ -1,4 +1,3 @@
-"use strict";
 import * as utils from "./utils.js";
 import { ATOM } from "./utils_atom.js";
 

--- a/src/main.js
+++ b/src/main.js
@@ -312,8 +312,7 @@ const rewindUI = new RewindUI({
 });
 rewindUI.updateButtonState();
 
-if (processor.fdc) new DiscVisualiser({ fdc: processor.fdc });
-else document.getElementById("disc-visualiser-open").classList.add("disabled");
+new DiscVisualiser({ fdc: processor.fdc });
 
 const layout = new Layout({
     screenCanvas,

--- a/src/models.js
+++ b/src/models.js
@@ -1,5 +1,3 @@
-"use strict";
-
 import { NoiseAwareWdFdc } from "./wd-fdc.js";
 import { NoiseAwareIntelFdc } from "./intel-fdc.js";
 import * as opcodes from "./6502.opcodes.js";

--- a/src/music5000.js
+++ b/src/music5000.js
@@ -1,5 +1,3 @@
-"use strict";
-
 // Code ported from Beebem (C to .js) by Jason Robson
 const AUDIO_BUFFER_SIZE = 256;
 

--- a/src/printer.js
+++ b/src/printer.js
@@ -1,5 +1,3 @@
-"use strict";
-
 /**
  * Centronics printer attached to the user VIA: acknowledges each character and keeps the most
  * recent output so it can be shown whenever a printer window is opened.

--- a/src/relaynoise.js
+++ b/src/relaynoise.js
@@ -1,4 +1,3 @@
-"use strict";
 // Cassette motor relay click sound (issue #296).
 // Audio samples recorded from a real BBC Master cassette motor relay.
 import { SamplePlayer } from "./sample-player.js";

--- a/src/rewind-thumbnail.js
+++ b/src/rewind-thumbnail.js
@@ -1,5 +1,3 @@
-"use strict";
-
 const ThumbnailWidth = 160;
 const ThumbnailHeight = 128;
 const FramebufferWidth = 1024;

--- a/src/rewind.js
+++ b/src/rewind.js
@@ -1,5 +1,3 @@
-"use strict";
-
 /**
  * Circular buffer of emulator state snapshots for rewind functionality.
  * Snapshots are stored directly without deep-copying, since

--- a/src/sample-player.js
+++ b/src/sample-player.js
@@ -1,4 +1,3 @@
-"use strict";
 import * as utils from "./utils.js";
 
 /**

--- a/src/serial.js
+++ b/src/serial.js
@@ -1,5 +1,3 @@
-"use strict";
-
 const table = [19200, 9600, 4800, 2400, 1200, 300, 150, 75];
 
 export class Serial {

--- a/src/snapshot-helpers.js
+++ b/src/snapshot-helpers.js
@@ -1,5 +1,3 @@
-"use strict";
-
 // Shared helpers for snapshot importers (bem-snapshot.js, uef-snapshot.js).
 // Contains volume table, default peripheral state, video state builder,
 // and the common snapshot envelope that wraps per-format parsed state.

--- a/src/snapshot.js
+++ b/src/snapshot.js
@@ -1,5 +1,3 @@
-"use strict";
-
 import { typedArrayToBase64, base64ToTypedArray } from "./state-utils.js";
 import { findModel } from "./models.js";
 

--- a/src/speech-output.js
+++ b/src/speech-output.js
@@ -1,5 +1,3 @@
-"use strict";
-
 /**
  * RS-423 handler that routes transmitted bytes to the Web Speech API.
  *

--- a/src/state-utils.js
+++ b/src/state-utils.js
@@ -1,5 +1,3 @@
-"use strict";
-
 /**
  * Convert a TypedArray to a base64 string for JSON serialization.
  * @param {ArrayBufferView} typedArray

--- a/src/sth.js
+++ b/src/sth.js
@@ -1,5 +1,3 @@
-"use strict";
-
 import * as utils from "./utils.js";
 
 // Always https, whatever the page was loaded over: the mirror redirects plain

--- a/src/tapes.js
+++ b/src/tapes.js
@@ -1,4 +1,3 @@
-"use strict";
 import * as utils from "./utils.js";
 
 function secsToClocks(secs, cpuSpeed) {

--- a/src/teletext.js
+++ b/src/teletext.js
@@ -1,4 +1,3 @@
-"use strict";
 import { makeChars } from "./teletext_data.js";
 import { makeFast32 } from "./utils.js";
 import { BbcDefaultPalette as BbcDefaultCollook } from "./bbc-palette.js";

--- a/src/teletext_adaptor.js
+++ b/src/teletext_adaptor.js
@@ -1,5 +1,3 @@
-"use strict";
-
 import * as utils from "./utils.js";
 
 // Code ported from Beebem (C to .js) by Jason Robson

--- a/src/teletext_data.js
+++ b/src/teletext_data.js
@@ -1,5 +1,3 @@
-"use strict";
-
 // Extremely heavily based on b-em.
 export function makeChars() {
     // prettier-ignore

--- a/src/touchscreen.js
+++ b/src/touchscreen.js
@@ -1,5 +1,3 @@
-"use strict";
-
 import * as utils from "./utils.js";
 
 const PollHz = 8; // Made up

--- a/src/tube.js
+++ b/src/tube.js
@@ -1,4 +1,3 @@
-"use strict";
 import * as utils from "./utils.js";
 
 //  this one should be declared more globally

--- a/src/uef-snapshot.js
+++ b/src/uef-snapshot.js
@@ -1,5 +1,3 @@
-"use strict";
-
 // BeebEm UEF save state parser.
 // Converts a BeebEm UEF save state file into a jsbeeb snapshot object, in the same way
 // that bem-snapshot.js converts B-em snapshots.

--- a/src/url-params.js
+++ b/src/url-params.js
@@ -295,17 +295,16 @@ export function guessModelFromHostname(hostname) {
 }
 
 /**
- * Parse disc or tape images from the query parameters
+ * Parse disc images from the query parameters
  * @param {Object} parsedQuery - The query parameters
- * @returns {Object} Object containing disc and tape information
+ * @returns {Object} Object containing disc information
  *   - discImage: disc image URL (?disc= or ?disc1=)
  *   - secondDiscImage: second disc URL (?disc2=)
- *   - tapeImage: tape image URL (?tape=)
  *   - mmcImage: MMC/SD card image URL (?mmc=, Atom only)
  */
 export function parseMediaParams(parsedQuery) {
-    const { disc, disc1, disc2, tape, mmc } = parsedQuery;
+    const { disc, disc1, disc2, mmc } = parsedQuery;
     const discImage = disc || disc1;
 
-    return { discImage, secondDiscImage: disc2, tapeImage: tape, mmcImage: mmc };
+    return { discImage, secondDiscImage: disc2, mmcImage: mmc };
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,4 +1,3 @@
-"use strict";
 // Minimal ZIP extractor. Supports methods 0 (stored) and 8 (deflate); other
 // methods (bzip2, lzma, etc.) will throw an error with the method number.
 
@@ -971,18 +970,6 @@ export function signExtend(val) {
 
 export function noop() {}
 
-export function bench() {
-    for (let j = 0; j < 10; ++j) {
-        let res = 0;
-        const start = Date.now();
-        for (let i = 0; i < 4096 * 1024; ++i) {
-            res += signExtend(i & 0xff);
-        }
-        const tt = Date.now() - start;
-        console.log(res, tt);
-    }
-}
-
 export function noteEvent(category, type, label) {
     if (
         !runningInNode &&
@@ -993,12 +980,6 @@ export function noteEvent(category, type, label) {
         gtag("event", category, { type, label });
     }
     console.log("event noted:", category, type, label);
-}
-
-let baseUrl = "";
-
-export function setBaseUrl(url) {
-    baseUrl = url;
 }
 
 export function uint8ArrayToString(array) {
@@ -1018,7 +999,7 @@ export function stringToUint8Array(str) {
 function loadDataHttp(url) {
     return new Promise(function (resolve, reject) {
         const request = new XMLHttpRequest();
-        request.open("GET", baseUrl + url, true);
+        request.open("GET", url, true);
         request.overrideMimeType("text/plain; charset=x-user-defined");
         request.onload = function () {
             if (request.status !== 200) {
@@ -1045,27 +1026,16 @@ export function setNodeBasePath(basePath) {
 }
 
 async function loadDataNode(url) {
-    if (typeof readbuffer !== "undefined") {
-        // d8 shell
-        /*global readbuffer*/
-        return new Uint8Array(readbuffer(url));
-    } else if (typeof read !== "undefined") {
-        // SpiderMonkey shell
-        /*global read*/
-        return read(url, "binary");
-    } else {
-        // Node
-        const fs = await import("fs");
-        const nodePath = await import("path");
-        if (_nodeBasePath) {
-            const publicPath = nodePath.join(_nodeBasePath, "public", url);
-            if (fs.existsSync(publicPath)) return fs.readFileSync(publicPath);
-            return fs.readFileSync(nodePath.join(_nodeBasePath, url));
-        }
-        if (url[0] === "/") url = "." + url;
-        if (fs.existsSync("public/" + url)) return fs.readFileSync("public/" + url);
-        return fs.readFileSync(url);
+    const fs = await import("fs");
+    const nodePath = await import("path");
+    if (_nodeBasePath) {
+        const publicPath = nodePath.join(_nodeBasePath, "public", url);
+        if (fs.existsSync(publicPath)) return fs.readFileSync(publicPath);
+        return fs.readFileSync(nodePath.join(_nodeBasePath, url));
     }
+    if (url[0] === "/") url = "." + url;
+    if (fs.existsSync("public/" + url)) return fs.readFileSync("public/" + url);
+    return fs.readFileSync(url);
 }
 
 export function loadData(url) {
@@ -1255,12 +1225,6 @@ export async function unzipDiscImage(data) {
 
 export async function unzipRomImage(data) {
     return unzipImage(data, knownRomExtensions);
-}
-
-export function resizeUint8Array(array, byteSize) {
-    const newArray = new Uint8Array(byteSize);
-    newArray.set(array.subarray(0, byteSize));
-    return newArray;
 }
 
 export class Fifo {

--- a/src/via.js
+++ b/src/via.js
@@ -1,4 +1,3 @@
-"use strict";
 import * as utils from "./utils.js";
 
 const ORB = 0x0,

--- a/src/video-filters/pal-composite.js
+++ b/src/video-filters/pal-composite.js
@@ -1,5 +1,3 @@
-"use strict";
-
 // PAL Composite Video Filter - Approach D: Baseband Chroma Blending
 //
 // Simulates PAL composite video artifacts by encoding the framebuffer to a

--- a/src/video-filters/passthrough-filter.js
+++ b/src/video-filters/passthrough-filter.js
@@ -1,5 +1,3 @@
-"use strict";
-
 import VERT_SHADER from "./shaders/passthrough.vert.glsl?raw";
 import FRAG_SHADER from "./shaders/passthrough.frag.glsl?raw";
 import { compileProgram } from "./shader-program.js";

--- a/src/video-filters/pixel-grid.js
+++ b/src/video-filters/pixel-grid.js
@@ -1,5 +1,3 @@
-"use strict";
-
 // Describing the logical pixel grid of jsbeeb's framebuffer, which is a
 // 1024-wide *raster* rather than a grid of BBC pixels: one logical pixel covers
 // up to eight texels across and two down. Filters need to know that, and only

--- a/src/video-filters/shader-program.js
+++ b/src/video-filters/shader-program.js
@@ -1,5 +1,3 @@
-"use strict";
-
 /**
  * Compile and link a shader program, throwing with the driver's own message if
  * either step fails.

--- a/src/video-filters/xbr-filter.js
+++ b/src/video-filters/xbr-filter.js
@@ -1,5 +1,3 @@
-"use strict";
-
 // The xBR-lv2 display mode. See shaders/xbr.frag.glsl for the algorithm, and
 // tests/shader, which runs it in a browser and asserts on what it draws.
 

--- a/src/video.js
+++ b/src/video.js
@@ -1,4 +1,3 @@
-"use strict";
 import { Teletext } from "./teletext.js";
 import * as utils from "./utils.js";
 import { BbcDefaultPalette as NulaDefaultPalette } from "./bbc-palette.js";

--- a/src/web/config.js
+++ b/src/web/config.js
@@ -1,4 +1,3 @@
-"use strict";
 import { allModels, findModel, tubeModelFor } from "../models.js";
 import { getFilterForMode } from "../canvas.js";
 import { AudioOutputs } from "../audio-output.js";

--- a/src/web/console-surface.js
+++ b/src/web/console-surface.js
@@ -1,5 +1,3 @@
-"use strict";
-
 import * as utils from "../utils.js";
 
 /**

--- a/src/web/debug.js
+++ b/src/web/debug.js
@@ -1,4 +1,3 @@
-"use strict";
 import { hexbyte, hexword, noop, parseAddr } from "../utils.js";
 import { toggle } from "../dom-utils.js";
 

--- a/src/web/disc-visualiser.js
+++ b/src/web/disc-visualiser.js
@@ -1,5 +1,3 @@
-"use strict";
-
 import { IbmDiscFormat } from "../disc.js";
 import {
     DensityPalette,

--- a/src/web/rewind-ui.js
+++ b/src/web/rewind-ui.js
@@ -1,5 +1,3 @@
-"use strict";
-
 import { renderThumbnails, executeUntilFrame } from "../rewind-thumbnail.js";
 
 /**

--- a/src/web/run-controls.js
+++ b/src/web/run-controls.js
@@ -1,5 +1,3 @@
-"use strict";
-
 /**
  * The play and pause buttons on the top bar, kept in step with the loop's
  * running state. pause() and resume() are also the desktop app's menu actions.

--- a/src/web/url-state.js
+++ b/src/web/url-state.js
@@ -9,8 +9,6 @@ export const UrlParamTypes = {
     embed: ParamTypes.BOOL,
     fasttape: ParamTypes.BOOL,
     noseek: ParamTypes.BOOL,
-    debug: ParamTypes.BOOL,
-    verbose: ParamTypes.BOOL,
     autoboot: ParamTypes.BOOL,
     autochain: ParamTypes.BOOL,
     autorun: ParamTypes.BOOL,
@@ -28,9 +26,9 @@ export const UrlParamTypes = {
     audioDebug: ParamTypes.BOOL,
 
     // Numeric parameters
-    speed: ParamTypes.INT,
     stationId: ParamTypes.INT,
     frameSkip: ParamTypes.INT,
+    videoCyclesBatch: ParamTypes.INT,
     audiofilterfreq: ParamTypes.FLOAT,
     audiofilterq: ParamTypes.FLOAT,
     speakerAmount: ParamTypes.FLOAT,
@@ -52,6 +50,12 @@ export const UrlParamTypes = {
     audioOutput: ParamTypes.STRING,
     drive0Tracks: ParamTypes.STRING,
     drive1Tracks: ParamTypes.STRING,
+    loadBasic: ParamTypes.STRING,
+    embedBasic: ParamTypes.STRING,
+    patch: ParamTypes.STRING,
+    sbLeft: ParamTypes.STRING,
+    sbRight: ParamTypes.STRING,
+    sbBottom: ParamTypes.STRING,
 };
 
 /**

--- a/tests/integration/dormann.js
+++ b/tests/integration/dormann.js
@@ -1,5 +1,3 @@
-"use strict";
-
 import { describe, it } from "vitest";
 import * as utils from "../../src/utils.js";
 import { fake6502, fake65C02, fake65C12 } from "../../src/fake6502.js";

--- a/tests/line-grid.js
+++ b/tests/line-grid.js
@@ -1,5 +1,3 @@
-"use strict";
-
 export const LineGridRendered = 0x80;
 export const LineGridVerticalDouble = 0x08;
 export const LineGridWidthMask = 0x07;

--- a/tests/pixel-runs.js
+++ b/tests/pixel-runs.js
@@ -1,5 +1,3 @@
-"use strict";
-
 /**
  * The length of the shortest run of equal texels between `from` and `to`.
  *

--- a/tests/shader/render.js
+++ b/tests/shader/render.js
@@ -1,5 +1,3 @@
-"use strict";
-
 // Renders patterns through the project's real GLSL in headless Chrome and hands
 // the pixels back, so a shader itself can be asserted on.
 //

--- a/tests/test-suite.js
+++ b/tests/test-suite.js
@@ -1,5 +1,3 @@
-"use strict";
-
 import * as utils from "../src/utils.js";
 import { fake6502 } from "../src/fake6502.js";
 

--- a/tests/unit/test-bcd.js
+++ b/tests/unit/test-bcd.js
@@ -5,7 +5,6 @@ import { fake65C12 } from "../../src/fake6502.js";
 const cpu = fake65C12();
 
 describe("BCD tests", function () {
-    "use strict";
     it("handles 65c12sbc1", async function () {
         await cpu.initialise();
         cpu.p.reset();

--- a/tests/unit/test-fifo.js
+++ b/tests/unit/test-fifo.js
@@ -3,7 +3,6 @@ import { describe, it, expect } from "vitest";
 import { Fifo } from "../../src/utils.js";
 
 describe("FIFO tests", function () {
-    "use strict";
     it("creates ok", function () {
         new Fifo(16);
     });

--- a/tests/unit/test-scheduler.js
+++ b/tests/unit/test-scheduler.js
@@ -2,7 +2,6 @@ import { describe, it, expect } from "vitest";
 import { Scheduler } from "../../src/scheduler.js";
 
 describe("Scheduler tests", function () {
-    "use strict";
     it("creates", function () {
         new Scheduler();
     });

--- a/tests/unit/test-tokenise.js
+++ b/tests/unit/test-tokenise.js
@@ -3,8 +3,6 @@ import * as Tokeniser from "../../src/basic-tokenise.js";
 const tokeniser = Tokeniser.create();
 
 describe("Tokeniser", function () {
-    "use strict";
-
     async function check(text, expected) {
         try {
             const t = await tokeniser;

--- a/tests/unit/test-url-params.js
+++ b/tests/unit/test-url-params.js
@@ -326,25 +326,22 @@ describe("URL Parameters", () => {
     });
 
     describe("parseMediaParams", () => {
-        it("should extract disc and tape images from query params", () => {
+        it("should extract disc images from query params", () => {
             const params = {
                 disc: "elite.ssd",
                 disc2: "games.ssd",
-                tape: "welcome.uef",
                 other: "value",
             };
 
             expect(parseMediaParams(params)).toEqual({
                 discImage: "elite.ssd",
                 secondDiscImage: "games.ssd",
-                tapeImage: "welcome.uef",
                 mmcImage: undefined,
             });
 
             expect(parseMediaParams({ disc1: "disc1.ssd" })).toEqual({
                 discImage: "disc1.ssd",
                 secondDiscImage: undefined,
-                tapeImage: undefined,
                 mmcImage: undefined,
             });
         });
@@ -353,7 +350,6 @@ describe("URL Parameters", () => {
             expect(parseMediaParams({ mmc: "sdcard.zip" })).toEqual({
                 discImage: undefined,
                 secondDiscImage: undefined,
-                tapeImage: undefined,
                 mmcImage: "sdcard.zip",
             });
         });

--- a/tests/unit/test-utils.js
+++ b/tests/unit/test-utils.js
@@ -23,8 +23,6 @@ import { ATOM, getKeyMapAtom } from "../../src/utils_atom.js";
 import { processInputParams } from "../../src/url-params.js";
 
 describe("Utils tests", function () {
-    "use strict";
-
     describe("parseAddr", function () {
         it("parses hex values with $ prefix", function () {
             expect(parseAddr("$1234")).toBe(0x1234);


### PR DESCRIPTION
Deletes the dead code called out in the cheap batch of #1002, with each claim re-verified against the current tree before removal.

What goes: the unimported `show`/`hide` helpers in `dom-utils.js`; `bench()`, `setBaseUrl` (and the always-empty `baseUrl` prefix it fed into `loadDataHttp`), `resizeUint8Array` and the d8/SpiderMonkey shell branches in `utils.js`; the `tapeImage` return from `parseMediaParams`, which no caller reads (main.js takes the tape straight from the parsed query); and the unreachable else branch on the `DiscVisualiser` construction in main.js (every non-Tube model defines an Fdc and `Cpu6502` constructs it unconditionally, so `processor.fdc` is always set).

`url-state.js` gets its declarations trued up in both directions: `speed`, `debug` and `verbose` are read nowhere and go; `videoCyclesBatch` (as INT), `loadBasic`, `embedBasic`, `patch`, `sbLeft`, `sbRight` and `sbBottom` are read but were undeclared and are added. The audit's counts had drifted: it said four `"use strict"` files, but 68 ES modules carried the directive, and all lose it since ES modules are always strict. It stays in the CommonJS Electron preload and in the generated `Function` bodies in `6502.opcodes.js`, where it still does something.

Part of #1002.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
