### PR TITLE
refactor: the loop, printer and rewind announce instead of calling forward

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -21,7 +21,7 @@ import { isSnapshotFile, SnapshotUI } from "./web/snapshot-ui.js";
 import { Autoboot } from "./web/autoboot.js";
 import { Display } from "./web/display.js";
 import { Layout } from "./web/layout.js";
-import { EmulationLoop, RewindCaptureInterval } from "./web/emulation-loop.js";
+import { EmulationLoop } from "./web/emulation-loop.js";
 import { RunControls } from "./web/run-controls.js";
 import { exposeConsoleSurface } from "./web/console-surface.js";
 import { KeyboardSetup } from "./web/keyboard-setup.js";
@@ -36,7 +36,6 @@ import { Settings } from "./web/settings.js";
 import { Config } from "./web/config.js";
 import { SpeechOutput } from "./speech-output.js";
 import { Printer } from "./printer.js";
-import { RewindBuffer } from "./rewind.js";
 import { RewindUI } from "./web/rewind-ui.js";
 import { DiscVisualiser } from "./web/disc-visualiser.js";
 import { downloadDriveData } from "./dom-utils.js";
@@ -92,14 +91,7 @@ if (!window.isSecureContext)
         quietKey: "quietInsecureGamepads",
     });
 
-const printer = new Printer({
-    onOutput: (char) => frontPanel.printChar(char),
-    onFirstOutput: () =>
-        toast("Printer output is being kept. Press Ctrl-B to open the printer window.", {
-            title: "Printer",
-            quietKey: "quietPrinterOutput",
-        }),
-});
+const printer = new Printer();
 
 const accessibilitySwitches = new AccessibilitySwitches();
 
@@ -218,7 +210,6 @@ const { keyboard } = new KeyboardSetup({
     keyLayout,
 });
 
-const rewindBuffer = new RewindBuffer(30);
 const loop = new EmulationLoop({
     processor,
     display,
@@ -226,9 +217,6 @@ const loop = new EmulationLoop({
     dbgr,
     gamepad,
     keyboard,
-    syncLights: () => frontPanel.syncLights(),
-    rewindBuffer,
-    onRewindCaptured: () => rewindUI.updateButtonState(),
     clocksPerSecond,
     cpuSpeed,
     fastTape: !!parsedQuery.fasttape,
@@ -301,19 +289,13 @@ if (settings.microphoneChannel !== undefined) {
 // Apply ADC source settings from URL parameters
 inputs.updateAdcSources(settings.mouseJoystickEnabled, settings.microphoneChannel);
 
-const frontPanel = new FrontPanel({ processor, model, printer });
+const frontPanel = new FrontPanel({ processor, model, printer, loop });
 
 // ------------------------------------------------------------------------
 // Rewind, the visualiser and the layout.
 // ------------------------------------------------------------------------
 
-const rewindUI = new RewindUI({
-    rewindBuffer,
-    processor,
-    video,
-    captureInterval: RewindCaptureInterval,
-    loop,
-});
+const rewindUI = new RewindUI({ processor, video, loop });
 rewindUI.updateButtonState();
 
 new DiscVisualiser({ fdc: processor.fdc });

--- a/src/printer.js
+++ b/src/printer.js
@@ -1,19 +1,14 @@
 /**
  * Centronics printer attached to the user VIA: acknowledges each character and keeps the most
- * recent output so it can be shown whenever a printer window is opened.
+ * recent output so it can be shown whenever a printer window is opened. Dispatches "output" with
+ * each character as its detail, and "first-output" once, when the machine first prints.
  */
 
 export const MaxBufferedChars = 64 * 1024;
 
-export class Printer {
-    /**
-     * @param {object} [handlers]
-     * @param {function(string): void} [handlers.onOutput] called with each character as it is printed
-     * @param {function(): void} [handlers.onFirstOutput] called once, when the machine first prints
-     */
-    constructor({ onOutput = () => {}, onFirstOutput = () => {} } = {}) {
-        this._onOutput = onOutput;
-        this._onFirstOutput = onFirstOutput;
+export class Printer extends EventTarget {
+    constructor() {
+        super();
         this._uservia = null;
         this._olderText = "";
         this._newerText = "";
@@ -50,8 +45,8 @@ export class Printer {
         }
         if (!this._hasPrinted) {
             this._hasPrinted = true;
-            this._onFirstOutput();
+            this.dispatchEvent(new Event("first-output"));
         }
-        this._onOutput(char);
+        this.dispatchEvent(new CustomEvent("output", { detail: char }));
     }
 }

--- a/src/web/emulation-loop.js
+++ b/src/web/emulation-loop.js
@@ -49,9 +49,10 @@ class VirtualSpeedUpdater {
 
 /**
  * Runs the machine in real time: the tick that turns wall-clock time into
- * cycles, starting and stopping, the audio lead, fast-forward, rewind capture
- * and the speed readout. Owns `running`, and dispatches a "running" event
- * whenever it changes hands. Anything that needs the machine held still while
+ * cycles, starting and stopping, the audio lead, fast-forward and the speed
+ * readout. Owns `running`, and dispatches a "running" event whenever it
+ * changes hands, "tick" each time it runs the machine, and "rewind-capture"
+ * every RewindCaptureInterval frames for whoever keeps the rewind history. Anything that needs the machine held still while
  * it works (a dialog, a snapshot, the rewind panel, a hidden tab) takes a
  * `pause()`; the loop runs again once every hold has let go, provided the user
  * still wants it running.
@@ -64,9 +65,6 @@ export class EmulationLoop extends EventTarget {
         dbgr,
         gamepad,
         keyboard,
-        syncLights,
-        rewindBuffer,
-        onRewindCaptured,
         clocksPerSecond,
         cpuSpeed,
         fastTape,
@@ -79,9 +77,6 @@ export class EmulationLoop extends EventTarget {
         this.dbgr = dbgr;
         this.gamepad = gamepad;
         this.keyboard = keyboard;
-        this.syncLights = syncLights;
-        this.rewindBuffer = rewindBuffer;
-        this.onRewindCaptured = onRewindCaptured;
         this.clocksPerSecond = clocksPerSecond;
         this.maxCyclesPerTick = clocksPerSecond / 10;
         this.rewindCaptureCycles = (RewindCaptureInterval * clocksPerSecond) / 50;
@@ -189,7 +184,7 @@ export class EmulationLoop extends EventTarget {
         this.scheduleTick(speedy ? 0 : TickMs);
 
         this.gamepad.update(processor.sysvia);
-        this.syncLights();
+        this.dispatchEvent(new Event("tick"));
         if (this.last !== 0) {
             let cycles;
             if (!speedy) {
@@ -212,8 +207,7 @@ export class EmulationLoop extends EventTarget {
                 this.rewindCycleCounter += cycles;
                 if (this.rewindCycleCounter >= this.rewindCaptureCycles) {
                     this.rewindCycleCounter -= this.rewindCaptureCycles;
-                    this.rewindBuffer.push(processor.snapshotState());
-                    this.onRewindCaptured();
+                    this.dispatchEvent(new Event("rewind-capture"));
                     snapshotMs = performance.now() - end;
                 }
                 if (this.audioStatsNode)

--- a/src/web/emulation-loop.js
+++ b/src/web/emulation-loop.js
@@ -51,8 +51,9 @@ class VirtualSpeedUpdater {
  * Runs the machine in real time: the tick that turns wall-clock time into
  * cycles, starting and stopping, the audio lead, fast-forward and the speed
  * readout. Owns `running`, and dispatches a "running" event whenever it
- * changes hands, "tick" each time it runs the machine, and "rewind-capture"
- * every RewindCaptureInterval frames for whoever keeps the rewind history. Anything that needs the machine held still while
+ * changes hands, "tick" on every tick while running (the first only takes the
+ * time), and "rewind-capture" every RewindCaptureInterval frames for whoever
+ * keeps the rewind history. Anything that needs the machine held still while
  * it works (a dialog, a snapshot, the rewind panel, a hidden tab) takes a
  * `pause()`; the loop runs again once every hold has let go, provided the user
  * still wants it running.

--- a/src/web/front-panel.js
+++ b/src/web/front-panel.js
@@ -18,12 +18,20 @@ class Light {
  * controls, and the pop-up window the printer prints into.
  */
 export class FrontPanel {
-    constructor({ processor, model, printer }) {
+    constructor({ processor, model, printer, loop }) {
         this.processor = processor;
         this.model = model;
         this.printer = printer;
         this.printerWindow = null;
         this.printerTextArea = null;
+        loop.addEventListener("tick", () => this.syncLights());
+        printer.addEventListener("output", (event) => this.printChar(event.detail));
+        printer.addEventListener("first-output", () =>
+            toast("Printer output is being kept. Press Ctrl-B to open the printer window.", {
+                title: "Printer",
+                quietKey: "quietPrinterOutput",
+            }),
+        );
 
         for (const link of document.querySelectorAll("#tape-menu a")) {
             link.addEventListener("click", (e) => {

--- a/src/web/rewind-ui.js
+++ b/src/web/rewind-ui.js
@@ -1,4 +1,8 @@
 import { renderThumbnails, executeUntilFrame } from "../rewind-thumbnail.js";
+import { RewindBuffer } from "../rewind.js";
+import { RewindCaptureInterval } from "./emulation-loop.js";
+
+const RewindBufferSnapshots = 30;
 
 /**
  * Rewind scrubber UI — a filmstrip overlay showing thumbnails of recent
@@ -7,18 +11,16 @@ import { renderThumbnails, executeUntilFrame } from "../rewind-thumbnail.js";
 export class RewindUI {
     /**
      * @param {object} options
-     * @param {object} options.rewindBuffer - RewindBuffer instance
      * @param {object} options.processor - Cpu6502 instance
      * @param {object} options.video - Video instance
-     * @param {number} options.captureInterval - rewind capture interval in frames
-     * @param {object} options.loop - the emulation loop, for pausing and resuming
+     * @param {object} options.loop - the emulation loop: says when to capture, and is held while the panel is open
      */
-    constructor({ rewindBuffer, processor, video, captureInterval, loop }) {
-        this.rewindBuffer = rewindBuffer;
+    constructor({ processor, video, loop }) {
+        this.rewindBuffer = new RewindBuffer(RewindBufferSnapshots);
         this.processor = processor;
         this.video = video;
-        this.captureInterval = captureInterval;
         this.loop = loop;
+        loop.addEventListener("rewind-capture", () => this.capture());
 
         this.panel = document.getElementById("rewind-panel");
         this.filmstrip = document.getElementById("rewind-filmstrip");
@@ -37,6 +39,11 @@ export class RewindUI {
             e.preventDefault();
             this.open();
         });
+    }
+
+    capture() {
+        this.rewindBuffer.push(this.processor.snapshotState());
+        this.updateButtonState();
     }
 
     /** Forget everything captured, as on a hard reset. */
@@ -61,7 +68,7 @@ export class RewindUI {
                 this.processor,
                 this.snapshots,
                 this.video,
-                this.captureInterval,
+                RewindCaptureInterval,
                 this.savedState,
             );
             this._populateFilmstrip(thumbnails);

--- a/tests/unit/test-emulation-loop.js
+++ b/tests/unit/test-emulation-loop.js
@@ -40,9 +40,6 @@ describe("EmulationLoop", () => {
             dbgr: { debug: vi.fn() },
             gamepad: { update: vi.fn() },
             keyboard: { postFrameShouldPause: vi.fn(() => false) },
-            syncLights: vi.fn(),
-            rewindBuffer: { push: vi.fn() },
-            onRewindCaptured: vi.fn(),
             clocksPerSecond: ClocksPerSecond,
             cpuSpeed: ClocksPerSecond,
             fastTape: false,
@@ -88,7 +85,6 @@ describe("EmulationLoop", () => {
         expect(cyclesExecuted()).toEqual([(10 * ClocksPerSecond) / 1000]);
         expect(deps.audioHandler.flushChipEvents).toHaveBeenCalled();
         expect(deps.gamepad.update).toHaveBeenCalledWith(deps.processor.sysvia);
-        expect(deps.syncLights).toHaveBeenCalled();
         expect(deps.display.takePaintMs).toHaveBeenCalled();
         expect(deps.display.setSpeedy).toHaveBeenLastCalledWith(false);
     });
@@ -163,14 +159,24 @@ describe("EmulationLoop", () => {
         expect(deps.processor.execute).not.toHaveBeenCalled();
     });
 
-    it("captures a rewind snapshot every interval", () => {
-        started();
+    it("announces every tick it runs the machine on", () => {
+        const loop = started();
+        const ticks = vi.fn();
+        loop.addEventListener("tick", ticks);
+        vi.advanceTimersByTime(100);
+        // A tick every 10ms.
+        expect(ticks).toHaveBeenCalledTimes(10);
+    });
+
+    it("asks for a rewind capture every interval", () => {
+        const loop = started();
+        const captures = vi.fn();
+        loop.addEventListener("rewind-capture", captures);
         // The capture interval is one emulated second.
         vi.advanceTimersByTime(1500);
-        expect(deps.rewindBuffer.push).toHaveBeenCalledTimes(1);
-        expect(deps.onRewindCaptured).toHaveBeenCalledTimes(1);
+        expect(captures).toHaveBeenCalledTimes(1);
         vi.advanceTimersByTime(1000);
-        expect(deps.rewindBuffer.push).toHaveBeenCalledTimes(2);
+        expect(captures).toHaveBeenCalledTimes(2);
     });
 
     it("starts once however often it is asked to go", () => {

--- a/tests/unit/test-front-panel.js
+++ b/tests/unit/test-front-panel.js
@@ -2,10 +2,12 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { FrontPanel } from "../../src/web/front-panel.js";
+import { Printer } from "../../src/printer.js";
 import { domFromIndexHtml, teardownDom, toasts } from "./helpers.js";
 
 describe("FrontPanel", () => {
     let processor;
+    let loop;
 
     beforeEach(() => {
         vi.spyOn(console, "log").mockImplementation(() => {});
@@ -17,11 +19,13 @@ describe("FrontPanel", () => {
             atomppia: { motorOn: false, playTape: vi.fn(), stopTape: vi.fn(), rewindTape: vi.fn() },
             econet: null,
         };
+        loop = new EventTarget();
     });
 
     afterEach(teardownDom);
 
-    const make = (isAtom = false, printer = { text: "" }) => new FrontPanel({ processor, model: { isAtom }, printer });
+    const make = (isAtom = false, printer = new Printer()) =>
+        new FrontPanel({ processor, model: { isAtom }, printer, loop });
     const lit = (id) => document.getElementById(id).classList.contains("on");
 
     describe("the lights", () => {
@@ -103,6 +107,13 @@ describe("FrontPanel", () => {
     });
 
     describe("the printer window", () => {
+        it("says how to open it the first time anything prints", () => {
+            const printer = new Printer();
+            make(false, printer);
+            printer.dispatchEvent(new Event("first-output"));
+            expect(toasts()).toEqual([expect.stringContaining("Ctrl-B")]);
+        });
+
         it("says when the pop-up was blocked", () => {
             vi.spyOn(window, "open").mockReturnValue(null);
             make().checkPrinterWindow();
@@ -121,10 +132,11 @@ describe("FrontPanel", () => {
                 document: { write: vi.fn(), getElementById: () => fakeArea },
             };
             vi.spyOn(window, "open").mockReturnValue(fakeWindow);
-            const panel = make(false, { text: "so far" });
+            const printer = Object.assign(new EventTarget(), { text: "so far" });
+            const panel = make(false, printer);
             panel.checkPrinterWindow();
             expect(fakeArea.value).toBe("so far");
-            panel.printChar("!");
+            printer.dispatchEvent(new CustomEvent("output", { detail: "!" }));
             expect(fakeArea.value).toBe("so far!");
             // A second check leaves the open window alone.
             panel.checkPrinterWindow();

--- a/tests/unit/test-printer.js
+++ b/tests/unit/test-printer.js
@@ -78,7 +78,8 @@ describe("Printer", () => {
     describe("live output", () => {
         it("reports each character as it is printed", () => {
             const seen = [];
-            attach(new Printer({ onOutput: (char) => seen.push(char) }));
+            const printer = attach(new Printer());
+            printer.addEventListener("output", (event) => seen.push(event.detail));
 
             print(uservia, "HI");
 
@@ -87,13 +88,10 @@ describe("Printer", () => {
 
         it("offers the buffered text to a window opened part way through", () => {
             let windowText = "";
-            const printer = attach(
-                new Printer({
-                    onOutput: (char) => {
-                        windowText += char;
-                    },
-                }),
-            );
+            const printer = attach(new Printer());
+            printer.addEventListener("output", (event) => {
+                windowText += event.detail;
+            });
 
             print(uservia, "BEFORE ");
             windowText = printer.text;
@@ -106,7 +104,7 @@ describe("Printer", () => {
     describe("first output notice", () => {
         it("reports only the first character printed", () => {
             let notices = 0;
-            attach(new Printer({ onFirstOutput: () => notices++ }));
+            attach(new Printer()).addEventListener("first-output", () => notices++);
 
             print(uservia, "HELLO");
 
@@ -115,7 +113,7 @@ describe("Printer", () => {
 
         it("says nothing until something is printed", () => {
             let notices = 0;
-            attach(new Printer({ onFirstOutput: () => notices++ }));
+            attach(new Printer()).addEventListener("first-output", () => notices++);
 
             expect(notices).toBe(0);
         });

--- a/tests/unit/test-rewind-ui.js
+++ b/tests/unit/test-rewind-ui.js
@@ -2,7 +2,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { RewindUI } from "../../src/web/rewind-ui.js";
-import { RewindBuffer } from "../../src/rewind.js";
 import { domFromIndexHtml, teardownDom } from "./helpers.js";
 
 const FakeContext = {
@@ -12,7 +11,6 @@ const FakeContext = {
 };
 
 describe("RewindUI", () => {
-    let rewindBuffer;
     let video;
     let processor;
     let resume;
@@ -27,7 +25,6 @@ describe("RewindUI", () => {
             if (tag === "canvas") element.getContext = () => FakeContext;
             return element;
         });
-        rewindBuffer = new RewindBuffer(5);
         video = { fb32: new Uint32Array(1024 * 625), frameCount: 0, clearPaintBuffer: () => {}, paint: vi.fn() };
         processor = {
             snapshotState: vi.fn(() => ({ live: true })),
@@ -37,21 +34,25 @@ describe("RewindUI", () => {
             }),
         };
         resume = vi.fn();
-        loop = { pause: vi.fn(() => resume) };
+        loop = Object.assign(new EventTarget(), { pause: vi.fn(() => resume) });
     });
 
     afterEach(teardownDom);
 
-    const make = () => new RewindUI({ rewindBuffer, processor, video, captureInterval: 50, loop });
+    const make = () => new RewindUI({ processor, video, loop });
     const panel = () => document.getElementById("rewind-panel");
     const thumbs = () => [...document.querySelectorAll(".rewind-thumb")];
     const selectedIndex = () => Number(document.querySelector(".rewind-thumb.selected").dataset.index);
     const lastRestored = () => processor.restoreState.mock.calls.at(-1)[0];
     const key = (name) => document.dispatchEvent(new KeyboardEvent("keydown", { key: name, cancelable: true }));
 
+    // The loop asking for captures, once a RewindUI is listening.
     const captured = (count) => {
         const snapshots = Array.from({ length: count }, (_, i) => ({ snapshot: i }));
-        for (const snapshot of snapshots) rewindBuffer.push(snapshot);
+        for (const snapshot of snapshots) {
+            processor.snapshotState.mockReturnValueOnce(snapshot);
+            loop.dispatchEvent(new Event("rewind-capture"));
+        }
         return snapshots;
     };
 
@@ -63,8 +64,8 @@ describe("RewindUI", () => {
         });
 
         it("pauses, fills the filmstrip with ages, and lands on now", () => {
-            const snapshots = captured(3);
             make();
+            const snapshots = captured(3);
             document.getElementById("rewind-open").click();
             expect(loop.pause).toHaveBeenCalledWith("the rewind panel");
             expect(panel().hidden).toBe(false);
@@ -79,11 +80,11 @@ describe("RewindUI", () => {
         });
 
         it("lets go and stays closed if the machine cannot be snapshotted", () => {
+            const ui = make();
             captured(1);
             processor.snapshotState.mockImplementation(() => {
                 throw new Error("no snapshot");
             });
-            const ui = make();
             expect(() => ui.open()).toThrow("no snapshot");
             expect(panel().hidden).toBe(true);
             expect(resume).toHaveBeenCalledTimes(1);
@@ -91,8 +92,8 @@ describe("RewindUI", () => {
         });
 
         it("opens once no matter how often it is asked", () => {
-            captured(1);
             const ui = make();
+            captured(1);
             ui.open();
             ui.open();
             expect(loop.pause).toHaveBeenCalledTimes(1);
@@ -102,16 +103,18 @@ describe("RewindUI", () => {
 
     describe("choosing a snapshot", () => {
         it("previews a clicked thumbnail without moving the machine on", () => {
+            const ui = make();
             const snapshots = captured(3);
-            make().open();
+            ui.open();
             thumbs()[0].click();
             expect(selectedIndex()).toBe(0);
             expect(lastRestored()).toBe(snapshots[0]);
         });
 
         it("walks the filmstrip with the arrow keys, stopping at the ends", () => {
+            const ui = make();
             captured(2);
-            make().open();
+            ui.open();
             key("ArrowLeft");
             expect(selectedIndex()).toBe(0);
             key("ArrowLeft");
@@ -122,8 +125,9 @@ describe("RewindUI", () => {
         });
 
         it("keeps every key from reaching the emulator while open", () => {
+            const ui = make();
             captured(1);
-            make().open();
+            ui.open();
             const leaked = vi.fn();
             document.addEventListener("keydown", leaked);
             key("a");
@@ -134,8 +138,9 @@ describe("RewindUI", () => {
 
     describe("closing", () => {
         it("commits the chosen snapshot on Enter and runs on from it", () => {
+            const ui = make();
             const snapshots = captured(2);
-            make().open();
+            ui.open();
             key("ArrowLeft");
             key("Enter");
             expect(lastRestored()).toBe(snapshots[0]);
@@ -145,8 +150,9 @@ describe("RewindUI", () => {
         });
 
         it("cancels back to the state from before it opened on Escape", () => {
+            const ui = make();
             captured(2);
-            make().open();
+            ui.open();
             key("ArrowLeft");
             key("Escape");
             expect(lastRestored()).toEqual({ live: true });
@@ -155,15 +161,17 @@ describe("RewindUI", () => {
         });
 
         it("cancels from the close button", () => {
+            const ui = make();
             captured(1);
-            make().open();
+            ui.open();
             document.getElementById("rewind-close").click();
             expect(panel().hidden).toBe(true);
         });
 
         it("stops listening for keys once closed", () => {
+            const ui = make();
             captured(2);
-            make().open();
+            ui.open();
             key("Escape");
             processor.restoreState.mockClear();
             key("ArrowLeft");
@@ -171,8 +179,8 @@ describe("RewindUI", () => {
         });
 
         it("lets go of its hold when it is reset", () => {
-            captured(1);
             const ui = make();
+            captured(1);
             ui.open();
             ui.reset();
             expect(resume).toHaveBeenCalledTimes(1);
@@ -192,12 +200,11 @@ describe("RewindUI", () => {
 
     describe("reset", () => {
         it("closes the panel and forgets everything captured", () => {
-            captured(3);
             const ui = make();
+            captured(3);
             ui.open();
             ui.reset();
             expect(panel().hidden).toBe(true);
-            expect(rewindBuffer.length).toBe(0);
             expect(document.getElementById("rewind-open").classList.contains("disabled")).toBe(true);
         });
     });


### PR DESCRIPTION
Theme C of #1002, first of two: the construction-order cycles and the rewind ownership split.

**Before.** `main.js` held three cycles together with closures over `const`s declared further down: the `Printer` was built with `onOutput: (char) => frontPanel.printChar(char)` before `frontPanel` existed; the loop was built with `syncLights: () => frontPanel.syncLights()` and `onRewindCaptured: () => rewindUI.updateButtonState()`; and the rewind buffer was built in `main.js`, handed to the loop to push into and to `RewindUI` to read from, with the capture interval re-exported between them. They worked because nothing fires before the script finishes, which is the kind of implicit ordering the e2e boot check exists to catch.

**After.** The loop dispatches `tick` each time it runs the machine and `rewind-capture` every capture interval, and knows nothing about lights or rewind. `FrontPanel` takes the loop and subscribes for its lights. `RewindUI` owns its buffer, subscribes for captures, and snapshots the processor itself; the capture cadence constant stays with the loop that keeps it, and `RewindUI` imports it for the age labels. `Printer` dispatches `output` (the character as its detail) and `first-output`; `FrontPanel` subscribes for its window and for the "press Ctrl-B" notice, which moves out of `main.js` to the thing that owns the window. Each subscriber attaches at its own construction, after the thing it listens to exists, so the order is now visible in the code rather than held by TDZ.

The two remaining forward references in `main.js` are deliberate and documented where they live: the keyboard shortcut actions bag (`KeyboardSetup` is told what each shortcut does, late-bound by design) and `MediaLoader`'s `loadSnapshot` callback into `SnapshotUI`. They stay.

Tests follow the events: the loop tests assert on `tick` and `rewind-capture` listeners rather than injected callbacks; the rewind tests drive captures through the loop event with a `RewindUI` listening (which also exercises `capture()` itself, previously untested); the front panel tests use a real `Printer` and check the first-output notice; the printer tests subscribe rather than pass handlers. The e2e suite, including the round-trip check from #1047, passes against the built bundle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)