### PR TITLE
refactor: settings dispatch events; the dialog and bar become views

### DIFF
--- a/src/app/electron.js
+++ b/src/app/electron.js
@@ -2,7 +2,7 @@
 // Handles IPC communication for loading disc/tape images and showing modals from Electron's main process.
 
 function init(args) {
-    const { loadDiscImage, loadTapeImage, loadStateFile, processor, modals, actions, config, media } = args;
+    const { loadDiscImage, loadTapeImage, loadStateFile, processor, modals, actions, settings, media } = args;
     const api = window.electronAPI;
 
     api.onLoadDisc(async (message) => {
@@ -52,8 +52,8 @@ function init(args) {
     }
 
     // Save settings when they change
-    if (config) {
-        config.addEventListener("settings-changed", (e) => {
+    if (settings) {
+        settings.addEventListener("change", (e) => {
             api.saveSettings(e.detail);
         });
     }

--- a/src/main.js
+++ b/src/main.js
@@ -33,6 +33,8 @@ import { Drives } from "./web/drives.js";
 import { UrlState } from "./web/url-state.js";
 import { Modals } from "./web/modals.js";
 import { Settings } from "./web/settings.js";
+import { Config } from "./web/config.js";
+import { SpeechOutput } from "./speech-output.js";
 import { Printer } from "./printer.js";
 import { RewindBuffer } from "./rewind.js";
 import { RewindUI } from "./web/rewind-ui.js";
@@ -102,8 +104,18 @@ const printer = new Printer({
 const accessibilitySwitches = new AccessibilitySwitches();
 
 const settings = new Settings({ urlState });
-const { config, speechOutput, keyLayout, displayMode, audioOutput, speakerAmount } = settings;
+const { keyLayout, displayMode, audioOutput, speakerAmount } = settings;
 const model = settings.model;
+const config = new Config(settings);
+
+const speechOutput = new SpeechOutput();
+const speak = (enabled) => {
+    speechOutput.enabled = enabled;
+    if (enabled && typeof speechSynthesis === "undefined")
+        toast("This browser has no speech synthesis, so speech output has nothing to speak with.", { title: "Speech" });
+};
+speak(settings.speechOutput);
+settings.on("speechOutput", speak);
 
 // Must come after we know the model, to validate names against those of the hardware.
 const keyMappingWarnings = processInputParams(
@@ -154,21 +166,14 @@ const audioHandler = new AudioHandler({
     noSeek,
     cpuSpeed,
     isAtom: model.isAtom,
-    hasMusic5000: config.hasMusic5000,
+    hasMusic5000: settings.hasMusic5000,
 });
 // Firefox will report that audio is suspended even when it will
 // start playing without user interaction, so we need to delay a
 // little to get a reliable indication.
 window.setTimeout(() => audioHandler.checkStatus(), 1000);
 
-const quickSettings = new QuickSettings(
-    {
-        onAudioOutput: (output) => settings.applyAudioOutput(output),
-        onSpeakerAmount: (amount) => settings.applySpeakerAmount(amount),
-        onDisplayMode: (mode) => settings.applyDisplayMode(mode),
-    },
-    { audioOutput, speakerAmount, displayMode },
-);
+new QuickSettings(settings);
 
 // ------------------------------------------------------------------------
 // The machine, the loop that runs it, and everything that feeds it.
@@ -177,7 +182,7 @@ const quickSettings = new QuickSettings(
 // Depends on the settings having applied the URL parameters.
 const machine = new Machine({
     model,
-    config,
+    settings,
     parsedQuery,
     keyLayout,
     cpuMultiplier,
@@ -283,11 +288,10 @@ const inputs = new AnalogueInputs({
     processor,
     screenCanvas,
     getGamepads: machine.emulationConfig.getGamepads,
-    urlState,
-    config,
+    settings,
     audioHandler,
 });
-if (parsedQuery.microphoneChannel !== undefined) {
+if (settings.microphoneChannel !== undefined) {
     // We need to use setTimeout to make sure this runs after the page has loaded
     // This is needed because some browsers require user interaction for audio context
     setTimeout(async () => {
@@ -295,7 +299,7 @@ if (parsedQuery.microphoneChannel !== undefined) {
     }, 1000);
 }
 // Apply ADC source settings from URL parameters
-inputs.updateAdcSources(parsedQuery.mouseJoystickEnabled, parsedQuery.microphoneChannel);
+inputs.updateAdcSources(settings.mouseJoystickEnabled, settings.microphoneChannel);
 
 const frontPanel = new FrontPanel({ processor, model, printer });
 
@@ -322,7 +326,35 @@ const layout = new Layout({
 });
 
 // Everything a setting can reach now exists.
-settings.wire({ audioHandler, display, layout, quickSettings, machine, keyboard, inputs, modals });
+settings.on("audioOutput", (output) => audioHandler.setAudioOutput(output));
+settings.on("speakerAmount", (amount) => audioHandler.setSpeakerAmount(amount));
+settings.on("displayMode", (mode) => {
+    display.setMode(mode);
+    // The monitor picture may have changed shape.
+    layout.resize();
+});
+settings.on("keyLayout", (chosen) => {
+    keyboard.setKeyLayout(chosen);
+    // A reset reads the layout from the machine's config again.
+    machine.emulationConfig.keyLayout = chosen;
+});
+settings.on("tubeCpuMultiplier", (multiplier) => {
+    if (processor.hasTube) processor.tube.cpuMultiplier = multiplier;
+});
+const rerouteAnalogue = () => inputs.updateAdcSources(settings.mouseJoystickEnabled, settings.microphoneChannel);
+settings.on("mouseJoystickEnabled", rerouteAnalogue);
+settings.on("microphoneChannel", (channel) => {
+    rerouteAnalogue();
+    if (channel !== undefined) inputs.setupMicrophone();
+});
+config.addEventListener("restart-required", async () => {
+    const restart = await modals.confirm(
+        "Your change is saved, but only takes effect when the emulator restarts. Restart now?",
+        "Restart now",
+        "Later",
+    );
+    if (restart) window.location.reload();
+});
 
 // ------------------------------------------------------------------------
 // The page's own handlers.
@@ -449,7 +481,7 @@ electron({
     loadDiscImage: media.loadDiscImage.bind(media),
     loadTapeImage: media.loadTapeImage.bind(media),
     processor,
-    config,
+    settings,
     media,
     modals: {
         show: (modalId, sthType) => {

--- a/src/web/analogue-inputs.js
+++ b/src/web/analogue-inputs.js
@@ -12,10 +12,9 @@ const AdcChannelCount = 4;
  * routed to whichever of them wants it.
  */
 export class AnalogueInputs {
-    constructor({ processor, screenCanvas, getGamepads, urlState, config, audioHandler }) {
+    constructor({ processor, screenCanvas, getGamepads, settings, audioHandler }) {
         this.processor = processor;
-        this.urlState = urlState;
-        this.config = config;
+        this.settings = settings;
 
         this.gamepadSource = new GamepadSource(getGamepads);
         // Create MicrophoneInput but don't enable by default
@@ -38,7 +37,7 @@ export class AnalogueInputs {
             if (processor.touchScreen) processor.touchScreen.onMouse(x, y, evt.buttons);
 
             // Handle mouse joystick if enabled
-            if (urlState.params.mouseJoystickEnabled && this.mouseJoystickSource.isEnabled()) {
+            if (settings.mouseJoystickEnabled && this.mouseJoystickSource.isEnabled()) {
                 // Use the API methods instead of direct manipulation
                 this.mouseJoystickSource.onMouseMove(x, y);
 
@@ -89,8 +88,7 @@ export class AnalogueInputs {
     }
 
     clearMicrophoneChannel() {
-        this.config.setMicrophoneChannel(undefined);
-        this.urlState.set({ microphoneChannel: undefined });
+        this.settings.set({ microphoneChannel: undefined });
     }
 
     async ensureMicrophoneRunning() {
@@ -109,7 +107,7 @@ export class AnalogueInputs {
 
     async setupMicrophone() {
         // The channel can have been turned off between the request and now.
-        if (this.urlState.params.microphoneChannel === undefined) return;
+        if (this.settings.microphoneChannel === undefined) return;
         const micPermissionStatus = document.getElementById("micPermissionStatus");
         micPermissionStatus.textContent = "Requesting microphone access...";
 

--- a/src/web/config.js
+++ b/src/web/config.js
@@ -49,45 +49,45 @@ export function restartPending(settings, running) {
     return RestartRequiredFields.some((field) => settings[field] !== running[field]);
 }
 
+/**
+ * The Settings dialog: shows the settings, applies the ones the machine can
+ * follow live as they are picked, and saves the rest when it closes. Dispatches
+ * "restart-required" after saving a change the running machine cannot follow.
+ */
 export class Config extends EventTarget {
-    /**
-     * @param {function(object)} onChange called as soon as a setting the emulator can follow live changes
-     * @param {function(object)} onClose called with the settings to apply and persist
-     * @param {function()} onRestartRequired called after the settings have been saved, when some of them
-     *     will only take effect once the machine is rebuilt
-     */
-    constructor(onChange, onClose, onRestartRequired) {
+    constructor(settings) {
         super();
-        this.onChange = onChange;
-        this.onClose = onClose;
-        this.onRestartRequired = onRestartRequired;
+        this.settings = settings;
         this.changed = {};
-        this.model = null;
-        for (const { field } of CheckboxSettings) this[field] = false;
-        this.runningSettings = null;
+        // Built before anything can change, so this is what the running machine was built with.
+        this.runningSettings = this.proposedSettings();
+        this.setModel(settings.model);
+        this.setKeyLayout(settings.keyLayout);
+        this.setMicrophoneChannel(settings.microphoneChannel);
+        this.setDisplayMode(settings.displayMode);
+        this.setAudioOutput(settings.audioOutput);
+        this.setSpeakerAmount(settings.speakerAmount);
+        settings.on("audioOutput", (audioOutput) => this.setAudioOutput(audioOutput));
+        settings.on("speakerAmount", (speakerAmount) => this.setSpeakerAmount(speakerAmount));
+        settings.on("displayMode", (displayMode) => this.setDisplayMode(displayMode));
+
         const configuration = document.getElementById("configuration");
         configuration.addEventListener("show.bs.modal", () => {
             this.changed = {};
-            // The startup settings are pushed in after construction, so what the running machine was
-            // built with is only knowable from the first time the dialog is opened.
-            if (!this.runningSettings) this.runningSettings = this.proposedSettings();
-            this.setDropdownText(this.model.name);
-            this.setTubeCpuMultiplier(this.tubeCpuMultiplier);
-            this.setCheckboxes(this);
+            this.setDropdownText(settings.model.name);
+            this.setTubeCpuMultiplier(settings.tubeCpuMultiplier);
+            this.setCheckboxes(settings);
             this.showRestartPending();
         });
 
         configuration.addEventListener("hide.bs.modal", () => {
             const changed = this.changed;
-            // Not setModel: that also renames the machine in the title bar, which has not changed yet.
-            if (changed.model !== undefined) this.model = findModel(changed.model);
-            this.setCheckboxes(changed);
-            this.onClose(changed);
+            this.changed = {};
             if (Object.keys(changed).length === 0) return;
-            this.dispatchEvent(new CustomEvent("settings-changed", { detail: changed }));
+            settings.set(changed);
             // changed records which controls were touched, so a value in it can be what is already running.
             if (needsRestart(changed) && restartPending(this.proposedSettings(), this.runningSettings))
-                this.onRestartRequired();
+                this.dispatchEvent(new Event("restart-required"));
         });
 
         const modelMenu = document.querySelector(".model-menu");
@@ -107,7 +107,10 @@ export class Config extends EventTarget {
             if (!link) return;
             this.changed.model = link.dataset.target;
             this.setDropdownText(link.textContent);
-            this.showTubeCpuMultiplier(this.tubeCpuMultiplier, findModel(link.dataset.target));
+            this.showTubeCpuMultiplier(
+                this.changed.tubeCpuMultiplier ?? this.settings.tubeCpuMultiplier,
+                findModel(link.dataset.target),
+            );
             this.showRestartPending();
         });
 
@@ -148,23 +151,18 @@ export class Config extends EventTarget {
         for (const option of document.querySelectorAll(".audio-output-option")) {
             option.addEventListener("click", (e) => {
                 e.preventDefault();
-                const audioOutput = e.currentTarget.dataset.output;
-                this.changed.audioOutput = audioOutput;
-                this.onChange({ audioOutput });
+                settings.set({ audioOutput: e.currentTarget.dataset.output });
             });
         }
 
         document.getElementById("speakerAmountSetting").addEventListener("input", (e) => {
-            this.onChange({ speakerAmount: parseFloat(e.currentTarget.value) });
+            settings.set({ speakerAmount: parseFloat(e.currentTarget.value) });
         });
 
         for (const option of document.querySelectorAll(".display-mode-option")) {
             option.addEventListener("click", (e) => {
                 e.preventDefault();
-                const mode = e.currentTarget.dataset.mode;
-                this.changed.displayMode = mode;
-                this.setDisplayMode(mode);
-                this.onChange({ displayMode: mode });
+                settings.set({ displayMode: e.currentTarget.dataset.mode });
             });
         }
     }
@@ -174,7 +172,7 @@ export class Config extends EventTarget {
      * menu and the URL use: the model by synonym rather than resolved, the fittings as booleans.
      */
     proposedSettings() {
-        const saved = (field) => (field === "model" ? this.model.synonyms[0] : this[field]);
+        const saved = (field) => (field === "model" ? this.settings.model.synonyms[0] : this.settings[field]);
         return Object.fromEntries(RestartRequiredFields.map((field) => [field, this.changed[field] ?? saved(field)]));
     }
 
@@ -183,13 +181,12 @@ export class Config extends EventTarget {
         document.getElementById("restart-pending").classList.toggle("d-none", !pending);
     }
 
-    /** Ticks the boxes named in `values` and adopts them, leaving any the object does not mention alone. */
+    /** Ticks the boxes named in `values`, leaving any the object does not mention alone. */
     setCheckboxes(values) {
         for (const { id, field, enables } of CheckboxSettings) {
             if (values[field] === undefined) continue;
             const checked = !!values[field];
             document.getElementById(id).checked = checked;
-            this[field] = checked;
             if (enables) document.getElementById(enables).disabled = !checked;
         }
     }
@@ -212,12 +209,12 @@ export class Config extends EventTarget {
         for (const el of document.querySelectorAll(".display-mode-text")) el.textContent = config.name;
     }
 
-    setModel(modelName) {
-        this.model = findModel(modelName);
-        for (const el of document.querySelectorAll(".bbc-model")) el.textContent = this.model.name;
-        for (const el of document.querySelectorAll(".bbc-model-short")) el.textContent = this.model.shortName;
+    /** Names the running machine everywhere the page shows it. */
+    setModel(model) {
+        for (const el of document.querySelectorAll(".bbc-model")) el.textContent = model.name;
+        for (const el of document.querySelectorAll(".bbc-model-short")) el.textContent = model.shortName;
         const settingsLink = document.getElementById("model-settings");
-        if (settingsLink) settingsLink.title = `${this.model.name}: emulation settings`;
+        if (settingsLink) settingsLink.title = `${model.name}: emulation settings`;
     }
 
     setKeyLayout(keyLayout) {
@@ -226,45 +223,16 @@ export class Config extends EventTarget {
     }
 
     setTubeCpuMultiplier(value) {
-        this.tubeCpuMultiplier = value;
         document.getElementById("tubeCpuMultiplier").value = value;
         this.showTubeCpuMultiplier(value);
     }
 
-    showTubeCpuMultiplier(value, model = this.model) {
+    showTubeCpuMultiplier(value, model = this.settings.model) {
         document.getElementById("tubeCpuMultiplierValue").textContent = tubeCpuSpeedLabel(value, model);
     }
 
     setDropdownText(modelName) {
         const el = document.querySelector("#bbc-model-dropdown .bbc-model");
         if (el) el.textContent = modelName;
-    }
-
-    get extraRoms() {
-        return fittedRoms(this);
-    }
-
-    mapLegacyModels(parsedQuery) {
-        if (!parsedQuery.model) {
-            return;
-        }
-
-        // "MasterTurbo" = Master + 6502 second processor
-        if (parsedQuery.model.toLowerCase() === "masterturbo") {
-            parsedQuery.model = "Master";
-            parsedQuery.coProcessor = true;
-        }
-
-        // "BMusic5000" = BBC DFS 1.2 + Music 5000
-        if (parsedQuery.model.toLowerCase() === "bmusic5000") {
-            parsedQuery.model = "B-DFS1.2";
-            parsedQuery.hasMusic5000 = true;
-        }
-
-        // "BTeletext" = BBC DFS 1.2 + Teletext adaptor
-        if (parsedQuery.model.toLowerCase() === "bteletext") {
-            parsedQuery.model = "B-DFS1.2";
-            parsedQuery.hasTeletextAdaptor = true;
-        }
     }
 }

--- a/src/web/machine.js
+++ b/src/web/machine.js
@@ -11,18 +11,26 @@ import { errorText, reportLoadFailure, showNotice } from "./reporting.js";
  * The machine's fittings as the CPU wants them handed over. Pure, so the bank
  * and flag decisions are testable on their own.
  */
-export function buildEmulationConfig({ config, parsedQuery, keyLayout, cpuMultiplier, extraRoms, userPort, printer }) {
+export function buildEmulationConfig({
+    settings,
+    parsedQuery,
+    keyLayout,
+    cpuMultiplier,
+    extraRoms,
+    userPort,
+    printer,
+}) {
     return {
         keyLayout,
         cpuMultiplier,
-        tubeCpuMultiplier: config.tubeCpuMultiplier,
+        tubeCpuMultiplier: settings.tubeCpuMultiplier,
         videoCyclesBatch: parsedQuery.videoCyclesBatch,
-        tube: config.coProcessor ? tubeModelFor(config.model) : null,
-        hasMusic5000: config.hasMusic5000,
-        hasTeletextAdaptor: config.hasTeletextAdaptor,
+        tube: settings.coProcessor ? tubeModelFor(settings.model) : null,
+        hasMusic5000: settings.hasMusic5000,
+        hasTeletextAdaptor: settings.hasTeletextAdaptor,
         // ROM order determines sideways bank allocation, and the fittings' ROMs claim banks
         // before any the user asked for with ?rom=.
-        extraRoms: [...config.extraRoms, ...extraRoms],
+        extraRoms: [...settings.extraRoms, ...extraRoms],
         userPort,
         printerPort: printer,
         getGamepads: function () {
@@ -40,7 +48,7 @@ export function buildEmulationConfig({ config, parsedQuery, keyLayout, cpuMultip
 export class Machine {
     constructor({
         model,
-        config,
+        settings,
         parsedQuery,
         keyLayout,
         cpuMultiplier,
@@ -59,7 +67,7 @@ export class Machine {
         this.speechOutput = speechOutput;
 
         this.econet = null;
-        if (config.hasEconet) {
+        if (settings.hasEconet) {
             this.econet = new Econet(stationId, model.cyclesPerSecond);
         } else {
             document.getElementById("fsmenuitem").style.display = "none";
@@ -79,7 +87,7 @@ export class Machine {
         );
 
         this.emulationConfig = buildEmulationConfig({
-            config,
+            settings,
             parsedQuery,
             keyLayout,
             cpuMultiplier,
@@ -95,7 +103,7 @@ export class Machine {
             soundChip: audioHandler.soundChip,
             ddNoise: audioHandler.ddNoise,
             relayNoise: audioHandler.relayNoise,
-            music5000: config.hasMusic5000 ? audioHandler.music5000 : null,
+            music5000: settings.hasMusic5000 ? audioHandler.music5000 : null,
             cmos: this.cmos,
             config: this.emulationConfig,
             econet: this.econet,

--- a/src/web/quick-settings.js
+++ b/src/web/quick-settings.js
@@ -1,44 +1,45 @@
 import { AudioOutputs } from "../audio-output.js";
 
 /**
- * The sound output, speaker amount and display mode controls on the top bar.
- * Choices go to the callbacks; what is shown follows the show methods, so the
- * bar can be kept in step with the same settings elsewhere.
+ * The sound output, speaker amount and display mode controls on the top bar:
+ * a view of those three settings, and a way to set them.
  */
 export class QuickSettings {
-    constructor({ onAudioOutput, onSpeakerAmount, onDisplayMode }, { audioOutput, speakerAmount, displayMode }) {
+    constructor(settings) {
         this.output = document.getElementById("audio-output");
         this.amount = document.getElementById("speaker-amount");
         this.display = document.getElementById("display-mode");
         if (!this.output || !this.amount || !this.display) return;
 
-        this.showAudioOutput(audioOutput);
-        this.showSpeakerAmount(speakerAmount);
-        this.showDisplayMode(displayMode);
+        this.showAudioOutput(settings.audioOutput);
+        this.showSpeakerAmount(settings.speakerAmount);
+        this.showDisplayMode(settings.displayMode);
+        settings.on("audioOutput", (audioOutput) => this.showAudioOutput(audioOutput));
+        settings.on("speakerAmount", (speakerAmount) => this.showSpeakerAmount(speakerAmount));
+        settings.on("displayMode", (displayMode) => this.showDisplayMode(displayMode));
 
         this.output.addEventListener("click", (e) => {
-            const value = e.target.closest("[data-output]")?.dataset.output;
-            if (value) onAudioOutput(value);
+            const audioOutput = e.target.closest("[data-output]")?.dataset.output;
+            if (audioOutput) settings.set({ audioOutput });
         });
-        this.amount.addEventListener("input", () => onSpeakerAmount(parseFloat(this.amount.value)));
+        this.amount.addEventListener("input", () => settings.set({ speakerAmount: parseFloat(this.amount.value) }));
         this.display.addEventListener("click", (e) => {
-            const mode = e.target.closest("[data-mode]")?.dataset.mode;
-            if (mode) onDisplayMode(mode);
+            const displayMode = e.target.closest("[data-mode]")?.dataset.mode;
+            if (displayMode) settings.set({ displayMode });
         });
     }
 
     showAudioOutput(audioOutput) {
-        if (!this.output) return;
         select(this.output.querySelectorAll("[data-output]"), (b) => b.dataset.output === audioOutput);
         this.amount.disabled = audioOutput !== AudioOutputs.speaker;
     }
 
     showSpeakerAmount(speakerAmount) {
-        if (this.amount) this.amount.value = speakerAmount;
+        this.amount.value = speakerAmount;
     }
 
     showDisplayMode(mode) {
-        if (this.display) select(this.display.querySelectorAll("[data-mode]"), (b) => b.dataset.mode === mode);
+        select(this.display.querySelectorAll("[data-mode]"), (b) => b.dataset.mode === mode);
     }
 }
 

--- a/src/web/settings.js
+++ b/src/web/settings.js
@@ -76,8 +76,10 @@ export class Settings extends EventTarget {
     /** Adopts `changes` (an undefined value clears a setting), persists them and tells the subscribers. */
     set(changes) {
         for (const [name, value] of Object.entries(changes)) {
-            this[name] = name === "model" ? findModel(value) : value;
-            if (StoredSettings.includes(name)) window.localStorage[name] = value;
+            this[name] = name === "model" ? (findModel(value) ?? this.model) : value;
+            if (!StoredSettings.includes(name)) continue;
+            if (value === undefined) window.localStorage.removeItem(name);
+            else window.localStorage[name] = value;
         }
         this.urlState.set(changes, { settle: "speakerAmount" in changes });
         for (const name of Object.keys(changes)) this.dispatchEvent(new Event(name));

--- a/src/web/settings.js
+++ b/src/web/settings.js
@@ -1,152 +1,86 @@
-import { Config } from "./config.js";
 import { DefaultModel, findModel } from "../models.js";
 import { DefaultAudioOutput, isAudioOutput } from "../audio-output.js";
-import { SpeechOutput } from "../speech-output.js";
 import { guessModelFromHostname } from "../url-params.js";
+import { fittedRoms } from "./config.js";
 import { toast } from "./toast.js";
 
+// Kept in browser storage for next time, as well as in the URL.
+const StoredSettings = ["keyLayout", "displayMode", "audioOutput", "speakerAmount"];
+
+/** The URL spellings of a model plus a fitting, from before fittings had settings of their own. */
+export function mapLegacyModels(parsedQuery) {
+    if (!parsedQuery.model) return;
+    switch (parsedQuery.model.toLowerCase()) {
+        case "masterturbo":
+            parsedQuery.model = "Master";
+            parsedQuery.coProcessor = true;
+            break;
+        case "bmusic5000":
+            parsedQuery.model = "B-DFS1.2";
+            parsedQuery.hasMusic5000 = true;
+            break;
+        case "bteletext":
+            parsedQuery.model = "B-DFS1.2";
+            parsedQuery.hasTeletextAdaptor = true;
+            break;
+    }
+}
+
 /**
- * The user's settings: resolved from the URL, browser storage and the
- * defaults, kept in step across the Settings dialog, the top bar, storage and
- * the URL, and applied to the machine. Built before anything it applies to;
- * wire() hands it the targets once they exist, which is before any setting
- * can change hands.
+ * The user's settings, resolved from the URL, browser storage and the
+ * defaults. set() adopts a change, persists it and dispatches an event named
+ * for each changed setting carrying its new value, then one "change" event
+ * carrying them all; whatever a setting reaches subscribes with on().
  */
-export class Settings {
-    constructor({ urlState, makeConfig = (...handlers) => new Config(...handlers) }) {
+export class Settings extends EventTarget {
+    constructor({ urlState }) {
+        super();
         this.urlState = urlState;
-        this.targets = null;
-        const parsedQuery = urlState.params;
+        const params = urlState.params;
+        mapLegacyModels(params);
 
-        // Speech output: initialised from URL param; can be toggled at runtime via the Settings panel.
-        // Must be created before Config so the onClose callback and the initial checkbox state can reference it.
-        this.speechOutput = new SpeechOutput();
-        this.setSpeechOutput(!!parsedQuery.speechOutput);
-
-        this.keyLayout = window.localStorage.keyLayout || "physical";
-        if (parsedQuery.keyLayout) {
-            this.keyLayout = (parsedQuery.keyLayout + "").toLowerCase();
-        }
-
-        this.config = makeConfig(
-            (changed) => {
-                if (changed.audioOutput) this.applyAudioOutput(changed.audioOutput);
-                if (changed.speakerAmount !== undefined) this.applySpeakerAmount(changed.speakerAmount);
-                if (changed.displayMode) this.applyDisplayMode(changed.displayMode);
-            },
-            (changed) => this.onDialogClosed(changed),
-            async () => {
-                const restart = await this.targets.modals.confirm(
-                    "Your change is saved, but only takes effect when the emulator restarts. Restart now?",
-                    "Restart now",
-                    "Later",
-                );
-                if (restart) window.location.reload();
-            },
-        );
-
-        // Perform mapping of legacy models to the new format
-        this.config.mapLegacyModels(parsedQuery);
-
-        const requestedModelName = parsedQuery.model || guessModelFromHostname(window.location.hostname);
-        const requestedModel = findModel(requestedModelName);
-        if (!requestedModel)
+        const requestedModelName = params.model || guessModelFromHostname(window.location.hostname);
+        this.model = findModel(requestedModelName);
+        if (!this.model) {
             toast(`There is no model called "${requestedModelName}". Using ${DefaultModel.name} instead.`, {
                 title: "Model",
             });
-        this.config.setModel((requestedModel ?? DefaultModel).name);
-        this.config.setKeyLayout(this.keyLayout);
-        this.config.setTubeCpuMultiplier(parsedQuery.tubeCpuMultiplier || 1);
-        this.config.setMicrophoneChannel(parsedQuery.microphoneChannel);
-        this.config.setCheckboxes({
-            coProcessor: !!parsedQuery.coProcessor,
-            hasEconet: !!parsedQuery.hasEconet,
-            hasMusic5000: !!parsedQuery.hasMusic5000,
-            hasTeletextAdaptor: !!parsedQuery.hasTeletextAdaptor,
-            mouseJoystickEnabled: !!parsedQuery.mouseJoystickEnabled,
-            speechOutput: this.speechOutput.enabled,
-        });
-
-        this.displayMode = parsedQuery.displayMode || window.localStorage.displayMode || "rgb";
-        this.config.setDisplayMode(this.displayMode);
+            this.model = DefaultModel;
+        }
+        this.keyLayout =
+            (params.keyLayout && `${params.keyLayout}`.toLowerCase()) || window.localStorage.keyLayout || "physical";
+        this.tubeCpuMultiplier = params.tubeCpuMultiplier || 1;
+        this.microphoneChannel = params.microphoneChannel;
+        this.coProcessor = !!params.coProcessor;
+        this.hasEconet = !!params.hasEconet;
+        this.hasMusic5000 = !!params.hasMusic5000;
+        this.hasTeletextAdaptor = !!params.hasTeletextAdaptor;
+        this.mouseJoystickEnabled = !!params.mouseJoystickEnabled;
+        this.speechOutput = !!params.speechOutput;
+        this.displayMode = params.displayMode || window.localStorage.displayMode || "rgb";
         this.audioOutput =
-            [parsedQuery.audioOutput, window.localStorage.audioOutput].find(isAudioOutput) ?? DefaultAudioOutput;
+            [params.audioOutput, window.localStorage.audioOutput].find(isAudioOutput) ?? DefaultAudioOutput;
         this.speakerAmount =
-            [parsedQuery.speakerAmount, parseFloat(window.localStorage.speakerAmount)].find(Number.isFinite) ?? 1;
-        this.config.setAudioOutput(this.audioOutput);
-        this.config.setSpeakerAmount(this.speakerAmount);
+            [params.speakerAmount, parseFloat(window.localStorage.speakerAmount)].find(Number.isFinite) ?? 1;
     }
 
-    get model() {
-        return this.config.model;
+    get extraRoms() {
+        return fittedRoms(this);
     }
 
-    /** What applying a setting reaches: everything here exists before a setting can change. */
-    wire(targets) {
-        this.targets = targets;
+    /** Calls `listener` with the new value whenever the setting `name` is set. */
+    on(name, listener) {
+        this.addEventListener(name, () => listener(this[name]));
     }
 
-    setSpeechOutput(enabled) {
-        this.speechOutput.enabled = enabled;
-        if (enabled && typeof speechSynthesis === "undefined")
-            toast("This browser has no speech synthesis, so speech output has nothing to speak with.", {
-                title: "Speech",
-            });
-    }
-
-    applyAudioOutput(output) {
-        this.audioOutput = output;
-        this.targets.audioHandler.setAudioOutput(output);
-        this.config.setAudioOutput(output);
-        this.targets.quickSettings?.showAudioOutput(output);
-        window.localStorage.audioOutput = output;
-        this.urlState.set({ audioOutput: output });
-    }
-
-    applySpeakerAmount(amount) {
-        this.speakerAmount = amount;
-        this.targets.audioHandler.setSpeakerAmount(amount);
-        this.config.setSpeakerAmount(amount);
-        this.targets.quickSettings?.showSpeakerAmount(amount);
-        window.localStorage.speakerAmount = amount;
-        this.urlState.set({ speakerAmount: amount }, { settle: true });
-    }
-
-    applyDisplayMode(mode) {
-        this.displayMode = mode;
-        this.targets.display.setMode(mode);
-        // The monitor picture may have changed shape.
-        this.targets.layout.resize();
-        this.config.setDisplayMode(mode);
-        this.targets.quickSettings?.showDisplayMode(mode);
-        window.localStorage.displayMode = mode;
-        this.urlState.set({ displayMode: mode });
-    }
-
-    onDialogClosed(changed) {
-        const { urlState } = this;
-        const { machine, keyboard, inputs } = this.targets;
-        const parsedQuery = urlState.params;
-        urlState.set(changed);
-        if (changed.keyLayout) {
-            window.localStorage.keyLayout = changed.keyLayout;
-            machine.emulationConfig.keyLayout = changed.keyLayout;
-            keyboard.setKeyLayout(changed.keyLayout);
+    /** Adopts `changes` (an undefined value clears a setting), persists them and tells the subscribers. */
+    set(changes) {
+        for (const [name, value] of Object.entries(changes)) {
+            this[name] = name === "model" ? findModel(value) : value;
+            if (StoredSettings.includes(name)) window.localStorage[name] = value;
         }
-        if (changed.mouseJoystickEnabled !== undefined || Object.hasOwn(changed, "microphoneChannel")) {
-            inputs.updateAdcSources(parsedQuery.mouseJoystickEnabled, parsedQuery.microphoneChannel);
-
-            if (changed.microphoneChannel !== undefined) {
-                inputs.setupMicrophone();
-            }
-        }
-        if (changed.speechOutput !== undefined) this.setSpeechOutput(!!changed.speechOutput);
-        if (changed.tubeCpuMultiplier !== undefined) {
-            machine.emulationConfig.tubeCpuMultiplier = changed.tubeCpuMultiplier;
-            this.config.setTubeCpuMultiplier(changed.tubeCpuMultiplier);
-            if (machine.processor.hasTube) {
-                machine.processor.tube.cpuMultiplier = changed.tubeCpuMultiplier;
-            }
-        }
+        this.urlState.set(changes, { settle: "speakerAmount" in changes });
+        for (const name of Object.keys(changes)) this.dispatchEvent(new Event(name));
+        this.dispatchEvent(new CustomEvent("change", { detail: changes }));
     }
 }

--- a/tests/unit/test-analogue-inputs.js
+++ b/tests/unit/test-analogue-inputs.js
@@ -2,6 +2,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { AnalogueInputs } from "../../src/web/analogue-inputs.js";
+import { Settings } from "../../src/web/settings.js";
 import { domFromIndexHtml, fakeUrlState, teardownDom, toasts } from "./helpers.js";
 
 describe("AnalogueInputs", () => {
@@ -20,11 +21,10 @@ describe("AnalogueInputs", () => {
             },
             screenCanvas: document.getElementById("screen"),
             getGamepads: () => [],
-            urlState: fakeUrlState(),
-            config: { setMicrophoneChannel: vi.fn() },
+            settings: new Settings({ urlState: fakeUrlState() }),
             audioHandler: { tryResume: vi.fn() },
         };
-        vi.spyOn(deps.urlState, "updateUrl");
+        vi.spyOn(deps.settings.urlState, "updateUrl");
     });
 
     afterEach(teardownDom);
@@ -63,14 +63,14 @@ describe("AnalogueInputs", () => {
         });
 
         it("refuses a channel that does not exist, says so, and clears the setting", () => {
-            deps.urlState.params.microphoneChannel = 5;
+            deps.settings.microphoneChannel = 5;
             const inputs = make();
             inputs.updateAdcSources(false, 5);
             for (let ch = 0; ch < 4; ch++) expect(channels[ch]).toBe(inputs.gamepadSource);
             expect(toasts()).toEqual([expect.stringContaining("no analogue channel 5")]);
-            expect(deps.config.setMicrophoneChannel).toHaveBeenCalledWith(undefined);
-            expect(deps.urlState.params.microphoneChannel).toBeUndefined();
-            expect(deps.urlState.updateUrl).toHaveBeenCalled();
+            expect(deps.settings.microphoneChannel).toBeUndefined();
+            expect(deps.settings.urlState.params.microphoneChannel).toBeUndefined();
+            expect(deps.settings.urlState.updateUrl).toHaveBeenCalled();
         });
     });
 
@@ -95,7 +95,7 @@ describe("AnalogueInputs", () => {
             mouse("mousedown");
             expect(down).not.toHaveBeenCalled();
 
-            deps.urlState.params.mouseJoystickEnabled = true;
+            deps.settings.mouseJoystickEnabled = true;
             vi.spyOn(inputs.mouseJoystickSource, "isEnabled").mockReturnValue(true);
             mouse("mousedown");
             expect(down).toHaveBeenCalledWith(0);
@@ -113,15 +113,15 @@ describe("AnalogueInputs", () => {
 
     describe("a microphone that cannot start", () => {
         it("reports, clears the setting and takes it out of the URL", async () => {
-            deps.urlState.params.microphoneChannel = 2;
+            deps.settings.microphoneChannel = 2;
             const inputs = make();
             vi.spyOn(inputs.microphoneInput, "initialise").mockResolvedValue(false);
             vi.spyOn(inputs.microphoneInput, "getErrorMessage").mockReturnValue("denied");
             await inputs.setupMicrophone();
             expect(document.getElementById("micPermissionStatus").textContent).toBe("Error: denied");
-            expect(deps.config.setMicrophoneChannel).toHaveBeenCalledWith(undefined);
-            expect(deps.urlState.params.microphoneChannel).toBeUndefined();
-            expect(deps.urlState.updateUrl).toHaveBeenCalled();
+            expect(deps.settings.microphoneChannel).toBeUndefined();
+            expect(deps.settings.urlState.params.microphoneChannel).toBeUndefined();
+            expect(deps.settings.urlState.updateUrl).toHaveBeenCalled();
         });
     });
 });

--- a/tests/unit/test-config.js
+++ b/tests/unit/test-config.js
@@ -2,7 +2,8 @@
 import { afterEach, beforeEach, describe, it, expect, vi } from "vitest";
 import { Config, fittedRoms, needsRestart, restartPending, tubeCpuSpeedLabel } from "../../src/web/config.js";
 import { allModels, findModel } from "../../src/models.js";
-import { domFromIndexHtml, teardownDom } from "./helpers.js";
+import { Settings } from "../../src/web/settings.js";
+import { domFromIndexHtml, fakeUrlState, teardownDom } from "./helpers.js";
 
 describe("fittedRoms", () => {
     const master = findModel("Master");
@@ -109,9 +110,9 @@ describe("tubeCpuSpeedLabel", () => {
 });
 
 describe("Config", () => {
-    let onChange;
-    let onClose;
-    let onRestartRequired;
+    let settings;
+    let changed;
+    let restartRequired;
     let config;
 
     const dialog = () => document.getElementById("configuration");
@@ -125,30 +126,16 @@ describe("Config", () => {
         tubeSlider().value = value;
         tubeSlider().dispatchEvent(new Event("input"));
     };
-    const lastClosedWith = () => onClose.mock.calls.at(-1)[0];
+    const lastSaved = () => changed.mock.calls.at(-1)[0];
 
     beforeEach(() => {
         domFromIndexHtml("configuration");
-        onChange = vi.fn();
-        onClose = vi.fn();
-        onRestartRequired = vi.fn();
-        config = new Config(onChange, onClose, onRestartRequired);
-        // What Settings pushes in after construction, resolved from the URL and storage.
-        config.setModel("B-DFS1.2");
-        config.setKeyLayout("physical");
-        config.setTubeCpuMultiplier(1);
-        config.setMicrophoneChannel(undefined);
-        config.setCheckboxes({
-            coProcessor: false,
-            hasEconet: false,
-            hasMusic5000: false,
-            hasTeletextAdaptor: false,
-            mouseJoystickEnabled: false,
-            speechOutput: false,
-        });
-        config.setDisplayMode("rgb");
-        config.setAudioOutput("speaker");
-        config.setSpeakerAmount(1);
+        settings = new Settings({ urlState: fakeUrlState("?model=B-DFS1.2") });
+        changed = vi.fn();
+        settings.addEventListener("change", (event) => changed(event.detail));
+        restartRequired = vi.fn();
+        config = new Config(settings);
+        config.addEventListener("restart-required", restartRequired);
     });
 
     afterEach(teardownDom);
@@ -165,14 +152,14 @@ describe("Config", () => {
             openDialog();
             clickModel("Master");
             expect(modelDropdownText()).toBe(findModel("Master").name);
-            expect(config.model).toBe(findModel("B-DFS1.2"));
+            expect(settings.model).toBe(findModel("B-DFS1.2"));
             closeDialog();
-            expect(config.model).toBe(findModel("Master"));
+            expect(settings.model).toBe(findModel("Master"));
         });
     });
 
     describe("opening the dialog", () => {
-        it("shows the settings it was handed", () => {
+        it("shows the settings as they are", () => {
             openDialog();
             expect(modelDropdownText()).toBe(findModel("B-DFS1.2").name);
             expect(document.getElementById("hasMusic5000").checked).toBe(false);
@@ -184,33 +171,29 @@ describe("Config", () => {
             openDialog();
             clickModel("Master");
             closeDialog();
-            onClose.mockClear();
+            changed.mockClear();
             openDialog();
             closeDialog();
-            expect(onClose).toHaveBeenCalledWith({});
+            expect(changed).not.toHaveBeenCalled();
         });
     });
 
     describe("closing the dialog", () => {
-        it("reports an untouched dialog as no changes at all", () => {
-            const settingsChanged = vi.fn();
-            config.addEventListener("settings-changed", settingsChanged);
+        it("saves nothing from an untouched dialog", () => {
             openDialog();
             closeDialog();
-            expect(onClose).toHaveBeenCalledWith({});
-            expect(settingsChanged).not.toHaveBeenCalled();
-            expect(onRestartRequired).not.toHaveBeenCalled();
+            expect(changed).not.toHaveBeenCalled();
+            expect(restartRequired).not.toHaveBeenCalled();
         });
 
-        it("hands the changes to the close callback and the settings-changed event alike", () => {
-            const settingsChanged = vi.fn();
-            config.addEventListener("settings-changed", settingsChanged);
+        it("saves the touched settings together", () => {
             openDialog();
             clickModel("Master");
             document.getElementById("hasMusic5000").click();
             closeDialog();
-            expect(onClose).toHaveBeenCalledWith({ model: "Master", hasMusic5000: true });
-            expect(settingsChanged.mock.calls[0][0].detail).toEqual({ model: "Master", hasMusic5000: true });
+            expect(changed).toHaveBeenCalledWith({ model: "Master", hasMusic5000: true });
+            expect(settings.hasMusic5000).toBe(true);
+            expect(settings.urlState.params.hasMusic5000).toBe(true);
         });
     });
 
@@ -221,20 +204,20 @@ describe("Config", () => {
             clickModel("Master");
             expect(restartPendingShown()).toBe(true);
             closeDialog();
-            expect(onRestartRequired).toHaveBeenCalledTimes(1);
+            expect(restartRequired).toHaveBeenCalledTimes(1);
         });
 
         it("stops asking once the setting is put back", () => {
             openDialog();
             document.getElementById("hasMusic5000").click();
             closeDialog();
-            expect(onRestartRequired).toHaveBeenCalledTimes(1);
+            expect(restartRequired).toHaveBeenCalledTimes(1);
             openDialog();
             document.getElementById("hasMusic5000").click();
             expect(restartPendingShown()).toBe(false);
             closeDialog();
-            expect(lastClosedWith()).toEqual({ hasMusic5000: false });
-            expect(onRestartRequired).toHaveBeenCalledTimes(1);
+            expect(lastSaved()).toEqual({ hasMusic5000: false });
+            expect(restartRequired).toHaveBeenCalledTimes(1);
         });
 
         it("does not ask when a touched control is back where the machine already is", () => {
@@ -242,8 +225,8 @@ describe("Config", () => {
             document.getElementById("hasMusic5000").click();
             document.getElementById("hasMusic5000").click();
             closeDialog();
-            expect(lastClosedWith()).toEqual({ hasMusic5000: false });
-            expect(onRestartRequired).not.toHaveBeenCalled();
+            expect(lastSaved()).toEqual({ hasMusic5000: false });
+            expect(restartRequired).not.toHaveBeenCalled();
         });
     });
 
@@ -261,7 +244,7 @@ describe("Config", () => {
             dragTubeSlider(2);
             expect(document.getElementById("tubeCpuMultiplierValue").textContent).toBe("2x (6MHz)");
             closeDialog();
-            expect(lastClosedWith()).toEqual({ tubeCpuMultiplier: 2 });
+            expect(settings.tubeCpuMultiplier).toBe(2);
         });
 
         it("labels the tube speed for a newly picked model's own second processor", () => {
@@ -277,7 +260,7 @@ describe("Config", () => {
             document.querySelector('.keyboard-menu a[data-target="natural"]').click();
             expect(document.querySelector(".keyboard-layout").textContent).toBe("Natural");
             closeDialog();
-            expect(lastClosedWith()).toEqual({ keyLayout: "natural" });
+            expect(settings.keyLayout).toBe("natural");
         });
 
         it("saves a microphone channel", () => {
@@ -285,7 +268,7 @@ describe("Config", () => {
             document.querySelector('.mic-channel-option[data-channel="2"]').click();
             expect(document.querySelector(".mic-channel-text").textContent).toBe("Channel 2");
             closeDialog();
-            expect(lastClosedWith()).toEqual({ microphoneChannel: 2 });
+            expect(settings.microphoneChannel).toBe(2);
         });
 
         it("saves disabling the microphone as a change, not an omission", () => {
@@ -293,75 +276,56 @@ describe("Config", () => {
             document.querySelector('.mic-channel-option[data-channel=""]').click();
             expect(document.querySelector(".mic-channel-text").textContent).toBe("Disabled");
             closeDialog();
-            expect(lastClosedWith()).toStrictEqual({ microphoneChannel: undefined });
+            expect(lastSaved()).toStrictEqual({ microphoneChannel: undefined });
         });
     });
 
     describe("the live settings", () => {
-        it("applies a sound output at once as well as saving it", () => {
+        it("sets a sound output at once, without waiting for the dialog to close", () => {
             openDialog();
             document.querySelector('.audio-output-option[data-output="board"]').click();
-            expect(onChange).toHaveBeenCalledWith({ audioOutput: "board" });
+            expect(settings.audioOutput).toBe("board");
+            expect(document.querySelector(".audio-output-text").textContent).toBe("Line out");
+            expect(document.getElementById("speakerAmountSetting").disabled).toBe(true);
             closeDialog();
-            expect(lastClosedWith()).toEqual({ audioOutput: "board" });
+            expect(changed).toHaveBeenCalledTimes(1);
         });
 
-        it("applies a display mode at once and shows its name", () => {
+        it("sets a display mode at once and shows its name", () => {
             openDialog();
             document.querySelector('.display-mode-option[data-mode="pal"]').click();
-            expect(onChange).toHaveBeenCalledWith({ displayMode: "pal" });
+            expect(settings.displayMode).toBe("pal");
             expect(document.querySelector(".display-mode-text").textContent).toBe("PAL TV");
         });
 
-        it("applies a dragged speaker amount at once", () => {
+        it("sets a dragged speaker amount at once", () => {
             const slider = document.getElementById("speakerAmountSetting");
             slider.value = 0.5;
             slider.dispatchEvent(new Event("input"));
-            expect(onChange).toHaveBeenCalledWith({ speakerAmount: 0.5 });
+            expect(settings.speakerAmount).toBe(0.5);
+        });
+
+        it("follows a live setting changed elsewhere", () => {
+            settings.set({ audioOutput: "off", displayMode: "xbr", speakerAmount: 0.25 });
+            expect(document.querySelector(".audio-output-text").textContent).toBe("Unfiltered");
+            expect(document.querySelector(".display-mode-text").textContent).toBe("Smoothed (xBR)");
+            expect(document.getElementById("speakerAmountSetting").value).toBe("0.25");
         });
     });
 
-    describe("being told the applied settings", () => {
-        it("names the model everywhere the page shows it", () => {
-            config.setModel("Master");
-            expect(document.querySelector(".modal-title .bbc-model").textContent).toBe(findModel("Master").name);
+    describe("naming the machine", () => {
+        it("names the running model everywhere the page shows it", () => {
+            expect(document.querySelector(".modal-title .bbc-model").textContent).toBe(findModel("B-DFS1.2").name);
+            expect(modelDropdownText()).toBe(findModel("B-DFS1.2").name);
+        });
+
+        it("keeps naming the running model after another is saved for the next start", () => {
+            openDialog();
+            clickModel("Master");
+            closeDialog();
+            expect(document.querySelector(".modal-title .bbc-model").textContent).toBe(findModel("B-DFS1.2").name);
+            openDialog();
             expect(modelDropdownText()).toBe(findModel("Master").name);
-        });
-
-        it("shows a sound output and gates the speaker slider on it", () => {
-            config.setAudioOutput("board");
-            expect(document.querySelector(".audio-output-text").textContent).toBe("Line out");
-            expect(document.getElementById("speakerAmountSetting").disabled).toBe(true);
-            config.setAudioOutput("speaker");
-            expect(document.getElementById("speakerAmountSetting").disabled).toBe(false);
-        });
-
-        it("offers the ROMs for the fittings that are ticked", () => {
-            config.setModel("Master");
-            config.setCheckboxes({ hasEconet: true, hasMusic5000: true });
-            expect(config.extraRoms).toEqual(["master/anfs-4.25.rom", "ample.rom"]);
-        });
-    });
-
-    describe("mapLegacyModels", () => {
-        it("splits the combination models into a model and its fitting", () => {
-            const turbo = { model: "MasterTurbo" };
-            config.mapLegacyModels(turbo);
-            expect(turbo).toEqual({ model: "Master", coProcessor: true });
-
-            const music = { model: "BMusic5000" };
-            config.mapLegacyModels(music);
-            expect(music).toEqual({ model: "B-DFS1.2", hasMusic5000: true });
-
-            const teletext = { model: "BTeletext" };
-            config.mapLegacyModels(teletext);
-            expect(teletext).toEqual({ model: "B-DFS1.2", hasTeletextAdaptor: true });
-        });
-
-        it("leaves a query with no model alone", () => {
-            const query = { autoboot: true };
-            config.mapLegacyModels(query);
-            expect(query).toEqual({ autoboot: true });
         });
     });
 });

--- a/tests/unit/test-quick-settings.js
+++ b/tests/unit/test-quick-settings.js
@@ -1,29 +1,30 @@
 // @vitest-environment jsdom
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import { QuickSettings } from "../../src/web/quick-settings.js";
-import { domFromIndexHtml, teardownDom } from "./helpers.js";
+import { Settings } from "../../src/web/settings.js";
+import { domFromIndexHtml, fakeUrlState, teardownDom } from "./helpers.js";
 
 describe("QuickSettings", () => {
-    let callbacks;
+    let settings;
 
     beforeEach(() => {
         domFromIndexHtml("quick-settings");
-        callbacks = { onAudioOutput: vi.fn(), onSpeakerAmount: vi.fn(), onDisplayMode: vi.fn() };
+        settings = new Settings({ urlState: fakeUrlState() });
     });
 
     afterEach(teardownDom);
 
-    const make = (initial = { audioOutput: "speaker", speakerAmount: 1, displayMode: "rgb" }) =>
-        new QuickSettings(callbacks, initial);
+    const make = () => new QuickSettings(settings);
     const pressed = (selector) =>
         Array.from(document.querySelectorAll(selector))
             .filter((b) => b.classList.contains("active"))
             .map((b) => b.dataset.output ?? b.dataset.mode);
     const amount = () => document.getElementById("speaker-amount");
 
-    it("shows the initial settings and only enables the amount for the speaker", () => {
-        make({ audioOutput: "board", speakerAmount: 0.4, displayMode: "pal" });
+    it("shows the settings as they are and only enables the amount for the speaker", () => {
+        settings.set({ audioOutput: "board", speakerAmount: 0.4, displayMode: "pal" });
+        make();
         expect(pressed("[data-output]")).toEqual(["board"]);
         expect(amount().value).toBe("0.4");
         expect(amount().disabled).toBe(true);
@@ -31,50 +32,43 @@ describe("QuickSettings", () => {
         expect(document.querySelector('[data-output="board"]').getAttribute("aria-pressed")).toBe("true");
     });
 
-    it("reports a chosen sound output, from a click anywhere on its button, without showing it itself", () => {
+    it("sets the sound output from a click anywhere on its button", () => {
         make();
         document.querySelector('[data-output="off"]').click();
-        expect(callbacks.onAudioOutput).toHaveBeenCalledWith("off");
-        const inner = document.querySelector('[data-output="speaker"]').appendChild(document.createElement("span"));
-        inner.click();
-        expect(callbacks.onAudioOutput).toHaveBeenLastCalledWith("speaker");
-        expect(pressed("[data-output]")).toEqual(["speaker"]);
-    });
-
-    it("follows the sound output it is shown", () => {
-        const settings = make();
-        settings.showAudioOutput("off");
+        expect(settings.audioOutput).toBe("off");
         expect(pressed("[data-output]")).toEqual(["off"]);
         expect(amount().disabled).toBe(true);
-        settings.showAudioOutput("speaker");
+        const inner = document.querySelector('[data-output="speaker"]').appendChild(document.createElement("span"));
+        inner.click();
+        expect(settings.audioOutput).toBe("speaker");
         expect(amount().disabled).toBe(false);
     });
 
-    it("reports the amount as it moves and follows the amount it is shown", () => {
-        const settings = make();
+    it("sets the amount as the slider moves", () => {
+        make();
         amount().value = "0.5";
         amount().dispatchEvent(new Event("input"));
-        expect(callbacks.onSpeakerAmount).toHaveBeenCalledWith(0.5);
-        settings.showSpeakerAmount(0.25);
-        expect(amount().value).toBe("0.25");
+        expect(settings.speakerAmount).toBe(0.5);
     });
 
-    it("reports the display mode and follows the one it is shown", () => {
-        const settings = make();
+    it("sets the display mode", () => {
+        make();
         document.querySelector('[data-mode="xbr"]').click();
-        expect(callbacks.onDisplayMode).toHaveBeenCalledWith("xbr");
-        expect(pressed("[data-mode]")).toEqual(["rgb"]);
-        settings.showDisplayMode("pal");
+        expect(settings.displayMode).toBe("xbr");
+        expect(pressed("[data-mode]")).toEqual(["xbr"]);
+    });
+
+    it("follows a setting changed elsewhere", () => {
+        make();
+        settings.set({ audioOutput: "off", speakerAmount: 0.25, displayMode: "pal" });
+        expect(pressed("[data-output]")).toEqual(["off"]);
+        expect(amount().value).toBe("0.25");
         expect(pressed("[data-mode]")).toEqual(["pal"]);
     });
 
     it("does nothing on a page without the controls", () => {
         document.body.innerHTML = "";
-        const settings = make();
-        expect(() => {
-            settings.showAudioOutput("off");
-            settings.showSpeakerAmount(0.5);
-            settings.showDisplayMode("pal");
-        }).not.toThrow();
+        make();
+        expect(() => settings.set({ audioOutput: "off" })).not.toThrow();
     });
 });

--- a/tests/unit/test-settings.js
+++ b/tests/unit/test-settings.js
@@ -1,47 +1,22 @@
 // @vitest-environment jsdom
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { Settings } from "../../src/web/settings.js";
+import { Settings, mapLegacyModels } from "../../src/web/settings.js";
 import { DefaultModel, findModel } from "../../src/models.js";
-import { domFromIndexHtml, fakeUrlState, teardownDom, toasts } from "./helpers.js";
+import { fakeUrlState, teardownDom, toasts } from "./helpers.js";
 
 describe("Settings", () => {
     let urlState;
-    let targets;
-
-    const dialog = () => document.getElementById("configuration");
-    const openDialog = () => dialog().dispatchEvent(new Event("show.bs.modal", { bubbles: true }));
-    const closeDialog = () => dialog().dispatchEvent(new Event("hide.bs.modal", { bubbles: true }));
-    const dragTubeSlider = (value) => {
-        const slider = document.getElementById("tubeCpuMultiplier");
-        slider.value = value;
-        slider.dispatchEvent(new Event("input"));
-    };
 
     beforeEach(() => {
         vi.useFakeTimers();
-        domFromIndexHtml("configuration");
         urlState = fakeUrlState();
         vi.spyOn(urlState, "updateUrl");
-        targets = {
-            audioHandler: { setAudioOutput: vi.fn(), setSpeakerAmount: vi.fn() },
-            display: { setMode: vi.fn() },
-            layout: { resize: vi.fn() },
-            quickSettings: { showAudioOutput: vi.fn(), showSpeakerAmount: vi.fn(), showDisplayMode: vi.fn() },
-            machine: { emulationConfig: {}, processor: { hasTube: false, tube: {} } },
-            keyboard: { setKeyLayout: vi.fn() },
-            inputs: { updateAdcSources: vi.fn(), setupMicrophone: vi.fn() },
-            modals: { confirm: vi.fn().mockResolvedValue(false) },
-        };
     });
 
     afterEach(teardownDom);
 
-    const make = () => {
-        const settings = new Settings({ urlState });
-        settings.wire(targets);
-        return settings;
-    };
+    const make = () => new Settings({ urlState });
 
     describe("resolving the initial values", () => {
         it("prefers the URL, then browser storage, then the defaults", () => {
@@ -53,6 +28,7 @@ describe("Settings", () => {
             expect(settings.audioOutput).toBe("board");
             expect(settings.speakerAmount).toBe(1);
             expect(settings.keyLayout).toBe("physical");
+            expect(settings.tubeCpuMultiplier).toBe(1);
         });
 
         it("ignores nonsense from storage", () => {
@@ -68,6 +44,17 @@ describe("Settings", () => {
             expect(make().keyLayout).toBe("gaming");
         });
 
+        it("resolves the model and the fittings", () => {
+            urlState.params.model = "Master";
+            urlState.params.hasMusic5000 = true;
+            urlState.params.hasEconet = true;
+            const settings = make();
+            expect(settings.model).toBe(findModel("Master"));
+            expect(settings.hasMusic5000).toBe(true);
+            expect(settings.coProcessor).toBe(false);
+            expect(settings.extraRoms).toEqual(["master/anfs-4.25.rom", "ample.rom"]);
+        });
+
         it("falls back to the default model with a notice when the name is unknown", () => {
             urlState.params.model = "PDP-11";
             const settings = make();
@@ -75,147 +62,95 @@ describe("Settings", () => {
             expect(toasts()).toEqual([expect.stringContaining('no model called "PDP-11"')]);
         });
 
-        it("shows the dialog everything it resolved", () => {
-            urlState.params.model = "Master";
-            urlState.params.hasMusic5000 = true;
+        it("understands the old combination model names", () => {
+            urlState.params.model = "MasterTurbo";
             const settings = make();
             expect(settings.model).toBe(findModel("Master"));
-            expect(document.querySelector("#bbc-model-dropdown .bbc-model").textContent).toBe(findModel("Master").name);
-            expect(document.getElementById("hasMusic5000").checked).toBe(true);
-            expect(document.querySelector(".audio-output-text").textContent).toBe("Internal speaker");
+            expect(settings.coProcessor).toBe(true);
         });
     });
 
-    describe("applying a setting", () => {
-        it("fans a sound output out to the audio, the dialog, the bar, storage and the URL", () => {
+    describe("setting a value", () => {
+        it("adopts it, keeps it in storage and writes the URL", () => {
             const settings = make();
-            settings.applyAudioOutput("board");
-            expect(targets.audioHandler.setAudioOutput).toHaveBeenCalledWith("board");
-            expect(document.querySelector(".audio-output-text").textContent).toBe("Line out");
-            expect(targets.quickSettings.showAudioOutput).toHaveBeenCalledWith("board");
+            settings.set({ audioOutput: "board" });
+            expect(settings.audioOutput).toBe("board");
             expect(window.localStorage.audioOutput).toBe("board");
             expect(urlState.params.audioOutput).toBe("board");
-            expect(settings.audioOutput).toBe("board");
-            expect(urlState.updateUrl).toHaveBeenCalled();
+            expect(urlState.updateUrl).toHaveBeenCalledTimes(1);
         });
 
-        it("applies a display mode through the display and writes the URL at once", () => {
+        it("keeps only the settings worth remembering in storage", () => {
             const settings = make();
-            settings.applyDisplayMode("pal");
-            expect(targets.display.setMode).toHaveBeenCalledWith("pal");
-            expect(targets.layout.resize).toHaveBeenCalledTimes(1);
-            expect(settings.displayMode).toBe("pal");
-            expect(urlState.params.displayMode).toBe("pal");
-            expect(urlState.updateUrl).toHaveBeenCalledTimes(1);
+            settings.set({ hasMusic5000: true, keyLayout: "natural" });
+            expect(window.localStorage.hasMusic5000).toBeUndefined();
+            expect(window.localStorage.keyLayout).toBe("natural");
+            expect(urlState.params.hasMusic5000).toBe(true);
         });
 
         it("lets a speaker amount drag settle before writing one history entry", () => {
             const settings = make();
-            settings.applySpeakerAmount(0.5);
-            settings.applySpeakerAmount(0.4);
-            settings.applySpeakerAmount(0.3);
-            expect(targets.audioHandler.setSpeakerAmount).toHaveBeenCalledTimes(3);
-            expect(urlState.params.speakerAmount).toBe(0.3);
+            settings.set({ speakerAmount: 0.5 });
+            settings.set({ speakerAmount: 0.4 });
+            settings.set({ speakerAmount: 0.3 });
             expect(settings.speakerAmount).toBe(0.3);
+            expect(urlState.params.speakerAmount).toBe(0.3);
             expect(urlState.updateUrl).not.toHaveBeenCalled();
             vi.advanceTimersByTime(300);
             expect(urlState.updateUrl).toHaveBeenCalledTimes(1);
         });
 
-        it("routes the dialog's live changes through the same appliers", () => {
-            make();
-            document.querySelector('.display-mode-option[data-mode="rgb"]').click();
-            expect(targets.display.setMode).toHaveBeenCalledWith("rgb");
-            const slider = document.getElementById("speakerAmountSetting");
-            slider.value = 0.7;
-            slider.dispatchEvent(new Event("input"));
-            expect(targets.audioHandler.setSpeakerAmount).toHaveBeenCalledWith(0.7);
-        });
-    });
-
-    describe("closing the dialog", () => {
-        it("merges the changes into the URL parameters and updates the URL", () => {
-            make();
-            openDialog();
-            document.getElementById("hasMusic5000").click();
-            closeDialog();
-            expect(urlState.params.hasMusic5000).toBe(true);
-            expect(urlState.updateUrl).toHaveBeenCalledTimes(1);
-        });
-
-        it("fans a key layout out to storage, the machine and the keyboard", () => {
-            make();
-            openDialog();
-            document.querySelector('.keyboard-menu a[data-target="natural"]').click();
-            closeDialog();
-            expect(window.localStorage.keyLayout).toBe("natural");
-            expect(targets.machine.emulationConfig.keyLayout).toBe("natural");
-            expect(targets.keyboard.setKeyLayout).toHaveBeenCalledWith("natural");
-        });
-
-        it("reroutes the analogue channels when the mouse joystick or microphone change", () => {
-            make();
-            openDialog();
-            document.getElementById("mouseJoystickEnabled").click();
-            closeDialog();
-            expect(targets.inputs.updateAdcSources).toHaveBeenCalledWith(true, undefined);
-            expect(targets.inputs.setupMicrophone).not.toHaveBeenCalled();
-            openDialog();
-            document.querySelector('.mic-channel-option[data-channel="2"]').click();
-            closeDialog();
-            expect(targets.inputs.setupMicrophone).toHaveBeenCalled();
-        });
-
-        it("reroutes the analogue channels when the microphone is disabled, without starting it", () => {
-            urlState.params.microphoneChannel = 2;
-            make();
-            openDialog();
-            document.querySelector('.mic-channel-option[data-channel=""]').click();
-            closeDialog();
-            expect(targets.inputs.updateAdcSources).toHaveBeenCalledWith(undefined, undefined);
-            expect(targets.inputs.setupMicrophone).not.toHaveBeenCalled();
-        });
-
-        it("passes a tube multiplier to a fitted tube only", () => {
-            make();
-            openDialog();
-            dragTubeSlider(4);
-            closeDialog();
-            expect(targets.machine.emulationConfig.tubeCpuMultiplier).toBe(4);
-            expect(targets.machine.processor.tube.cpuMultiplier).toBeUndefined();
-
-            targets.machine.processor.hasTube = true;
-            openDialog();
-            dragTubeSlider(8);
-            closeDialog();
-            expect(targets.machine.processor.tube.cpuMultiplier).toBe(8);
-        });
-    });
-
-    describe("a change that needs a restart", () => {
-        it("asks before reloading", () => {
-            make();
-            openDialog();
-            document.getElementById("hasEconet").click();
-            closeDialog();
-            expect(targets.modals.confirm).toHaveBeenCalledWith(
-                expect.stringContaining("Restart now?"),
-                "Restart now",
-                "Later",
-            );
-        });
-    });
-
-    describe("speech output", () => {
-        it("follows the URL parameter and the dialog", () => {
-            urlState.params.speechOutput = true;
+        it("resolves a model by name and puts the name in the URL", () => {
             const settings = make();
-            expect(settings.speechOutput.enabled).toBe(true);
-            openDialog();
-            expect(document.getElementById("speechOutput").checked).toBe(true);
-            document.getElementById("speechOutput").click();
-            closeDialog();
-            expect(settings.speechOutput.enabled).toBe(false);
+            settings.set({ model: "Master" });
+            expect(settings.model).toBe(findModel("Master"));
+            expect(urlState.params.model).toBe("Master");
+        });
+
+        it("clears a setting given undefined", () => {
+            urlState.params.microphoneChannel = 2;
+            const settings = make();
+            settings.set({ microphoneChannel: undefined });
+            expect(settings.microphoneChannel).toBeUndefined();
+            expect("microphoneChannel" in urlState.params).toBe(false);
+        });
+
+        it("tells each setting's subscribers its new value, then everyone about the lot", () => {
+            const settings = make();
+            const onAudio = vi.fn();
+            const onMic = vi.fn();
+            const onChange = vi.fn();
+            settings.on("audioOutput", onAudio);
+            settings.on("microphoneChannel", onMic);
+            settings.addEventListener("change", (event) => onChange(event.detail));
+            settings.set({ audioOutput: "off", microphoneChannel: undefined });
+            expect(onAudio).toHaveBeenCalledWith("off");
+            expect(onMic).toHaveBeenCalledWith(undefined);
+            expect(onChange).toHaveBeenCalledWith({ audioOutput: "off", microphoneChannel: undefined });
+            settings.set({ displayMode: "pal" });
+            expect(onAudio).toHaveBeenCalledTimes(1);
+        });
+    });
+
+    describe("mapLegacyModels", () => {
+        it("splits the combination models into a model and its fitting", () => {
+            const turbo = { model: "MasterTurbo" };
+            mapLegacyModels(turbo);
+            expect(turbo).toEqual({ model: "Master", coProcessor: true });
+
+            const music = { model: "BMusic5000" };
+            mapLegacyModels(music);
+            expect(music).toEqual({ model: "B-DFS1.2", hasMusic5000: true });
+
+            const teletext = { model: "BTeletext" };
+            mapLegacyModels(teletext);
+            expect(teletext).toEqual({ model: "B-DFS1.2", hasTeletextAdaptor: true });
+        });
+
+        it("leaves a query with no model alone", () => {
+            const query = { autoboot: true };
+            mapLegacyModels(query);
+            expect(query).toEqual({ autoboot: true });
         });
     });
 });

--- a/tests/unit/test-settings.js
+++ b/tests/unit/test-settings.js
@@ -107,6 +107,20 @@ describe("Settings", () => {
             expect(urlState.params.model).toBe("Master");
         });
 
+        it("keeps the model it has when given a name it does not know", () => {
+            const settings = make();
+            settings.set({ model: "PDP-11" });
+            expect(settings.model).toBe(DefaultModel);
+        });
+
+        it("forgets a stored setting that is cleared", () => {
+            window.localStorage.keyLayout = "natural";
+            const settings = make();
+            settings.set({ keyLayout: undefined });
+            expect(window.localStorage.keyLayout).toBeUndefined();
+            expect(settings.keyLayout).toBeUndefined();
+        });
+
         it("clears a setting given undefined", () => {
             urlState.params.microphoneChannel = 2;
             const settings = make();

--- a/tests/unit/test-web-machine.js
+++ b/tests/unit/test-web-machine.js
@@ -4,7 +4,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { Machine, buildEmulationConfig } from "../../src/web/machine.js";
 import { domFromIndexHtml, teardownDom, toasts } from "./helpers.js";
 
-const config = (overrides = {}) => ({
+const settings = (overrides = {}) => ({
     tubeCpuMultiplier: 1,
     coProcessor: false,
     model: { name: "B-DFS1.2" },
@@ -18,7 +18,7 @@ const config = (overrides = {}) => ({
 describe("buildEmulationConfig", () => {
     const build = (overrides = {}) =>
         buildEmulationConfig({
-            config: config(),
+            settings: settings(),
             parsedQuery: {},
             keyLayout: "physical",
             cpuMultiplier: 1,
@@ -29,13 +29,13 @@ describe("buildEmulationConfig", () => {
         });
 
     it("lets the fittings' ROMs claim banks before the URL's", () => {
-        const built = build({ config: config({ extraRoms: ["fitted.rom"] }), extraRoms: ["user.rom"] });
+        const built = build({ settings: settings({ extraRoms: ["fitted.rom"] }), extraRoms: ["user.rom"] });
         expect(built.extraRoms).toEqual(["fitted.rom", "user.rom"]);
     });
 
     it("fits a tube only when a co-processor was asked for", () => {
         expect(build().tube).toBeNull();
-        expect(build({ config: config({ coProcessor: true }) }).tube).toBeTruthy();
+        expect(build({ settings: settings({ coProcessor: true }) }).tube).toBeTruthy();
     });
 
     it("turns the FDC logging flags on by their presence alone", () => {
@@ -60,7 +60,7 @@ describe("Machine", () => {
         };
         deps = {
             model: { isAtom: false, cyclesPerSecond: 2000000, cmosOverride: undefined },
-            config: config(),
+            settings: settings(),
             parsedQuery: {},
             keyLayout: "physical",
             cpuMultiplier: 1,
@@ -98,7 +98,7 @@ describe("Machine", () => {
     });
 
     it("fits an Econet when asked, sharing it with the CMOS", () => {
-        deps.config = config({ hasEconet: true });
+        deps.settings = settings({ hasEconet: true });
         const machine = make();
         expect(machine.econet).toBeTruthy();
         expect(document.getElementById("fsmenuitem").style.display).toBe("");


### PR DESCRIPTION
Theme A of #1002. Best reviewed after #1047, whose end-to-end round-trip check is the guard for this change; it passes against this branch locally.

**Before.** `Settings` did four jobs: resolved values from the URL, storage and the defaults; persisted them; *applied* them by reaching into the bag `wire()` handed over (`audioHandler`, `display`, `layout`, `machine`, `keyboard`, `inputs`, `modals`, `quickSettings`); and fanned every change to both views by hand (`config.setX` and `quickSettings.showX`). The views pointed back at it: `Config` through three constructor callbacks *and* a `settings-changed` event for the same `hide.bs.modal`, `QuickSettings` through three more. Each setting's flow was written in three places, and `Settings` knew that a display-mode change needs `layout.resize()` and that a restart needs `modals.confirm()`.

**After.** `Settings` is an `EventTarget` with one verb. `set(changes)` adopts the values, persists them (browser storage for the four worth remembering, the URL for all, settling a speaker drag into one history entry), dispatches an event named for each changed setting, then one `change` event carrying them all. `on(name, listener)` hands a subscriber the new value. Resolution stays in the constructor, and `mapLegacyModels` moves here from `Config`, since it is about URL parameters.

`Config` and `QuickSettings` are views: each takes the settings, renders from them, follows the live ones (`audioOutput`, `speakerAmount`, `displayMode`) and calls `set()` on user input. `Config` saves the touched settings together on close and dispatches `restart-required` when a saved change needs a rebuilt machine; its callbacks and `settings-changed` are gone, and it no longer keeps its own copies of the model, fittings and tube multiplier (`runningSettings` is captured at construction, which is before anything can change, so the "knowable only on first open" workaround goes too).

Everything a setting reaches subscribes in `main.js` where it is built: the audio handler, display plus layout, keyboard, tube multiplier, analogue inputs, speech output, and the restart prompt. `wire()` and the targets bag are deleted. `Machine`, `AnalogueInputs` and the Electron hook take `settings` in place of `config` (Electron saves on `change`, which now also covers the top-bar controls; before, only dialog changes reached its store).

**Two audit claims corrected while doing this.** The `emulationConfig.keyLayout` write was called dead in #1002; it is read again on every reset (`6502.js` `reset`), so it stays, with the reason on it. The `emulationConfig.tubeCpuMultiplier` write really was dead (read only when the Tube is constructed) and goes. Electron's `settings-changed` listener was the second consumer the audit missed; it moves to the new `change` event.

**Tests.** `test-settings.js` covers resolution, `set()` (persistence, settling, model by name, clearing with `undefined`, per-setting and whole-change events), and `mapLegacyModels`. `test-config.js`, `test-quick-settings.js` and `test-analogue-inputs.js` drive their subject against a real `Settings`, asserting on its values and URL rather than on callback mocks. One detail worth knowing: subscribers receive the setting's own value rather than `CustomEvent.detail`, because `detail` turns `undefined` into `null`, and clearing the microphone channel would then have started the microphone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)