### PR TITLE
fix: stop the fast-forward and frameSkip frame skips multiplying

### DIFF
--- a/src/web/display.js
+++ b/src/web/display.js
@@ -75,7 +75,8 @@ export class Display {
      * configured frameSkip wins, so the two never multiply together.
      */
     setSpeedy(speedy) {
-        this.video.frameSkipCount = speedy ? Math.max(SpeedyFrameSkip, this.frameSkip) | 1 : 0;
+        const skip = Math.max(SpeedyFrameSkip, this.frameSkip);
+        this.video.frameSkipCount = speedy ? (skip % 2 ? skip : skip + 1) : 0;
     }
 
     onPaint(video, minx, miny, maxx, maxy) {

--- a/src/web/display.js
+++ b/src/web/display.js
@@ -2,6 +2,11 @@ import * as canvasLib from "../canvas.js";
 import { FakeVideo, Video } from "../video.js";
 import { toast } from "./toast.js";
 
+// While running fast the state machines still run accurately, but painting is
+// the most expensive part of jsbeeb, so most frames are skipped. Odd, so that
+// interlaced modes (MODE 7) alternate fields across the frames that do paint.
+const SpeedyFrameSkip = 9;
+
 /**
  * The picture: the canvas and its filter, the video chip that paints into a
  * framebuffer of our own, and the animation frame that presents it. A stalled
@@ -64,10 +69,22 @@ export class Display {
         this.setCrtPic();
     }
 
+    /**
+     * While running fast the skip moves into the video chip, which skips the
+     * render as well as the present; the deeper of the chip's skip and any
+     * configured frameSkip wins, so the two never multiply together.
+     */
+    setSpeedy(speedy) {
+        this.video.frameSkipCount = speedy ? Math.max(SpeedyFrameSkip, this.frameSkip) | 1 : 0;
+    }
+
     onPaint(video, minx, miny, maxx, maxy) {
-        this.frames++;
-        if (this.frames < this.frameSkip) return;
-        this.frames = 0;
+        // Optional: the chip paints once from its own constructor, before this.video is set.
+        if (!this.video?.frameSkipCount) {
+            this.frames++;
+            if (this.frames < this.frameSkip) return;
+            this.frames = 0;
+        }
         const start = performance.now();
         this.canvas.fb32.set(this.videoFb32.subarray(miny * 1024, maxy * 1024), miny * 1024);
         if (this.pendingFrame.lineGrid.length !== video.lineGrid.length)

--- a/src/web/display.js
+++ b/src/web/display.js
@@ -79,7 +79,7 @@ export class Display {
     }
 
     onPaint(video, minx, miny, maxx, maxy) {
-        // Optional: the chip paints once from its own constructor, before this.video is set.
+        // The chip paints once from its own constructor, before this.video is set.
         if (!this.video?.frameSkipCount) {
             this.frames++;
             if (this.frames < this.frameSkip) return;

--- a/src/web/display.js
+++ b/src/web/display.js
@@ -80,8 +80,7 @@ export class Display {
     }
 
     onPaint(video, minx, miny, maxx, maxy) {
-        // The chip paints once from its own constructor, before this.video is set.
-        if (!this.video?.frameSkipCount) {
+        if (!video.frameSkipCount) {
             this.frames++;
             if (this.frames < this.frameSkip) return;
             this.frames = 0;

--- a/src/web/emulation-loop.js
+++ b/src/web/emulation-loop.js
@@ -149,12 +149,7 @@ export class EmulationLoop extends EventTarget {
         const motorOn = processor.acia.motorOn;
         const speedy = this.fastAsPossible || (this.fastTape && motorOn);
 
-        // In speedy mode, we still run all the state machines accurately
-        // but we paint less often because painting is the most expensive
-        // part of jsbeeb at this time.
-        // We need need to paint per odd number of frames so that interlace
-        // modes, i.e. MODE 7, still look ok.
-        display.video.frameSkipCount = speedy ? 9 : 0;
+        display.setSpeedy(speedy);
 
         this.scheduleTick(speedy ? 0 : TickMs);
 

--- a/tests/unit/test-display.js
+++ b/tests/unit/test-display.js
@@ -90,6 +90,29 @@ describe("Display", () => {
         expect(rafCallbacks).toHaveLength(1);
     });
 
+    describe("running fast", () => {
+        it("moves the skip into the video chip and back out again", () => {
+            const display = make();
+            display.setSpeedy(true);
+            expect(display.video.frameSkipCount).toBe(9);
+            display.setSpeedy(false);
+            expect(display.video.frameSkipCount).toBe(0);
+        });
+
+        it("keeps a deeper configured frameSkip, rounded up to alternate interlace fields", () => {
+            const display = make({ frameSkip: 100 });
+            display.setSpeedy(true);
+            expect(display.video.frameSkipCount).toBe(101);
+        });
+
+        it("presents every frame the chip paints rather than skipping twice", () => {
+            const display = make({ frameSkip: 3 });
+            display.setSpeedy(true);
+            display.onPaint(paintedFrom(), 0, 0, FbWidth, 8);
+            expect(rafCallbacks).toHaveLength(1);
+        });
+    });
+
     it("carries the interlace bases and line grid to the presenter", () => {
         const display = make();
         const from = { lineGrid: new Uint8Array([1, 2, 3]), lineBaseEven: 5, lineBaseOdd: 6 };

--- a/tests/unit/test-display.js
+++ b/tests/unit/test-display.js
@@ -39,7 +39,12 @@ describe("Display", () => {
         return display;
     };
 
-    const paintedFrom = () => ({ lineGrid: new Uint8Array(4), lineBaseEven: 1, lineBaseOdd: 2 });
+    const paintedFrom = (frameSkipCount = 0) => ({
+        lineGrid: new Uint8Array(4),
+        lineBaseEven: 1,
+        lineBaseOdd: 2,
+        frameSkipCount,
+    });
     const presentAll = () => {
         for (const callback of rafCallbacks.splice(0)) callback();
     };
@@ -108,7 +113,7 @@ describe("Display", () => {
         it("presents every frame the chip paints rather than skipping twice", () => {
             const display = make({ frameSkip: 3 });
             display.setSpeedy(true);
-            display.onPaint(paintedFrom(), 0, 0, FbWidth, 8);
+            display.onPaint(paintedFrom(display.video.frameSkipCount), 0, 0, FbWidth, 8);
             expect(rafCallbacks).toHaveLength(1);
         });
     });

--- a/tests/unit/test-emulation-loop.js
+++ b/tests/unit/test-emulation-loop.js
@@ -25,7 +25,8 @@ describe("EmulationLoop", () => {
                 snapshotState: vi.fn(() => ({})),
             },
             display: {
-                video: { frameSkipCount: 0, polltime: vi.fn() },
+                video: { polltime: vi.fn() },
+                setSpeedy: vi.fn(),
                 takePaintMs: vi.fn(() => 0),
                 takePresentMs: vi.fn(() => 0),
                 frameSkip: 0,
@@ -89,6 +90,7 @@ describe("EmulationLoop", () => {
         expect(deps.gamepad.update).toHaveBeenCalledWith(deps.processor.sysvia);
         expect(deps.syncLights).toHaveBeenCalled();
         expect(deps.display.takePaintMs).toHaveBeenCalled();
+        expect(deps.display.setSpeedy).toHaveBeenLastCalledWith(false);
     });
 
     it("never emulates more than a tenth of a second in one tick", () => {
@@ -106,7 +108,7 @@ describe("EmulationLoop", () => {
         loop.toggleFastAsPossible();
         vi.advanceTimersByTime(10);
         expect(cyclesExecuted().at(-1)).toBe(ClocksPerSecond / 50);
-        expect(deps.display.video.frameSkipCount).toBe(9);
+        expect(deps.display.setSpeedy).toHaveBeenLastCalledWith(true);
     });
 
     it("speeds up for a tape motor only when told fast tape", () => {


### PR DESCRIPTION
Part of #1002.

Two independent frame-skip mechanisms existed. `Display.frameSkip` comes from the `?frameSkip=` URL parameter (and the console benchmarks set it to a million) and drops presents in `onPaint`. `Video.frameSkipCount` is set to 9 by the emulation loop while fast-forwarding or fast-taping and drops whole renders at flyback. With both active they applied in turn, so `?frameSkip=2` during fast-forward showed one frame in 18.

Chosen semantics: the deeper skip wins, and Display owns the composition. The loop now calls `display.setSpeedy(speedy)` instead of poking the video chip. While speedy, the whole skip lives in the video chip at `max(9, frameSkip)`, rounded up to odd so interlaced modes (MODE 7) still alternate fields, and Display presents every frame the chip paints. Outside speedy mode the chip renders every frame and Display presents one in `frameSkip`, exactly as today.

Someone setting only `?frameSkip=` sees identical behaviour (same frames presented, every frame still rendered, which keeps both interlace fields fresh in the framebuffer). Someone only fast-forwarding gets the same one-in-nine as before. Only the combined case changes, from multiplied to the deeper of the two.

Unit tests pin the composition: the skip moving into the chip and back, a deeper configured skip surviving speedy mode, and no double skipping while the chip is skipping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
