### PR TITLE
test: scale test workers to the machine and use its GPU for e2e

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,7 +17,9 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 - `npm run test:e2e` - Build, then drive the built page in the system Chrome with Playwright and check the things
   unit tests cannot see (main.js constructing everything against the built bundle, Bootstrap layout at real widths, a
   real keystroke, WebGL and WebAudio). Part of `npm test`, and needs Chrome like the shader tests;
-  `BASE_URL=http://localhost:5173/ npx playwright test --project chrome` runs it against a server that is already up
+  `BASE_URL=http://localhost:5173/ npx playwright test --project chrome` runs it against a server that is already up.
+  Chrome uses the machine's GPU when it has one and the software renderer otherwise, which is what CI runs;
+  `E2E_GL=software` or `E2E_GL=hardware` forces one
 - `npm run ci-checks` - Run linting checks for CI
 - `vitest run tests/unit/test-gzip.js` - Run a single test file
 

--- a/package.json
+++ b/package.json
@@ -121,7 +121,7 @@
   },
   "lint-staged": {
     "*.js": [
-      "vitest related --run --exclude tests/integration --exclude tests/shader --no-file-parallelism",
+      "vitest related --run --project unit --no-file-parallelism",
       "eslint --cache --fix",
       "prettier --write"
     ],

--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
     "test:cpu": "node tests/test-suite.js",
     "test:shader": "vitest run --silent=true tests/shader",
     "coverage:unit": "vitest run tests/unit --coverage",
-    "dom-unit-tests": "vitest run --silent=true --exclude tests/integration --exclude tests/shader $(grep -rl domFromIndexHtml tests/unit)",
+    "dom-unit-tests": "vitest run --silent=true --project unit $(grep -rl domFromIndexHtml tests/unit)",
     "coverage:all-tests": "vitest run --coverage",
     "benchmark": "node src/app-bench.js",
     "mirror-sth": "node tools/mirror-sth.js --out .sth-mirror",

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -1,4 +1,5 @@
 import { defineConfig } from "@playwright/test";
+import { existsSync } from "node:fs";
 
 import { workersFor } from "./tools/test-workers.js";
 
@@ -9,6 +10,18 @@ const PreviewHost = "127.0.0.1";
 const PreviewPort = 5198;
 const PreviewUrl = `http://${PreviewHost}:${PreviewPort}/`;
 const BaseUrl = process.env.BASE_URL;
+
+// CI's runners have no GPU, so the software renderer is what CI tests. On a
+// machine with one, Chrome is pointed at it instead: a filter's shaders then
+// compile in an instant rather than the minute a paging laptop has taken.
+// E2E_GL=software or E2E_GL=hardware overrides the choice.
+const RenderNode = "/dev/dri/renderD128";
+const GlArgs = {
+    software: ["--use-gl=angle", "--use-angle=swiftshader"],
+    hardware: ["--use-gl=angle", "--use-angle=gl", "--ignore-gpu-blocklist"],
+};
+const Gl = process.env.E2E_GL ?? (process.env.CI || !existsSync(RenderNode) ? "software" : "hardware");
+if (!GlArgs[Gl]) throw new Error(`E2E_GL must be one of ${Object.keys(GlArgs).join(", ")}, not "${Gl}"`);
 
 export default defineConfig({
     testDir: "tests/playwright",
@@ -27,15 +40,16 @@ export default defineConfig({
     expect: { timeout: 10000 },
     use: {
         // Without this a click on a selector that matches nothing waits out
-        // the whole test timeout.
-        actionTimeout: 10000,
+        // the whole test timeout; a laptop that is paging has held an honest
+        // click for ten seconds.
+        actionTimeout: 30000,
         baseURL: BaseUrl ?? PreviewUrl,
         viewport: { width: 1400, height: 900 },
         trace: "retain-on-failure",
         launchOptions: {
             // Playwright's own headless switches already mute audio and keep
             // shared memory out of /dev/shm; these are what the app needs on top.
-            args: ["--use-gl=angle", "--use-angle=swiftshader", "--autoplay-policy=no-user-gesture-required"],
+            args: [...GlArgs[Gl], "--autoplay-policy=no-user-gesture-required"],
         },
     },
     projects: [

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -12,8 +12,8 @@ const PreviewUrl = `http://${PreviewHost}:${PreviewPort}/`;
 const BaseUrl = process.env.BASE_URL;
 
 // CI's runners have no GPU, so the software renderer is what CI tests. On a
-// machine with one, Chrome is pointed at it instead: a filter's shaders then
-// compile in an instant rather than the minute a paging laptop has taken.
+// machine with one, Chrome is pointed at it instead, which takes a filter's
+// shader compile from tens of seconds to an instant.
 // E2E_GL=software or E2E_GL=hardware overrides the choice.
 const RenderNode = "/dev/dri/renderD128";
 const GlArgs = {
@@ -29,19 +29,17 @@ export default defineConfig({
     forbidOnly: !!process.env.CI,
     // Deliberately none, anywhere: a flake is a bug to root-cause.
     retries: 0,
-    // Each worker is a whole Chrome running the machine in real time; a 15GB
-    // laptop showed four of them paging each other to death. One worker per
-    // eight hardware threads keeps small machines serial and big ones parallel.
+    // Each worker is a whole Chrome running the machine in real time. One worker
+    // per eight hardware threads keeps small machines serial and big ones parallel.
     workers: process.env.CI ? 2 : workersFor(8, 4),
     reporter: process.env.CI ? [["list"], ["github"], ["html", { open: "never" }]] : "list",
-    // A hang detector. The dearest test compiles three filters' shaders under
-    // software GL, which a laptop that is paging has taken over a minute to do.
+    // A hang detector: the dearest test compiles three filters' shaders, which
+    // under software GL can run to minutes.
     timeout: 180000,
     expect: { timeout: 10000 },
     use: {
         // Without this a click on a selector that matches nothing waits out
-        // the whole test timeout; a laptop that is paging has held an honest
-        // click for ten seconds.
+        // the whole test timeout.
         actionTimeout: 30000,
         baseURL: BaseUrl ?? PreviewUrl,
         viewport: { width: 1400, height: 900 },

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -1,5 +1,5 @@
 import { defineConfig } from "@playwright/test";
-import { existsSync } from "node:fs";
+import { readdirSync } from "node:fs";
 
 import { workersFor } from "./tools/test-workers.js";
 
@@ -15,12 +15,18 @@ const BaseUrl = process.env.BASE_URL;
 // machine with one, Chrome is pointed at it instead, which takes a filter's
 // shader compile from tens of seconds to an instant.
 // E2E_GL=software or E2E_GL=hardware overrides the choice.
-const RenderNode = "/dev/dri/renderD128";
 const GlArgs = {
     software: ["--use-gl=angle", "--use-angle=swiftshader"],
     hardware: ["--use-gl=angle", "--use-angle=gl", "--ignore-gpu-blocklist"],
 };
-const Gl = process.env.E2E_GL ?? (process.env.CI || !existsSync(RenderNode) ? "software" : "hardware");
+const hasGpu = () => {
+    try {
+        return readdirSync("/dev/dri").some((node) => /^(card|renderD)\d+$/.test(node));
+    } catch {
+        return false;
+    }
+};
+const Gl = process.env.E2E_GL ?? (process.env.CI || !hasGpu() ? "software" : "hardware");
 if (!GlArgs[Gl]) throw new Error(`E2E_GL must be one of ${Object.keys(GlArgs).join(", ")}, not "${Gl}"`);
 
 export default defineConfig({
@@ -33,14 +39,12 @@ export default defineConfig({
     // per eight hardware threads keeps small machines serial and big ones parallel.
     workers: process.env.CI ? 2 : workersFor(8, 4),
     reporter: process.env.CI ? [["list"], ["github"], ["html", { open: "never" }]] : "list",
-    // A hang detector: the dearest test compiles three filters' shaders, which
-    // under software GL can run to minutes.
-    timeout: 180000,
+    timeout: 60000,
     expect: { timeout: 10000 },
     use: {
         // Without this a click on a selector that matches nothing waits out
         // the whole test timeout.
-        actionTimeout: 30000,
+        actionTimeout: 10000,
         baseURL: BaseUrl ?? PreviewUrl,
         viewport: { width: 1400, height: 900 },
         trace: "retain-on-failure",

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -1,5 +1,6 @@
 import { defineConfig } from "@playwright/test";
-import os from "node:os";
+
+import { workersFor } from "./tools/test-workers.js";
 
 // The preview of dist/ the tests drive, on a port of its own so a dev server
 // can run alongside. BASE_URL points the suite at a server that is already
@@ -15,13 +16,14 @@ export default defineConfig({
     forbidOnly: !!process.env.CI,
     // Deliberately none, anywhere: a flake is a bug to root-cause.
     retries: 0,
-    // Each worker is a whole Chrome running the machine in real time, and
-    // starved emulators time out rather than slow down; a 15GB laptop showed
-    // four of them paging each other to death. One worker per eight hardware
-    // threads keeps small machines serial and big ones parallel.
-    workers: process.env.CI ? 2 : Math.max(1, Math.min(4, Math.floor(os.availableParallelism() / 8))),
+    // Each worker is a whole Chrome running the machine in real time; a 15GB
+    // laptop showed four of them paging each other to death. One worker per
+    // eight hardware threads keeps small machines serial and big ones parallel.
+    workers: process.env.CI ? 2 : workersFor(8, 4),
     reporter: process.env.CI ? [["list"], ["github"], ["html", { open: "never" }]] : "list",
-    timeout: 60000,
+    // A hang detector. The dearest test compiles three filters' shaders under
+    // software GL, which a laptop that is paging has taken over a minute to do.
+    timeout: 180000,
     expect: { timeout: 10000 },
     use: {
         // Without this a click on a selector that matches nothing waits out

--- a/tests/integration/atom-hardware.js
+++ b/tests/integration/atom-hardware.js
@@ -1,7 +1,7 @@
 import { describe, it, expect } from "vitest";
 import { TestMachine } from "../test-machine.js";
 
-describe("Atom hardware", { timeout: 30000 }, () => {
+describe("Atom hardware", () => {
     let machine;
 
     async function bootAtom() {

--- a/tests/integration/bcd.js
+++ b/tests/integration/bcd.js
@@ -2,7 +2,7 @@ import { describe, it } from "vitest";
 import { TestMachine } from "../test-machine.js";
 import assert from "assert";
 
-describe("test binary coded decimal behaviour", { timeout: 30000 }, function () {
+describe("test binary coded decimal behaviour", function () {
     const doTest = async (model) => {
         const testMachine = new TestMachine(model);
         await testMachine.initialise();

--- a/tests/integration/disc-layout.js
+++ b/tests/integration/disc-layout.js
@@ -30,7 +30,7 @@ function fortyTrackImage(name, fileSector, fill) {
     return data;
 }
 
-describe("disc track layouts", { timeout: 60000 }, function () {
+describe("disc track layouts", function () {
     async function machineWith(image) {
         const testMachine = new TestMachine();
         await testMachine.initialise();

--- a/tests/integration/dormann.js
+++ b/tests/integration/dormann.js
@@ -82,7 +82,7 @@ function logFailure(processor) {
     );
 }
 
-describe("dormann tests", { timeout: 30000 }, function () {
+describe("dormann tests", function () {
     it("should pass 6502 functional tests", async () => {
         const cpu = fake6502();
         await cpu.initialise();
@@ -100,7 +100,7 @@ describe("dormann tests", { timeout: 30000 }, function () {
     });
 });
 
-describe("dormann tests (non-cycle-accurate)", { timeout: 30000 }, function () {
+describe("dormann tests (non-cycle-accurate)", function () {
     it("should pass 6502 functional tests", async () => {
         const cpu = fake6502(undefined, { cycleAccurate: false });
         await cpu.initialise();

--- a/tests/integration/dp111timing.js
+++ b/tests/integration/dp111timing.js
@@ -2,7 +2,7 @@ import { describe, it } from "vitest";
 import { TestMachine } from "../test-machine.js";
 import assert from "assert";
 
-describe("test dp111's timing tests", { timeout: 30000 }, function () {
+describe("test dp111's timing tests", function () {
     const doTest = async (disc, machine) => {
         const testMachine = new TestMachine(machine);
         await testMachine.initialise();

--- a/tests/integration/media-loader.js
+++ b/tests/integration/media-loader.js
@@ -29,7 +29,7 @@ class FileBackedXhr {
     }
 }
 
-describe("the built-in disc list", { timeout: 60000 }, () => {
+describe("the built-in disc list", () => {
     beforeEach(() => {
         domFromIndexHtml("header-bar", "discs", "econetfs", "tapes", "paste-text");
         vi.stubGlobal("XMLHttpRequest", FileBackedXhr);

--- a/tests/integration/nops.js
+++ b/tests/integration/nops.js
@@ -3,7 +3,7 @@ import assert from "assert";
 import * as utils from "../../src/utils.js";
 import { TestMachine } from "../test-machine.js";
 
-describe("test various NOP timings", { timeout: 30000 }, function () {
+describe("test various NOP timings", function () {
     it("should match the nops.bas code", async () => {
         const testMachine = new TestMachine("Master");
         await testMachine.initialise();

--- a/tests/integration/pixel-grid.js
+++ b/tests/integration/pixel-grid.js
@@ -83,7 +83,7 @@ function gridDescribesPixels(frame, band, left, right) {
     return null;
 }
 
-describe("logical pixel grid over real screens", { timeout: 60000 }, () => {
+describe("logical pixel grid over real screens", () => {
     // Single-pixel-wide vertical stripes with a gap between them. If the grid
     // claimed pixels were wider than they are, a lit and an unlit pixel would
     // land inside one and gridDescribesPixels would say so. A grid that claimed

--- a/tests/integration/protection.js
+++ b/tests/integration/protection.js
@@ -1,7 +1,7 @@
 import { describe, it } from "vitest";
 import { TestMachine } from "../test-machine.js";
 
-describe("test Kevin Edwards' gnarly protection system", { timeout: 10000 }, function () {
+describe("test Kevin Edwards' gnarly protection system", function () {
     const doTest = async (name) => {
         const testMachine = new TestMachine();
         await testMachine.initialise();

--- a/tests/integration/seddon-timing.js
+++ b/tests/integration/seddon-timing.js
@@ -4,7 +4,7 @@ import { TestMachine } from "../test-machine.js";
 // Tom Seddon's 6502/65C02 timing tests.
 // Source: https://github.com/tom-seddon/beeb_6502_timing_tests
 // Tests edge cases in dead cycles, page boundary crossing, and 1MHz bus timing.
-describe("test tom-seddon's timing tests", { timeout: 60000 }, function () {
+describe("test tom-seddon's timing tests", function () {
     const doTest = async (machine) => {
         const testMachine = new TestMachine(machine);
         await testMachine.initialise();

--- a/tests/integration/snapshot.js
+++ b/tests/integration/snapshot.js
@@ -15,7 +15,7 @@ function screenText(machine) {
     return text;
 }
 
-describe("save state round trip", { timeout: 60000 }, () => {
+describe("save state round trip", () => {
     it("continues identically in a fresh machine restored through the gzipped file format", async () => {
         const original = new TestMachine();
         await original.initialise();

--- a/tests/integration/teletext-hardware.js
+++ b/tests/integration/teletext-hardware.js
@@ -36,7 +36,7 @@ async function compareToReference(page, actualPng) {
     );
 }
 
-describe("Teletext hardware test disc", { timeout: 120000 }, () => {
+describe("Teletext hardware test disc", () => {
     for (const page of Pages) {
         it(`should render ${page} as the hardware does`, async () => {
             await compareToReference(page, await renderPage(page));

--- a/tests/integration/teletext.js
+++ b/tests/integration/teletext.js
@@ -72,7 +72,7 @@ async function compare(video, testMachine, expectedName) {
     );
 }
 
-describe("Test Ceefax test page", { timeout: 30000 }, () => {
+describe("Test Ceefax test page", () => {
     it("should match the Ceefax test page (no flash)", async () => {
         const video = new CapturingVideo();
         const testMachine = await setupCeefaxTestMachine(video);
@@ -99,7 +99,7 @@ describe("Test Ceefax test page", { timeout: 30000 }, () => {
     });
 });
 
-describe("Test other teletext test pages", { timeout: 30000 }, () => {
+describe("Test other teletext test pages", () => {
     it("should work with hoglet's test case", async () => {
         const video = new CapturingVideo();
         const testMachine = new TestMachine(null, { video: video });

--- a/tests/integration/teletext.js
+++ b/tests/integration/teletext.js
@@ -68,7 +68,7 @@ async function compare(video, testMachine, expectedName) {
     assert.equal(
         numDiffPixels,
         0,
-        `Images do not match - expected ${expectedFile}, got ${outputFile}, diffs: ${diffFile}}`,
+        `Images do not match - expected ${expectedFile}, got ${outputFile}, diffs: ${diffFile}`,
     );
 }
 

--- a/tests/playwright/fixtures.js
+++ b/tests/playwright/fixtures.js
@@ -60,8 +60,10 @@ class Beeb {
         return before;
     }
 
-    async expectRunningPast(cycles) {
-        await expect.poll(() => this.cycles(), { message: "the emulator to run again" }).toBeGreaterThan(cycles);
+    async expectRunningPast(cycles, timeout = undefined) {
+        await expect
+            .poll(() => this.cycles(), { message: "the emulator to run again", timeout })
+            .toBeGreaterThan(cycles);
     }
 
     /** Held long enough for the OS to scan the matrix and see it down. */

--- a/tests/playwright/smoke.spec.js
+++ b/tests/playwright/smoke.spec.js
@@ -28,6 +28,7 @@ const ConsoleSurface = [
 ];
 
 const OneRowWidth = 4000;
+const ShaderCompileBudgetMs = 60000;
 // The bar expands at Bootstrap's lg breakpoint, 992px.
 const LaptopWidths = [993, 1024, 1280, 1400, 1440, 1512, 1536, 1600];
 
@@ -119,9 +120,12 @@ test("every display mode and sound output on the bar can be picked", async ({ be
     expect(outputs).not.toEqual([]);
     for (const mode of modes) {
         // Picking a mode compiles its shaders under software GL, which blocks
-        // the page well past the action default on a slow machine.
-        await page.click(`#display-mode [data-mode="${mode}"]`, { timeout: 30000 });
+        // the page well past the action default on a slow machine; the next
+        // action would otherwise pay for it.
+        const before = await beeb.cycles();
+        await page.click(`#display-mode [data-mode="${mode}"]`, { timeout: ShaderCompileBudgetMs });
         await expect(page.locator("#display-mode .active")).toHaveAttribute("data-mode", mode);
+        await beeb.expectRunningPast(before, ShaderCompileBudgetMs);
     }
     for (const output of outputs) {
         await page.click(`#audio-output [data-output="${output}"]`);

--- a/tests/playwright/smoke.spec.js
+++ b/tests/playwright/smoke.spec.js
@@ -124,7 +124,9 @@ test("every display mode and sound output on the bar can be picked", async ({ be
         // action would otherwise pay for it.
         const before = await beeb.cycles();
         await page.click(`#display-mode [data-mode="${mode}"]`, { timeout: ShaderCompileBudgetMs });
-        await expect(page.locator("#display-mode .active")).toHaveAttribute("data-mode", mode);
+        await expect(page.locator("#display-mode .active")).toHaveAttribute("data-mode", mode, {
+            timeout: ShaderCompileBudgetMs,
+        });
         await beeb.expectRunningPast(before, ShaderCompileBudgetMs);
     }
     for (const output of outputs) {

--- a/tests/playwright/smoke.spec.js
+++ b/tests/playwright/smoke.spec.js
@@ -28,7 +28,7 @@ const ConsoleSurface = [
 ];
 
 const OneRowWidth = 4000;
-const ShaderCompileBudgetMs = 60000;
+const ShaderCompileBudgetMs = 30000;
 // The bar expands at Bootstrap's lg breakpoint, 992px.
 const LaptopWidths = [993, 1024, 1280, 1400, 1440, 1512, 1536, 1600];
 

--- a/tools/test-workers.js
+++ b/tools/test-workers.js
@@ -1,0 +1,16 @@
+import os from "node:os";
+
+/**
+ * How many of a suite's workers can run at once without starving each other,
+ * from what one costs in hardware threads. A test that runs an emulated
+ * machine keeps a thread busy for as long as it runs, and a starved emulator
+ * times out rather than slowing down, so the count comes from the machine and
+ * not from vitest's default of one worker per thread.
+ *
+ * @param {number} threadsPerWorker hardware threads one worker keeps busy
+ * @param {number} [max] most workers worth having, however big the machine
+ * @returns {number}
+ */
+export function workersFor(threadsPerWorker, max = Infinity) {
+    return Math.max(1, Math.min(max, Math.floor(os.availableParallelism() / threadsPerWorker)));
+}

--- a/vite.config.js
+++ b/vite.config.js
@@ -15,8 +15,7 @@ export default defineConfig({
         testTimeout: 15000,
         // Every worker runs CPU-bound JavaScript (an emulated machine, or jsdom),
         // so a hyperthread sibling would only share its core: one worker per two
-        // threads. That is also fewer copies of the process on a laptop that is
-        // already paging.
+        // threads.
         maxWorkers: workersFor(2),
         projects: [
             { extends: true, test: { name: "unit", include: ["tests/unit/**/test-*.js"] } },

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,7 +1,6 @@
-import { configDefaults } from "vitest/config";
-
 import { defineConfig } from "vitest/config";
 import { firShaderPlugin } from "./tools/vite-plugin-fir-shader.js";
+import { workersFor } from "./tools/test-workers.js";
 
 /** @type {import("vite").UserConfig} */
 export default defineConfig({
@@ -13,15 +12,25 @@ export default defineConfig({
         assetsInlineLimit: 0,
     },
     test: {
-        include: [
-            ...configDefaults.include,
-            "tests/unit/**/test-*.js",
-            "tests/integration/**/*.js",
-            "tests/shader/test-*.js",
-        ],
-        // Playwright's runner owns these; vitest's default globs would take the spec files.
-        exclude: [...configDefaults.exclude, "tests/playwright/**"],
         testTimeout: 15000,
+        // Every worker runs CPU-bound JavaScript (an emulated machine, or jsdom),
+        // so a hyperthread sibling would only share its core: one worker per two
+        // threads. That is also fewer copies of the process on a laptop that is
+        // already paging.
+        maxWorkers: workersFor(2),
+        projects: [
+            { extends: true, test: { name: "unit", include: ["tests/unit/**/test-*.js"] } },
+            {
+                extends: true,
+                test: {
+                    name: "integration",
+                    include: ["tests/integration/**/*.js"],
+                    // A hang detector; the dearest test costs under ten seconds uncontended.
+                    testTimeout: 120000,
+                },
+            },
+            { extends: true, test: { name: "shader", include: ["tests/shader/test-*.js"] } },
+        ],
         slowTestThreshold: 1000,
         coverage: {
             provider: "v8",


### PR DESCRIPTION
`npm test` times out on a four-core laptop with a browser open. Two causes, both measured there:

- vitest's default of one worker per hardware thread runs seven emulated machines flat out on four cores. Under that, nops ran two to seven times slower than serial and blew its 30s limit; a full run under paging did the same to protection's 10s.
- The display mode smoke test compiles three filters' shaders under software GL. Each compile blocks the page, and while the machine was paging one took over a minute; the action after it was the one that timed out.

What changes:

- `tools/test-workers.js` derives a worker count from hardware threads, the rule `playwright.config.js` already applied ad hoc. Every vitest project now gets one worker per two threads: a worker here is CPU-bound JavaScript (an emulator, or jsdom) and a hyperthread sibling only shares its core. Unit tests got faster, not slower, and it is fewer copies of the process on a machine short of memory.
- vitest is split into `unit`, `integration` and `shader` projects. The integration project owns one timeout, sized as a hang detector, replacing the per-describe overrides that fought it. lint-staged selects the unit project by name, since `--exclude` no longer reaches into projects.
- Playwright points Chrome at the machine's GPU when it has a DRM node, which turns the display mode test from minutes into two seconds here. CI has no GPU and keeps the software renderer it tests today; `E2E_GL=software` or `E2E_GL=hardware` forces either.
- The smoke test waits for the emulator to run again after each mode switch, with the compile budget from #1034 on that wait and on the active-mode check, so the cost lands where it is incurred. Playwright's global timeouts stay as #1034 left them.

Nothing is skipped anywhere. CI's four-thread runner gets two vitest workers instead of three.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
