### PR TITLE
test: share the PNG comparison and stop integration tests depending on cwd

### DIFF
--- a/tests/integration/dormann.js
+++ b/tests/integration/dormann.js
@@ -1,14 +1,18 @@
 import { describe, it } from "vitest";
+import { readFileSync } from "node:fs";
+import path from "node:path";
 import * as utils from "../../src/utils.js";
 import { fake6502, fake65C02, fake65C12 } from "../../src/fake6502.js";
 import { TEST_65C02, TEST_65C12 } from "../../src/models.js";
+import { RepoRoot } from "./helpers.js";
 
 import assert from "assert";
 
 const log = false;
+const BinDir = path.join(RepoRoot, "tests/6502_65C02_functional_tests/bin_files");
 
 async function runTest(processor, test, name) {
-    const base = "tests/6502_65C02_functional_tests/bin_files/" + test;
+    const base = path.join(BinDir, test);
 
     function parseSuccess(listing) {
         let expectedPc = null;
@@ -27,8 +31,8 @@ async function runTest(processor, test, name) {
         return expectedPc;
     }
 
-    const expectedPc = parseSuccess((await utils.loadData(base + ".lst")).toString());
-    const data = await utils.loadData(base + ".bin");
+    const expectedPc = parseSuccess(readFileSync(base + ".lst", "utf8"));
+    const data = readFileSync(base + ".bin");
     for (let i = 0; i < data.length; ++i) processor.writemem(i, data[i]);
 
     processor.pc = 0x400;

--- a/tests/integration/ensure-submodules.js
+++ b/tests/integration/ensure-submodules.js
@@ -1,11 +1,13 @@
 import { describe, it } from "vitest";
 import assert from "assert";
 import * as fs from "fs";
+import path from "node:path";
+import { RepoRoot } from "./helpers.js";
 
 describe("ensure git submodules are present", function () {
     it("should have functional tests", function () {
         try {
-            fs.accessSync("tests/6502_65C02_functional_tests/README.md");
+            fs.accessSync(path.join(RepoRoot, "tests/6502_65C02_functional_tests/README.md"));
         } catch {
             assert.fail(
                 "Functional tests submodule missing. Ensure git submodules are fetched (git submodule update --init).",
@@ -15,7 +17,7 @@ describe("ensure git submodules are present", function () {
 
     it("should have timing tests", function () {
         try {
-            fs.accessSync("tests/integration/dp111_6502Timing/README.md");
+            fs.accessSync(path.join(RepoRoot, "tests/integration/dp111_6502Timing/README.md"));
         } catch {
             assert.fail(
                 "Timing tests submodule missing. Ensure git submodules are fetched  (git submodule update --init).",

--- a/tests/integration/helpers.js
+++ b/tests/integration/helpers.js
@@ -23,7 +23,12 @@ export async function expectPngToMatch(actualPng, expectedFile, outputStem, mism
         .ensureAlpha()
         .raw()
         .toBuffer({ resolveWithObject: true });
-    const actual = await sharp(actualPng).ensureAlpha().raw().toBuffer();
+    const { data: actual, info: actualInfo } = await sharp(actualPng)
+        .ensureAlpha()
+        .raw()
+        .toBuffer({ resolveWithObject: true });
+    const shape = ({ width, height, channels }) => ({ width, height, channels });
+    expect(shape(actualInfo), `${mismatch} - expected ${expectedFile}, got ${actualFile}`).toEqual(shape(info));
     const diff = new Uint8Array(info.width * info.height * info.channels);
 
     const numDiffPixels = pixelmatch(expected, actual, diff, info.width, info.height, {

--- a/tests/integration/helpers.js
+++ b/tests/integration/helpers.js
@@ -1,0 +1,34 @@
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { expect } from "vitest";
+import pixelmatch from "pixelmatch";
+import sharp from "sharp";
+
+const ScriptDir = path.dirname(fileURLToPath(import.meta.url));
+export const RepoRoot = path.resolve(ScriptDir, "../..");
+export const OutputDir = path.join(ScriptDir, "output");
+
+const PixelmatchThreshold = 0.1;
+
+/**
+ * Writes `actualPng` and its diff against `expectedFile` into OutputDir as `<outputStem>.png` and
+ * `<outputStem>.diff.png`, and fails naming all three files if any pixel differs.
+ */
+export async function expectPngToMatch(actualPng, expectedFile, outputStem, mismatch = "Images do not match") {
+    const actualFile = path.join(OutputDir, `${outputStem}.png`);
+    const diffFile = path.join(OutputDir, `${outputStem}.diff.png`);
+
+    await sharp(actualPng).toFile(actualFile);
+    const { data: expected, info } = await sharp(expectedFile)
+        .ensureAlpha()
+        .raw()
+        .toBuffer({ resolveWithObject: true });
+    const actual = await sharp(actualPng).ensureAlpha().raw().toBuffer();
+    const diff = new Uint8Array(info.width * info.height * info.channels);
+
+    const numDiffPixels = pixelmatch(expected, actual, diff, info.width, info.height, {
+        threshold: PixelmatchThreshold,
+    });
+    await sharp(diff, { raw: info }).removeAlpha().toFile(diffFile);
+    expect(numDiffPixels, `${mismatch} - expected ${expectedFile}, got ${actualFile}, diffs: ${diffFile}`).toBe(0);
+}

--- a/tests/integration/media-loader.js
+++ b/tests/integration/media-loader.js
@@ -1,5 +1,6 @@
 // @vitest-environment jsdom
 import { existsSync, readFileSync } from "node:fs";
+import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { MediaLoader } from "../../src/web/media-loader.js";
@@ -7,6 +8,7 @@ import { Drives } from "../../src/web/drives.js";
 import { DriveTracks } from "../../src/url-params.js";
 import { TestMachine } from "../test-machine.js";
 import { domFromIndexHtml, fakeUrlState, teardownDom } from "../unit/helpers.js";
+import { RepoRoot } from "./helpers.js";
 
 // jsdom makes utils.loadData take the browser branch, so back XMLHttpRequest
 // with the files the dev server would serve.
@@ -18,9 +20,10 @@ class FileBackedXhr {
     overrideMimeType() {}
 
     send() {
-        const path = existsSync(`public/${this._url}`) ? `public/${this._url}` : this._url;
+        const served = path.join(RepoRoot, "public", this._url);
+        const file = existsSync(served) ? served : path.join(RepoRoot, this._url);
         try {
-            this.response = new Uint8Array(readFileSync(path));
+            this.response = new Uint8Array(readFileSync(file));
             this.status = 200;
         } catch {
             this.status = 404;

--- a/tests/integration/nops.js
+++ b/tests/integration/nops.js
@@ -1,15 +1,16 @@
 import { describe, it } from "vitest";
 import assert from "assert";
-import * as utils from "../../src/utils.js";
+import { readFileSync } from "node:fs";
+import path from "node:path";
 import { TestMachine } from "../test-machine.js";
+import { RepoRoot } from "./helpers.js";
 
 describe("test various NOP timings", function () {
     it("should match the nops.bas code", async () => {
         const testMachine = new TestMachine("Master");
         await testMachine.initialise();
         await testMachine.runUntilInput();
-        const data = await utils.loadData("tests/integration/nops.bas");
-        await testMachine.loadBasic(utils.uint8ArrayToString(data));
+        await testMachine.loadBasic(readFileSync(path.join(RepoRoot, "tests/integration/nops.bas"), "latin1"));
 
         let numCaptures = 0;
         testMachine.captureText((elem) => {

--- a/tests/integration/teletext-hardware.js
+++ b/tests/integration/teletext-hardware.js
@@ -1,9 +1,7 @@
 import { describe, it } from "vitest";
-import assert from "assert";
 import path from "node:path";
-import sharp from "sharp";
-import pixelmatch from "pixelmatch";
 import { Pages, RefDir, renderPage } from "../hardware/teletext/render-page.js";
+import { expectPngToMatch } from "./helpers.js";
 
 // The T1 to T6 and T8 reference images were checked against a real BBC Master 128
 // running MOS 3.20 and agreed with it on every page, so they pin behaviour we have
@@ -11,28 +9,13 @@ import { Pages, RefDir, renderPage } from "../hardware/teletext/render-page.js";
 // opposite power-on clock phase, a known half-cell ambiguity; the box widths and
 // half-cell edges agreed). T7 awaits a photograph. See
 // tests/hardware/teletext/README.md for what each page tests.
-const OutputDir = "tests/integration/output";
-
 async function compareToReference(page, actualPng) {
     const name = page.toLowerCase();
-    const expectedFile = path.join(RefDir, `${name}.png`);
-    const actualFile = `${OutputDir}/actual_hardware_${name}.png`;
-    const diffFile = `${OutputDir}/actual_hardware_${name}.diff.png`;
-
-    await sharp(actualPng).toFile(actualFile);
-    const { data: expected, info } = await sharp(expectedFile)
-        .ensureAlpha()
-        .raw()
-        .toBuffer({ resolveWithObject: true });
-    const actual = await sharp(actualPng).ensureAlpha().raw().toBuffer();
-    const diff = new Uint8Array(info.width * info.height * info.channels);
-
-    const numDiffPixels = pixelmatch(expected, actual, diff, info.width, info.height, { threshold: 0.1 });
-    await sharp(diff, { raw: info }).removeAlpha().toFile(diffFile);
-    assert.equal(
-        numDiffPixels,
-        0,
-        `${page} does not match the hardware reference - expected ${expectedFile}, got ${actualFile}, diffs: ${diffFile}`,
+    await expectPngToMatch(
+        actualPng,
+        path.join(RefDir, `${name}.png`),
+        `actual_hardware_${name}`,
+        `${page} does not match the hardware reference`,
     );
 }
 

--- a/tests/integration/teletext.js
+++ b/tests/integration/teletext.js
@@ -1,9 +1,9 @@
 import { describe, it } from "vitest";
-import { TestMachine } from "../test-machine.js";
-import assert from "assert";
-import { Video } from "../../src/video.js";
+import path from "node:path";
 import sharp from "sharp";
-import pixelmatch from "pixelmatch";
+import { TestMachine } from "../test-machine.js";
+import { Video } from "../../src/video.js";
+import { RepoRoot, expectPngToMatch } from "./helpers.js";
 
 class CapturingVideo extends Video {
     constructor() {
@@ -29,7 +29,7 @@ class CapturingVideo extends Video {
         this._capturing = true;
         await testMachine.runUntilVblank();
         if (this._capturing) throw new Error("Should have captured by now");
-        return this._captureSharp;
+        return this._captureSharp.removeAlpha().png().toBuffer();
     }
 }
 
@@ -43,33 +43,12 @@ async function setupCeefaxTestMachine(video) {
     return testMachine;
 }
 
-const rootDir = "tests/integration/teletext";
-const outputDir = `tests/integration/output`;
+const RefDir = path.join(RepoRoot, "tests/integration/teletext");
 
 async function compare(video, testMachine, expectedName) {
-    const outputName = `${expectedName.replace("expected", "actual")}`;
-    const captureSharp = await video.capture(testMachine);
-    const outputFile = `${outputDir}/${outputName}`;
-    await captureSharp.removeAlpha().toFile(outputFile);
-    const expectedFile = `${rootDir}/${expectedName}`;
-    const diffFile = `${outputDir}/${outputName.replace(".png", ".diff.png")}`;
-
-    const { data: expectedData, info } = await sharp(expectedFile)
-        .ensureAlpha()
-        .raw()
-        .toBuffer({ resolveWithObject: true });
-    const actualData = await sharp(outputFile).ensureAlpha().raw().toBuffer();
-    const diffData = new Uint8Array(info.width * info.height * info.channels);
-
-    const numDiffPixels = pixelmatch(expectedData, actualData, diffData, info.width, info.height, {
-        threshold: 0.1,
-    });
-    await sharp(diffData, { raw: info }).removeAlpha().toFile(diffFile);
-    assert.equal(
-        numDiffPixels,
-        0,
-        `Images do not match - expected ${expectedFile}, got ${outputFile}, diffs: ${diffFile}`,
-    );
+    const actualPng = await video.capture(testMachine);
+    const outputStem = expectedName.replace("expected", "actual").replace(".png", "");
+    await expectPngToMatch(actualPng, path.join(RefDir, expectedName), outputStem);
 }
 
 describe("Test Ceefax test page", () => {

--- a/tests/test-machine.js
+++ b/tests/test-machine.js
@@ -3,11 +3,14 @@ import * as fdc from "../src/fdc.js";
 import { fake6502 } from "../src/fake6502.js";
 import { findModel } from "../src/models.js";
 import assert from "assert";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
 import * as utils from "../src/utils.js";
 import * as utils_atom from "../src/utils_atom.js";
 import * as Tokeniser from "../src/basic-tokenise.js";
 
 const MaxCyclesPerIter = 100 * 1000;
+const RepoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 
 export class TestMachine {
     constructor(model, opts) {
@@ -25,6 +28,7 @@ export class TestMachine {
     }
 
     async initialise() {
+        utils.setNodeBasePath(RepoRoot);
         await this.processor.initialise();
         if (this.model.isAtom) this._startAtomVSync();
     }

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,4 +1,4 @@
-import { defineConfig } from "vitest/config";
+import { configDefaults, defineConfig } from "vitest/config";
 import { firShaderPlugin } from "./tools/vite-plugin-fir-shader.js";
 import { workersFor } from "./tools/test-workers.js";
 
@@ -24,6 +24,7 @@ export default defineConfig({
                 test: {
                     name: "integration",
                     include: ["tests/integration/**/*.js"],
+                    exclude: [...configDefaults.exclude, "tests/integration/helpers.js"],
                     // A hang detector; the dearest test costs under ten seconds uncontended.
                     testTimeout: 120000,
                 },


### PR DESCRIPTION
Part of #1002: the last Theme E item concerning `tests/integration/`.

`teletext.js` and `teletext-hardware.js` each carried their own pixelmatch routine. `expectPngToMatch` in the new `tests/integration/helpers.js` is now the single copy; it writes the actual and diff images to the same output directory under the same names, and fails with the same message naming all three files (the hardware test still leads with its page name).

Every path under `tests/integration/` was relative to the process cwd, the ROMs and discs included, so `vitest run` on a single file from anywhere but the repo root failed inside `TestMachine.initialise`. `TestMachine` now sets the loader's base path from its own location (as `MachineSession` already does), and the files that name fixtures directly (`dormann.js`, `ensure-submodules.js`, `nops.js`, `media-loader.js`, the two teletext tests) resolve them from `RepoRoot`, which `helpers.js` derives from `import.meta.url`. Verified by running the touched files with `tests/` as the working directory: they fail on `main` and pass here.

`helpers.js` is excluded from the integration project's include glob, which otherwise matches every `.js` file in the directory. No assertion changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
