### PR TITLE
test: the checks the old smoke list still wanted, at the level that can see them

### DIFF
--- a/tests/integration/helpers.js
+++ b/tests/integration/helpers.js
@@ -1,42 +1,9 @@
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { expect } from "vitest";
-import pixelmatch from "pixelmatch";
-import sharp from "sharp";
 
 const ScriptDir = path.dirname(fileURLToPath(import.meta.url));
 export const RepoRoot = path.resolve(ScriptDir, "../..");
 export const OutputDir = path.join(ScriptDir, "output");
-
-const PixelmatchThreshold = 0.1;
-
-/**
- * Writes `actualPng` and its diff against `expectedFile` into OutputDir as `<outputStem>.png` and
- * `<outputStem>.diff.png`, and fails naming all three files if any pixel differs.
- */
-export async function expectPngToMatch(actualPng, expectedFile, outputStem, mismatch = "Images do not match") {
-    const actualFile = path.join(OutputDir, `${outputStem}.png`);
-    const diffFile = path.join(OutputDir, `${outputStem}.diff.png`);
-
-    await sharp(actualPng).toFile(actualFile);
-    const { data: expected, info } = await sharp(expectedFile)
-        .ensureAlpha()
-        .raw()
-        .toBuffer({ resolveWithObject: true });
-    const { data: actual, info: actualInfo } = await sharp(actualPng)
-        .ensureAlpha()
-        .raw()
-        .toBuffer({ resolveWithObject: true });
-    const shape = ({ width, height, channels }) => ({ width, height, channels });
-    expect(shape(actualInfo), `${mismatch} - expected ${expectedFile}, got ${actualFile}`).toEqual(shape(info));
-    const diff = new Uint8Array(info.width * info.height * info.channels);
-
-    const numDiffPixels = pixelmatch(expected, actual, diff, info.width, info.height, {
-        threshold: PixelmatchThreshold,
-    });
-    await sharp(diff, { raw: info }).removeAlpha().toFile(diffFile);
-    expect(numDiffPixels, `${mismatch} - expected ${expectedFile}, got ${actualFile}, diffs: ${diffFile}`).toBe(0);
-}
 
 const Mode7ScreenStart = 0x7c00;
 const Mode7ScreenEnd = 0x8000;

--- a/tests/integration/helpers.js
+++ b/tests/integration/helpers.js
@@ -37,3 +37,16 @@ export async function expectPngToMatch(actualPng, expectedFile, outputStem, mism
     await sharp(diff, { raw: info }).removeAlpha().toFile(diffFile);
     expect(numDiffPixels, `${mismatch} - expected ${expectedFile}, got ${actualFile}, diffs: ${diffFile}`).toBe(0);
 }
+
+const Mode7ScreenStart = 0x7c00;
+const Mode7ScreenEnd = 0x8000;
+
+/** The mode 7 screen as text, unprintable bytes as spaces. */
+export function mode7Text(machine) {
+    let text = "";
+    for (let addr = Mode7ScreenStart; addr < Mode7ScreenEnd; addr++) {
+        const c = machine.readbyte(addr);
+        text += c >= 0x20 && c < 0x7f ? String.fromCharCode(c) : " ";
+    }
+    return text;
+}

--- a/tests/integration/media-loader.js
+++ b/tests/integration/media-loader.js
@@ -43,7 +43,7 @@ describe("the built-in disc list", () => {
         teardownDom();
     });
 
-    it("clicks Elite into drive 0, names it in the URL and catalogues it", async () => {
+    const setUp = async () => {
         const machine = new TestMachine();
         await machine.initialise();
         const urlState = fakeUrlState();
@@ -62,6 +62,11 @@ describe("the built-in disc list", () => {
             isSnapshotFile: () => false,
             loadSnapshot: () => {},
         });
+        return { machine, urlState, modals, drives, media };
+    };
+
+    it("clicks Elite into drive 0, names it in the URL and catalogues it", async () => {
+        const { machine, urlState, modals, media } = await setUp();
         const mediaEvents = [];
         media.addEventListener("media-changed", (e) => mediaEvents.push(e.detail));
 
@@ -85,5 +90,12 @@ describe("the built-in disc list", () => {
         const catalogue = seen.join("\n");
         expect(catalogue).toContain("Elite");
         expect(catalogue).toContain("LOAD");
+    });
+
+    it("rejects a disc that is not there and leaves the drive empty", async () => {
+        const { machine, drives, media } = await setUp();
+        await expect(media.loadDiscImage("nosuch.ssd", drives.layoutForDrive(0))).rejects.toThrow(/404/);
+        expect(machine.processor.fdc.drives[0].disc).toBeUndefined();
+        await machine.runUntilInput();
     });
 });

--- a/tests/integration/media-loader.js
+++ b/tests/integration/media-loader.js
@@ -94,7 +94,10 @@ describe("the built-in disc list", () => {
 
     it("rejects a disc that is not there and leaves the drive empty", async () => {
         const { machine, drives, media } = await setUp();
-        await expect(media.loadDiscImage("nosuch.ssd", drives.layoutForDrive(0))).rejects.toThrow(/404/);
+        expect(machine.processor.fdc.drives[0].disc).toBeUndefined();
+        await expect(media.loadDiscImage("nosuch.ssd", drives.layoutForDrive(0))).rejects.toThrow(
+            "Unable to load discs/nosuch.ssd, http code 404",
+        );
         expect(machine.processor.fdc.drives[0].disc).toBeUndefined();
         await machine.runUntilInput();
     });

--- a/tests/integration/png.js
+++ b/tests/integration/png.js
@@ -1,0 +1,36 @@
+import path from "node:path";
+import { expect } from "vitest";
+import pixelmatch from "pixelmatch";
+import sharp from "sharp";
+
+import { OutputDir } from "./helpers.js";
+
+const PixelmatchThreshold = 0.1;
+
+/**
+ * Writes `actualPng` and its diff against `expectedFile` into OutputDir as `<outputStem>.png` and
+ * `<outputStem>.diff.png`, and fails naming all three files if any pixel differs.
+ */
+export async function expectPngToMatch(actualPng, expectedFile, outputStem, mismatch = "Images do not match") {
+    const actualFile = path.join(OutputDir, `${outputStem}.png`);
+    const diffFile = path.join(OutputDir, `${outputStem}.diff.png`);
+
+    await sharp(actualPng).toFile(actualFile);
+    const { data: expected, info } = await sharp(expectedFile)
+        .ensureAlpha()
+        .raw()
+        .toBuffer({ resolveWithObject: true });
+    const { data: actual, info: actualInfo } = await sharp(actualPng)
+        .ensureAlpha()
+        .raw()
+        .toBuffer({ resolveWithObject: true });
+    const shape = ({ width, height, channels }) => ({ width, height, channels });
+    expect(shape(actualInfo), `${mismatch} - expected ${expectedFile}, got ${actualFile}`).toEqual(shape(info));
+    const diff = new Uint8Array(info.width * info.height * info.channels);
+
+    const numDiffPixels = pixelmatch(expected, actual, diff, info.width, info.height, {
+        threshold: PixelmatchThreshold,
+    });
+    await sharp(diff, { raw: info }).removeAlpha().toFile(diffFile);
+    expect(numDiffPixels, `${mismatch} - expected ${expectedFile}, got ${actualFile}, diffs: ${diffFile}`).toBe(0);
+}

--- a/tests/integration/reset.js
+++ b/tests/integration/reset.js
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+
+import { TestMachine } from "../test-machine.js";
+import { mode7Text } from "./helpers.js";
+
+describe("reset", () => {
+    const booted = async () => {
+        const machine = new TestMachine();
+        await machine.initialise();
+        await machine.runUntilInput();
+        await machine.type('10 PRINT "KEPT"');
+        await machine.runUntilInput();
+        return machine;
+    };
+
+    it("comes back to the prompt from a soft reset with the program still in memory", async () => {
+        const machine = await booted();
+        machine.reset(false);
+        await machine.runUntilInput();
+        expect(mode7Text(machine)).toContain("BASIC");
+        await machine.type("OLD");
+        await machine.runUntilInput();
+        await machine.type("LIST");
+        await machine.runUntilInput();
+        expect(mode7Text(machine)).toContain('10 PRINT "KEPT"');
+    });
+
+    it("comes back to the prompt from a hard reset with the screen cleared", async () => {
+        const machine = await booted();
+        expect(mode7Text(machine)).toContain("KEPT");
+        machine.reset(true);
+        await machine.runUntilInput();
+        expect(mode7Text(machine)).toContain("BASIC");
+        expect(mode7Text(machine)).not.toContain("KEPT");
+    });
+});

--- a/tests/integration/snapshot.js
+++ b/tests/integration/snapshot.js
@@ -2,18 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import { createSnapshot, restoreSnapshot, snapshotFromJSON, snapshotToJSON } from "../../src/snapshot.js";
 import { TestMachine } from "../test-machine.js";
-
-const Mode7ScreenStart = 0x7c00;
-const Mode7ScreenEnd = 0x8000;
-
-function screenText(machine) {
-    let text = "";
-    for (let addr = Mode7ScreenStart; addr < Mode7ScreenEnd; addr++) {
-        const c = machine.readbyte(addr);
-        text += c >= 0x20 && c < 0x7f ? String.fromCharCode(c) : " ";
-    }
-    return text;
-}
+import { mode7Text } from "./helpers.js";
 
 describe("save state round trip", () => {
     it("continues identically in a fresh machine restored through the gzipped file format", async () => {
@@ -22,7 +11,7 @@ describe("save state round trip", () => {
         await original.runUntilInput();
         await original.type('PRINT "SNAPSHOT"');
         await original.runUntilInput();
-        expect(screenText(original)).toContain("SNAPSHOT");
+        expect(mode7Text(original)).toContain("SNAPSHOT");
 
         const json = snapshotToJSON(createSnapshot(original.processor, original.model));
         const compressed = await new Response(
@@ -39,7 +28,7 @@ describe("save state round trip", () => {
         await restored.initialise();
         restoreSnapshot(restored.processor, restored.model, snapshot);
 
-        expect(screenText(restored)).toContain("SNAPSHOT");
+        expect(mode7Text(restored)).toContain("SNAPSHOT");
         expect(restored.processor.pc).toBe(original.processor.pc);
 
         const cycles = 4 * 1000 * 1000;
@@ -47,7 +36,7 @@ describe("save state round trip", () => {
         await restored.runFor(cycles);
 
         for (const reg of ["pc", "a", "x", "y", "s"]) expect(restored.processor[reg]).toBe(original.processor[reg]);
-        expect(screenText(restored)).toBe(screenText(original));
-        expect(screenText(restored)).toContain("SNAPSHOT");
+        expect(mode7Text(restored)).toBe(mode7Text(original));
+        expect(mode7Text(restored)).toContain("SNAPSHOT");
     });
 });

--- a/tests/integration/teletext-hardware.js
+++ b/tests/integration/teletext-hardware.js
@@ -1,7 +1,7 @@
 import { describe, it } from "vitest";
 import path from "node:path";
 import { Pages, RefDir, renderPage } from "../hardware/teletext/render-page.js";
-import { expectPngToMatch } from "./helpers.js";
+import { expectPngToMatch } from "./png.js";
 
 // The T1 to T6 and T8 reference images were checked against a real BBC Master 128
 // running MOS 3.20 and agreed with it on every page, so they pin behaviour we have

--- a/tests/integration/teletext.js
+++ b/tests/integration/teletext.js
@@ -3,7 +3,8 @@ import path from "node:path";
 import sharp from "sharp";
 import { TestMachine } from "../test-machine.js";
 import { Video } from "../../src/video.js";
-import { RepoRoot, expectPngToMatch } from "./helpers.js";
+import { RepoRoot } from "./helpers.js";
+import { expectPngToMatch } from "./png.js";
 
 class CapturingVideo extends Video {
     constructor() {

--- a/tests/playwright/smoke.spec.js
+++ b/tests/playwright/smoke.spec.js
@@ -128,6 +128,32 @@ test("a setting changed in the dialog applies at once, reaches the URL and survi
     await expect(page.locator("#audio-output .active")).toHaveAttribute("data-output", "board");
 });
 
+test("a setting that needs a restart asks first, and Later keeps it for next time", async ({ beeb, page }) => {
+    await beeb.open();
+    await beeb.expectScreenText(">");
+    await beeb.armModalShown("configuration");
+    await page.click('a[data-bs-target="#configuration"]');
+    await beeb.expectModalShown();
+    await page.click("#bbc-model-dropdown");
+    await page.click('#configuration .model-menu a[data-target="Master"]');
+    await expect(page.locator("#restart-pending")).toBeVisible();
+    // The prompt is raised from inside the settings dialog's own hide.
+    await beeb.armModalShown("are-you-sure");
+    await page.click("#configuration .btn-close");
+    await beeb.expectModalShown();
+    await expect(page.locator("#are-you-sure .context")).toContainText("Restart now?");
+    const held = await beeb.expectHeld();
+    await page.click("#are-you-sure .ays-no");
+    await expect(page.locator("#are-you-sure")).toBeHidden();
+    await expect(page.locator("#configuration")).toBeHidden();
+    await beeb.expectRunningPast(held);
+    expect(new URL(page.url()).searchParams.get("model")).toBe("Master");
+    await beeb.armModalShown("configuration");
+    await page.click('a[data-bs-target="#configuration"]');
+    await beeb.expectModalShown();
+    await expect(page.locator("#restart-pending")).toBeVisible();
+});
+
 test("every display mode and sound output on the bar can be picked", async ({ beeb, page }) => {
     await beeb.open();
     await beeb.expectScreenText(">");

--- a/tests/unit/test-hfe-picker.js
+++ b/tests/unit/test-hfe-picker.js
@@ -155,4 +155,16 @@ describe("HfePicker", () => {
             expect(picker.archive.fetch).toHaveBeenCalledWith("Games/ELITE.hfe");
         });
     });
+
+    describe("the dialog", () => {
+        it("fills the catalogue as it opens and focuses the filter once shown", () => {
+            const picker = make();
+            const populate = vi.spyOn(picker.archive, "populate").mockResolvedValue();
+            const hfe = document.getElementById("hfe");
+            hfe.dispatchEvent(new Event("show.bs.modal", { bubbles: true }));
+            expect(populate).toHaveBeenCalledTimes(1);
+            hfe.dispatchEvent(new Event("shown.bs.modal", { bubbles: true }));
+            expect(document.activeElement).toBe(document.getElementById("hfe-filter"));
+        });
+    });
 });

--- a/vite.config.js
+++ b/vite.config.js
@@ -24,7 +24,7 @@ export default defineConfig({
                 test: {
                     name: "integration",
                     include: ["tests/integration/**/*.js"],
-                    exclude: [...configDefaults.exclude, "tests/integration/helpers.js"],
+                    exclude: [...configDefaults.exclude, "tests/integration/helpers.js", "tests/integration/png.js"],
                     // A hang detector; the dearest test costs under ten seconds uncontended.
                     testTimeout: 120000,
                 },


### PR DESCRIPTION
Closes out Theme E of #1002. The eight "smoke gaps" in that issue were written before the Playwright suite existed; re-audited against today's tests, six were already covered at unit level against the real `index.html`, one turned up #1053 (fixed in #1055), and four checks were still worth having, each at the lowest level that can see the behaviour:

- **The restart prompt, end to end.** Pick another model in Settings, close: the "Restart now?" dialog appears, raised from inside the settings dialog's own `hide.bs.modal` with two pause holds nesting, which only a real Bootstrap can show (#717 was a bug exactly here). "Later" leaves both dialogs gone and the machine running, the URL carries the new model, and reopening Settings still shows the restart pending.
- **A disc that is not there**, through the real loader: `MediaLoader.loadDiscImage("nosuch.ssd")` rejects with the 404 from the `FileBackedXhr` shim and leaves drive 0 empty. The unit test in `test-web-machine.js` mocks that link; this closes it.
- **Soft and hard reset** on a headless machine: both come back to the BASIC prompt; after the soft one `OLD` recovers the program, after the hard one the screen is clear.
- **The HFE dialog's own wiring**: `show.bs.modal` fills the catalogue and `shown.bs.modal` focuses the filter, the last two uncovered lines of that module.

The mode 7 screen reader the snapshot test kept to itself moves to `tests/integration/helpers.js` so the reset test can share it. Not added, deliberately: the disc visualiser and the rewind panel, both already driven against the real markup in jsdom, where an e2e check would add nothing but a real canvas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)