### PR TITLE
test: cover the Config dialog with the real index.html DOM

### DIFF
--- a/tests/unit/test-config.js
+++ b/tests/unit/test-config.js
@@ -115,8 +115,8 @@ describe("Config", () => {
     let config;
 
     const dialog = () => document.getElementById("configuration");
-    const openDialog = () => dialog().dispatchEvent(new Event("show.bs.modal"));
-    const closeDialog = () => dialog().dispatchEvent(new Event("hide.bs.modal"));
+    const openDialog = () => dialog().dispatchEvent(new Event("show.bs.modal", { bubbles: true }));
+    const closeDialog = () => dialog().dispatchEvent(new Event("hide.bs.modal", { bubbles: true }));
     const modelDropdownText = () => document.querySelector("#bbc-model-dropdown .bbc-model").textContent;
     const restartPendingShown = () => !document.getElementById("restart-pending").classList.contains("d-none");
     const clickModel = (synonym) => document.querySelector(`.model-menu a[data-target="${synonym}"]`).click();

--- a/tests/unit/test-config.js
+++ b/tests/unit/test-config.js
@@ -1,6 +1,8 @@
-import { describe, it, expect } from "vitest";
-import { fittedRoms, needsRestart, restartPending, tubeCpuSpeedLabel } from "../../src/web/config.js";
-import { findModel } from "../../src/models.js";
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, it, expect, vi } from "vitest";
+import { Config, fittedRoms, needsRestart, restartPending, tubeCpuSpeedLabel } from "../../src/web/config.js";
+import { allModels, findModel } from "../../src/models.js";
+import { domFromIndexHtml, teardownDom } from "./helpers.js";
 
 describe("fittedRoms", () => {
     const master = findModel("Master");
@@ -103,5 +105,263 @@ describe("tubeCpuSpeedLabel", () => {
 
     it("keeps a repeating multiplier from a URL readable", () => {
         expect(tubeCpuSpeedLabel(4 / 3, bbcB)).toBe("1.33x (4MHz)");
+    });
+});
+
+describe("Config", () => {
+    let onChange;
+    let onClose;
+    let onRestartRequired;
+    let config;
+
+    const dialog = () => document.getElementById("configuration");
+    const openDialog = () => dialog().dispatchEvent(new Event("show.bs.modal"));
+    const closeDialog = () => dialog().dispatchEvent(new Event("hide.bs.modal"));
+    const modelDropdownText = () => document.querySelector("#bbc-model-dropdown .bbc-model").textContent;
+    const restartPendingShown = () => !document.getElementById("restart-pending").classList.contains("d-none");
+    const clickModel = (synonym) => document.querySelector(`.model-menu a[data-target="${synonym}"]`).click();
+    const tubeSlider = () => document.getElementById("tubeCpuMultiplier");
+    const dragTubeSlider = (value) => {
+        tubeSlider().value = value;
+        tubeSlider().dispatchEvent(new Event("input"));
+    };
+    const lastClosedWith = () => onClose.mock.calls.at(-1)[0];
+
+    beforeEach(() => {
+        domFromIndexHtml("configuration");
+        onChange = vi.fn();
+        onClose = vi.fn();
+        onRestartRequired = vi.fn();
+        config = new Config(onChange, onClose, onRestartRequired);
+        // What Settings pushes in after construction, resolved from the URL and storage.
+        config.setModel("B-DFS1.2");
+        config.setKeyLayout("physical");
+        config.setTubeCpuMultiplier(1);
+        config.setMicrophoneChannel(undefined);
+        config.setCheckboxes({
+            coProcessor: false,
+            hasEconet: false,
+            hasMusic5000: false,
+            hasTeletextAdaptor: false,
+            mouseJoystickEnabled: false,
+            speechOutput: false,
+        });
+        config.setDisplayMode("rgb");
+        config.setAudioOutput("speaker");
+        config.setSpeakerAmount(1);
+    });
+
+    afterEach(teardownDom);
+
+    describe("the model menu", () => {
+        it("offers every selectable model under its first synonym, in catalogue order", () => {
+            const selectable = allModels.filter((model) => model.synonyms.length > 0);
+            const items = [...document.querySelectorAll(".model-menu a")];
+            expect(items.map((item) => item.textContent)).toEqual(selectable.map((model) => model.name));
+            expect(items.map((item) => item.dataset.target)).toEqual(selectable.map((model) => model.synonyms[0]));
+        });
+
+        it("shows the chosen model without adopting it until the dialog closes", () => {
+            openDialog();
+            clickModel("Master");
+            expect(modelDropdownText()).toBe(findModel("Master").name);
+            expect(config.model).toBe(findModel("B-DFS1.2"));
+            closeDialog();
+            expect(config.model).toBe(findModel("Master"));
+        });
+    });
+
+    describe("opening the dialog", () => {
+        it("shows the settings it was handed", () => {
+            openDialog();
+            expect(modelDropdownText()).toBe(findModel("B-DFS1.2").name);
+            expect(document.getElementById("hasMusic5000").checked).toBe(false);
+            expect(tubeSlider().disabled).toBe(true);
+            expect(restartPendingShown()).toBe(false);
+        });
+
+        it("forgets a previous visit's changes", () => {
+            openDialog();
+            clickModel("Master");
+            closeDialog();
+            onClose.mockClear();
+            openDialog();
+            closeDialog();
+            expect(onClose).toHaveBeenCalledWith({});
+        });
+    });
+
+    describe("closing the dialog", () => {
+        it("reports an untouched dialog as no changes at all", () => {
+            const settingsChanged = vi.fn();
+            config.addEventListener("settings-changed", settingsChanged);
+            openDialog();
+            closeDialog();
+            expect(onClose).toHaveBeenCalledWith({});
+            expect(settingsChanged).not.toHaveBeenCalled();
+            expect(onRestartRequired).not.toHaveBeenCalled();
+        });
+
+        it("hands the changes to the close callback and the settings-changed event alike", () => {
+            const settingsChanged = vi.fn();
+            config.addEventListener("settings-changed", settingsChanged);
+            openDialog();
+            clickModel("Master");
+            document.getElementById("hasMusic5000").click();
+            closeDialog();
+            expect(onClose).toHaveBeenCalledWith({ model: "Master", hasMusic5000: true });
+            expect(settingsChanged.mock.calls[0][0].detail).toEqual({ model: "Master", hasMusic5000: true });
+        });
+    });
+
+    describe("a change that needs a restart", () => {
+        it("warns as soon as the model is picked and asks for the restart on close", () => {
+            openDialog();
+            expect(restartPendingShown()).toBe(false);
+            clickModel("Master");
+            expect(restartPendingShown()).toBe(true);
+            closeDialog();
+            expect(onRestartRequired).toHaveBeenCalledTimes(1);
+        });
+
+        it("stops asking once the setting is put back", () => {
+            openDialog();
+            document.getElementById("hasMusic5000").click();
+            closeDialog();
+            expect(onRestartRequired).toHaveBeenCalledTimes(1);
+            openDialog();
+            document.getElementById("hasMusic5000").click();
+            expect(restartPendingShown()).toBe(false);
+            closeDialog();
+            expect(lastClosedWith()).toEqual({ hasMusic5000: false });
+            expect(onRestartRequired).toHaveBeenCalledTimes(1);
+        });
+
+        it("does not ask when a touched control is back where the machine already is", () => {
+            openDialog();
+            document.getElementById("hasMusic5000").click();
+            document.getElementById("hasMusic5000").click();
+            closeDialog();
+            expect(lastClosedWith()).toEqual({ hasMusic5000: false });
+            expect(onRestartRequired).not.toHaveBeenCalled();
+        });
+    });
+
+    describe("the co-processor controls", () => {
+        it("only lets the tube speed be set while the co-processor is ticked", () => {
+            openDialog();
+            document.getElementById("65c02").click();
+            expect(tubeSlider().disabled).toBe(false);
+            document.getElementById("65c02").click();
+            expect(tubeSlider().disabled).toBe(true);
+        });
+
+        it("labels a dragged tube speed with the machine it will drive", () => {
+            openDialog();
+            dragTubeSlider(2);
+            expect(document.getElementById("tubeCpuMultiplierValue").textContent).toBe("2x (6MHz)");
+            closeDialog();
+            expect(lastClosedWith()).toEqual({ tubeCpuMultiplier: 2 });
+        });
+
+        it("labels the tube speed for a newly picked model's own second processor", () => {
+            openDialog();
+            clickModel("Master");
+            expect(document.getElementById("tubeCpuMultiplierValue").textContent).toBe("1x (4MHz)");
+        });
+    });
+
+    describe("the dropdown pickers", () => {
+        it("saves a keyboard layout and shows it capitalised", () => {
+            openDialog();
+            document.querySelector('.keyboard-menu a[data-target="natural"]').click();
+            expect(document.querySelector(".keyboard-layout").textContent).toBe("Natural");
+            closeDialog();
+            expect(lastClosedWith()).toEqual({ keyLayout: "natural" });
+        });
+
+        it("saves a microphone channel", () => {
+            openDialog();
+            document.querySelector('.mic-channel-option[data-channel="2"]').click();
+            expect(document.querySelector(".mic-channel-text").textContent).toBe("Channel 2");
+            closeDialog();
+            expect(lastClosedWith()).toEqual({ microphoneChannel: 2 });
+        });
+
+        it("saves disabling the microphone as a change, not an omission", () => {
+            openDialog();
+            document.querySelector('.mic-channel-option[data-channel=""]').click();
+            expect(document.querySelector(".mic-channel-text").textContent).toBe("Disabled");
+            closeDialog();
+            expect(lastClosedWith()).toStrictEqual({ microphoneChannel: undefined });
+        });
+    });
+
+    describe("the live settings", () => {
+        it("applies a sound output at once as well as saving it", () => {
+            openDialog();
+            document.querySelector('.audio-output-option[data-output="board"]').click();
+            expect(onChange).toHaveBeenCalledWith({ audioOutput: "board" });
+            closeDialog();
+            expect(lastClosedWith()).toEqual({ audioOutput: "board" });
+        });
+
+        it("applies a display mode at once and shows its name", () => {
+            openDialog();
+            document.querySelector('.display-mode-option[data-mode="pal"]').click();
+            expect(onChange).toHaveBeenCalledWith({ displayMode: "pal" });
+            expect(document.querySelector(".display-mode-text").textContent).toBe("PAL TV");
+        });
+
+        it("applies a dragged speaker amount at once", () => {
+            const slider = document.getElementById("speakerAmountSetting");
+            slider.value = 0.5;
+            slider.dispatchEvent(new Event("input"));
+            expect(onChange).toHaveBeenCalledWith({ speakerAmount: 0.5 });
+        });
+    });
+
+    describe("being told the applied settings", () => {
+        it("names the model everywhere the page shows it", () => {
+            config.setModel("Master");
+            expect(document.querySelector(".modal-title .bbc-model").textContent).toBe(findModel("Master").name);
+            expect(modelDropdownText()).toBe(findModel("Master").name);
+        });
+
+        it("shows a sound output and gates the speaker slider on it", () => {
+            config.setAudioOutput("board");
+            expect(document.querySelector(".audio-output-text").textContent).toBe("Line out");
+            expect(document.getElementById("speakerAmountSetting").disabled).toBe(true);
+            config.setAudioOutput("speaker");
+            expect(document.getElementById("speakerAmountSetting").disabled).toBe(false);
+        });
+
+        it("offers the ROMs for the fittings that are ticked", () => {
+            config.setModel("Master");
+            config.setCheckboxes({ hasEconet: true, hasMusic5000: true });
+            expect(config.extraRoms).toEqual(["master/anfs-4.25.rom", "ample.rom"]);
+        });
+    });
+
+    describe("mapLegacyModels", () => {
+        it("splits the combination models into a model and its fitting", () => {
+            const turbo = { model: "MasterTurbo" };
+            config.mapLegacyModels(turbo);
+            expect(turbo).toEqual({ model: "Master", coProcessor: true });
+
+            const music = { model: "BMusic5000" };
+            config.mapLegacyModels(music);
+            expect(music).toEqual({ model: "B-DFS1.2", hasMusic5000: true });
+
+            const teletext = { model: "BTeletext" };
+            config.mapLegacyModels(teletext);
+            expect(teletext).toEqual({ model: "B-DFS1.2", hasTeletextAdaptor: true });
+        });
+
+        it("leaves a query with no model alone", () => {
+            const query = { autoboot: true };
+            config.mapLegacyModels(query);
+            expect(query).toEqual({ autoboot: true });
+        });
     });
 });

--- a/tests/unit/test-settings.js
+++ b/tests/unit/test-settings.js
@@ -3,35 +3,24 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { Settings } from "../../src/web/settings.js";
 import { DefaultModel, findModel } from "../../src/models.js";
-import { fakeUrlState, teardownDom } from "./helpers.js";
-
-/** Stands in for the Config dialog: remembers what it was told and hands back the callbacks. */
-function fakeConfig(onChange, onClose, onRestartRequired) {
-    return {
-        onChange,
-        onClose,
-        onRestartRequired,
-        model: undefined,
-        mapLegacyModels: vi.fn(),
-        setModel: vi.fn(function (name) {
-            this.model = findModel(name);
-        }),
-        setKeyLayout: vi.fn(),
-        setTubeCpuMultiplier: vi.fn(),
-        setMicrophoneChannel: vi.fn(),
-        setCheckboxes: vi.fn(),
-        setDisplayMode: vi.fn(),
-        setAudioOutput: vi.fn(),
-        setSpeakerAmount: vi.fn(),
-    };
-}
+import { domFromIndexHtml, fakeUrlState, teardownDom, toasts } from "./helpers.js";
 
 describe("Settings", () => {
     let urlState;
     let targets;
 
+    const dialog = () => document.getElementById("configuration");
+    const openDialog = () => dialog().dispatchEvent(new Event("show.bs.modal"));
+    const closeDialog = () => dialog().dispatchEvent(new Event("hide.bs.modal"));
+    const dragTubeSlider = (value) => {
+        const slider = document.getElementById("tubeCpuMultiplier");
+        slider.value = value;
+        slider.dispatchEvent(new Event("input"));
+    };
+
     beforeEach(() => {
         vi.useFakeTimers();
+        domFromIndexHtml("configuration");
         urlState = fakeUrlState();
         vi.spyOn(urlState, "updateUrl");
         targets = {
@@ -49,7 +38,7 @@ describe("Settings", () => {
     afterEach(teardownDom);
 
     const make = () => {
-        const settings = new Settings({ urlState, makeConfig: (...handlers) => fakeConfig(...handlers) });
+        const settings = new Settings({ urlState });
         settings.wire(targets);
         return settings;
     };
@@ -83,15 +72,17 @@ describe("Settings", () => {
             urlState.params.model = "PDP-11";
             const settings = make();
             expect(settings.model.name).toBe(DefaultModel.name);
-            expect(document.querySelector(".toast").textContent).toContain('no model called "PDP-11"');
+            expect(toasts()).toEqual([expect.stringContaining('no model called "PDP-11"')]);
         });
 
-        it("tells the dialog everything it resolved", () => {
+        it("shows the dialog everything it resolved", () => {
             urlState.params.model = "Master";
+            urlState.params.hasMusic5000 = true;
             const settings = make();
-            expect(settings.config.setModel).toHaveBeenCalledWith(findModel("Master").name);
-            expect(settings.config.setCheckboxes).toHaveBeenCalled();
-            expect(settings.config.setAudioOutput).toHaveBeenCalledWith("speaker");
+            expect(settings.model).toBe(findModel("Master"));
+            expect(document.querySelector("#bbc-model-dropdown .bbc-model").textContent).toBe(findModel("Master").name);
+            expect(document.getElementById("hasMusic5000").checked).toBe(true);
+            expect(document.querySelector(".audio-output-text").textContent).toBe("Internal speaker");
         });
     });
 
@@ -100,7 +91,7 @@ describe("Settings", () => {
             const settings = make();
             settings.applyAudioOutput("board");
             expect(targets.audioHandler.setAudioOutput).toHaveBeenCalledWith("board");
-            expect(settings.config.setAudioOutput).toHaveBeenCalledWith("board");
+            expect(document.querySelector(".audio-output-text").textContent).toBe("Line out");
             expect(targets.quickSettings.showAudioOutput).toHaveBeenCalledWith("board");
             expect(window.localStorage.audioOutput).toBe("board");
             expect(urlState.params.audioOutput).toBe("board");
@@ -132,63 +123,81 @@ describe("Settings", () => {
         });
 
         it("routes the dialog's live changes through the same appliers", () => {
-            const settings = make();
-            settings.config.onChange({ displayMode: "rgb" });
+            make();
+            document.querySelector('.display-mode-option[data-mode="rgb"]').click();
             expect(targets.display.setMode).toHaveBeenCalledWith("rgb");
-            settings.config.onChange({ speakerAmount: 0.7 });
+            const slider = document.getElementById("speakerAmountSetting");
+            slider.value = 0.7;
+            slider.dispatchEvent(new Event("input"));
             expect(targets.audioHandler.setSpeakerAmount).toHaveBeenCalledWith(0.7);
         });
     });
 
     describe("closing the dialog", () => {
         it("merges the changes into the URL parameters and updates the URL", () => {
-            const settings = make();
-            settings.config.onClose({ hasMusic5000: true });
+            make();
+            openDialog();
+            document.getElementById("hasMusic5000").click();
+            closeDialog();
             expect(urlState.params.hasMusic5000).toBe(true);
             expect(urlState.updateUrl).toHaveBeenCalledTimes(1);
         });
 
         it("fans a key layout out to storage, the machine and the keyboard", () => {
-            const settings = make();
-            settings.config.onClose({ keyLayout: "natural" });
+            make();
+            openDialog();
+            document.querySelector('.keyboard-menu a[data-target="natural"]').click();
+            closeDialog();
             expect(window.localStorage.keyLayout).toBe("natural");
             expect(targets.machine.emulationConfig.keyLayout).toBe("natural");
             expect(targets.keys.setKeyLayout).toHaveBeenCalledWith("natural");
         });
 
         it("reroutes the analogue channels when the mouse joystick or microphone change", () => {
-            const settings = make();
-            settings.config.onClose({ mouseJoystickEnabled: true });
+            make();
+            openDialog();
+            document.getElementById("mouseJoystickEnabled").click();
+            closeDialog();
             expect(targets.inputs.updateAdcSources).toHaveBeenCalledWith(true, undefined);
             expect(targets.inputs.setupMicrophone).not.toHaveBeenCalled();
-            settings.config.onClose({ microphoneChannel: 2 });
+            openDialog();
+            document.querySelector('.mic-channel-option[data-channel="2"]').click();
+            closeDialog();
             expect(targets.inputs.setupMicrophone).toHaveBeenCalled();
         });
 
         it("reroutes the analogue channels when the microphone is disabled, without starting it", () => {
             urlState.params.microphoneChannel = 2;
-            const settings = make();
-            settings.config.onClose({ microphoneChannel: undefined });
+            make();
+            openDialog();
+            document.querySelector('.mic-channel-option[data-channel=""]').click();
+            closeDialog();
             expect(targets.inputs.updateAdcSources).toHaveBeenCalledWith(undefined, undefined);
             expect(targets.inputs.setupMicrophone).not.toHaveBeenCalled();
         });
 
         it("passes a tube multiplier to a fitted tube only", () => {
-            const settings = make();
-            settings.config.onClose({ tubeCpuMultiplier: 4 });
+            make();
+            openDialog();
+            dragTubeSlider(4);
+            closeDialog();
             expect(targets.machine.emulationConfig.tubeCpuMultiplier).toBe(4);
             expect(targets.machine.processor.tube.cpuMultiplier).toBeUndefined();
 
             targets.machine.processor.hasTube = true;
-            settings.config.onClose({ tubeCpuMultiplier: 8 });
+            openDialog();
+            dragTubeSlider(8);
+            closeDialog();
             expect(targets.machine.processor.tube.cpuMultiplier).toBe(8);
         });
     });
 
     describe("a change that needs a restart", () => {
         it("asks before reloading", () => {
-            const settings = make();
-            settings.config.onRestartRequired();
+            make();
+            openDialog();
+            document.getElementById("hasEconet").click();
+            closeDialog();
             expect(targets.modals.confirm).toHaveBeenCalledWith(
                 expect.stringContaining("Restart now?"),
                 "Restart now",
@@ -202,7 +211,10 @@ describe("Settings", () => {
             urlState.params.speechOutput = true;
             const settings = make();
             expect(settings.speechOutput.enabled).toBe(true);
-            settings.config.onClose({ speechOutput: false });
+            openDialog();
+            expect(document.getElementById("speechOutput").checked).toBe(true);
+            document.getElementById("speechOutput").click();
+            closeDialog();
             expect(settings.speechOutput.enabled).toBe(false);
         });
     });

--- a/tests/unit/test-settings.js
+++ b/tests/unit/test-settings.js
@@ -10,8 +10,8 @@ describe("Settings", () => {
     let targets;
 
     const dialog = () => document.getElementById("configuration");
-    const openDialog = () => dialog().dispatchEvent(new Event("show.bs.modal"));
-    const closeDialog = () => dialog().dispatchEvent(new Event("hide.bs.modal"));
+    const openDialog = () => dialog().dispatchEvent(new Event("show.bs.modal", { bubbles: true }));
+    const closeDialog = () => dialog().dispatchEvent(new Event("hide.bs.modal", { bubbles: true }));
     const dragTubeSlider = (value) => {
         const slider = document.getElementById("tubeCpuMultiplier");
         slider.value = value;


### PR DESCRIPTION
The Config coverage item from issue #1002's Theme E.

`src/web/config.js` was the least covered web module: only its pure helpers had tests, and everything that talks to the class mocks it. The first commit drives the real class through `domFromIndexHtml("configuration")`: the model menu it builds, the open/close lifecycle and its changed bag, the restart-pending flow, the live-change callbacks, and the setters Settings pushes resolved values through.

The second commit retires `test-settings.js`'s hand-written `fakeConfig`, which could not fail when Config changes. Settings now builds its real Config in the tests, and the interplay is driven the way the page drives it: clicks on the dialog's controls and the modal's own show and hide events, with assertions on the dialog DOM instead of on stub calls.

Branched off main independently of #1039; both touch `tests/unit/test-settings.js`, so whichever lands second will see a small conflict there.

Part of #1002.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
