### PR TITLE
refactor: one pause-depth mechanism on the loop instead of four latches

### DIFF
--- a/src/web/emulation-loop.js
+++ b/src/web/emulation-loop.js
@@ -96,7 +96,7 @@ export class EmulationLoop extends EventTarget {
         this.emulationLeadMs = 0;
         this.rewindCycleCounter = 0;
         this.wanted = false;
-        this.pauseDepth = 0;
+        this.holds = new Set();
         this.resumeOnVisible = null;
 
         this.virtualSpeedUpdater = new VirtualSpeedUpdater(cpuSpeed);
@@ -111,7 +111,11 @@ export class EmulationLoop extends EventTarget {
 
     go() {
         this.wanted = true;
-        if (this.pauseDepth === 0) this.start();
+        if (this.holds.size === 0) this.start();
+        else
+            console.warn(
+                `Emulator held by ${[...this.holds].map((hold) => hold.reason).join(", ")}; it runs when they let go`,
+            );
     }
 
     stop(debug) {
@@ -122,15 +126,16 @@ export class EmulationLoop extends EventTarget {
 
     /**
      * Holds the machine stopped until the returned function is called. Holds
-     * nest, and letting go twice counts once.
+     * nest, and letting go twice counts once. `reason` names the holder when a
+     * go() has to wait, so a hold that is never released can be found.
      */
-    pause() {
-        if (this.pauseDepth++ === 0 && this.running) this.halt();
-        let held = true;
+    pause(reason) {
+        if (this.holds.size === 0 && this.running) this.halt();
+        const hold = { reason };
+        this.holds.add(hold);
         return () => {
-            if (!held) return;
-            held = false;
-            if (--this.pauseDepth === 0 && this.wanted) this.start();
+            if (!this.holds.delete(hold)) return;
+            if (this.holds.size === 0 && this.wanted) this.start();
         };
     }
 
@@ -254,7 +259,7 @@ export class EmulationLoop extends EventTarget {
         if (document.visibilityState === "hidden") {
             const keepRunningWhenHidden =
                 processor.acia.motorOn || processor.fdc.motorOn[0] || processor.fdc.motorOn[1];
-            if (!keepRunningWhenHidden && !this.resumeOnVisible) this.resumeOnVisible = this.pause();
+            if (!keepRunningWhenHidden && !this.resumeOnVisible) this.resumeOnVisible = this.pause("the hidden tab");
         } else if (this.resumeOnVisible) {
             this.resumeOnVisible();
             this.resumeOnVisible = null;

--- a/src/web/emulation-loop.js
+++ b/src/web/emulation-loop.js
@@ -51,7 +51,10 @@ class VirtualSpeedUpdater {
  * Runs the machine in real time: the tick that turns wall-clock time into
  * cycles, starting and stopping, the audio lead, fast-forward, rewind capture
  * and the speed readout. Owns `running`, and dispatches a "running" event
- * whenever it changes hands.
+ * whenever it changes hands. Anything that needs the machine held still while
+ * it works (a dialog, a snapshot, the rewind panel, a hidden tab) takes a
+ * `pause()`; the loop runs again once every hold has let go, provided the user
+ * still wants it running.
  */
 export class EmulationLoop extends EventTarget {
     constructor({
@@ -92,7 +95,9 @@ export class EmulationLoop extends EventTarget {
         this.tickToken = null;
         this.emulationLeadMs = 0;
         this.rewindCycleCounter = 0;
-        this.wasPreviouslyRunning = false;
+        this.wanted = false;
+        this.pauseDepth = 0;
+        this.resumeOnVisible = null;
 
         this.virtualSpeedUpdater = new VirtualSpeedUpdater(cpuSpeed);
         this.audioDebugLog = { start: 0, ticks: 0, cycles: 0, maxIdle: 0, maxExecute: 0, maxPaint: 0, maxSnapshot: 0 };
@@ -105,17 +110,41 @@ export class EmulationLoop extends EventTarget {
     }
 
     go() {
+        this.wanted = true;
+        if (this.pauseDepth === 0) this.start();
+    }
+
+    stop(debug) {
+        this.wanted = false;
+        this.halt();
+        if (debug) this.dbgr.debug(this.processor.pc);
+    }
+
+    /**
+     * Holds the machine stopped until the returned function is called. Holds
+     * nest, and letting go twice counts once.
+     */
+    pause() {
+        if (this.pauseDepth++ === 0 && this.running) this.halt();
+        let held = true;
+        return () => {
+            if (!held) return;
+            held = false;
+            if (--this.pauseDepth === 0 && this.wanted) this.start();
+        };
+    }
+
+    start() {
         this.audioHandler.unmute();
         this.running = true;
         this.dispatchEvent(new Event("running"));
         this.run();
     }
 
-    stop(debug) {
+    halt() {
         this.running = false;
         this.dispatchEvent(new Event("running"));
         this.processor.stop();
-        if (debug) this.dbgr.debug(this.processor.pc);
         this.audioHandler.mute();
     }
 
@@ -222,16 +251,12 @@ export class EmulationLoop extends EventTarget {
     handleVisibilityChange() {
         const { processor } = this;
         if (document.visibilityState === "hidden") {
-            this.wasPreviouslyRunning = this.running;
             const keepRunningWhenHidden =
                 processor.acia.motorOn || processor.fdc.motorOn[0] || processor.fdc.motorOn[1];
-            if (this.running && !keepRunningWhenHidden) {
-                this.stop(false);
-            }
-        } else {
-            if (this.wasPreviouslyRunning) {
-                this.go();
-            }
+            if (!keepRunningWhenHidden && !this.resumeOnVisible) this.resumeOnVisible = this.pause();
+        } else if (this.resumeOnVisible) {
+            this.resumeOnVisible();
+            this.resumeOnVisible = null;
         }
     }
 

--- a/src/web/emulation-loop.js
+++ b/src/web/emulation-loop.js
@@ -135,6 +135,7 @@ export class EmulationLoop extends EventTarget {
     }
 
     start() {
+        if (this.running) return;
         this.audioHandler.unmute();
         this.running = true;
         this.dispatchEvent(new Event("running"));

--- a/src/web/modals.js
+++ b/src/web/modals.js
@@ -15,13 +15,13 @@ export class Modals {
         this.aysEl = document.getElementById("are-you-sure");
         this.aysModal = new bootstrap.Modal(this.aysEl);
 
-        let savedRunning = false;
-        document.addEventListener("show.bs.modal", () => {
-            if (!this.anyVisible()) savedRunning = loop.isRunning();
-            if (loop.isRunning()) loop.stop(false);
+        const holds = new WeakMap();
+        document.addEventListener("show.bs.modal", (event) => {
+            if (!holds.has(event.target)) holds.set(event.target, loop.pause());
         });
-        document.addEventListener("hidden.bs.modal", () => {
-            if (!this.anyVisible() && savedRunning) loop.go();
+        document.addEventListener("hidden.bs.modal", (event) => {
+            holds.get(event.target)?.();
+            holds.delete(event.target);
         });
     }
 

--- a/src/web/modals.js
+++ b/src/web/modals.js
@@ -17,7 +17,7 @@ export class Modals {
 
         const holds = new WeakMap();
         document.addEventListener("show.bs.modal", (event) => {
-            if (!holds.has(event.target)) holds.set(event.target, loop.pause());
+            if (!holds.has(event.target)) holds.set(event.target, loop.pause(`the ${event.target.id} dialog`));
         });
         document.addEventListener("hidden.bs.modal", (event) => {
             holds.get(event.target)?.();

--- a/src/web/rewind-ui.js
+++ b/src/web/rewind-ui.js
@@ -53,12 +53,10 @@ export class RewindUI {
         this.snapshots = this.rewindBuffer.getAll();
         if (this.snapshots.length === 0) return;
 
-        this.resumeLoop = this.loop.pause();
-
+        this.resumeLoop = this.loop.pause("the rewind panel");
         this.isOpen = true;
-        this.savedState = this.processor.snapshotState();
-
         try {
+            this.savedState = this.processor.snapshotState();
             const thumbnails = renderThumbnails(
                 this.processor,
                 this.snapshots,
@@ -67,21 +65,20 @@ export class RewindUI {
                 this.savedState,
             );
             this._populateFilmstrip(thumbnails);
+            this.panel.hidden = false;
+            // Use capture phase so keys don't leak to the emulator's keyboard handler
+            document.addEventListener("keydown", this._onKeyDown, true);
+
+            // Select the newest snapshot ("now") and jump to it
+            this.selectedIndex = this.snapshots.length - 1;
+            this._restoreAndPaint(this.selectedIndex);
+            this._updateSelectionHighlight();
+            this.filmstrip.scrollLeft = this.filmstrip.scrollWidth;
         } catch (e) {
-            this.processor.restoreState(this.savedState);
+            if (this.savedState) this.processor.restoreState(this.savedState);
             this._closePanel();
             throw e;
         }
-
-        this.panel.hidden = false;
-        // Use capture phase so keys don't leak to the emulator's keyboard handler
-        document.addEventListener("keydown", this._onKeyDown, true);
-
-        // Select the newest snapshot ("now") and jump to it
-        this.selectedIndex = this.snapshots.length - 1;
-        this._restoreAndPaint(this.selectedIndex);
-        this._updateSelectionHighlight();
-        this.filmstrip.scrollLeft = this.filmstrip.scrollWidth;
     }
 
     /**

--- a/src/web/rewind-ui.js
+++ b/src/web/rewind-ui.js
@@ -26,7 +26,7 @@ export class RewindUI {
         this.openBtn = document.getElementById("rewind-open");
 
         this.isOpen = false;
-        this.wasRunning = false;
+        this.resumeLoop = null;
         this.selectedIndex = -1;
         this.snapshots = [];
         this.savedState = null;
@@ -53,8 +53,7 @@ export class RewindUI {
         this.snapshots = this.rewindBuffer.getAll();
         if (this.snapshots.length === 0) return;
 
-        this.wasRunning = this.loop.isRunning();
-        if (this.wasRunning) this.loop.stop(false);
+        this.resumeLoop = this.loop.pause();
 
         this.isOpen = true;
         this.savedState = this.processor.snapshotState();
@@ -71,7 +70,6 @@ export class RewindUI {
         } catch (e) {
             this.processor.restoreState(this.savedState);
             this._closePanel();
-            if (this.wasRunning) this.loop.go();
             throw e;
         }
 
@@ -98,7 +96,6 @@ export class RewindUI {
             this.processor.restoreState(this.snapshots[this.selectedIndex]);
         }
         this._closePanel();
-        if (this.wasRunning) this.loop.go();
     }
 
     /**
@@ -108,7 +105,6 @@ export class RewindUI {
         if (!this.isOpen) return;
         this._renderState(this.savedState);
         this._closePanel();
-        if (this.wasRunning) this.loop.go();
     }
 
     /** Alias for cancel — closing the panel without explicit commit cancels. */
@@ -144,6 +140,8 @@ export class RewindUI {
         this.snapshots = [];
         this.savedState = null;
         document.removeEventListener("keydown", this._onKeyDown, true);
+        this.resumeLoop?.();
+        this.resumeLoop = null;
     }
 
     /**

--- a/src/web/snapshot-ui.js
+++ b/src/web/snapshot-ui.js
@@ -113,8 +113,7 @@ export class SnapshotUI {
     }
 
     async saveState() {
-        const wasRunning = this.loop.isRunning();
-        if (wasRunning) this.loop.stop(false);
+        const resume = this.loop.pause();
         let failure = null;
         try {
             const manifest = snapshotMedia(this.processor.fdc.drives, this.urlState.params, this.defaultBootDisc);
@@ -125,16 +124,14 @@ export class SnapshotUI {
             downloadBlob(blob, `jsbeeb-${this.model.name}-${timestamp}.json.gz`);
         } catch (e) {
             failure = e;
+        } finally {
+            resume();
         }
-        // Resume before reporting failure: the error dialog pauses a running
-        // loop itself, and resumes it on close.
-        if (wasRunning) this.loop.go();
         if (failure) this.modals.showError("saving state", failure);
     }
 
     async loadStateFromFile(file, preReadBuffer) {
-        const wasRunning = this.loop.isRunning();
-        if (wasRunning) this.loop.stop(false);
+        const resume = this.loop.pause();
         let failure = null;
         try {
             const arrayBuffer = preReadBuffer || (await file.arrayBuffer());
@@ -153,8 +150,9 @@ export class SnapshotUI {
             this.video.paint();
         } catch (e) {
             failure = e;
+        } finally {
+            resume();
         }
-        if (wasRunning) this.loop.go();
         if (failure) this.modals.showError("loading state", failure);
     }
 

--- a/src/web/snapshot-ui.js
+++ b/src/web/snapshot-ui.js
@@ -113,7 +113,7 @@ export class SnapshotUI {
     }
 
     async saveState() {
-        const resume = this.loop.pause();
+        const resume = this.loop.pause("saving state");
         try {
             const manifest = snapshotMedia(this.processor.fdc.drives, this.urlState.params, this.defaultBootDisc);
             const snapshot = createSnapshot(this.processor, this.model, manifest);
@@ -129,7 +129,7 @@ export class SnapshotUI {
     }
 
     async loadStateFromFile(file, preReadBuffer) {
-        const resume = this.loop.pause();
+        const resume = this.loop.pause("loading state");
         try {
             const arrayBuffer = preReadBuffer || (await file.arrayBuffer());
             const snapshot = await readSnapshot(arrayBuffer);

--- a/src/web/snapshot-ui.js
+++ b/src/web/snapshot-ui.js
@@ -114,7 +114,6 @@ export class SnapshotUI {
 
     async saveState() {
         const resume = this.loop.pause();
-        let failure = null;
         try {
             const manifest = snapshotMedia(this.processor.fdc.drives, this.urlState.params, this.defaultBootDisc);
             const snapshot = createSnapshot(this.processor, this.model, manifest);
@@ -123,16 +122,14 @@ export class SnapshotUI {
             const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
             downloadBlob(blob, `jsbeeb-${this.model.name}-${timestamp}.json.gz`);
         } catch (e) {
-            failure = e;
+            this.modals.showError("saving state", e);
         } finally {
             resume();
         }
-        if (failure) this.modals.showError("saving state", failure);
     }
 
     async loadStateFromFile(file, preReadBuffer) {
         const resume = this.loop.pause();
-        let failure = null;
         try {
             const arrayBuffer = preReadBuffer || (await file.arrayBuffer());
             const snapshot = await readSnapshot(arrayBuffer);
@@ -149,11 +146,10 @@ export class SnapshotUI {
             // Force a repaint so the display updates even while paused
             this.video.paint();
         } catch (e) {
-            failure = e;
+            this.modals.showError("loading state", e);
         } finally {
             resume();
         }
-        if (failure) this.modals.showError("loading state", failure);
     }
 
     /** Picks up the state a cross-model reload stashed, once the matching machine is up. */

--- a/tests/unit/test-emulation-loop.js
+++ b/tests/unit/test-emulation-loop.js
@@ -182,7 +182,7 @@ describe("EmulationLoop", () => {
     describe("being held", () => {
         it("stops while held and runs again once let go", () => {
             const loop = started();
-            const resume = loop.pause();
+            const resume = loop.pause("the test");
             expect(loop.isRunning()).toBe(false);
             expect(deps.audioHandler.mute).toHaveBeenCalled();
             resume();
@@ -191,8 +191,8 @@ describe("EmulationLoop", () => {
 
         it("runs again only when the last hold has let go", () => {
             const loop = started();
-            const first = loop.pause();
-            const second = loop.pause();
+            const first = loop.pause("the test");
+            const second = loop.pause("the test");
             first();
             expect(loop.isRunning()).toBe(false);
             second();
@@ -201,8 +201,8 @@ describe("EmulationLoop", () => {
 
         it("counts letting go twice as once", () => {
             const loop = started();
-            const first = loop.pause();
-            const second = loop.pause();
+            const first = loop.pause("the test");
+            const second = loop.pause("the test");
             first();
             first();
             expect(loop.isRunning()).toBe(false);
@@ -212,24 +212,27 @@ describe("EmulationLoop", () => {
 
         it("stays stopped if the user stopped it while held", () => {
             const loop = started();
-            const resume = loop.pause();
+            const resume = loop.pause("the test");
             loop.stop(false);
             resume();
             expect(loop.isRunning()).toBe(false);
         });
 
-        it("waits for the hold to end before honouring a go", () => {
+        it("waits for the hold to end before honouring a go, and says who is holding", () => {
+            const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
             const loop = make();
-            const resume = loop.pause();
+            const resume = loop.pause("the test");
+            loop.pause("another test");
             loop.go();
             expect(loop.isRunning()).toBe(false);
+            expect(warn).toHaveBeenCalledWith(expect.stringContaining("held by the test, another test"));
             resume();
-            expect(loop.isRunning()).toBe(true);
+            expect(loop.isRunning()).toBe(false);
         });
 
         it("leaves a stopped machine stopped when let go", () => {
             const loop = make();
-            loop.pause()();
+            loop.pause("the test")();
             expect(loop.isRunning()).toBe(false);
             expect(deps.audioHandler.unmute).not.toHaveBeenCalled();
         });
@@ -275,7 +278,7 @@ describe("EmulationLoop", () => {
 
         it("stays held for whoever else is holding it when the tab comes back", () => {
             const loop = started();
-            const resume = loop.pause();
+            const resume = loop.pause("the test");
             hide();
             show();
             expect(loop.isRunning()).toBe(false);

--- a/tests/unit/test-emulation-loop.js
+++ b/tests/unit/test-emulation-loop.js
@@ -173,6 +173,62 @@ describe("EmulationLoop", () => {
         expect(deps.rewindBuffer.push).toHaveBeenCalledTimes(2);
     });
 
+    describe("being held", () => {
+        it("stops while held and runs again once let go", () => {
+            const loop = started();
+            const resume = loop.pause();
+            expect(loop.isRunning()).toBe(false);
+            expect(deps.audioHandler.mute).toHaveBeenCalled();
+            resume();
+            expect(loop.isRunning()).toBe(true);
+        });
+
+        it("runs again only when the last hold has let go", () => {
+            const loop = started();
+            const first = loop.pause();
+            const second = loop.pause();
+            first();
+            expect(loop.isRunning()).toBe(false);
+            second();
+            expect(loop.isRunning()).toBe(true);
+        });
+
+        it("counts letting go twice as once", () => {
+            const loop = started();
+            const first = loop.pause();
+            const second = loop.pause();
+            first();
+            first();
+            expect(loop.isRunning()).toBe(false);
+            second();
+            expect(loop.isRunning()).toBe(true);
+        });
+
+        it("stays stopped if the user stopped it while held", () => {
+            const loop = started();
+            const resume = loop.pause();
+            loop.stop(false);
+            resume();
+            expect(loop.isRunning()).toBe(false);
+        });
+
+        it("waits for the hold to end before honouring a go", () => {
+            const loop = make();
+            const resume = loop.pause();
+            loop.go();
+            expect(loop.isRunning()).toBe(false);
+            resume();
+            expect(loop.isRunning()).toBe(true);
+        });
+
+        it("leaves a stopped machine stopped when let go", () => {
+            const loop = make();
+            loop.pause()();
+            expect(loop.isRunning()).toBe(false);
+            expect(deps.audioHandler.unmute).not.toHaveBeenCalled();
+        });
+    });
+
     describe("a hidden tab", () => {
         let visibility;
         beforeEach(() => {
@@ -209,6 +265,16 @@ describe("EmulationLoop", () => {
             hide();
             show();
             expect(loop.isRunning()).toBe(false);
+        });
+
+        it("stays held for whoever else is holding it when the tab comes back", () => {
+            const loop = started();
+            const resume = loop.pause();
+            hide();
+            show();
+            expect(loop.isRunning()).toBe(false);
+            resume();
+            expect(loop.isRunning()).toBe(true);
         });
     });
 

--- a/tests/unit/test-emulation-loop.js
+++ b/tests/unit/test-emulation-loop.js
@@ -173,6 +173,12 @@ describe("EmulationLoop", () => {
         expect(deps.rewindBuffer.push).toHaveBeenCalledTimes(2);
     });
 
+    it("starts once however often it is asked to go", () => {
+        const loop = started();
+        loop.go();
+        expect(deps.audioHandler.unmute).toHaveBeenCalledTimes(1);
+    });
+
     describe("being held", () => {
         it("stops while held and runs again once let go", () => {
             const loop = started();

--- a/tests/unit/test-modals.js
+++ b/tests/unit/test-modals.js
@@ -37,7 +37,7 @@ describe("Modals", () => {
     describe("holding the emulator", () => {
         it("holds the emulator while a modal is up and lets go when it goes", () => {
             raise("info");
-            expect(loop.pause).toHaveBeenCalledTimes(1);
+            expect(loop.pause).toHaveBeenCalledWith("the info dialog");
             expect(resumes()[0]).not.toHaveBeenCalled();
             lower("info");
             expect(resumes()[0]).toHaveBeenCalledTimes(1);

--- a/tests/unit/test-modals.js
+++ b/tests/unit/test-modals.js
@@ -5,29 +5,21 @@ import { Modals } from "../../src/web/modals.js";
 import { domFromIndexHtml, teardownDom, toasts } from "./helpers.js";
 
 describe("Modals", () => {
-    let emulator;
+    let loop;
     let modals;
 
     beforeEach(() => {
         vi.useFakeTimers();
         domFromIndexHtml("error-dialog", "loading-dialog", "are-you-sure", "info", "discs");
-        emulator = { running: true, stop: vi.fn(), go: vi.fn() };
-        modals = new Modals({
-            loop: {
-                isRunning: () => emulator.running,
-                stop: (debug) => {
-                    emulator.running = false;
-                    emulator.stop(debug);
-                },
-                go: () => {
-                    emulator.running = true;
-                    emulator.go();
-                },
-            },
-        });
+        loop = { pause: vi.fn(() => vi.fn()) };
+        modals = new Modals({ loop });
     });
 
     afterEach(teardownDom);
+
+    // The resume handles this test's Modals took, in order. Earlier tests'
+    // instances still listen on the shared document, but call their own loop.
+    const resumes = () => loop.pause.mock.results.map((result) => result.value);
 
     // What Bootstrap does around a modal: the events bubble up to the
     // document, and the element carries "show" while it is up.
@@ -42,38 +34,30 @@ describe("Modals", () => {
         el.dispatchEvent(new Event("hidden.bs.modal", { bubbles: true }));
     };
 
-    describe("pausing the emulator", () => {
-        it("stops the emulator when a modal appears and starts it again when it goes", () => {
+    describe("holding the emulator", () => {
+        it("holds the emulator while a modal is up and lets go when it goes", () => {
             raise("info");
-            expect(emulator.stop).toHaveBeenCalledWith(false);
-            expect(emulator.go).not.toHaveBeenCalled();
+            expect(loop.pause).toHaveBeenCalledTimes(1);
+            expect(resumes()[0]).not.toHaveBeenCalled();
             lower("info");
-            expect(emulator.go).toHaveBeenCalledTimes(1);
+            expect(resumes()[0]).toHaveBeenCalledTimes(1);
         });
 
-        it("leaves a stopped emulator stopped", () => {
-            emulator.running = false;
-            raise("info");
-            lower("info");
-            expect(emulator.stop).not.toHaveBeenCalled();
-            expect(emulator.go).not.toHaveBeenCalled();
-        });
-
-        it("waits for the last of several modals before resuming", () => {
+        it("takes one hold per modal and lets each go with its own", () => {
             raise("info");
             raise("discs");
-            lower("discs");
-            expect(emulator.go).not.toHaveBeenCalled();
+            expect(loop.pause).toHaveBeenCalledTimes(2);
             lower("info");
-            expect(emulator.go).toHaveBeenCalledTimes(1);
+            expect(resumes()[0]).toHaveBeenCalledTimes(1);
+            expect(resumes()[1]).not.toHaveBeenCalled();
+            lower("discs");
+            expect(resumes()[1]).toHaveBeenCalledTimes(1);
         });
 
-        it("remembers the state from before the first modal, not the second", () => {
+        it("does not take a second hold when a modal is shown twice", () => {
             raise("info");
-            raise("discs");
-            lower("info");
-            lower("discs");
-            expect(emulator.go).toHaveBeenCalledTimes(1);
+            raise("info");
+            expect(loop.pause).toHaveBeenCalledTimes(1);
         });
 
         it("reports whether any modal is up", () => {

--- a/tests/unit/test-rewind-ui.js
+++ b/tests/unit/test-rewind-ui.js
@@ -15,7 +15,7 @@ describe("RewindUI", () => {
     let rewindBuffer;
     let video;
     let processor;
-    let running;
+    let resume;
     let loop;
 
     beforeEach(() => {
@@ -36,8 +36,8 @@ describe("RewindUI", () => {
                 video.frameCount++;
             }),
         };
-        running = true;
-        loop = { isRunning: () => running, stop: vi.fn(() => (running = false)), go: vi.fn(() => (running = true)) };
+        resume = vi.fn();
+        loop = { pause: vi.fn(() => resume) };
     });
 
     afterEach(teardownDom);
@@ -59,14 +59,14 @@ describe("RewindUI", () => {
         it("does nothing when nothing has been captured", () => {
             make().open();
             expect(panel().hidden).toBe(true);
-            expect(loop.stop).not.toHaveBeenCalled();
+            expect(loop.pause).not.toHaveBeenCalled();
         });
 
         it("pauses, fills the filmstrip with ages, and lands on now", () => {
             const snapshots = captured(3);
             make();
             document.getElementById("rewind-open").click();
-            expect(loop.stop).toHaveBeenCalledWith(false);
+            expect(loop.pause).toHaveBeenCalledTimes(1);
             expect(panel().hidden).toBe(false);
             expect(thumbs().map((thumb) => thumb.querySelector(".rewind-thumb-label").textContent)).toEqual([
                 "-2s",
@@ -83,7 +83,7 @@ describe("RewindUI", () => {
             const ui = make();
             ui.open();
             ui.open();
-            expect(loop.stop).toHaveBeenCalledTimes(1);
+            expect(loop.pause).toHaveBeenCalledTimes(1);
             expect(thumbs()).toHaveLength(1);
         });
     });
@@ -129,7 +129,7 @@ describe("RewindUI", () => {
             expect(lastRestored()).toBe(snapshots[0]);
             expect(panel().hidden).toBe(true);
             expect(thumbs()).toHaveLength(0);
-            expect(loop.go).toHaveBeenCalledTimes(1);
+            expect(resume).toHaveBeenCalledTimes(1);
         });
 
         it("cancels back to the state from before it opened on Escape", () => {
@@ -139,7 +139,7 @@ describe("RewindUI", () => {
             key("Escape");
             expect(lastRestored()).toEqual({ live: true });
             expect(panel().hidden).toBe(true);
-            expect(loop.go).toHaveBeenCalledTimes(1);
+            expect(resume).toHaveBeenCalledTimes(1);
         });
 
         it("cancels from the close button", () => {
@@ -158,14 +158,12 @@ describe("RewindUI", () => {
             expect(processor.restoreState).not.toHaveBeenCalled();
         });
 
-        it("leaves a machine that was paused before opening paused", () => {
+        it("lets go of its hold when it is reset", () => {
             captured(1);
-            running = false;
             const ui = make();
             ui.open();
-            ui.commit();
-            expect(loop.stop).not.toHaveBeenCalled();
-            expect(loop.go).not.toHaveBeenCalled();
+            ui.reset();
+            expect(resume).toHaveBeenCalledTimes(1);
         });
     });
 

--- a/tests/unit/test-rewind-ui.js
+++ b/tests/unit/test-rewind-ui.js
@@ -66,7 +66,7 @@ describe("RewindUI", () => {
             const snapshots = captured(3);
             make();
             document.getElementById("rewind-open").click();
-            expect(loop.pause).toHaveBeenCalledTimes(1);
+            expect(loop.pause).toHaveBeenCalledWith("the rewind panel");
             expect(panel().hidden).toBe(false);
             expect(thumbs().map((thumb) => thumb.querySelector(".rewind-thumb-label").textContent)).toEqual([
                 "-2s",
@@ -76,6 +76,18 @@ describe("RewindUI", () => {
             expect(selectedIndex()).toBe(2);
             expect(lastRestored()).toBe(snapshots[2]);
             expect(video.paint).toHaveBeenCalled();
+        });
+
+        it("lets go and stays closed if the machine cannot be snapshotted", () => {
+            captured(1);
+            processor.snapshotState.mockImplementation(() => {
+                throw new Error("no snapshot");
+            });
+            const ui = make();
+            expect(() => ui.open()).toThrow("no snapshot");
+            expect(panel().hidden).toBe(true);
+            expect(resume).toHaveBeenCalledTimes(1);
+            expect(processor.restoreState).not.toHaveBeenCalled();
         });
 
         it("opens once no matter how often it is asked", () => {

--- a/tests/unit/test-snapshot-ui.js
+++ b/tests/unit/test-snapshot-ui.js
@@ -88,8 +88,10 @@ describe("isSnapshotFile", () => {
 
 describe("SnapshotUI", () => {
     let deps;
+    let resume;
 
     beforeEach(() => {
+        resume = vi.fn();
         domFromIndexHtml("save-state", "load-state");
         deps = {
             processor: { fdc: { drives: [{ disc: null }, { disc: null }] }, hasTube: false, execute: vi.fn() },
@@ -99,7 +101,7 @@ describe("SnapshotUI", () => {
             drives: { putDiscIn: vi.fn() },
             urlState: { params: {}, urlWith: vi.fn() },
             modals: { showError: vi.fn() },
-            loop: { isRunning: () => true, stop: vi.fn(), go: vi.fn() },
+            loop: { pause: vi.fn(() => resume) },
         };
     });
 
@@ -108,18 +110,11 @@ describe("SnapshotUI", () => {
     const make = () => new SnapshotUI(deps);
 
     describe("loading a state", () => {
-        it("stops the emulator, reports a file it cannot read, and runs on", async () => {
+        it("holds the emulator, reports a file it cannot read, and lets go", async () => {
             await make().loadStateFromFile(null, new Uint8Array([0x00, 0x01, 0x02]).buffer);
-            expect(deps.loop.stop).toHaveBeenCalledWith(false);
+            expect(deps.loop.pause).toHaveBeenCalledTimes(1);
             expect(deps.modals.showError).toHaveBeenCalledWith("loading state", expect.anything());
-            expect(deps.loop.go).toHaveBeenCalledTimes(1);
-        });
-
-        it("leaves a stopped emulator stopped afterwards", async () => {
-            deps.loop.isRunning = () => false;
-            await make().loadStateFromFile(null, new Uint8Array([0]).buffer);
-            expect(deps.loop.stop).not.toHaveBeenCalled();
-            expect(deps.loop.go).not.toHaveBeenCalled();
+            expect(resume).toHaveBeenCalledTimes(1);
         });
 
         const snapshotBuffer = (snapshot) =>
@@ -133,7 +128,7 @@ describe("SnapshotUI", () => {
             expect(window.location.hash).toBe("#stashed");
             expect(JSON.parse(sessionStorage.getItem("jsbeeb-pending-state")).model).toBe("Master");
             expect(deps.video.paint).not.toHaveBeenCalled();
-            expect(deps.loop.go).not.toHaveBeenCalled();
+            expect(resume).toHaveBeenCalledTimes(1);
             window.location.hash = "";
         });
 
@@ -152,7 +147,7 @@ describe("SnapshotUI", () => {
             expect(deps.video.paint).toHaveBeenCalledTimes(1);
             expect(deps.modals.showError).not.toHaveBeenCalled();
             expect(sessionStorage.getItem("jsbeeb-pending-state")).toBeNull();
-            expect(deps.loop.go).toHaveBeenCalledTimes(1);
+            expect(resume).toHaveBeenCalledTimes(1);
         });
     });
 
@@ -164,15 +159,17 @@ describe("SnapshotUI", () => {
             domFromIndexHtml("error-dialog", "loading-dialog", "are-you-sure");
             vi.useFakeTimers();
             loop = {
-                running: true,
+                holds: 0,
                 isRunning() {
-                    return this.running;
+                    return this.holds === 0;
                 },
-                stop() {
-                    this.running = false;
-                },
-                go() {
-                    this.running = true;
+                pause() {
+                    this.holds++;
+                    let held = true;
+                    return () => {
+                        if (held) this.holds--;
+                        held = false;
+                    };
                 },
             };
             modals = new Modals({ loop });
@@ -205,18 +202,6 @@ describe("SnapshotUI", () => {
             const ui = makeWithModals();
             await ui.loadStateFromFile(null, new Uint8Array([0x00, 0x01, 0x02]).buffer);
             await expectPausedBehindDialogThenResumedOnClose();
-        });
-
-        it("leaves a stopped emulator stopped after the error dialog closes", async () => {
-            const ui = makeWithModals();
-            loop.running = false;
-            await ui.loadStateFromFile(null, new Uint8Array([0x00, 0x01, 0x02]).buffer);
-            await vi.runAllTimersAsync();
-            expect(modals.anyVisible()).toBe(true);
-            expect(loop.isRunning()).toBe(false);
-            modals.hide("error-dialog");
-            await vi.runAllTimersAsync();
-            expect(loop.isRunning()).toBe(false);
         });
     });
 

--- a/tests/unit/test-snapshot-ui.js
+++ b/tests/unit/test-snapshot-ui.js
@@ -112,7 +112,7 @@ describe("SnapshotUI", () => {
     describe("loading a state", () => {
         it("holds the emulator, reports a file it cannot read, and lets go", async () => {
             await make().loadStateFromFile(null, new Uint8Array([0x00, 0x01, 0x02]).buffer);
-            expect(deps.loop.pause).toHaveBeenCalledTimes(1);
+            expect(deps.loop.pause).toHaveBeenCalledWith("loading state");
             expect(deps.modals.showError).toHaveBeenCalledWith("loading state", expect.anything());
             expect(resume).toHaveBeenCalledTimes(1);
         });


### PR DESCRIPTION
Theme B of #1002.

**Before.** Four owners each remembered whether the machine had been running so they could put it back: `Modals` (a `savedRunning` latch guarded by `anyVisible()`, the #1001 item 2 fix), `SnapshotUI.saveState` and `loadStateFromFile` (a local `wasRunning` each), `RewindUI` (`this.wasRunning` across open, commit and cancel) and the loop's own hidden-tab handler (`wasPreviouslyRunning`). Each latch only knew its own owner: when they nested, the inner one looked after the outer one had already stopped the loop and recorded "not running". The comment in snapshot-ui ("resume before reporting failure: the error dialog pauses a running loop itself") existed to keep two of them from colliding.

**After.** `EmulationLoop` holds a pause depth and the user's intent separately. `pause()` halts the machine on the first hold and returns a resume function; the machine runs again when the last hold has let go, and only if `go()` was the last thing the user asked for. Resume handles are idempotent, so a `cancel` after a `commit`, or a `finally` after an early return, cannot double-release. `go()` and `stop()` remain the user's verbs and set the intent; `stop(true)` into the debugger is unchanged.

Each former owner is now a plain holder: `Modals` takes one hold per modal element (a `WeakMap` from element to its resume, so stacked dialogs need no `anyVisible()` guard), the snapshot paths release in `finally`, `RewindUI` releases in `_closePanel`, and the hidden-tab handler is a hold too, so a tab hidden and shown while a dialog is open no longer restarts the loop under the dialog.

**One deliberate change.** A `go()` while something holds the machine (the rewind panel open, say) used to start the loop regardless. It is now honoured once the holds are gone, so nothing runs under a dialog or the rewind filmstrip.

**Leaked holds.** That change means a hold that is never released cannot be cleared from the UI, where the old latches could always be overridden by pressing resume. Snapshot save and load release in `finally`, and the hidden-tab hold is guarded against stacking, so neither can leak. `RewindUI.open` could: it snapshotted the machine after taking the hold but outside its `try`, so a throwing `snapshotState` left the hold in place for good (the old `wasRunning` leaked the same way, but was recoverable). Everything after the hold now runs inside the `try`, and every failure reaches `_closePanel`, which releases. `Modals` relies on Bootstrap pairing `show.bs.modal` with a later `hidden.bs.modal` on the same element; nothing in jsbeeb cancels a show or disposes a modal, so that pairing holds today. Holds carry a reason, and a `go()` that has to wait logs who is holding, so if a hold ever does leak it is named in the console rather than guessed at. There is deliberately no force-release: a second `go()` clearing the holds would hide exactly the bug the warning is there to expose.

Loop unit tests pin the depth semantics (nesting, idempotent release, user stop while held, go while held, a stopped machine staying stopped, a hidden tab under another hold). The three owners' tests assert on holds taken and released rather than on `stop`/`go` calls; the intent cases they used to carry belong to the loop now and live there. The modals test was also made immune to a pre-existing leak: earlier tests' `Modals` instances keep listening on the shared jsdom document.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
