### PR TITLE
perf: build the BASIC tokeniser's Master CPU once and share it

### DIFF
--- a/src/basic-tokenise.js
+++ b/src/basic-tokenise.js
@@ -3,7 +3,7 @@ import * as utils from "./utils.js";
 import * as models from "./models.js";
 import { fake6502 } from "./fake6502.js";
 
-export async function create() {
+async function makeTokeniser() {
     const cpu = fake6502(models.basicOnly);
     const callTokeniser = function (line) {
         // Address of the tokenisation subroutine in the Master's BASIC ROM.
@@ -101,4 +101,20 @@ export async function create() {
     };
     await cpu.initialise();
     return { tokenise };
+}
+
+let tokeniser = null;
+
+/**
+ * Building the tokeniser stands up a whole Master CPU and loads its ROMs, so
+ * the one instance is shared by every caller; each call to the tokeniser
+ * resets all the machine state it uses.
+ */
+export function create() {
+    if (!tokeniser)
+        tokeniser = makeTokeniser().catch((error) => {
+            tokeniser = null;
+            throw error;
+        });
+    return tokeniser;
 }

--- a/tests/unit/test-tokenise.js
+++ b/tests/unit/test-tokenise.js
@@ -62,4 +62,18 @@ describe("Tokeniser", function () {
     it("gives error for overlong input", async function () {
         await checkThrows("10" + "ENVELOPE".repeat(252), "Line 10 tokenised length 252 > 251 bytes");
     });
+
+    describe("reuse", function () {
+        it("hands every caller the same instance", async function () {
+            expect(await Tokeniser.create()).toBe(await Tokeniser.create());
+        });
+
+        it("matches a fresh tokeniser's output after other programs have been through it", async function () {
+            const t = await tokeniser;
+            t.tokenise("30" + "ENVELOPE".repeat(100));
+            expect(t.tokenise('10 PRINT "hello"\n20 GOTO 10\n')).toBe(
+                '\r\x00\x0a\x0e \xf1 "hello"\r\x00\x14\x0b \xe5 \x8d\x54\x4a\x40\r\xff',
+            );
+        });
+    });
 });


### PR DESCRIPTION
Part of #1002.

`basic-tokenise.js` stood up a full Master CPU and loaded its ROMs on every `create()`, and callers construct one per use: the web autoboot's `insertBasic` and TestMachine's `runBasic` both call `create()` each time. The instance is now memoised at module scope, so every caller shares one machine; a failed build is not cached, so a transient ROM load error can be retried.

Reuse is safe because each `tokenise` call rewrites everything the ROM routine reads before running it: the pc and stack pointer, the statement flags and text pointer in zero page, the ROM latch, and the workspace text with its own terminator. The unit suite has in fact always shared a single instance across all its programs. A new test pins the contract directly: after other programs have been through the shared tokeniser, it still reproduces the output the fresh-instance tests expect, and `create()` hands every caller the same object.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
