### PR TITLE
refactor: drop the fdc that google-drive.js only passed through

### DIFF
--- a/src/google-drive.js
+++ b/src/google-drive.js
@@ -136,14 +136,14 @@ export class GoogleDriveLoader {
         });
     }
 
-    async create(fdc, name, data) {
+    async create(name, data) {
         console.log(`Google Drive: creating disc image: '${name}'`);
         const response = await this.saveFile(name, data);
         const meta = response.result;
-        return { fileId: meta.id, disc: this.makeDisc(fdc, data, meta) };
+        return { fileId: meta.id, disc: this.makeDisc(data, meta) };
     }
 
-    makeDisc(fdc, data, meta, layout) {
+    makeDisc(data, meta, layout) {
         let flusher = null;
         const name = meta.name;
         const id = meta.id;
@@ -160,9 +160,9 @@ export class GoogleDriveLoader {
         return discFor(name, data, flusher, layout);
     }
 
-    async load(fdc, fileId, layout) {
+    async load(fileId, layout) {
         const meta = (await this.driveClient.files.get({ fileId, fields: FILE_FIELDS })).result;
         const data = (await this.driveClient.files.get({ fileId, alt: "media" })).body;
-        return this.makeDisc(fdc, data, meta, layout);
+        return this.makeDisc(data, meta, layout);
     }
 }

--- a/src/web/google-drive-picker.js
+++ b/src/web/google-drive-picker.js
@@ -98,7 +98,7 @@ export class GoogleDrivePicker {
                 }
             }
 
-            const ssd = await this.googleDrive.load(this.processor.fdc, cat.id, layout);
+            const ssd = await this.googleDrive.load(cat.id, layout);
             console.log("Google Drive loading finished");
             this.modals.loadingFinished();
             if (!ssd.savesChanges) {
@@ -188,7 +188,7 @@ export class GoogleDrivePicker {
         }
 
         try {
-            const result = await this.googleDrive.create(this.processor.fdc, name, data);
+            const result = await this.googleDrive.create(name, data);
             this.media.setDisc1Image("gd:" + result.fileId + "/" + name);
             this.drives.putDiscIn(0, result.disc);
             this.modals.loadingFinished();

--- a/tests/unit/test-google-drive-picker.js
+++ b/tests/unit/test-google-drive-picker.js
@@ -37,7 +37,7 @@ describe("GoogleDrivePicker", () => {
             const ssd = { savesChanges: true };
             loader.load.mockResolvedValue(ssd);
             const got = await make().load({ id: "abc", name: "mine.ssd" }, "auto");
-            expect(loader.load).toHaveBeenCalledWith(deps.processor.fdc, "abc", "auto");
+            expect(loader.load).toHaveBeenCalledWith("abc", "auto");
             expect(deps.modals.popupLoading).toHaveBeenCalledWith("Loading 'mine.ssd' from Google Drive");
             expect(deps.modals.loadingFinished).toHaveBeenCalledWith();
             expect(got).toBe(ssd);
@@ -160,7 +160,7 @@ describe("GoogleDrivePicker", () => {
             document.querySelector("#google-drive .disc-name").value = "fresh.ssd";
             submit();
             await vi.waitFor(() => expect(deps.drives.putDiscIn).toHaveBeenCalled());
-            const [, name, data] = loader.create.mock.calls[0];
+            const [name, data] = loader.create.mock.calls[0];
             expect(name).toBe("fresh.ssd");
             expect(data.length).toBeGreaterThan(0);
             expect(deps.media.setDisc1Image).toHaveBeenCalledWith("gd:xyz/fresh.ssd");


### PR DESCRIPTION
Follow-up to #1037, which removed the unread `fdc` argument from `discFor` but stopped short of `google-drive.js`, whose `create`, `load` and `makeDisc` only carried it through to that call; their callers in `google-drive-picker.js` were being edited by #1035 at the time. Both have landed, so the parameter goes here, along with the two picker test expectations that spelled it out.

Part of #1002.

🤖 Generated with [Claude Code](https://claude.com/claude-code)