### PR TITLE
refactor: the page's own handlers move out of main.js

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -39,7 +39,7 @@ import { Printer } from "./printer.js";
 import { RewindBuffer } from "./rewind.js";
 import { RewindUI } from "./web/rewind-ui.js";
 import { DiscVisualiser } from "./web/disc-visualiser.js";
-import { downloadDriveData } from "./dom-utils.js";
+import { PageActions } from "./web/page-actions.js";
 import { parseMediaParams, processAutobootParams, processDriveTrackParams, processInputParams } from "./url-params.js";
 
 installIcons();
@@ -73,11 +73,6 @@ const stationId = parsedQuery.stationId !== undefined ? parsedQuery.stationId : 
 
 const tryGl = parsedQuery.glEnabled ?? true;
 const lowLatency = parsedQuery.lowLatency ?? true;
-
-if (parsedQuery.embed) {
-    for (const el of document.querySelectorAll(".embed-hide")) el.style.display = "none";
-    document.body.style.backgroundColor = "transparent";
-}
 
 // ------------------------------------------------------------------------
 // The pieces that exist before the machine: settings, screen, sound.
@@ -321,7 +316,7 @@ new DiscVisualiser({ fdc: processor.fdc });
 const layout = new Layout({
     screenCanvas,
     display,
-    embed: parsedQuery.embed !== undefined,
+    embed: !!parsedQuery.embed,
     sidebars: { left: parsedQuery.sbLeft, right: parsedQuery.sbRight, bottom: parsedQuery.sbBottom },
 });
 
@@ -356,63 +351,7 @@ config.addEventListener("restart-required", async () => {
     if (restart) window.location.reload();
 });
 
-// ------------------------------------------------------------------------
-// The page's own handlers.
-// ------------------------------------------------------------------------
-
-for (const el of document.querySelectorAll(".initially-hidden")) el.classList.remove("initially-hidden");
-
-document.getElementById("paste-form").addEventListener("submit", (event) => event.preventDefault());
-
-window.addEventListener("blur", function () {
-    keyboard.clearKeys();
-    loop.setEmulationLead(audioHandler.setWindowFocused(false));
-});
-window.addEventListener("focus", () => loop.setEmulationLead(audioHandler.setWindowFocused(true)));
-
-// To lower chance of data loss, only accept drop events in the drop
-// zone in the menu bar.
-document.addEventListener("dragover", function (event) {
-    event.preventDefault();
-    event.dataTransfer.dropEffect = "none";
-});
-document.addEventListener("drop", function (event) {
-    event.preventDefault();
-});
-
-window.addEventListener("beforeunload", function (event) {
-    if (loop.isRunning() && processor.sysvia.hasAnyKeyDown()) {
-        const message =
-            "It seems like you're still using the emulator. If you're in Chrome, it's impossible for jsbeeb to prevent some shortcuts (like ctrl-W) from performing their default behaviour (e.g. closing the window).\n" +
-            "As a workarond, create an 'Application Shortcut' from the Tools menu.  When jsbeeb runs as an application, it *can* prevent ctrl-W from closing the window.";
-        event.preventDefault();
-        event.returnValue = message;
-        return message;
-    }
-});
-
-function hardReset() {
-    rewindUI.reset();
-    processor.reset(true);
-}
-
-document.getElementById("hard-reset").addEventListener("click", function (event) {
-    hardReset();
-    event.preventDefault();
-});
-
-document.getElementById("soft-reset").addEventListener("click", function (event) {
-    processor.reset(false);
-    event.preventDefault();
-});
-
-document.getElementById("download-filestore-link").addEventListener("click", function () {
-    if (!processor.filestore) return;
-    downloadDriveData(processor.filestore.scsi, "scsi", ".dat");
-});
-
-if (Object.hasOwn(parsedQuery, "about")) modals.show("info");
-if (Object.hasOwn(parsedQuery, "pp-tos")) modals.show("pp-tos");
+const page = new PageActions({ loop, processor, keyboard, audioHandler, rewindUI, modals, parsedQuery, version });
 
 // ------------------------------------------------------------------------
 // Start it up.
@@ -494,17 +433,11 @@ electron({
     },
     loadStateFile: snapshots.loadStateFromFile.bind(snapshots),
     actions: {
-        "soft-reset": () => processor.reset(false),
-        "hard-reset": hardReset,
+        "soft-reset": () => page.softReset(),
+        "hard-reset": () => page.hardReset(),
         "save-state": () => snapshots.saveState(),
         rewind: () => rewindUI.open(),
         pause: () => runControls.pause(),
         resume: () => runControls.resume(),
     },
 });
-
-// Display version in About dialog
-const versionElement = document.getElementById("jsbeeb-version");
-if (versionElement) {
-    versionElement.textContent = `Version ${version}`;
-}

--- a/src/web/layout.js
+++ b/src/web/layout.js
@@ -78,6 +78,10 @@ export class Layout {
         this.cubMonitorPic = document.getElementById("cub-monitor-pic");
         this.borderReservedSize = embed ? 0 : 100;
         this.bottomReservedSize = embed ? 0 : 68;
+        if (embed) {
+            for (const el of document.querySelectorAll(".embed-hide")) el.style.display = "none";
+            document.body.style.backgroundColor = "transparent";
+        }
 
         window.addEventListener("resize", () => this.resize());
         window.setTimeout(() => this.resize(), 1);

--- a/src/web/page-actions.js
+++ b/src/web/page-actions.js
@@ -2,7 +2,7 @@ import { downloadDriveData } from "../dom-utils.js";
 
 const UnloadWarning =
     "It seems like you're still using the emulator. If you're in Chrome, it's impossible for jsbeeb to prevent some shortcuts (like ctrl-W) from performing their default behaviour (e.g. closing the window).\n" +
-    "As a workarond, create an 'Application Shortcut' from the Tools menu.  When jsbeeb runs as an application, it *can* prevent ctrl-W from closing the window.";
+    "As a workaround, create an 'Application Shortcut' from the Tools menu.  When jsbeeb runs as an application, it *can* prevent ctrl-W from closing the window.";
 
 /**
  * The page around the emulator: the reset menu items and the filestore
@@ -13,28 +13,42 @@ export class PageActions {
     constructor({ loop, processor, keyboard, audioHandler, rewindUI, modals, parsedQuery, version }) {
         this.processor = processor;
         this.rewindUI = rewindUI;
+        this.pageListeners = new AbortController();
+        const { signal } = this.pageListeners;
 
         for (const el of document.querySelectorAll(".initially-hidden")) el.classList.remove("initially-hidden");
         document.getElementById("paste-form").addEventListener("submit", (event) => event.preventDefault());
 
-        window.addEventListener("blur", () => {
-            keyboard.clearKeys();
-            loop.setEmulationLead(audioHandler.setWindowFocused(false));
-        });
-        window.addEventListener("focus", () => loop.setEmulationLead(audioHandler.setWindowFocused(true)));
+        window.addEventListener(
+            "blur",
+            () => {
+                keyboard.clearKeys();
+                loop.setEmulationLead(audioHandler.setWindowFocused(false));
+            },
+            { signal },
+        );
+        window.addEventListener("focus", () => loop.setEmulationLead(audioHandler.setWindowFocused(true)), { signal });
 
         // To lower the chance of data loss, only the drop zone in the menu bar accepts drops.
-        document.addEventListener("dragover", (event) => {
-            event.preventDefault();
-            event.dataTransfer.dropEffect = "none";
-        });
-        document.addEventListener("drop", (event) => event.preventDefault());
+        document.addEventListener(
+            "dragover",
+            (event) => {
+                event.preventDefault();
+                event.dataTransfer.dropEffect = "none";
+            },
+            { signal },
+        );
+        document.addEventListener("drop", (event) => event.preventDefault(), { signal });
 
-        window.addEventListener("beforeunload", (event) => {
-            if (!loop.isRunning() || !processor.sysvia.hasAnyKeyDown()) return;
-            event.preventDefault();
-            event.returnValue = UnloadWarning;
-        });
+        window.addEventListener(
+            "beforeunload",
+            (event) => {
+                if (!loop.isRunning() || !processor.sysvia.hasAnyKeyDown()) return;
+                event.preventDefault();
+                event.returnValue = UnloadWarning;
+            },
+            { signal },
+        );
 
         document.getElementById("hard-reset").addEventListener("click", (event) => {
             event.preventDefault();
@@ -51,6 +65,11 @@ export class PageActions {
 
         const versionElement = document.getElementById("jsbeeb-version");
         if (versionElement) versionElement.textContent = `Version ${version}`;
+    }
+
+    /** Stops listening to the window and document; the elements go with the page. */
+    dispose() {
+        this.pageListeners.abort();
     }
 
     hardReset() {

--- a/src/web/page-actions.js
+++ b/src/web/page-actions.js
@@ -1,0 +1,69 @@
+import { downloadDriveData } from "../dom-utils.js";
+
+const UnloadWarning =
+    "It seems like you're still using the emulator. If you're in Chrome, it's impossible for jsbeeb to prevent some shortcuts (like ctrl-W) from performing their default behaviour (e.g. closing the window).\n" +
+    "As a workarond, create an 'Application Shortcut' from the Tools menu.  When jsbeeb runs as an application, it *can* prevent ctrl-W from closing the window.";
+
+/**
+ * The page around the emulator: the reset menu items and the filestore
+ * download, what focus and unload do to the machine, the drop guard, the
+ * dialogs a URL can ask for, and the version stamp.
+ */
+export class PageActions {
+    constructor({ loop, processor, keyboard, audioHandler, rewindUI, modals, parsedQuery, version }) {
+        this.processor = processor;
+        this.rewindUI = rewindUI;
+
+        for (const el of document.querySelectorAll(".initially-hidden")) el.classList.remove("initially-hidden");
+        document.getElementById("paste-form").addEventListener("submit", (event) => event.preventDefault());
+
+        window.addEventListener("blur", () => {
+            keyboard.clearKeys();
+            loop.setEmulationLead(audioHandler.setWindowFocused(false));
+        });
+        window.addEventListener("focus", () => loop.setEmulationLead(audioHandler.setWindowFocused(true)));
+
+        // To lower the chance of data loss, only the drop zone in the menu bar accepts drops.
+        document.addEventListener("dragover", (event) => {
+            event.preventDefault();
+            event.dataTransfer.dropEffect = "none";
+        });
+        document.addEventListener("drop", (event) => event.preventDefault());
+
+        window.addEventListener("beforeunload", (event) => {
+            if (!loop.isRunning() || !processor.sysvia.hasAnyKeyDown()) return;
+            event.preventDefault();
+            event.returnValue = UnloadWarning;
+        });
+
+        document.getElementById("hard-reset").addEventListener("click", (event) => {
+            event.preventDefault();
+            this.hardReset();
+        });
+        document.getElementById("soft-reset").addEventListener("click", (event) => {
+            event.preventDefault();
+            this.softReset();
+        });
+        document.getElementById("download-filestore-link").addEventListener("click", () => this.downloadFilestore());
+
+        if (Object.hasOwn(parsedQuery, "about")) modals.show("info");
+        if (Object.hasOwn(parsedQuery, "pp-tos")) modals.show("pp-tos");
+
+        const versionElement = document.getElementById("jsbeeb-version");
+        if (versionElement) versionElement.textContent = `Version ${version}`;
+    }
+
+    hardReset() {
+        this.rewindUI.reset();
+        this.processor.reset(true);
+    }
+
+    softReset() {
+        this.processor.reset(false);
+    }
+
+    downloadFilestore() {
+        if (!this.processor.filestore) return;
+        downloadDriveData(this.processor.filestore.scsi, "scsi", ".dat");
+    }
+}

--- a/tests/unit/test-layout.js
+++ b/tests/unit/test-layout.js
@@ -132,6 +132,17 @@ describe("Layout", () => {
             expect(canvas.style.top).toBe("64px");
         });
 
+        it("hides the page furniture and sees through the body when embedded", () => {
+            make();
+            expect(document.querySelector(".embed-hide").style.display).toBe("none");
+            expect(document.body.style.backgroundColor).toBe("transparent");
+        });
+
+        it("leaves the page furniture alone when not embedded", () => {
+            make({ embed: false });
+            expect(document.querySelector(".embed-hide").style.display).toBe("");
+        });
+
         it("reserves room for the page furniture when not embedded", () => {
             make({ embed: false });
             resize();

--- a/tests/unit/test-page-actions.js
+++ b/tests/unit/test-page-actions.js
@@ -6,6 +6,7 @@ import { domFromIndexHtml, teardownDom } from "./helpers.js";
 
 describe("PageActions", () => {
     let deps;
+    let page;
 
     beforeEach(() => {
         domFromIndexHtml("header-bar", "audio-warning", "info", "download-filestore-link");
@@ -22,12 +23,11 @@ describe("PageActions", () => {
     });
 
     afterEach(() => {
-        // Earlier tests' instances still listen on the shared window; keep theirs quiet.
-        deps.loop.isRunning.mockReturnValue(false);
+        page.dispose();
         return teardownDom();
     });
 
-    const make = () => new PageActions(deps);
+    const make = () => (page = new PageActions(deps));
     const click = (id) => {
         const event = new MouseEvent("click", { bubbles: true, cancelable: true });
         document.getElementById(id).dispatchEvent(event);

--- a/tests/unit/test-page-actions.js
+++ b/tests/unit/test-page-actions.js
@@ -1,0 +1,151 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { PageActions } from "../../src/web/page-actions.js";
+import { domFromIndexHtml, teardownDom } from "./helpers.js";
+
+describe("PageActions", () => {
+    let deps;
+
+    beforeEach(() => {
+        domFromIndexHtml("header-bar", "audio-warning", "info", "download-filestore-link");
+        deps = {
+            loop: { isRunning: vi.fn(() => true), setEmulationLead: vi.fn() },
+            processor: { reset: vi.fn(), sysvia: { hasAnyKeyDown: vi.fn(() => false) }, filestore: null },
+            keyboard: { clearKeys: vi.fn() },
+            audioHandler: { setWindowFocused: vi.fn((focused) => (focused ? 20 : 0)) },
+            rewindUI: { reset: vi.fn() },
+            modals: { show: vi.fn() },
+            parsedQuery: {},
+            version: "1.2.3",
+        };
+    });
+
+    afterEach(() => {
+        // Earlier tests' instances still listen on the shared window; keep theirs quiet.
+        deps.loop.isRunning.mockReturnValue(false);
+        return teardownDom();
+    });
+
+    const make = () => new PageActions(deps);
+    const click = (id) => {
+        const event = new MouseEvent("click", { bubbles: true, cancelable: true });
+        document.getElementById(id).dispatchEvent(event);
+        return event;
+    };
+
+    it("reveals what the page keeps hidden until the script has run", () => {
+        expect(document.querySelectorAll(".initially-hidden").length).toBeGreaterThan(0);
+        make();
+        expect(document.querySelectorAll(".initially-hidden")).toHaveLength(0);
+    });
+
+    it("stamps the version on the about dialog", () => {
+        make();
+        expect(document.getElementById("jsbeeb-version").textContent).toBe("Version 1.2.3");
+    });
+
+    describe("the reset menu", () => {
+        it("hard resets the machine and forgets the rewind history", () => {
+            make();
+            expect(click("hard-reset").defaultPrevented).toBe(true);
+            expect(deps.rewindUI.reset).toHaveBeenCalledTimes(1);
+            expect(deps.processor.reset).toHaveBeenCalledWith(true);
+        });
+
+        it("soft resets the machine alone", () => {
+            make();
+            expect(click("soft-reset").defaultPrevented).toBe(true);
+            expect(deps.rewindUI.reset).not.toHaveBeenCalled();
+            expect(deps.processor.reset).toHaveBeenCalledWith(false);
+        });
+    });
+
+    describe("the filestore download", () => {
+        it("does nothing on a machine without a filestore", () => {
+            const anchorClick = vi.spyOn(HTMLAnchorElement.prototype, "click");
+            make();
+            click("download-filestore-link");
+            expect(anchorClick).not.toHaveBeenCalled();
+        });
+
+        it("saves the filestore's disc image", () => {
+            vi.stubGlobal("URL", { ...URL, createObjectURL: vi.fn(() => "blob:scsi"), revokeObjectURL: vi.fn() });
+            const anchorClick = vi.spyOn(HTMLAnchorElement.prototype, "click").mockImplementation(function () {
+                this.dataset.clicked = `${this.download} from ${this.href}`;
+            });
+            deps.processor.filestore = { scsi: new Uint8Array([1, 2, 3]) };
+            make();
+            click("download-filestore-link");
+            expect(anchorClick).toHaveBeenCalledTimes(1);
+            expect(anchorClick.mock.contexts[0].dataset.clicked).toBe("scsi.dat from blob:scsi");
+        });
+    });
+
+    describe("focus", () => {
+        it("lets go of the keys and takes the unfocused audio lead when the window blurs", () => {
+            make();
+            window.dispatchEvent(new Event("blur"));
+            expect(deps.keyboard.clearKeys).toHaveBeenCalledTimes(1);
+            expect(deps.audioHandler.setWindowFocused).toHaveBeenCalledWith(false);
+            expect(deps.loop.setEmulationLead).toHaveBeenCalledWith(0);
+        });
+
+        it("takes the focused audio lead back when the window focuses", () => {
+            make();
+            window.dispatchEvent(new Event("focus"));
+            expect(deps.audioHandler.setWindowFocused).toHaveBeenCalledWith(true);
+            expect(deps.loop.setEmulationLead).toHaveBeenCalledWith(20);
+        });
+    });
+
+    describe("leaving the page", () => {
+        const beforeUnload = () => {
+            const event = new Event("beforeunload", { cancelable: true });
+            window.dispatchEvent(event);
+            return event;
+        };
+
+        it("warns when a key is held while running, since a shortcut probably caused this", () => {
+            deps.processor.sysvia.hasAnyKeyDown.mockReturnValue(true);
+            make();
+            expect(beforeUnload().defaultPrevented).toBe(true);
+        });
+
+        it("lets a stopped machine, or one with no key down, go quietly", () => {
+            make();
+            expect(beforeUnload().defaultPrevented).toBe(false);
+            deps.processor.sysvia.hasAnyKeyDown.mockReturnValue(true);
+            deps.loop.isRunning.mockReturnValue(false);
+            expect(beforeUnload().defaultPrevented).toBe(false);
+        });
+    });
+
+    describe("drops", () => {
+        it("refuses drops anywhere but the drop zone", () => {
+            make();
+            const over = new Event("dragover", { cancelable: true, bubbles: true });
+            over.dataTransfer = { dropEffect: "copy" };
+            document.body.dispatchEvent(over);
+            expect(over.defaultPrevented).toBe(true);
+            expect(over.dataTransfer.dropEffect).toBe("none");
+            const drop = new Event("drop", { cancelable: true, bubbles: true });
+            document.body.dispatchEvent(drop);
+            expect(drop.defaultPrevented).toBe(true);
+        });
+    });
+
+    describe("dialogs the URL asks for", () => {
+        it("opens the about and terms dialogs when named", () => {
+            deps.parsedQuery = { about: true, "pp-tos": true };
+            make();
+            expect(deps.modals.show).toHaveBeenCalledWith("info");
+            expect(deps.modals.show).toHaveBeenCalledWith("pp-tos");
+        });
+
+        it("opens nothing otherwise", () => {
+            make();
+            expect(deps.modals.show).not.toHaveBeenCalled();
+        });
+    });
+});


### PR DESCRIPTION
Theme C of #1002, second of two: the loose page wiring. Independent of #1049 (different files), either order merges cleanly.

**Before.** Fifty lines at the bottom of `main.js` did the page's own housekeeping inline: revealing `.initially-hidden` elements, swallowing the paste form's submit, clearing keys and switching the audio lead on blur and focus, the drop guard, the `beforeunload` warning when a key is held, the hard and soft reset menu items, the filestore download, the `?about` and `?pp-tos` deep links, and the version stamp. `hardReset` was a function declared among them so Electron's actions could reach it, and `?embed` hid the page furniture in a separate block near the top of the file.

**After.** `PageActions` owns all of that, given the loop, processor, keyboard, audio handler, rewind UI, modals, the parsed query and the version; `hardReset()`, `softReset()` and `downloadFilestore()` are its methods, and Electron's reset actions call them. The `?embed` hiding moves into `Layout`, which already took the flag for its geometry. One small unification came with that: `Layout` read `embed` as "present in the URL" while the hiding read it as truthy, so `?embed=false` gave an embedded layout with the furniture showing; both now read it as truthy.

`main.js` is down to construction and start-up; what remains is the ordered building of the pieces and the two documented late-bound callbacks.

**Tests.** `test-page-actions.js` drives the real DOM from `index.html`: the reveal, the version stamp, both resets (and that their clicks are prevented), the filestore download with and without a filestore (observed at the anchor click), blur and focus, the unload warning in both directions, the drop guard, and the deep links. `test-layout.js` gains the embed hiding. As with the `Modals` tests, earlier instances keep listening on jsdom's shared window, so the teardown quiets them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)