### PR TITLE
feat: the session loads discs by any reference the page's URL accepts, through one headless resolver

### DIFF
--- a/src/loader.js
+++ b/src/loader.js
@@ -32,6 +32,11 @@ export function setNodeBasePath(basePath) {
 }
 
 async function loadDataNode(url) {
+    if (/^https?:\/\//.test(url)) {
+        const response = await fetch(url);
+        if (!response.ok) throw new Error(`Unable to load ${url}, http code ${response.status}`);
+        return new Uint8Array(await response.arrayBuffer());
+    }
     const fs = await import("fs");
     const nodePath = await import("path");
     if (_nodeBasePath) {

--- a/src/loader.js
+++ b/src/loader.js
@@ -32,6 +32,11 @@ export function setNodeBasePath(basePath) {
 }
 
 async function loadDataNode(url) {
+    if (url.startsWith("file:")) {
+        const fs = await import("fs");
+        const { fileURLToPath } = await import("url");
+        return fs.readFileSync(fileURLToPath(url));
+    }
     if (/^https?:\/\//.test(url)) {
         const response = await fetch(url);
         if (!response.ok) throw new Error(`Unable to load ${url}, http code ${response.status}`);

--- a/src/machine-session.js
+++ b/src/machine-session.js
@@ -17,6 +17,9 @@ import { InstrumentedSoundChip, FakeSoundChip } from "./soundchip.js";
 // files relative to this package regardless of the calling process's cwd.
 const _jsbeebRoot = path.dirname(path.dirname(fileURLToPath(import.meta.url)));
 import * as fdc from "./fdc.js";
+import { MediaResolver } from "./media-resolver.js";
+import { StairwayToHell } from "./sth.js";
+import { BbcDiscArchive } from "./bbcdiscs.js";
 import { Video } from "./video.js";
 import { findModel } from "./models.js";
 import sharp from "sharp";
@@ -354,6 +357,27 @@ export class MachineSession {
     loadDisc(imagePath) {
         const data = new Uint8Array(readFileSync(imagePath));
         this._machine.processor.fdc.loadDisc(0, fdc.discFor(imagePath, data));
+    }
+
+    /**
+     * Put a disc in a drive by any reference the web page's URL accepts: a bare
+     * name from the built-in discs, `sth:` or `hfe:` for the archives, or a URL.
+     * Returns the name of the image loaded and any others the archive held.
+     */
+    async loadDiscImage(ref, drive = 0) {
+        const { name, data, ignored } = await this.mediaResolver().resolve("disc", ref);
+        this._machine.processor.fdc.loadDisc(drive, fdc.discFor(name, data));
+        return { name, ignored };
+    }
+
+    mediaResolver() {
+        if (!this._mediaResolver) {
+            const quiet = () => {};
+            this._mediaResolver = new MediaResolver();
+            this._mediaResolver.addSource("sth", (file) => new StairwayToHell(quiet, quiet, quiet).fetch(file));
+            this._mediaResolver.addSource("hfe", (path) => new BbcDiscArchive(quiet, quiet, quiet).fetch(path));
+        }
+        return this._mediaResolver;
     }
 
     /**

--- a/src/media-resolver.js
+++ b/src/media-resolver.js
@@ -52,11 +52,9 @@ export class MediaResolver {
                 return unzipDiscImage(stringToUint8Array(atob(image)));
             case "http":
             case "https":
-            case "file": {
-                const url = `${schema}://${image}`;
+            case "file":
                 // The URL may end in query parameters, which would upset the extension check.
-                return openIfZip(new URL(url).pathname, await this.load(url));
-            }
+                return openIfZip(new URL(ref).pathname, await this.load(ref));
             default:
                 return openIfZip(image, await this.load(`${folder}/${image}`));
         }

--- a/src/media-resolver.js
+++ b/src/media-resolver.js
@@ -1,0 +1,70 @@
+import { unzipDiscImage } from "./archive.js";
+import { stringToUint8Array } from "./binary.js";
+import { loadData } from "./loader.js";
+
+/** Splits an image reference into its schema (empty for a bare name) and the image it names. */
+export function splitImage(image) {
+    const match = image.match(/(([^:]+):\/?\/?|[!^|])?(.*)/);
+    return { schema: match[2] || match[1] || "", image: match[3] };
+}
+
+// Where a bare name is looked for, and which registered source serves the archive.
+const Kinds = {
+    disc: { folder: "discs", sth: "sth" },
+    tape: { folder: "tapes", sth: "tapeSth" },
+};
+
+/** The image itself when `name` is a zip, else the bytes as given, either way as `{ name, data, ignored }`. */
+export function openIfZip(name, data) {
+    return /\.zip/i.test(name) ? unzipDiscImage(data) : { name, data, ignored: [] };
+}
+
+/**
+ * Turns any image reference the URL can name into bytes, `{ name, data, ignored }`,
+ * for a disc or a tape: the archives through the sources registered for them,
+ * `data:` and `b64data:` inline, `http:`, `https:` and `file:` by URL, and a
+ * bare name from the built-in folder. Zips are opened once, here. Nothing in
+ * it needs a page, so a headless machine can load the same references.
+ */
+export class MediaResolver {
+    constructor({ load = loadData } = {}) {
+        this.sources = {};
+        this.load = load;
+    }
+
+    /** Registers the fetcher behind an archive schema; each archive registers as it is constructed. */
+    addSource(schema, fetcher) {
+        this.sources[schema] = fetcher;
+    }
+
+    async resolve(kind, ref) {
+        const { schema, image } = splitImage(ref);
+        const { folder, sth } = Kinds[kind];
+        switch (schema) {
+            case "|":
+            case "sth":
+                return this.source(sth)(image);
+            case "hfe":
+                return { name: image, data: await this.source("hfe")(image), ignored: [] };
+            case "b64data":
+                return { name: "disk.ssd", data: stringToUint8Array(atob(image)), ignored: [] };
+            case "data":
+                return unzipDiscImage(stringToUint8Array(atob(image)));
+            case "http":
+            case "https":
+            case "file": {
+                const url = `${schema}://${image}`;
+                // The URL may end in query parameters, which would upset the extension check.
+                return openIfZip(new URL(url).pathname, await this.load(url));
+            }
+            default:
+                return openIfZip(image, await this.load(`${folder}/${image}`));
+        }
+    }
+
+    source(schema) {
+        const fetcher = this.sources[schema];
+        if (!fetcher) throw new Error(`No ${schema} archive is available here`);
+        return fetcher;
+    }
+}

--- a/src/web/media-loader.js
+++ b/src/web/media-loader.js
@@ -2,10 +2,10 @@ import * as disc from "../fdc.js";
 import { DiscLayout } from "../disc.js";
 import { loadTapeFromData } from "../tapes.js";
 import { toast } from "./toast.js";
-import { errorText, reportIgnoredFiles, reportLoadFailure, unzipAndReport } from "./reporting.js";
+import { errorText, reportIgnoredFiles, reportLoadFailure } from "./reporting.js";
+import { MediaResolver, openIfZip, splitImage } from "../media-resolver.js";
 import { stringToUint8Array } from "../binary.js";
 import { noteEvent } from "./analytics.js";
-import { loadData } from "../loader.js";
 
 /** The images offered on the Discs dialog's built-in list. */
 export const BuiltInImages = [
@@ -25,13 +25,6 @@ export const BuiltInImages = [
         file: "5000mstr36008.ssd",
     },
 ];
-
-export function splitImage(image) {
-    const match = image.match(/(([^:]+):\/?\/?|[!^|])?(.*)/);
-    const schema = match[2] || match[1] || "";
-    image = match[3];
-    return { image: image, schema: schema };
-}
 
 function readFileAsBinaryString(file) {
     return new Promise((resolve, reject) => {
@@ -65,7 +58,8 @@ export class MediaLoader extends EventTarget {
         this.drives = drives;
         this.urlState = urlState;
         this.modals = modals;
-        this.sources = {};
+        this.resolver = new MediaResolver();
+        this.driveSource = null;
 
         document.getElementById("disc_load").addEventListener("change", async (evt) => {
             if (evt.target.files.length === 0) return;
@@ -97,14 +91,12 @@ export class MediaLoader extends EventTarget {
             noteEvent("local", "clickTape"); // NB no filename here
 
             try {
-                let tapeData = await readFileAsBinaryString(file);
-                let tapeName = file.name;
-                if (/\.zip/i.test(tapeName)) {
-                    const unzipped = await unzipAndReport(stringToUint8Array(tapeData));
-                    tapeData = unzipped.data;
-                    tapeName = unzipped.name;
-                }
-                this.setProcessorTape(await loadTapeFromData(tapeName, tapeData, model));
+                const { name, data, ignored } = await openIfZip(
+                    file.name,
+                    stringToUint8Array(await readFileAsBinaryString(file)),
+                );
+                reportIgnoredFiles(name, ignored);
+                this.setProcessorTape(await loadTapeFromData(name, data, model));
                 urlState.set({ tape: undefined });
                 modals.hide("tapes");
             } catch (error) {
@@ -168,7 +160,8 @@ export class MediaLoader extends EventTarget {
 
     /** Register the fetcher behind an image schema; each picker calls this as it is constructed. */
     addSource(schema, fetcher) {
-        this.sources[schema] = fetcher;
+        if (schema === "drive") this.driveSource = fetcher;
+        else this.resolver.addSource(schema, fetcher);
     }
 
     /** Route tape to the correct interface (ACIA for BBC, PPIA for Atom) */
@@ -225,16 +218,18 @@ export class MediaLoader extends EventTarget {
 
     async loadDiscImage(discImage, layout = DiscLayout.auto) {
         if (!discImage) return null;
-        const split = splitImage(discImage);
-        discImage = split.image;
-        const schema = split.schema;
+        const { schema, image } = splitImage(discImage);
         if (schema[0] === "!" || schema === "local") {
-            return disc.localDisc(discImage, layout, (error) =>
+            return disc.localDisc(image, layout, (error) =>
                 toast(
-                    `Browser storage would not take changes to ${discImage} (${errorText(error)}). Use Discs, Download to keep a copy.`,
+                    `Browser storage would not take changes to ${image} (${errorText(error)}). Use Discs, Download to keep a copy.`,
                     { title: "Disc", quietKey: "quietLocalDiscSaveFailed" },
                 ),
             );
+        }
+        if (schema === "gd") {
+            const [, id, name = "(unknown)"] = image.match(/([^/]+)\/?(.*)/) ?? [null, image];
+            return this.driveSource({ name, id }, layout);
         }
         // TODO(#822) come up with a decent UX for passing an 'onChange' parameter to each of these.
         // Consider:
@@ -242,99 +237,15 @@ export class MediaLoader extends EventTarget {
         //   to load the modified disc on load.
         // * popping up a message that notes the disc has changed, and offers a way to make a local image
         // * Dialog box (ugh) saying "is this ok?"
-        switch (schema) {
-            case "|":
-            case "sth": {
-                const { name, data, ignored } = await this.sources.sth(discImage);
-                reportIgnoredFiles(name, ignored);
-                return disc.discFor(name, data, undefined, layout);
-            }
-
-            case "hfe":
-                return disc.discFor(discImage, await this.sources.hfe(discImage), undefined, layout);
-
-            case "gd": {
-                const splat = discImage.match(/([^/]+)\/?(.*)/);
-                let name = "(unknown)";
-                if (splat) {
-                    discImage = splat[1];
-                    name = splat[2];
-                }
-                return this.sources.drive({ name, id: discImage }, layout);
-            }
-            case "b64data":
-                return disc.discFor("disk.ssd", atob(discImage), undefined, layout);
-
-            case "data": {
-                const arr = Array.prototype.map.call(atob(discImage), (x) => x.charCodeAt(0));
-                const { name, data } = await unzipAndReport(arr);
-                return disc.discFor(name, data, undefined, layout);
-            }
-            case "http":
-            case "https":
-            case "file": {
-                const asUrl = `${schema}://${discImage}`;
-                // url may end in query params etc, which can upset the DSD/SSD etc detection on the extension.
-                discImage = new URL(asUrl).pathname;
-                let discData = await loadData(asUrl);
-                if (/\.zip/i.test(discImage)) {
-                    const unzipped = await unzipAndReport(discData);
-                    discData = unzipped.data;
-                    discImage = unzipped.name;
-                }
-                return disc.discFor(discImage, discData, undefined, layout);
-            }
-            default:
-                return disc.discFor(discImage, await disc.load("discs/" + discImage), undefined, layout);
-        }
+        const { name, data, ignored } = await this.resolver.resolve("disc", discImage);
+        reportIgnoredFiles(name, ignored);
+        return disc.discFor(name, data, undefined, layout);
     }
 
     async loadTapeImage(tapeImage) {
         if (!tapeImage) return null;
-        const split = splitImage(tapeImage);
-        tapeImage = split.image;
-        const schema = split.schema;
-
-        switch (schema) {
-            case "|":
-            case "sth": {
-                const { name, data, ignored } = await this.sources.tapeSth(tapeImage);
-                reportIgnoredFiles(name, ignored);
-                return await loadTapeFromData(name, data, this.model);
-            }
-
-            case "data": {
-                const arr = Array.prototype.map.call(atob(tapeImage), (x) => x.charCodeAt(0));
-                const { name, data } = await unzipAndReport(arr);
-                return await loadTapeFromData(name, data, this.model);
-            }
-
-            case "http":
-            case "https":
-            case "file": {
-                const asUrl = `${schema}://${tapeImage}`;
-                // url may end in query params etc, which can upset file handling
-                tapeImage = new URL(asUrl).pathname;
-                let tapeData = await loadData(asUrl);
-                if (/\.zip/i.test(tapeImage)) {
-                    const unzipped = await unzipAndReport(tapeData);
-                    tapeData = unzipped.data;
-                    tapeImage = unzipped.name;
-                }
-                return await loadTapeFromData(tapeImage, tapeData, this.model);
-            }
-
-            default: {
-                const tapePath = "tapes/" + tapeImage;
-                let tapeData = await loadData(tapePath);
-                let tapeName = tapeImage;
-                if (/\.zip/i.test(tapeName)) {
-                    const unzipped = await unzipAndReport(tapeData);
-                    tapeData = unzipped.data;
-                    tapeName = unzipped.name;
-                }
-                return await loadTapeFromData(tapeName, tapeData, this.model);
-            }
-        }
+        const { name, data, ignored } = await this.resolver.resolve("tape", tapeImage);
+        reportIgnoredFiles(name, ignored);
+        return loadTapeFromData(name, data, this.model);
     }
 }

--- a/src/web/reporting.js
+++ b/src/web/reporting.js
@@ -1,5 +1,4 @@
 import { toast } from "./toast.js";
-import { unzipDiscImage } from "../archive.js";
 
 export const errorText = (error) => error?.message ?? `${error}`;
 
@@ -13,12 +12,6 @@ export function reportIgnoredFiles(name, ignored) {
     toast(`Loaded ${name}. The archive also holds ${ignored.join(", ")}, and only one file is loaded from it.`, {
         title: "Archive",
     });
-}
-
-export async function unzipAndReport(data) {
-    const unzipped = await unzipDiscImage(data);
-    reportIgnoredFiles(unzipped.name, unzipped.ignored);
-    return unzipped;
 }
 
 /** Handles a component's "notice" event by toasting it. */

--- a/tests/integration/machine-session.js
+++ b/tests/integration/machine-session.js
@@ -237,3 +237,20 @@ describe("MachineSession snapshots", () => {
         BootTimeout,
     );
 });
+
+describe("MachineSession disc images", () => {
+    it(
+        "puts a built-in disc in drive 0 by its bare name and catalogues it",
+        async () => {
+            const session = new MachineSession("B-DFS1.2");
+            await session.initialise();
+            await session.boot(30);
+            expect(await session.loadDiscImage("elite.ssd")).toEqual({ name: "elite.ssd", ignored: [] });
+            await session.type("*CAT");
+            const { screenText } = await session.runUntilPrompt(30);
+            expect(screenText).toContain("Elite");
+            session.destroy();
+        },
+        BootTimeout,
+    );
+});

--- a/tests/unit/test-loader.js
+++ b/tests/unit/test-loader.js
@@ -10,6 +10,11 @@ describe("loadData in node", () => {
         expect(data.length).toBe(16384);
     });
 
+    it("reads a file: URL as the file it names", async () => {
+        const data = await loadData(new URL("../../public/roms/os.rom", import.meta.url).href);
+        expect(data.length).toBe(16384);
+    });
+
     it("fetches a URL", async () => {
         vi.stubGlobal(
             "fetch",

--- a/tests/unit/test-loader.js
+++ b/tests/unit/test-loader.js
@@ -1,0 +1,29 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { loadData } from "../../src/loader.js";
+
+describe("loadData in node", () => {
+    afterEach(() => vi.unstubAllGlobals());
+
+    it("reads a bare path from public", async () => {
+        const data = await loadData("roms/os.rom");
+        expect(data.length).toBe(16384);
+    });
+
+    it("fetches a URL", async () => {
+        vi.stubGlobal(
+            "fetch",
+            vi.fn(async () => new Response(new Uint8Array([1, 2, 3]))),
+        );
+        expect(await loadData("https://example.com/a.ssd")).toEqual(new Uint8Array([1, 2, 3]));
+        expect(fetch).toHaveBeenCalledWith("https://example.com/a.ssd");
+    });
+
+    it("reports a URL that is not there", async () => {
+        vi.stubGlobal(
+            "fetch",
+            vi.fn(async () => new Response(null, { status: 404 })),
+        );
+        await expect(loadData("https://example.com/nosuch.ssd")).rejects.toThrow("http code 404");
+    });
+});

--- a/tests/unit/test-media-loader.js
+++ b/tests/unit/test-media-loader.js
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { BuiltInImages, MediaLoader, splitImage } from "../../src/web/media-loader.js";
+import { BuiltInImages, MediaLoader } from "../../src/web/media-loader.js";
 import { DiscLayout } from "../../src/disc.js";
 import { discFor } from "../../src/fdc.js";
 import { toHfe } from "../../src/disc-hfe.js";
@@ -49,21 +49,6 @@ describe("MediaLoader", () => {
         for (const [schema, fetcher] of Object.entries(sources)) media.addSource(schema, fetcher);
         return media;
     };
-
-    describe("splitImage", () => {
-        it.each([
-            ["sth:ELITE.zip", "sth", "ELITE.zip"],
-            ["|ELITE.zip", "|", "ELITE.zip"],
-            ["hfe:3A1DAB83.hfe", "hfe", "3A1DAB83.hfe"],
-            ["gd:abc123/name.ssd", "gd", "abc123/name.ssd"],
-            ["local:mydisc", "local", "mydisc"],
-            ["!mydisc", "!", "mydisc"],
-            ["https://example.com/a.ssd", "https", "example.com/a.ssd"],
-            ["elite.ssd", "", "elite.ssd"],
-        ])("splits %s into schema %j and image %j", (ref, schema, image) => {
-            expect(splitImage(ref)).toEqual({ schema, image });
-        });
-    });
 
     describe("loadDiscImage", () => {
         it("returns nothing for no reference", async () => {

--- a/tests/unit/test-media-resolver.js
+++ b/tests/unit/test-media-resolver.js
@@ -1,0 +1,98 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { createZipBlob } from "../../src/archive.js";
+import { MediaResolver, splitImage } from "../../src/media-resolver.js";
+
+describe("splitImage", () => {
+    it.each([
+        ["sth:ELITE.zip", "sth", "ELITE.zip"],
+        ["|ELITE.zip", "|", "ELITE.zip"],
+        ["hfe:3A1DAB83.hfe", "hfe", "3A1DAB83.hfe"],
+        ["gd:abc123/name.ssd", "gd", "abc123/name.ssd"],
+        ["local:mydisc", "local", "mydisc"],
+        ["!mydisc", "!", "mydisc"],
+        ["https://example.com/a.ssd", "https", "example.com/a.ssd"],
+        ["elite.ssd", "", "elite.ssd"],
+    ])("splits %s into schema %j and image %j", (ref, schema, image) => {
+        expect(splitImage(ref)).toEqual({ schema, image });
+    });
+});
+
+describe("MediaResolver", () => {
+    const bytes = (text) => new TextEncoder().encode(text);
+    const zipOf = async (files) =>
+        new Uint8Array(await createZipBlob(files.map(([name, text]) => ({ name, data: bytes(text) }))).arrayBuffer());
+    const make = (files = {}) => {
+        const load = vi.fn(async (url) => {
+            if (!(url in files)) throw new Error(`Unable to load ${url}, http code 404`);
+            return files[url];
+        });
+        return { resolver: new MediaResolver({ load }), load };
+    };
+
+    it("takes a bare disc name from the built-in discs and a bare tape name from the tapes", async () => {
+        const { resolver, load } = make({ "discs/elite.ssd": bytes("disc"), "tapes/game.uef": bytes("tape") });
+        expect(await resolver.resolve("disc", "elite.ssd")).toEqual({
+            name: "elite.ssd",
+            data: bytes("disc"),
+            ignored: [],
+        });
+        expect(await resolver.resolve("tape", "game.uef")).toEqual({
+            name: "game.uef",
+            data: bytes("tape"),
+            ignored: [],
+        });
+        expect(load.mock.calls.map(([url]) => url)).toEqual(["discs/elite.ssd", "tapes/game.uef"]);
+    });
+
+    it("fetches a URL, keeping only its path as the name", async () => {
+        const { resolver } = make({ "https://example.com/dir/a.ssd?v=2": bytes("x") });
+        const { name } = await resolver.resolve("disc", "https://example.com/dir/a.ssd?v=2");
+        expect(name).toBe("/dir/a.ssd");
+    });
+
+    it("opens a zip once, wherever it came from, and names what it passed over", async () => {
+        const zip = await zipOf([
+            ["side1.ssd", "one"],
+            ["side2.ssd", "two"],
+        ]);
+        const { resolver } = make({ "discs/game.zip": zip });
+        const fromFolder = await resolver.resolve("disc", "game.zip");
+        expect(fromFolder).toEqual({ name: "side1.ssd", data: bytes("one"), ignored: ["side2.ssd"] });
+        const inline = await resolver.resolve("disc", `data:${btoa(String.fromCharCode(...zip))}`);
+        expect(inline.name).toBe("side1.ssd");
+    });
+
+    it("decodes a b64data disc as a plain SSD", async () => {
+        const { resolver } = make();
+        expect(await resolver.resolve("disc", `b64data:${btoa("raw")}`)).toEqual({
+            name: "disk.ssd",
+            data: bytes("raw"),
+            ignored: [],
+        });
+    });
+
+    it("hands the archives to their sources, disc and tape apart", async () => {
+        const { resolver } = make();
+        const sth = vi.fn(async () => ({ name: "ELITE.ssd", data: bytes("e"), ignored: [] }));
+        const tapeSth = vi.fn(async () => ({ name: "ELITE.uef", data: bytes("t"), ignored: [] }));
+        const hfe = vi.fn(async () => bytes("h"));
+        resolver.addSource("sth", sth);
+        resolver.addSource("tapeSth", tapeSth);
+        resolver.addSource("hfe", hfe);
+        await resolver.resolve("disc", "sth:ELITE.zip");
+        await resolver.resolve("tape", "|ELITE.zip");
+        expect(sth).toHaveBeenCalledWith("ELITE.zip");
+        expect(tapeSth).toHaveBeenCalledWith("ELITE.zip");
+        expect(await resolver.resolve("disc", "hfe:3A1DAB83.hfe")).toEqual({
+            name: "3A1DAB83.hfe",
+            data: bytes("h"),
+            ignored: [],
+        });
+    });
+
+    it("says when an archive has not been registered", async () => {
+        const { resolver } = make();
+        await expect(resolver.resolve("disc", "sth:ELITE.zip")).rejects.toThrow("No sth archive is available here");
+    });
+});

--- a/tests/unit/test-media-resolver.js
+++ b/tests/unit/test-media-resolver.js
@@ -45,10 +45,15 @@ describe("MediaResolver", () => {
         expect(load.mock.calls.map(([url]) => url)).toEqual(["discs/elite.ssd", "tapes/game.uef"]);
     });
 
-    it("fetches a URL, keeping only its path as the name", async () => {
-        const { resolver } = make({ "https://example.com/dir/a.ssd?v=2": bytes("x") });
+    it("fetches a URL as given, keeping only its path as the name", async () => {
+        const { resolver, load } = make({
+            "https://example.com/dir/a.ssd?v=2": bytes("x"),
+            "file:///tmp/b.ssd": bytes("y"),
+        });
         const { name } = await resolver.resolve("disc", "https://example.com/dir/a.ssd?v=2");
         expect(name).toBe("/dir/a.ssd");
+        expect((await resolver.resolve("disc", "file:///tmp/b.ssd")).name).toBe("/tmp/b.ssd");
+        expect(load).toHaveBeenLastCalledWith("file:///tmp/b.ssd");
     });
 
     it("opens a zip once, wherever it came from, and names what it passed over", async () => {

--- a/tests/unit/test-reporting.js
+++ b/tests/unit/test-reporting.js
@@ -1,20 +1,8 @@
 // @vitest-environment jsdom
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import * as fs from "fs";
-import { dirname, join } from "path";
-import { fileURLToPath } from "url";
 
-import {
-    errorText,
-    reportIgnoredFiles,
-    reportLoadFailure,
-    showNotice,
-    unzipAndReport,
-} from "../../src/web/reporting.js";
+import { errorText, reportIgnoredFiles, reportLoadFailure, showNotice } from "../../src/web/reporting.js";
 import { teardownDom, toasts } from "./helpers.js";
-
-const __dirname = dirname(fileURLToPath(import.meta.url));
-const readZip = (name) => new Uint8Array(fs.readFileSync(join(__dirname, "zip", name)));
 
 describe("reporting", () => {
     beforeEach(() => {
@@ -60,21 +48,6 @@ describe("reporting", () => {
             expect(toasts()).toEqual([
                 expect.stringContaining("Loaded side1.ssd. The archive also holds side2.ssd, notes.txt"),
             ]);
-        });
-    });
-
-    describe("unzipAndReport", () => {
-        it("returns the unzipped image and reports the members it passed over", async () => {
-            const unzipped = await unzipAndReport(readZip("test-two-sides.zip"));
-            expect(unzipped.name).toBe("side1.ssd");
-            expect(unzipped.ignored).toEqual(["side2.ssd"]);
-            expect(toasts()).toEqual([expect.stringContaining("side2.ssd")]);
-        });
-
-        it("is quiet about an archive with nothing else loadable in it", async () => {
-            const unzipped = await unzipAndReport(readZip("test-mixed.zip"));
-            expect(unzipped.name).toBe("test.ssd");
-            expect(toasts()).toEqual([]);
         });
     });
 


### PR DESCRIPTION
Item 4 of #1072, and a feature for the MCP server: `MachineSession.loadDiscImage(ref, drive)` is new, so this is a `feat:`. Scoped against #824: the picker there wants one thing that turns any reference into an image regardless of source, and this is that seam, kept ignorant of drives, layouts and dialogs so the picker can sit on top of it.

**Before.** The dispatch over `sth:`, `hfe:`, `gd:`, `local:`, `data:`, `b64data:`, `http(s):`, `file:` and bare names lived inside `MediaLoader`, a class whose constructor wires up dialog inputs, so the MCP server could not boot an archive disc without reimplementing it. `loadDiscImage` and `loadTapeImage` each carried the whole switch, and the zip dance appeared four times in that file.

**After.** `MediaResolver` in `src/media-resolver.js` does the reference-to-bytes part once: the archives through sources registered by whoever has them, `data:` and `b64data:` inline, URLs by `loadData`, bare names from the built-in folder for the kind, and `openIfZip` as the one place a zip is opened, returning `{ name, data, ignored }` so the caller can say what was passed over. `MediaLoader` keeps what genuinely belongs to the page: the two schemas that produce a `Disc` with web concerns (`local:` with its storage toast, `gd:` with its layout) and the toast about ignored files; its two loaders are a few lines each. `reporting.js` loses `unzipAndReport`, which had become the only copy of that dance and now has no callers.

`loadData` in node fetches an `http(s)` URL instead of treating it as a file path, so the resolver behaves the same headless. `MachineSession` gains `loadDiscImage(ref, drive)`: the MCP server can now put a disc in a drive by a bare name, an `sth:` or `hfe:` reference, or a URL, with `StairwayToHell` and `BbcDiscArchive` (which already used `fetch`) as the session's sources. The existing `loadDisc(path)` is unchanged.

Tests: `test-media-resolver.js` covers `splitImage` (moved with the function) and the resolver (bare names per kind, URL naming, zips from a folder and inline, `b64data`, the archive sources for disc and tape, and the error for an unregistered archive); `test-loader.js` covers the node URL fetch; the media loader tests run unchanged against the delegating loader; the session integration suite loads Elite by its bare name and catalogues it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
