### PR TITLE
refactor: drop the unread fdc argument from discFor and localDisc

### DIFF
--- a/src/app-bench.js
+++ b/src/app-bench.js
@@ -23,7 +23,7 @@ async function main() {
     const cpu = fake6502(models.findModel("B"));
     await cpu.initialise();
     const data = await disc.load("discs/" + discName + ".ssd");
-    cpu.fdc.loadDisc(0, disc.discFor(cpu.fdc, discName, data));
+    cpu.fdc.loadDisc(0, disc.discFor(discName, data));
     cpu.sysvia.keyDown(16);
     cpu.execute(10 * 1000 * 1000);
     cpu.sysvia.keyUp(16);

--- a/src/fdc.js
+++ b/src/fdc.js
@@ -267,7 +267,7 @@ function is40TrackLayout(discType, data, name, layout) {
  * Create a disc object of the appropriate type based on the file name
  * @param {string} name - The file name with extension
  * @param {string|Uint8Array} stringData - The disc image data as string or Uint8Array
- * @param {function(Uint8Array): void} onChange - Optional callback when disc content changes
+ * @param {function(Uint8Array): void} [onChange] - called when disc content changes
  * @param {string} [layout] - one of DiscLayout; by default the image is asked what it is
  * @returns {Disc} The loaded disc object
  */

--- a/src/fdc.js
+++ b/src/fdc.js
@@ -265,14 +265,13 @@ function is40TrackLayout(discType, data, name, layout) {
 
 /**
  * Create a disc object of the appropriate type based on the file name
- * @param {Object} fdc - The FDC controller object
  * @param {string} name - The file name with extension
  * @param {string|Uint8Array} stringData - The disc image data as string or Uint8Array
  * @param {function(Uint8Array): void} onChange - Optional callback when disc content changes
  * @param {string} [layout] - one of DiscLayout; by default the image is asked what it is
  * @returns {Disc} The loaded disc object
  */
-export function discFor(fdc, name, stringData, onChange, layout = DiscLayout.auto) {
+export function discFor(name, stringData, onChange, layout = DiscLayout.auto) {
     const data = typeof stringData !== "string" ? stringData : utils.stringToUint8Array(stringData);
     const discType = guessDiscTypeFromName(name);
     const config = new DiscConfig();
@@ -291,14 +290,13 @@ export function discFor(fdc, name, stringData, onChange, layout = DiscLayout.aut
 
 /**
  * Create or open a disc held in the browser's local storage.
- * @param {Object} fdc - The FDC controller object
  * @param {string} name - The file name with extension
  * @param {string} [layout] - one of DiscLayout; by default the image is asked what it is
  * @param {function(*): void} [onSaveError] - called with whatever was thrown, the first time a write
  *   cannot be stored
  * @returns {Disc} The loaded disc object
  */
-export function localDisc(fdc, name, layout = DiscLayout.auto, onSaveError = () => {}) {
+export function localDisc(name, layout = DiscLayout.auto, onSaveError = () => {}) {
     const discName = "disc_" + name;
     let data;
     const dataString = window.localStorage[discName];
@@ -328,5 +326,5 @@ export function localDisc(fdc, name, layout = DiscLayout.auto, onSaveError = () 
             onSaveError(e);
         }
     };
-    return discFor(fdc, name, data, onChange, layout);
+    return discFor(name, data, onChange, layout);
 }

--- a/src/google-drive.js
+++ b/src/google-drive.js
@@ -159,7 +159,7 @@ export class GoogleDriveLoader {
         } else {
             console.log("Making read-only disc");
         }
-        return discFor(fdc, name, data, flusher, layout);
+        return discFor(name, data, flusher, layout);
     }
 
     async load(fdc, fileId, layout) {

--- a/src/machine-session.js
+++ b/src/machine-session.js
@@ -516,8 +516,7 @@ export class MachineSession {
      */
     loadDisc(imagePath) {
         const data = new Uint8Array(readFileSync(imagePath));
-        const machineFdc = this._machine.processor.fdc;
-        machineFdc.loadDisc(0, fdc.discFor(machineFdc, imagePath, data));
+        this._machine.processor.fdc.loadDisc(0, fdc.discFor(imagePath, data));
     }
 
     /**

--- a/src/web/media-loader.js
+++ b/src/web/media-loader.js
@@ -195,13 +195,7 @@ export class MediaLoader extends EventTarget {
 
     async loadHTMLFile(file) {
         const imageData = utils.stringToUint8Array(await readFileAsBinaryString(file));
-        const loadedDisc = disc.discFor(
-            this.processor.fdc,
-            file.name,
-            imageData,
-            undefined,
-            this.drives.layoutForDrive(0),
-        );
+        const loadedDisc = disc.discFor(file.name, imageData, undefined, this.drives.layoutForDrive(0));
         // Local file: retain the image bytes for embedding in save-to-file snapshots.
         loadedDisc.setOriginalImage(imageData);
         this.drives.putDiscIn(0, loadedDisc);
@@ -233,7 +227,7 @@ export class MediaLoader extends EventTarget {
         discImage = split.image;
         const schema = split.schema;
         if (schema[0] === "!" || schema === "local") {
-            return disc.localDisc(this.processor.fdc, discImage, layout, (error) =>
+            return disc.localDisc(discImage, layout, (error) =>
                 toast(
                     `Browser storage would not take changes to ${discImage} (${errorText(error)}). Use Discs, Download to keep a copy.`,
                     { title: "Disc", quietKey: "quietLocalDiscSaveFailed" },
@@ -251,17 +245,11 @@ export class MediaLoader extends EventTarget {
             case "sth": {
                 const { name, data, ignored } = await this.sources.sth(discImage);
                 reportIgnoredFiles(name, ignored);
-                return disc.discFor(this.processor.fdc, name, data, undefined, layout);
+                return disc.discFor(name, data, undefined, layout);
             }
 
             case "hfe":
-                return disc.discFor(
-                    this.processor.fdc,
-                    discImage,
-                    await this.sources.hfe(discImage),
-                    undefined,
-                    layout,
-                );
+                return disc.discFor(discImage, await this.sources.hfe(discImage), undefined, layout);
 
             case "gd": {
                 const splat = discImage.match(/([^/]+)\/?(.*)/);
@@ -273,12 +261,12 @@ export class MediaLoader extends EventTarget {
                 return this.sources.drive({ name, id: discImage }, layout);
             }
             case "b64data":
-                return disc.discFor(this.processor.fdc, "disk.ssd", atob(discImage), undefined, layout);
+                return disc.discFor("disk.ssd", atob(discImage), undefined, layout);
 
             case "data": {
                 const arr = Array.prototype.map.call(atob(discImage), (x) => x.charCodeAt(0));
                 const { name, data } = await unzipAndReport(arr);
-                return disc.discFor(this.processor.fdc, name, data, undefined, layout);
+                return disc.discFor(name, data, undefined, layout);
             }
             case "http":
             case "https":
@@ -292,16 +280,10 @@ export class MediaLoader extends EventTarget {
                     discData = unzipped.data;
                     discImage = unzipped.name;
                 }
-                return disc.discFor(this.processor.fdc, discImage, discData, undefined, layout);
+                return disc.discFor(discImage, discData, undefined, layout);
             }
             default:
-                return disc.discFor(
-                    this.processor.fdc,
-                    discImage,
-                    await disc.load("discs/" + discImage),
-                    undefined,
-                    layout,
-                );
+                return disc.discFor(discImage, await disc.load("discs/" + discImage), undefined, layout);
         }
     }
 

--- a/src/web/snapshot-ui.js
+++ b/src/web/snapshot-ui.js
@@ -199,7 +199,7 @@ export class SnapshotUI {
                         ? savedMedia[imageDataKey]
                         : new Uint8Array(Object.values(savedMedia[imageDataKey]));
                 const discName = savedMedia[discKey + "Name"] || "snapshot.ssd";
-                loadedDisc = disc.discFor(this.processor.fdc, discName, imageData, undefined, layout);
+                loadedDisc = disc.discFor(discName, imageData, undefined, layout);
                 // Retain the image bytes so subsequent saves can re-embed them.
                 loadedDisc.setOriginalImage(imageData);
             }

--- a/tests/integration/disc-layout.js
+++ b/tests/integration/disc-layout.js
@@ -61,7 +61,7 @@ describe("disc track layouts", { timeout: 60000 }, function () {
         const testMachine = new TestMachine();
         await testMachine.initialise();
         const image = await load("discs/elite.hfe");
-        testMachine.processor.fdc.loadDisc(0, discFor(testMachine.processor.fdc, "elite.hfe", image));
+        testMachine.processor.fdc.loadDisc(0, discFor("elite.hfe", image));
         await testMachine.runUntilInput();
         const seen = [];
         testMachine.captureText((element) => seen.push(element.text));

--- a/tests/test-machine.js
+++ b/tests/test-machine.js
@@ -212,7 +212,7 @@ export class TestMachine {
 
     async loadDisc(image) {
         const data = await fdc.load(image);
-        this.processor.fdc.loadDisc(0, fdc.discFor(this.processor.fdc, image, data));
+        this.processor.fdc.loadDisc(0, fdc.discFor(image, data));
     }
 
     /**
@@ -220,7 +220,7 @@ export class TestMachine {
      * @param {Uint8Array|Buffer} data - raw disc image bytes
      */
     loadDiscData(data) {
-        this.processor.fdc.loadDisc(0, fdc.discFor(this.processor.fdc, "", data));
+        this.processor.fdc.loadDisc(0, fdc.discFor("", data));
     }
 
     /**

--- a/tests/unit/test-disc-visualiser.js
+++ b/tests/unit/test-disc-visualiser.js
@@ -132,7 +132,7 @@ describe("DiscVisualiser", () => {
     describe("with a disc in the drive", () => {
         beforeEach(() => {
             vi.spyOn(console, "log").mockImplementation(() => {});
-            fdc.drives[0].disc = discFor(null, "elite.ssd", ssdImage());
+            fdc.drives[0].disc = discFor("elite.ssd", ssdImage());
             fdc.drives[0].spinning = true;
         });
 

--- a/tests/unit/test-fdc.js
+++ b/tests/unit/test-fdc.js
@@ -31,13 +31,13 @@ describe("loading a disc image", () => {
     afterEach(() => vi.restoreAllMocks());
 
     it("lays a 40 track image out for a 40 track drive", () => {
-        expect(discFor(null, "test.ssd", catalogued(400)).is40Track).toBe(true);
-        expect(discFor(null, "test.ssd", catalogued(800)).is40Track).toBe(false);
+        expect(discFor("test.ssd", catalogued(400)).is40Track).toBe(true);
+        expect(discFor("test.ssd", catalogued(800)).is40Track).toBe(false);
     });
 
     it("does as it is told when a snapshot says how the disc was laid out", () => {
-        expect(discFor(null, "test.ssd", catalogued(400), null, DiscLayout.contiguous).is40Track).toBe(false);
-        expect(discFor(null, "test.ssd", catalogued(800), null, DiscLayout.expanded40).is40Track).toBe(true);
+        expect(discFor("test.ssd", catalogued(400), null, DiscLayout.contiguous).is40Track).toBe(false);
+        expect(discFor("test.ssd", catalogued(800), null, DiscLayout.expanded40).is40Track).toBe(true);
     });
 
     it("knows which formats hold a catalogue name", () => {
@@ -58,17 +58,17 @@ describe("knowing whether a disc keeps its changes", () => {
     afterEach(() => vi.restoreAllMocks());
 
     it("says no for a disc loaded without anywhere to write back to", () => {
-        expect(discFor(null, "test.ssd", catalogued(800), undefined, DiscLayout.contiguous).savesChanges).toBe(false);
+        expect(discFor("test.ssd", catalogued(800), undefined, DiscLayout.contiguous).savesChanges).toBe(false);
     });
 
     it("says yes once a writeback is wired up", () => {
-        expect(discFor(null, "test.ssd", catalogued(800), () => {}, DiscLayout.contiguous).savesChanges).toBe(true);
+        expect(discFor("test.ssd", catalogued(800), () => {}, DiscLayout.contiguous).savesChanges).toBe(true);
     });
 
     it("says no for the ADFS formats, which discard the writeback they are handed", () => {
         const adfsImage = new Uint8Array(80 * 16 * SectorSize);
         for (const name of ["test.adf", "test.adl"])
-            expect(discFor(null, name, adfsImage, () => {}, DiscLayout.contiguous).savesChanges).toBe(false);
+            expect(discFor(name, adfsImage, () => {}, DiscLayout.contiguous).savesChanges).toBe(false);
     });
 });
 
@@ -90,7 +90,7 @@ describe("a disc held in browser local storage", () => {
         const stored = {};
         stubStorage({ setItem: (key, value) => (stored[key] = value) });
 
-        const created = localDisc(null, "kept.ssd", DiscLayout.contiguous);
+        const created = localDisc("kept.ssd", DiscLayout.contiguous);
         writeTrack(created, 0);
 
         expect(created.savesChanges).toBe(true);
@@ -106,7 +106,7 @@ describe("a disc held in browser local storage", () => {
         });
         const refused = [];
 
-        const created = localDisc(null, "full.ssd", DiscLayout.contiguous, (error) => refused.push(error));
+        const created = localDisc("full.ssd", DiscLayout.contiguous, (error) => refused.push(error));
         for (const trackNum of [0, 1, 2]) writeTrack(created, trackNum);
 
         expect(refused).toEqual([refusal]);
@@ -117,7 +117,7 @@ describe("a disc held in browser local storage", () => {
         let refusals = 0;
 
         writeTrack(
-            localDisc(null, "fine.ssd", DiscLayout.contiguous, () => refusals++),
+            localDisc("fine.ssd", DiscLayout.contiguous, () => refusals++),
             0,
         );
 

--- a/tests/unit/test-media-loader.js
+++ b/tests/unit/test-media-loader.js
@@ -84,7 +84,7 @@ describe("MediaLoader", () => {
         });
 
         it("fetches an hfe: reference from the archive", async () => {
-            sources.hfe.mockResolvedValue(toHfe(discFor(null, "x.ssd", ssdImage())));
+            sources.hfe.mockResolvedValue(toHfe(discFor("x.ssd", ssdImage())));
             const loaded = await make().loadDiscImage("hfe:3A1DAB83.hfe");
             expect(sources.hfe).toHaveBeenCalledWith("3A1DAB83.hfe");
             expect(loaded.name).toBe("3A1DAB83.hfe");

--- a/tests/unit/test-snapshot.js
+++ b/tests/unit/test-snapshot.js
@@ -504,7 +504,7 @@ describe("Snapshot coordinator", () => {
         it("should only store CRC32 (not image data) via discFor", () => {
             const ssdData = new Uint8Array(256 * 10);
             ssdData[0] = 0x42;
-            const loaded = discFor(null, "test.ssd", ssdData);
+            const loaded = discFor("test.ssd", ssdData);
 
             expect(loaded.originalImageCrc32).toBe(crc32(ssdData));
             expect(loaded.originalImageData).toBeNull();


### PR DESCRIPTION
`discFor` and `localDisc` in `src/fdc.js` take an `fdc` first argument that neither body reads; every caller was threading a controller (or null, in the unit tests) through for nothing. This drops the parameter, updates all call sites (media-loader, snapshot-ui, google-drive, app-bench, machine-session, test-machine and the test files) and the JSDoc.

One deliberate stop: the `create`/`load`/`makeDisc` chain in `google-drive.js` still accepts an `fdc` from its callers in `src/web`; that ripple is left for a follow-up so this change stays confined to the two signatures the audit named.

Part of #1002.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
