### PR TITLE
refactor: TestMachine moves into src, with one VDU text decoder

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,8 +17,7 @@
   "exports": {
     ".": "./src/app/app.js",
     "./machine-session": "./src/machine-session.js",
-    "./src/*": "./src/*",
-    "./tests/test-machine.js": "./src/test-machine.js"
+    "./src/*": "./src/*"
   },
   "files": [
     "src/",

--- a/package.json
+++ b/package.json
@@ -18,11 +18,10 @@
     ".": "./src/app/app.js",
     "./machine-session": "./src/machine-session.js",
     "./src/*": "./src/*",
-    "./tests/test-machine.js": "./tests/test-machine.js"
+    "./tests/test-machine.js": "./src/test-machine.js"
   },
   "files": [
     "src/",
-    "tests/test-machine.js",
     "public/roms/"
   ],
   "dependencies": {

--- a/src/machine-session.js
+++ b/src/machine-session.js
@@ -8,7 +8,8 @@
 import { readFileSync } from "fs";
 import { fileURLToPath } from "url";
 import path from "path";
-import { TestMachine } from "../tests/test-machine.js";
+import { TestMachine } from "./test-machine.js";
+import { VduTextCapture } from "./vdu-capture.js";
 import { InstrumentedSoundChip, FakeSoundChip } from "./soundchip.js";
 
 // Resolve the jsbeeb package root from our own location (src/machine-session.js
@@ -86,7 +87,7 @@ export class MachineSession {
 
         // Accumulated VDU text output, drained by callers
         this._pendingOutput = [];
-        this._flushCapture = () => {};
+        this._capture = new VduTextCapture((element) => this._pendingOutput.push(element), { isAtom: this._isAtom });
 
         // Breakpoint management, with persistent hooks that survive across run calls
         this._breakpoints = new Map(); // id → { hook, type, address, hit }
@@ -100,7 +101,7 @@ export class MachineSession {
         if (this._opts.discImage) {
             this.loadDisc(this._opts.discImage);
         }
-        this._installCaptureHook();
+        this._machine.onVduChar((c) => this._capture.onChar(c));
     }
 
     /**
@@ -110,170 +111,6 @@ export class MachineSession {
     async boot(timeoutSecs = 30) {
         await this._machine.runUntilInput(timeoutSecs);
         return this.drainOutput();
-    }
-
-    /**
-     * Install the VDU character-output capture hook.
-     *
-     * WRCHV discovery: RAM at the OS write-character vector (0x20E on BBC,
-     * 0x208 on Atom) initialises to 0x0000 before the OS runs.  We read
-     * directly from cpu.ramRomOs (two array lookups, no readmem() dispatch
-     * overhead) on every instruction, waiting for the value to change from
-     * its initial 0xFFFF.  Once the OS installs a real handler we use that
-     * address for the lifetime of the session.  Programs that later install
-     * a custom VDU driver are handled seamlessly because we always re-read
-     * from the live memory.
-     *
-     * Text elements: { x, y, text, foreground, background, mode }
-     * Screenshots (via the real Video chip) are the right tool for anything
-     * visual; this capture is a lightweight aid for text-mode output only.
-     */
-    _installCaptureHook() {
-        const cpu = this._machine.processor;
-        const ram = cpu.ramRomOs; // direct Uint8Array, no dispatch overhead
-        // WRCHV vector: BBC at $020E, Atom at $0208.
-        const wrchvAddr = this._isAtom ? 0x208 : 0x20e;
-        const initialWrchv = ram[wrchvAddr] | (ram[wrchvAddr + 1] << 8); // 0xFFFF pre-boot
-
-        const attributes = { x: 0, y: 0, text: "", foreground: 7, background: 0, mode: 7 };
-        let currentText = "";
-        let params = [];
-        let nextN = 0;
-        let vduProc = null;
-
-        const onElement = (elem) => this._pendingOutput.push({ ...elem });
-
-        function flush() {
-            if (currentText.length) {
-                attributes.text = currentText;
-                onElement({ ...attributes });
-                attributes.x += currentText.length;
-            }
-            currentText = "";
-        }
-
-        // Expose flush so drainOutput can capture trailing text
-        // that hasn't been terminated by a control character.
-        this._flushCapture = flush;
-
-        // Expose the decoder's cursor so snapshot()/restore() can rewind it too:
-        // text captured after a restore would otherwise carry the coordinates
-        // and colours the abandoned run had reached.
-        this._snapshotCapture = () => ({
-            attributes: { ...attributes },
-            currentText,
-            params: [...params],
-            nextN,
-        });
-        this._restoreCapture = (state) => {
-            Object.assign(attributes, state.attributes);
-            currentText = state.currentText;
-            params = [...state.params];
-            nextN = state.nextN;
-            // vduProc is a closure and does not survive, so a snapshot taken
-            // mid-sequence resumes with nextN still swallowing the parameters:
-            // the sequence is dropped rather than printed as text.
-            vduProc = null;
-        };
-
-        const isAtom = this._isAtom;
-
-        function onChar(c) {
-            if (nextN) {
-                params.push(c);
-                if (--nextN === 0) {
-                    if (vduProc) vduProc(params);
-                    params = [];
-                    vduProc = null;
-                }
-                return;
-            }
-            switch (c) {
-                case 10: // LF
-                    flush();
-                    attributes.y++;
-                    break;
-                case 12: // CLS
-                    flush();
-                    attributes.x = 0;
-                    attributes.y = 0;
-                    break;
-                case 13: // CR
-                    flush();
-                    attributes.x = 0;
-                    break;
-                default:
-                    // BBC VDU control codes (multi-byte sequences).
-                    // The Atom doesn't use these; skip them to avoid
-                    // swallowing printable characters.
-                    if (!isAtom) {
-                        switch (c) {
-                            case 1: // next char to printer only
-                                nextN = 1;
-                                return;
-                            case 17: // COLOUR n
-                                nextN = 1;
-                                vduProc = (p) => {
-                                    if (p[0] & 0x80) attributes.background = p[0] & 0xf;
-                                    else attributes.foreground = p[0] & 0xf;
-                                };
-                                return;
-                            case 18: // GCOL
-                                nextN = 2;
-                                return;
-                            case 19: // define logical colour
-                                nextN = 5;
-                                return;
-                            case 22: // MODE n
-                                nextN = 1;
-                                vduProc = (p) => {
-                                    flush();
-                                    attributes.mode = p[0];
-                                    attributes.x = 0;
-                                    attributes.y = 0;
-                                    attributes.foreground = 7;
-                                    attributes.background = 0;
-                                };
-                                return;
-                            case 25: // PLOT
-                                nextN = 5;
-                                return;
-                            case 28: // define text window
-                                nextN = 4;
-                                return;
-                            case 29: // define graphics origin
-                                nextN = 4;
-                                return;
-                            case 31: // TAB(x,y)
-                                nextN = 2;
-                                vduProc = (p) => {
-                                    flush();
-                                    attributes.x = p[0];
-                                    attributes.y = p[1];
-                                };
-                                return;
-                        }
-                    }
-                    if (c >= 32 && c < 0x7f) {
-                        currentText += String.fromCharCode(c);
-                    } else {
-                        flush();
-                    }
-                    break;
-            }
-        }
-
-        cpu.debugInstruction.add((addr) => {
-            // Two direct array reads, no function-call dispatch overhead.
-            // Once the OS sets WRCHV (it changes from 0xFFFF), we start
-            // capturing.  Programs that install a custom VDU driver mid-run
-            // are handled transparently because we re-read on every call.
-            const wrchv = ram[wrchvAddr] | (ram[wrchvAddr + 1] << 8);
-            if (wrchv !== initialWrchv && addr === wrchv) {
-                onChar(cpu.a);
-            }
-            return false;
-        });
     }
 
     /**
@@ -313,7 +150,7 @@ export class MachineSession {
         return {
             machine: this._machine.snapshot({ includeRoms }),
             pendingOutput: this._pendingOutput.map((element) => ({ ...element })),
-            capture: this._snapshotCapture(),
+            capture: this._capture.snapshot(),
         };
     }
 
@@ -326,7 +163,7 @@ export class MachineSession {
     restore(state) {
         this._machine.restore(state.machine);
         this._pendingOutput = state.pendingOutput.map((element) => ({ ...element }));
-        this._restoreCapture(state.capture);
+        this._capture.restore(state.capture);
     }
 
     /** Tokenise BBC BASIC source and write it into PAGE */
@@ -531,7 +368,7 @@ export class MachineSession {
      * Also includes a flat `screenText` reconstruction.
      */
     drainOutput({ clear = true } = {}) {
-        this._flushCapture();
+        this._capture.flush();
         const elements = clear ? this._pendingOutput.splice(0) : [...this._pendingOutput];
         return {
             elements,

--- a/src/test-machine.js
+++ b/src/test-machine.js
@@ -1,14 +1,15 @@
-import { basicIdleAddr, installBasic } from "../src/basic-loader.js";
-import * as fdc from "../src/fdc.js";
-import { fake6502 } from "../src/fake6502.js";
-import { findModel } from "../src/models.js";
+import { basicIdleAddr, installBasic } from "./basic-loader.js";
+import * as fdc from "./fdc.js";
+import { fake6502 } from "./fake6502.js";
+import { findModel } from "./models.js";
 import assert from "assert";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import * as utils_atom from "../src/keymap-atom.js";
-import * as Tokeniser from "../src/basic-tokenise.js";
-import { setNodeBasePath } from "../src/loader.js";
-import { keyCodes } from "../src/keymap.js";
+import * as utils_atom from "./keymap-atom.js";
+import * as Tokeniser from "./basic-tokenise.js";
+import { VduTextCapture } from "./vdu-capture.js";
+import { setNodeBasePath } from "./loader.js";
+import { keyCodes } from "./keymap.js";
 
 const MaxCyclesPerIter = 100 * 1000;
 const RepoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
@@ -60,22 +61,35 @@ export class TestMachine {
     }
 
     /**
-     * Install the character capture hook (once). All characters sent
-     * through WRCHV are accumulated and can be read with drainText().
-     * Safe to call multiple times — only installs one hook.
+     * Calls `listener` with each character the machine sends to the VDU, by
+     * watching the write-character vector (WRCHV, $020E on the BBC and $0208 on
+     * the Atom) as the OS or a program leaves it. Returns a function that stops
+     * listening.
      */
+    onVduChar(listener) {
+        if (!this._vduListeners) {
+            this._vduListeners = [];
+            const cpu = this.processor;
+            const ram = cpu.ramRomOs;
+            const wrchvAddr = this.model.isAtom ? 0x0208 : 0x020e;
+            cpu.debugInstruction.add((addr) => {
+                if (addr === (ram[wrchvAddr] | (ram[wrchvAddr + 1] << 8))) {
+                    for (const listen of this._vduListeners) listen(cpu.a);
+                }
+                return false;
+            });
+        }
+        this._vduListeners.push(listener);
+        return () => {
+            this._vduListeners = this._vduListeners.filter((other) => other !== listener);
+        };
+    }
+
+    /** Accumulates every character sent to the VDU for drainText(); safe to call more than once. */
     startCapture() {
         if (this._captureHookInstalled) return;
         this._captureHookInstalled = true;
-        // WRCHV is at 0x0208 on Atom, 0x020E on BBC.
-        const wrchvAddr = this.model.isAtom ? 0x0208 : 0x020e;
-        this.processor.debugInstruction.add((addr) => {
-            const wrchv = this.readword(wrchvAddr);
-            if (addr === wrchv) {
-                this._capturedChars.push(this.processor.a);
-            }
-            return false;
-        });
+        this.onVduChar((c) => this._capturedChars.push(c));
     }
 
     /**
@@ -515,100 +529,13 @@ export class TestMachine {
         return this.readbyte(addr) | (this.readbyte(addr + 1) << 8);
     }
 
+    /**
+     * Decodes the machine's VDU output into text elements for `onElement`
+     * until the returned capture's `stop()` is called; see VduTextCapture.
+     */
     captureText(onElement) {
-        const attributes = {
-            x: 0,
-            y: 0,
-            text: "",
-            foreground: 7,
-            background: 0,
-            mode: 7,
-        };
-        let currentText = "";
-        let params = [];
-        let nextN = 0;
-        let vduProc = null;
-
-        function flush() {
-            if (currentText.length) {
-                attributes.text = currentText;
-                onElement(attributes);
-                attributes.x += currentText.length; // Approximately...anyway
-            }
-            currentText = "";
-        }
-
-        function onChar(c) {
-            if (nextN) {
-                params.push(c);
-                if (--nextN === 0) {
-                    if (vduProc) vduProc(params);
-                    params = [];
-                    vduProc = null;
-                }
-                return;
-            }
-            switch (c) {
-                case 1: // Next char to printer
-                    nextN = 1;
-                    break;
-                case 10:
-                    attributes.y++;
-                    break;
-                case 12: // CLS
-                    attributes.x = 0;
-                    attributes.y = 0;
-                    break;
-                case 13:
-                    attributes.x = 0;
-                    break;
-                case 17: // Text colour
-                    nextN = 1;
-                    vduProc = function (params) {
-                        if (params[0] & 0x80) attributes.background = params[0] & 0xf;
-                        else attributes.foreground = params[0] & 0xf;
-                    };
-                    break;
-                case 18: // GCOL
-                    nextN = 2;
-                    break;
-                case 19: // logical colour
-                    nextN = 5;
-                    break;
-                case 22: // mode
-                    nextN = 1;
-                    vduProc = function (params) {
-                        attributes.mode = params[0];
-                        attributes.x = 0;
-                        attributes.y = 0;
-                    };
-                    break;
-                case 25: // plot
-                    nextN = 5;
-                    break;
-                case 28: // text window
-                    nextN = 4;
-                    break;
-                case 29: // origin
-                    nextN = 4;
-                    break;
-                case 31: // text location
-                    nextN = 2;
-                    vduProc = function (params) {
-                        attributes.x = params[0];
-                        attributes.y = params[1];
-                    };
-            }
-            if (c >= 32 && c < 0x7f) {
-                currentText += String.fromCharCode(c);
-            } else flush();
-            return false;
-        }
-
-        const wrchv = this.readword(0x20e);
-        this.processor.debugInstruction.add((addr) => {
-            if (addr === wrchv) onChar(this.processor.a);
-            return false;
-        });
+        const capture = new VduTextCapture(onElement, { isAtom: this.model.isAtom });
+        capture.stop = this.onVduChar((c) => capture.onChar(c));
+        return capture;
     }
 }

--- a/src/vdu-capture.js
+++ b/src/vdu-capture.js
@@ -1,0 +1,121 @@
+/**
+ * Turns the bytes a program sends to the VDU into text elements,
+ * `{ x, y, text, foreground, background, mode }`, following the cursor and
+ * colour codes and swallowing the parameters of the rest. Text-mode output
+ * only; anything visual wants a screenshot.
+ */
+// How many parameter bytes follow each BBC VDU code that takes any.
+const SequenceParamCounts = {
+    1: 1, // next character to the printer only
+    17: 1, // COLOUR n
+    18: 2, // GCOL
+    19: 5, // define logical colour
+    22: 1, // MODE n
+    25: 5, // PLOT
+    28: 4, // define text window
+    29: 4, // define graphics origin
+    31: 2, // TAB(x,y)
+};
+
+export class VduTextCapture {
+    constructor(onElement, { isAtom = false } = {}) {
+        this.onElement = onElement;
+        this.isAtom = isAtom;
+        this.attributes = { x: 0, y: 0, text: "", foreground: 7, background: 0, mode: 7 };
+        this.currentText = "";
+        this.params = [];
+        this.nextN = 0;
+        this.vduProc = null;
+    }
+
+    flush() {
+        if (this.currentText.length) {
+            this.onElement({ ...this.attributes, text: this.currentText });
+            this.attributes.x += this.currentText.length;
+        }
+        this.currentText = "";
+    }
+
+    onChar(c) {
+        const attributes = this.attributes;
+        if (this.nextN) {
+            this.params.push(c);
+            if (--this.nextN === 0) {
+                if (this.vduProc) this.vduProc(this.params);
+                this.params = [];
+                this.vduProc = null;
+            }
+            return;
+        }
+        switch (c) {
+            case 10:
+                this.flush();
+                attributes.y++;
+                return;
+            case 12:
+                this.flush();
+                attributes.x = 0;
+                attributes.y = 0;
+                return;
+            case 13:
+                this.flush();
+                attributes.x = 0;
+                return;
+        }
+        // The Atom has no multi-byte VDU sequences; treating its bytes as
+        // parameters would swallow printable characters.
+        const paramCount = this.isAtom ? undefined : SequenceParamCounts[c];
+        if (paramCount !== undefined) {
+            this.flush();
+            this.nextN = paramCount;
+            this.vduProc = this.sequenceHandlers[c] ?? null;
+            return;
+        }
+        if (c >= 32 && c < 0x7f) this.currentText += String.fromCharCode(c);
+        else this.flush();
+    }
+
+    get sequenceHandlers() {
+        const attributes = this.attributes;
+        return {
+            17: (p) => {
+                if (p[0] & 0x80) attributes.background = p[0] & 0xf;
+                else attributes.foreground = p[0] & 0xf;
+            },
+            22: (p) => {
+                attributes.mode = p[0];
+                attributes.x = 0;
+                attributes.y = 0;
+                attributes.foreground = 7;
+                attributes.background = 0;
+            },
+            31: (p) => {
+                attributes.x = p[0];
+                attributes.y = p[1];
+            },
+        };
+    }
+
+    /** The decoder's position in the byte stream, for a machine snapshot to carry. */
+    snapshot() {
+        return {
+            attributes: { ...this.attributes },
+            currentText: this.currentText,
+            params: [...this.params],
+            nextN: this.nextN,
+        };
+    }
+
+    /**
+     * Puts back a snapshot(). The handler for a half-read sequence is a
+     * closure and does not survive, so such a sequence is dropped rather
+     * than printed as text.
+     */
+    restore(state) {
+        Object.assign(this.attributes, state.attributes);
+        this.currentText = state.currentText;
+        this.params = [...state.params];
+        this.nextN = state.nextN;
+        this.vduProc = null;
+    }
+}

--- a/src/vdu-capture.js
+++ b/src/vdu-capture.js
@@ -26,6 +26,19 @@ export class VduTextCapture {
         this.params = [];
         this.nextN = 0;
         this.vduProc = null;
+        this.sequenceHandlers = {
+            17: (p) => {
+                if (p[0] & 0x80) this.attributes.background = p[0] & 0xf;
+                else this.attributes.foreground = p[0] & 0xf;
+            },
+            22: (p) => {
+                Object.assign(this.attributes, { mode: p[0], x: 0, y: 0, foreground: 7, background: 0 });
+            },
+            31: (p) => {
+                this.attributes.x = p[0];
+                this.attributes.y = p[1];
+            },
+        };
     }
 
     flush() {
@@ -73,27 +86,6 @@ export class VduTextCapture {
         }
         if (c >= 32 && c < 0x7f) this.currentText += String.fromCharCode(c);
         else this.flush();
-    }
-
-    get sequenceHandlers() {
-        const attributes = this.attributes;
-        return {
-            17: (p) => {
-                if (p[0] & 0x80) attributes.background = p[0] & 0xf;
-                else attributes.foreground = p[0] & 0xf;
-            },
-            22: (p) => {
-                attributes.mode = p[0];
-                attributes.x = 0;
-                attributes.y = 0;
-                attributes.foreground = 7;
-                attributes.background = 0;
-            },
-            31: (p) => {
-                attributes.x = p[0];
-                attributes.y = p[1];
-            },
-        };
     }
 
     /** The decoder's position in the byte stream, for a machine snapshot to carry. */

--- a/tests/integration/atom-hardware.js
+++ b/tests/integration/atom-hardware.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { TestMachine } from "../test-machine.js";
+import { TestMachine } from "../../src/test-machine.js";
 
 describe("Atom hardware", () => {
     let machine;

--- a/tests/integration/atom-keyboard.js
+++ b/tests/integration/atom-keyboard.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { TestMachine } from "../test-machine.js";
+import { TestMachine } from "../../src/test-machine.js";
 
 describe("Atom keyboard", () => {
     let machine;

--- a/tests/integration/bcd.js
+++ b/tests/integration/bcd.js
@@ -1,5 +1,5 @@
 import { describe, it } from "vitest";
-import { TestMachine } from "../test-machine.js";
+import { TestMachine } from "../../src/test-machine.js";
 import assert from "assert";
 
 describe("test binary coded decimal behaviour", function () {

--- a/tests/integration/disc-layout.js
+++ b/tests/integration/disc-layout.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { TestMachine } from "../test-machine.js";
+import { TestMachine } from "../../src/test-machine.js";
 import { discFor, load } from "../../src/fdc.js";
 
 const SectorSize = 256;

--- a/tests/integration/dp111timing.js
+++ b/tests/integration/dp111timing.js
@@ -1,5 +1,5 @@
 import { describe, it } from "vitest";
-import { TestMachine } from "../test-machine.js";
+import { TestMachine } from "../../src/test-machine.js";
 import assert from "assert";
 
 describe("test dp111's timing tests", function () {

--- a/tests/integration/media-loader.js
+++ b/tests/integration/media-loader.js
@@ -6,7 +6,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { MediaLoader } from "../../src/web/media-loader.js";
 import { Drives } from "../../src/web/drives.js";
 import { DriveTracks } from "../../src/url-params.js";
-import { TestMachine } from "../test-machine.js";
+import { TestMachine } from "../../src/test-machine.js";
 import { domFromIndexHtml, fakeUrlState, teardownDom } from "../unit/helpers.js";
 import { RepoRoot } from "./helpers.js";
 

--- a/tests/integration/nops.js
+++ b/tests/integration/nops.js
@@ -2,7 +2,7 @@ import { describe, it } from "vitest";
 import assert from "assert";
 import { readFileSync } from "node:fs";
 import path from "node:path";
-import { TestMachine } from "../test-machine.js";
+import { TestMachine } from "../../src/test-machine.js";
 import { RepoRoot } from "./helpers.js";
 
 describe("test various NOP timings", function () {

--- a/tests/integration/pixel-grid.js
+++ b/tests/integration/pixel-grid.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { TestMachine } from "../test-machine.js";
+import { TestMachine } from "../../src/test-machine.js";
 import { Video } from "../../src/video.js";
 import { decodeLineGrid, findBands } from "../line-grid.js";
 

--- a/tests/integration/protection.js
+++ b/tests/integration/protection.js
@@ -1,5 +1,5 @@
 import { describe, it } from "vitest";
-import { TestMachine } from "../test-machine.js";
+import { TestMachine } from "../../src/test-machine.js";
 
 describe("test Kevin Edwards' gnarly protection system", function () {
     const doTest = async (name) => {

--- a/tests/integration/reset.js
+++ b/tests/integration/reset.js
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { TestMachine } from "../test-machine.js";
+import { TestMachine } from "../../src/test-machine.js";
 import { mode7Text } from "./helpers.js";
 
 describe("reset", () => {

--- a/tests/integration/rmw.js
+++ b/tests/integration/rmw.js
@@ -1,5 +1,5 @@
 import { describe, it } from "vitest";
-import { TestMachine } from "../test-machine.js";
+import { TestMachine } from "../../src/test-machine.js";
 import assert from "assert";
 import { hexbyte } from "../../src/hex.js";
 

--- a/tests/integration/seddon-timing.js
+++ b/tests/integration/seddon-timing.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { TestMachine } from "../test-machine.js";
+import { TestMachine } from "../../src/test-machine.js";
 
 // Tom Seddon's 6502/65C02 timing tests.
 // Source: https://github.com/tom-seddon/beeb_6502_timing_tests

--- a/tests/integration/snapshot.js
+++ b/tests/integration/snapshot.js
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import { createSnapshot, restoreSnapshot, snapshotFromJSON, snapshotToJSON } from "../../src/snapshot.js";
-import { TestMachine } from "../test-machine.js";
+import { TestMachine } from "../../src/test-machine.js";
 import { mode7Text } from "./helpers.js";
 
 describe("save state round trip", () => {

--- a/tests/integration/teletext-adaptor.js
+++ b/tests/integration/teletext-adaptor.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { TestMachine } from "../test-machine.js";
+import { TestMachine } from "../../src/test-machine.js";
 
 const TeletextStatusRegister = 0xfc10;
 // INT, DOR and FSYN, all latched by the adaptor once a frame of broadcast data is ready.

--- a/tests/integration/teletext.js
+++ b/tests/integration/teletext.js
@@ -1,7 +1,7 @@
 import { describe, it } from "vitest";
 import path from "node:path";
 import sharp from "sharp";
-import { TestMachine } from "../test-machine.js";
+import { TestMachine } from "../../src/test-machine.js";
 import { Video } from "../../src/video.js";
 import { RepoRoot } from "./helpers.js";
 import { expectPngToMatch } from "./png.js";

--- a/tests/integration/timings.js
+++ b/tests/integration/timings.js
@@ -1,5 +1,5 @@
 import { describe, it } from "vitest";
-import { TestMachine } from "../test-machine.js";
+import { TestMachine } from "../../src/test-machine.js";
 import assert from "assert";
 
 describe("test timings", function () {

--- a/tests/integration/tube.js
+++ b/tests/integration/tube.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { TestMachine } from "../test-machine.js";
+import { TestMachine } from "../../src/test-machine.js";
 
 // The ULA's M flag, which lets pending R3 data raise the parasite's NMI.
 const TubeStatusEnableParasiteNmiFromR3 = 0x08;

--- a/tests/integration/via.js
+++ b/tests/integration/via.js
@@ -1,5 +1,5 @@
 import { describe, it } from "vitest";
-import { TestMachine } from "../test-machine.js";
+import { TestMachine } from "../../src/test-machine.js";
 import assert from "assert";
 
 async function runViaProgram(source, model) {

--- a/tests/unit/test-vdu-capture.js
+++ b/tests/unit/test-vdu-capture.js
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "vitest";
+
+import { VduTextCapture } from "../../src/vdu-capture.js";
+
+describe("VduTextCapture", () => {
+    const capture = (options) => {
+        const elements = [];
+        const decoder = new VduTextCapture((element) => elements.push(element), options);
+        const send = (...bytes) => {
+            for (const byte of bytes) decoder.onChar(typeof byte === "string" ? byte.charCodeAt(0) : byte);
+        };
+        return { decoder, elements, send, text: (s) => send(...s) };
+    };
+
+    it("emits a line of text where the cursor was when a newline arrives", () => {
+        const { elements, text, send } = capture();
+        text("HELLO");
+        send(13, 10);
+        expect(elements).toEqual([{ x: 0, y: 0, text: "HELLO", foreground: 7, background: 0, mode: 7 }]);
+        text("WORLD");
+        send(13, 10);
+        expect(elements[1]).toMatchObject({ x: 0, y: 1, text: "WORLD" });
+    });
+
+    it("hands out copies, so later output cannot change an earlier element", () => {
+        const { elements, text, send } = capture();
+        text("A");
+        send(10);
+        text("B");
+        send(10);
+        expect(elements[0].y).toBe(0);
+    });
+
+    it("follows TAB, COLOUR and MODE, and MODE resets the colours", () => {
+        const { elements, text, send } = capture();
+        send(31, 5, 3, 17, 2, 17, 0x81);
+        text("HI");
+        send(22, 1);
+        expect(elements).toEqual([{ x: 5, y: 3, text: "HI", foreground: 2, background: 1, mode: 7 }]);
+        text("X");
+        send(10);
+        expect(elements[1]).toMatchObject({ x: 0, y: 0, mode: 1, foreground: 7, background: 0 });
+    });
+
+    it("swallows the parameters of the other VDU sequences", () => {
+        const { elements, text, send } = capture();
+        send(19, 1, 2, 3, 4, 5, 25, 4, 0, 0, 0, 0, 1, 65);
+        text("OK");
+        send(10);
+        expect(elements.map((e) => e.text)).toEqual(["OK"]);
+    });
+
+    it("treats every byte as a character on the Atom, which has no such sequences", () => {
+        const { elements, send } = capture({ isAtom: true });
+        send(31, 65, 66, 10);
+        expect(elements.map((e) => e.text)).toEqual(["AB"]);
+    });
+
+    it("carries its cursor through a snapshot, dropping a half-read sequence", () => {
+        const { decoder, elements, text, send } = capture();
+        text("AB");
+        send(31, 4);
+        const state = decoder.snapshot();
+        const other = new VduTextCapture((element) => elements.push(element));
+        other.restore(state);
+        other.onChar(9);
+        other.onChar(67);
+        other.onChar(10);
+        // AB was flushed when the TAB began; the TAB itself is lost, so C follows on.
+        expect(elements.map(({ x, y, text }) => ({ x, y, text }))).toEqual([
+            { x: 0, y: 0, text: "AB" },
+            { x: 2, y: 0, text: "C" },
+        ]);
+    });
+
+    it("flushes text that no control code has terminated yet", () => {
+        const { decoder, elements, text } = capture();
+        text("PROMPT>");
+        expect(elements).toEqual([]);
+        decoder.flush();
+        expect(elements.map((e) => e.text)).toEqual(["PROMPT>"]);
+    });
+});

--- a/tools/audio-sweep.js
+++ b/tools/audio-sweep.js
@@ -605,7 +605,7 @@ function parseArgs(argv) {
 }
 
 async function runReference(outFile, { model = "Master", rate = "48000", output = "board" }) {
-    const { TestMachine } = await import("../tests/test-machine.js");
+    const { TestMachine } = await import("../src/test-machine.js");
     const { SoundChip } = await import("../src/soundchip.js");
     const { PolyphaseResampler } = await import("../src/resampler.js");
     const { ResamplerCutoffOfOutputRate, ResamplerTaps, isAudioOutput, outputStages } =


### PR DESCRIPTION
Item 3 of #1072.

**Before.** `src/machine-session.js` imported `TestMachine` from `tests/`, which is why `package.json` exported and published `./tests/test-machine.js`. The two carried separate copies of the VDU text decoder, differing in ways that mattered: `TestMachine`'s handed callers its live attributes object (so a later line could rewrite an earlier element), moved the cursor before flushing on CR and LF (so an element carried the coordinates of the line after it), read WRCHV once at install (so a program's own VDU driver was missed), and could not snapshot its cursor. The session's flushed before moving but never flushed before a `COLOUR` or `TAB`, so text either side of a colour change merged into one element.

**After.** `TestMachine` is the headless front end and lives in `src/`. `VduTextCapture` in `src/vdu-capture.js` is the one decoder, with the union of the two behaviours where they were each right: elements are copies, the cursor moves after the flush, every parameterised code flushes before it is read (with the parameter counts in one table), MODE resets the colours, the Atom's bytes are never taken as parameters, and the cursor can be snapshotted and restored. `TestMachine.captureText` uses it and returns the capture, whose `stop()` removes the listener; the session composes one directly instead of installing a hook of its own. One WRCHV watcher per machine (`onVduChar`) reads the vector live and feeds the raw `drainText` capture and the decoded captures alike.

`tests/` leaves the published package (`files` is `src/` and the ROMs), and the `./tests/test-machine.js` export goes with it: nothing in the repo imports that path, and `jsbeeb/src/test-machine.js` is reachable through the `./src/*` export. An external importer of the old path, if one exists, changes one string. Every integration test and the audio sweep tool import from the new home.

The decoder has its own unit tests (line and cursor handling, copies, TAB/COLOUR/MODE, swallowed parameters, the Atom case, snapshot and restore, trailing text). The NOP timing test, which counts elements, was the one that caught the merged-colour case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
