### PR TITLE
test: check a setting applies, reaches the URL and survives a reload

### DIFF
--- a/tests/playwright/smoke.spec.js
+++ b/tests/playwright/smoke.spec.js
@@ -106,6 +106,27 @@ test("a modal pauses the emulator and closing it resumes", async ({ beeb, page }
     await beeb.expectRunningPast(during);
 });
 
+test("a setting changed in the dialog applies at once, reaches the URL and survives a reload", async ({
+    beeb,
+    page,
+}) => {
+    await beeb.open();
+    await beeb.expectScreenText(">");
+    await expect(page.locator("#audio-output .active")).not.toHaveAttribute("data-output", "board");
+    await beeb.armModalShown("configuration");
+    await page.click('a[data-bs-target="#configuration"]');
+    await beeb.expectModalShown();
+    await page.click("#audioOutputDropdown");
+    await page.click('#configuration .audio-output-option[data-output="board"]');
+    await expect(page.locator("#audio-output .active")).toHaveAttribute("data-output", "board");
+    expect(new URL(page.url()).searchParams.get("audioOutput")).toBe("board");
+    await page.click("#configuration .btn-close");
+    // Back to a bare URL: only browser storage can carry the setting across.
+    await beeb.open();
+    await beeb.expectScreenText(">");
+    await expect(page.locator("#audio-output .active")).toHaveAttribute("data-output", "board");
+});
+
 test("every display mode and sound output on the bar can be picked", async ({ beeb, page }) => {
     await beeb.open();
     await beeb.expectScreenText(">");


### PR DESCRIPTION
First step of Theme A in #1002, landed on its own so the refactor that follows has an end-to-end guard in place before anything moves.

The check picks a sound output in the Settings dialog and asserts three things the settings plumbing promises: the top bar reflects it at once, the URL carries it, and after returning to a bare URL (so only browser storage can carry it) the page comes back with it applied. Sound output is the cheapest setting with all three properties; display mode would compile shaders under software GL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)