### PR TITLE
test: shared-helper hygiene for the unit estate

### DIFF
--- a/tests/unit/helpers.js
+++ b/tests/unit/helpers.js
@@ -67,6 +67,7 @@ export function teardownDom() {
         vi.useRealTimers();
     }
     vi.restoreAllMocks();
+    vi.unstubAllGlobals();
     document.body.innerHTML = "";
     window.localStorage.clear();
     window.sessionStorage.clear();

--- a/tests/unit/helpers.js
+++ b/tests/unit/helpers.js
@@ -56,18 +56,35 @@ export function ssdImage(sectors = 800) {
     return data;
 }
 
+// A toast left mid-show leaks timers past this file's jsdom window: bootstrap
+// fakes transitionend with an uncancellable short timer, which in turn arms
+// the five second autohide. Let the transition finish while this window is
+// still current, then dispose to cancel the autohide; either timer firing
+// later crashes the run from whichever test file is running at the time.
+async function disposeToasts() {
+    if (!document.querySelector(".toast")) return;
+    await vi.waitFor(() => {
+        for (const el of document.querySelectorAll(".toast")) expect(el.classList.contains("showing")).toBe(false);
+    });
+    // Imported lazily: bootstrap cannot load outside jsdom, and node-environment
+    // tests share this module for its other helpers.
+    const { Toast } = await import("bootstrap");
+    for (const el of document.querySelectorAll(".toast")) Toast.getInstance(el)?.dispose();
+}
+
 /**
  * For afterEach. Fake timers left running would outlive the file's jsdom
  * window and fail the run from outside any test when they fire, so they are
  * flushed before the clock goes back to real.
  */
-export function teardownDom() {
+export async function teardownDom() {
     if (vi.isFakeTimers()) {
         vi.runAllTimers();
         vi.useRealTimers();
     }
     vi.restoreAllMocks();
     vi.unstubAllGlobals();
+    await disposeToasts();
     document.body.innerHTML = "";
     window.localStorage.clear();
     window.sessionStorage.clear();

--- a/tests/unit/helpers.js
+++ b/tests/unit/helpers.js
@@ -48,11 +48,20 @@ export const fakeUrlState = (search = "") =>
 export const toasts = () =>
     [...document.querySelectorAll(".toast")].map((el) => el.textContent.replace(/\s+/g, " ").trim());
 
-/** A catalogued single-density image, the smallest thing discFor accepts. */
-export function ssdImage(sectors = 800) {
-    const data = new Uint8Array(80 * 10 * 256);
+/**
+ * A single-density image whose DFS catalogue claims `sectors` sectors and
+ * holds a file starting at each of `starts`, the smallest thing discFor accepts.
+ */
+export function ssdImage(sectors = 800, { starts = [], length = 80 * 10 * 256 } = {}) {
+    const data = new Uint8Array(length);
+    data[0x105] = starts.length * 8;
     data[0x106] = (sectors >>> 8) & 3;
     data[0x107] = sectors & 0xff;
+    starts.forEach((start, entry) => {
+        const offset = 0x108 + entry * 8;
+        data[offset + 6] = (start >>> 8) & 3;
+        data[offset + 7] = start & 0xff;
+    });
     return data;
 }
 

--- a/tests/unit/helpers.js
+++ b/tests/unit/helpers.js
@@ -48,6 +48,20 @@ export const fakeUrlState = (search = "") =>
 export const toasts = () =>
     [...document.querySelectorAll(".toast")].map((el) => el.textContent.replace(/\s+/g, " ").trim());
 
+/** A fetch response carrying an archive manifest of `files`. */
+export const manifestResponse = (files) => ({
+    ok: true,
+    status: 200,
+    json: async () => ({ schemaVersion: 1, files }),
+});
+
+/** A fetch response carrying `body` as its bytes. */
+export const bytesResponse = (body = new Uint8Array()) => ({
+    ok: true,
+    status: 200,
+    arrayBuffer: async () => body.buffer.slice(body.byteOffset, body.byteOffset + body.byteLength),
+});
+
 /**
  * A single-density image whose DFS catalogue claims `sectors` sectors and
  * holds a file starting at each of `starts`, the smallest thing discFor accepts.

--- a/tests/unit/test-analogue-inputs.js
+++ b/tests/unit/test-analogue-inputs.js
@@ -2,7 +2,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { AnalogueInputs } from "../../src/web/analogue-inputs.js";
-import { domFromIndexHtml, fakeUrlState, teardownDom } from "./helpers.js";
+import { domFromIndexHtml, fakeUrlState, teardownDom, toasts } from "./helpers.js";
 
 describe("AnalogueInputs", () => {
     let deps;
@@ -67,7 +67,7 @@ describe("AnalogueInputs", () => {
             const inputs = make();
             inputs.updateAdcSources(false, 5);
             for (let ch = 0; ch < 4; ch++) expect(channels[ch]).toBe(inputs.gamepadSource);
-            expect(document.querySelector(".toast .message").textContent).toContain("no analogue channel 5");
+            expect(toasts()).toEqual([expect.stringContaining("no analogue channel 5")]);
             expect(deps.config.setMicrophoneChannel).toHaveBeenCalledWith(undefined);
             expect(deps.urlState.params.microphoneChannel).toBeUndefined();
             expect(deps.urlState.updateUrl).toHaveBeenCalled();

--- a/tests/unit/test-audio-handler.js
+++ b/tests/unit/test-audio-handler.js
@@ -1,11 +1,9 @@
 // @vitest-environment jsdom
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import * as bootstrap from "bootstrap";
-
 import { Scheduler } from "../../src/scheduler.js";
 import { AudioHandler } from "../../src/web/audio-handler.js";
-import { domFromIndexHtml } from "./helpers.js";
+import { domFromIndexHtml, teardownDom } from "./helpers.js";
 
 const SuspendedText = "Your browser has suspended audio";
 
@@ -75,10 +73,7 @@ describe("AudioHandler", () => {
         vi.stubGlobal("webkitAudioContext", undefined);
     });
 
-    afterEach(() => {
-        vi.unstubAllGlobals();
-        document.body.innerHTML = "";
-    });
+    afterEach(teardownDom);
 
     describe("without an audio worklet API", () => {
         beforeEach(() => stubAudio({ hasWorklet: false }));
@@ -226,21 +221,6 @@ describe("AudioHandler", () => {
         };
 
         beforeEach(() => vi.spyOn(console, "error").mockImplementation(() => {}));
-
-        // A toast left mid-show leaks timers past this file's jsdom window:
-        // bootstrap fakes transitionend with an uncancellable short timer,
-        // which in turn arms the five second autohide. Let the transition
-        // finish while this window is still current, then dispose to cancel
-        // the autohide; either timer firing later crashes the run from
-        // whichever test file is running at the time.
-        afterEach(async () => {
-            vi.restoreAllMocks();
-            await vi.waitFor(() => {
-                for (const el of document.querySelectorAll(".toast"))
-                    expect(el.classList.contains("showing")).toBe(false);
-            });
-            for (const el of document.querySelectorAll(".toast")) bootstrap.Toast.getInstance(el)?.dispose();
-        });
 
         it("says there will be no sound in the banner, and leaves it up", async () => {
             stubAudio({ addModule: rejectModule("audio-renderer") });

--- a/tests/unit/test-audio-handler.js
+++ b/tests/unit/test-audio-handler.js
@@ -3,7 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { Scheduler } from "../../src/scheduler.js";
 import { AudioHandler } from "../../src/web/audio-handler.js";
-import { domFromIndexHtml, teardownDom } from "./helpers.js";
+import { domFromIndexHtml, teardownDom, toasts } from "./helpers.js";
 
 const SuspendedText = "Your browser has suspended audio";
 
@@ -239,8 +239,7 @@ describe("AudioHandler", () => {
 
             makeHandler({ hasMusic5000: true });
 
-            await vi.waitFor(() => expect(document.querySelector(".toast .message")).not.toBeNull());
-            expect(document.querySelector(".toast .message").textContent).toContain("Music 5000 will be silent");
+            await vi.waitFor(() => expect(toasts()).toEqual([expect.stringContaining("Music 5000 will be silent")]));
             expect(warningShown()).toBe(false);
         });
     });

--- a/tests/unit/test-bbcdiscs.js
+++ b/tests/unit/test-bbcdiscs.js
@@ -8,20 +8,9 @@ import {
     Provenance,
     provenancesIn,
 } from "../../src/bbcdiscs.js";
+import { bytesResponse, manifestResponse } from "./helpers.js";
 
 const ArchiveBase = "https://bbc.xania.org/archive/bbcdiscs";
-
-const manifestResponse = (files) => ({
-    ok: true,
-    status: 200,
-    json: async () => ({ schemaVersion: 1, files }),
-});
-
-const bytesResponse = (body) => ({
-    ok: true,
-    status: 200,
-    arrayBuffer: async () => body.buffer.slice(body.byteOffset, body.byteOffset + body.byteLength),
-});
 
 const entry = (overrides = {}) => ({
     path: "B88911B2-BF6048A8.hfe",

--- a/tests/unit/test-disc.js
+++ b/tests/unit/test-disc.js
@@ -11,6 +11,7 @@ import {
     toSsdOrDsd,
 } from "../../src/disc.js";
 import * as fs from "node:fs";
+import { ssdImage } from "./helpers.js";
 
 afterEach(() => vi.restoreAllMocks());
 
@@ -373,26 +374,11 @@ describe("40 track SSD images", () => {
 });
 
 describe("telling a 40 track image from an 80 track one", () => {
-    /** An image with a DFS catalogue claiming `sectors` sectors and holding `starts` files. */
-    function catalogued(sectors, starts = [], length = 80 * TrackSize) {
-        const data = new Uint8Array(length);
-        data.set(new TextEncoder().encode("A DISC"), 0);
-        data[0x105] = starts.length * 8;
-        data[0x106] = (sectors >>> 8) & 3;
-        data[0x107] = sectors & 0xff;
-        starts.forEach((start, entry) => {
-            const offset = 0x108 + entry * 8;
-            data[offset + 6] = (start >>> 8) & 3;
-            data[offset + 7] = start & 0xff;
-        });
-        return data;
-    }
-
     const is40Track = (data, isDsd = false) => sniffDfsLayout(data, isDsd).is40Track;
 
     it("goes by the sector count a catalogue claims", () => {
-        expect(is40Track(catalogued(400))).toBe(true);
-        expect(is40Track(catalogued(800))).toBe(false);
+        expect(is40Track(ssdImage(400))).toBe(true);
+        expect(is40Track(ssdImage(800))).toBe(false);
     });
 
     it("leaves a disc nobody has formatted alone", () => {
@@ -400,29 +386,29 @@ describe("telling a 40 track image from an 80 track one", () => {
     });
 
     it("cares nothing for the size of the file", () => {
-        expect(is40Track(catalogued(400, [], 8 * TrackSize))).toBe(true);
-        expect(is40Track(catalogued(800, [], 8 * TrackSize))).toBe(false);
+        expect(is40Track(ssdImage(400, { length: 8 * TrackSize }))).toBe(true);
+        expect(is40Track(ssdImage(800, { length: 8 * TrackSize }))).toBe(false);
     });
 
     it("wants a catalogue at all", () => {
-        expect(is40Track(catalogued(400).slice(0, 300))).toBe(false);
-        const garbage = catalogued(400);
+        expect(is40Track(ssdImage(400).slice(0, 300))).toBe(false);
+        const garbage = ssdImage(400);
         garbage[0x105] = 3;
         expect(is40Track(garbage)).toBe(false);
     });
 
     it("does not mind a catalogue whose files are in an order DFS would not have written", () => {
-        expect(is40Track(catalogued(400, [2, 50, 100]))).toBe(true);
+        expect(is40Track(ssdImage(400, { starts: [2, 50, 100] }))).toBe(true);
     });
 
     it("turns down an image with data past where 40 tracks reach", () => {
-        const beyond = catalogued(400);
+        const beyond = ssdImage(400);
         beyond[43 * TrackSize] = 1;
         expect(is40Track(beyond)).toBe(false);
     });
 
     it("counts a double sided image's tracks across both of its sides", () => {
-        const dsd = catalogued(400, [], 80 * TrackSize * 2);
+        const dsd = ssdImage(400, { length: 80 * TrackSize * 2 });
         dsd[80 * TrackSize] = 1;
 
         expect(is40Track(dsd, true)).toBe(true);

--- a/tests/unit/test-display.js
+++ b/tests/unit/test-display.js
@@ -2,7 +2,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { Display } from "../../src/web/display.js";
-import { domFromIndexHtml, teardownDom } from "./helpers.js";
+import { domFromIndexHtml, teardownDom, toasts } from "./helpers.js";
 
 const FbWidth = 1024;
 
@@ -125,8 +125,7 @@ describe("Display", () => {
                 return fakeCanvas;
             },
         });
-        const toastText = document.querySelector(".toast")?.textContent ?? "";
-        expect(toastText).toContain("no WebGL");
+        expect(toasts()).toEqual([expect.stringContaining("no WebGL")]);
     });
 
     it("uses a fake video chip when asked", () => {

--- a/tests/unit/test-dom-utils.js
+++ b/tests/unit/test-dom-utils.js
@@ -2,6 +2,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { downloadBlob, downloadDriveData } from "../../src/dom-utils.js";
+import { teardownDom } from "./helpers.js";
 
 describe("dom-utils", () => {
     describe("downloadBlob", () => {
@@ -17,10 +18,7 @@ describe("dom-utils", () => {
             vi.spyOn(URL, "revokeObjectURL").mockImplementation(() => {});
         });
 
-        afterEach(() => {
-            vi.restoreAllMocks();
-            vi.useRealTimers();
-        });
+        afterEach(teardownDom);
 
         it("clicks an anchor in the document with the given file name", () => {
             downloadBlob(new Blob(["data"]), "disc.ssd");
@@ -52,12 +50,7 @@ describe("dom-utils", () => {
             vi.stubGlobal("URL", { ...URL, createObjectURL: () => "blob:disc", revokeObjectURL: () => {} });
         });
 
-        afterEach(() => {
-            vi.runAllTimers();
-            vi.useRealTimers();
-            vi.restoreAllMocks();
-            vi.unstubAllGlobals();
-        });
+        afterEach(teardownDom);
 
         it("names the file for the format it is in", () => {
             downloadDriveData(new Uint8Array([1, 2, 3]), "elite.ssd", ".hfe");

--- a/tests/unit/test-fdc.js
+++ b/tests/unit/test-fdc.js
@@ -5,18 +5,11 @@ import { Disc, DiscConfig, DiscLayout, loadSsd } from "../../src/disc.js";
 import { IntelFdc } from "../../src/intel-fdc.js";
 import { Scheduler } from "../../src/scheduler.js";
 import { fake6502 } from "../../src/fake6502.js";
+import { ssdImage } from "./helpers.js";
 
 const SectorSize = 256;
 const SectorsPerTrack = 10;
 const TrackSize = SectorSize * SectorsPerTrack;
-
-/** An image with a DFS catalogue claiming a disc of `sectors` sectors and holding no files. */
-function catalogued(sectors, length = 80 * TrackSize) {
-    const data = new Uint8Array(length);
-    data[0x106] = (sectors >>> 8) & 3;
-    data[0x107] = sectors & 0xff;
-    return data;
-}
 
 function ssdDisc(numTracks, is40Track) {
     const config = new DiscConfig();
@@ -31,13 +24,13 @@ describe("loading a disc image", () => {
     afterEach(() => vi.restoreAllMocks());
 
     it("lays a 40 track image out for a 40 track drive", () => {
-        expect(discFor(null, "test.ssd", catalogued(400)).is40Track).toBe(true);
-        expect(discFor(null, "test.ssd", catalogued(800)).is40Track).toBe(false);
+        expect(discFor(null, "test.ssd", ssdImage(400)).is40Track).toBe(true);
+        expect(discFor(null, "test.ssd", ssdImage(800)).is40Track).toBe(false);
     });
 
     it("does as it is told when a snapshot says how the disc was laid out", () => {
-        expect(discFor(null, "test.ssd", catalogued(400), null, DiscLayout.contiguous).is40Track).toBe(false);
-        expect(discFor(null, "test.ssd", catalogued(800), null, DiscLayout.expanded40).is40Track).toBe(true);
+        expect(discFor(null, "test.ssd", ssdImage(400), null, DiscLayout.contiguous).is40Track).toBe(false);
+        expect(discFor(null, "test.ssd", ssdImage(800), null, DiscLayout.expanded40).is40Track).toBe(true);
     });
 
     it("knows which formats hold a catalogue name", () => {
@@ -58,11 +51,11 @@ describe("knowing whether a disc keeps its changes", () => {
     afterEach(() => vi.restoreAllMocks());
 
     it("says no for a disc loaded without anywhere to write back to", () => {
-        expect(discFor(null, "test.ssd", catalogued(800), undefined, DiscLayout.contiguous).savesChanges).toBe(false);
+        expect(discFor(null, "test.ssd", ssdImage(800), undefined, DiscLayout.contiguous).savesChanges).toBe(false);
     });
 
     it("says yes once a writeback is wired up", () => {
-        expect(discFor(null, "test.ssd", catalogued(800), () => {}, DiscLayout.contiguous).savesChanges).toBe(true);
+        expect(discFor(null, "test.ssd", ssdImage(800), () => {}, DiscLayout.contiguous).savesChanges).toBe(true);
     });
 
     it("says no for the ADFS formats, which discard the writeback they are handed", () => {

--- a/tests/unit/test-front-panel.js
+++ b/tests/unit/test-front-panel.js
@@ -2,7 +2,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { FrontPanel } from "../../src/web/front-panel.js";
-import { domFromIndexHtml, teardownDom } from "./helpers.js";
+import { domFromIndexHtml, teardownDom, toasts } from "./helpers.js";
 
 describe("FrontPanel", () => {
     let processor;
@@ -106,7 +106,7 @@ describe("FrontPanel", () => {
         it("says when the pop-up was blocked", () => {
             vi.spyOn(window, "open").mockReturnValue(null);
             make().checkPrinterWindow();
-            expect(document.querySelector(".toast").textContent).toContain("blocked");
+            expect(toasts()).toEqual([expect.stringContaining("blocked")]);
         });
 
         it("quietly keeps output until a window is open", () => {

--- a/tests/unit/test-modals.js
+++ b/tests/unit/test-modals.js
@@ -2,7 +2,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { Modals } from "../../src/web/modals.js";
-import { domFromIndexHtml, teardownDom } from "./helpers.js";
+import { domFromIndexHtml, teardownDom, toasts } from "./helpers.js";
 
 describe("Modals", () => {
     let emulator;
@@ -106,13 +106,13 @@ describe("Modals", () => {
         it("toasts a message on finishing when given one", () => {
             modals.popupLoading("Loading Elite");
             modals.loadingFinished("Unable to load Elite");
-            expect(document.querySelector(".toast").textContent).toContain("Unable to load Elite");
+            expect(toasts()).toEqual([expect.stringContaining("Unable to load Elite")]);
         });
 
         it("says nothing on finishing quietly", () => {
             modals.popupLoading("Loading Elite");
             modals.loadingFinished();
-            expect(document.querySelector(".toast")).toBeNull();
+            expect(toasts()).toEqual([]);
         });
     });
 

--- a/tests/unit/test-settings.js
+++ b/tests/unit/test-settings.js
@@ -3,7 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { Settings } from "../../src/web/settings.js";
 import { DefaultModel, findModel } from "../../src/models.js";
-import { fakeUrlState, teardownDom } from "./helpers.js";
+import { fakeUrlState, teardownDom, toasts } from "./helpers.js";
 
 /** Stands in for the Config dialog: remembers what it was told and hands back the callbacks. */
 function fakeConfig(onChange, onClose, onRestartRequired) {
@@ -83,7 +83,7 @@ describe("Settings", () => {
             urlState.params.model = "PDP-11";
             const settings = make();
             expect(settings.model.name).toBe(DefaultModel.name);
-            expect(document.querySelector(".toast").textContent).toContain('no model called "PDP-11"');
+            expect(toasts()).toEqual([expect.stringContaining('no model called "PDP-11"')]);
         });
 
         it("tells the dialog everything it resolved", () => {

--- a/tests/unit/test-sth.js
+++ b/tests/unit/test-sth.js
@@ -4,25 +4,10 @@ import * as fs from "fs";
 import { dirname, join } from "path";
 import { fileURLToPath } from "url";
 import { StairwayToHell } from "../../src/sth.js";
+import { bytesResponse, manifestResponse } from "./helpers.js";
 
 const ARCHIVE_BASE = "https://bbc.xania.org/archive/sth";
 const __dirname = dirname(fileURLToPath(import.meta.url));
-
-function makeManifestResponse(files) {
-    return {
-        ok: true,
-        status: 200,
-        json: async () => ({ schemaVersion: 1, files }),
-    };
-}
-
-function makeOk(body = new Uint8Array()) {
-    return {
-        ok: true,
-        status: 200,
-        arrayBuffer: async () => body.buffer.slice(body.byteOffset, body.byteOffset + body.byteLength),
-    };
-}
 
 describe("StairwayToHell", () => {
     afterEach(() => {
@@ -32,7 +17,7 @@ describe("StairwayToHell", () => {
     it("populates the disc catalog from the disk manifest", async () => {
         vi.spyOn(globalThis, "fetch").mockImplementation(async (url) => {
             expect(url).toBe(`${ARCHIVE_BASE}/diskimages/manifest.json`);
-            return makeManifestResponse([
+            return manifestResponse([
                 { path: "Acornsoft/Elite.zip", size: 12345, mtime: null },
                 { path: "Cheats/CHT_ChuckieEgg-ExtraColours.zip", size: 9992, mtime: null },
             ]);
@@ -54,7 +39,7 @@ describe("StairwayToHell", () => {
         const seen = [];
         vi.spyOn(globalThis, "fetch").mockImplementation(async (url) => {
             seen.push(url);
-            return makeManifestResponse([]);
+            return manifestResponse([]);
         });
 
         const sth = new StairwayToHell(
@@ -106,7 +91,7 @@ describe("StairwayToHell", () => {
         const seen = [];
         vi.spyOn(globalThis, "fetch").mockImplementation(async (url) => {
             seen.push(url);
-            return makeOk(new Uint8Array());
+            return bytesResponse(new Uint8Array());
         });
         vi.spyOn(console, "log").mockImplementation(() => {});
         vi.spyOn(console, "error").mockImplementation(() => {});
@@ -124,7 +109,7 @@ describe("StairwayToHell", () => {
 
     it("returns the name of the file found inside the zip, not the zip's own path", async () => {
         const zip = new Uint8Array(fs.readFileSync(join(__dirname, "zip", "test-ssd.zip")));
-        vi.spyOn(globalThis, "fetch").mockResolvedValue(makeOk(zip));
+        vi.spyOn(globalThis, "fetch").mockResolvedValue(bytesResponse(zip));
         vi.spyOn(console, "log").mockImplementation(() => {});
 
         const sth = new StairwayToHell(


### PR DESCRIPTION
The shared-helper items from issue #1002's Theme E, one concern per commit, with no change to what is tested.

- `teardownDom` now disposes live Bootstrap toasts, so the timer-leak cure `test-audio-handler.js` carried for the whole suite lives with the teardown it belongs to.
- `teardownDom` also calls `vi.unstubAllGlobals()`, and the files that wrote their own copy now use the shared teardown. The node-environment files (`test-fdc`, `test-audio-utils`) keep theirs because `teardownDom` is a DOM teardown, and `test-audio-renderer` keeps its `afterAll` because its stubs deliberately outlive each test.
- The files that hand-read the toast DOM now use the `toasts()` helper.
- `test-fdc` and `test-disc` build their catalogued images with the shared `ssdImage`, which learned the file-entry and length knobs `test-disc` needed.
- `test-sth` and `test-bbcdiscs` share their fake fetch responses; the audit's third copy had already been refactored away.

Part of #1002.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
