### PR TITLE
refactor: the model knows the shape of its machine

### DIFF
--- a/src/basic-loader.js
+++ b/src/basic-loader.js
@@ -1,5 +1,3 @@
-/** Where the OS sits waiting for a keypress, per machine: the place to interrupt with a program. */
-
 /**
  * Pokes a tokenised BASIC program into memory at PAGE, and sets TOP and
  * VARTOP after it, exactly as if it had just been typed.

--- a/src/basic-loader.js
+++ b/src/basic-loader.js
@@ -1,7 +1,4 @@
 /** Where the OS sits waiting for a keypress, per machine: the place to interrupt with a program. */
-export function basicIdleAddr(model) {
-    return model.isMaster ? 0xe7e6 : 0xe581;
-}
 
 /**
  * Pokes a tokenised BASIC program into memory at PAGE, and sets TOP and

--- a/src/build-machine.js
+++ b/src/build-machine.js
@@ -1,4 +1,3 @@
-import { AtomCpu6502, Cpu6502 } from "./6502.js";
 import { Cmos } from "./cmos.js";
 import { FakeDdNoise } from "./ddnoise.js";
 import { FakeMusic5000 } from "./music5000.js";
@@ -56,8 +55,7 @@ export function isMachineSpec(config) {
 /** The processor for `model`, fitted as `spec` says, talking to the peripherals in `io`. */
 export function buildMachine({ model, spec, io, cycleAccurate = true }) {
     if (!isMachineSpec(spec)) throw new Error("A machine's config must come from machineSpec()");
-    const CpuClass = model.isAtom ? AtomCpu6502 : Cpu6502;
-    return new CpuClass(model, { ...io, config: spec, cycleAccurate });
+    return new model.Cpu(model, { ...io, config: spec, cycleAccurate });
 }
 
 /** Peripherals that go nowhere, for a machine run headless. */

--- a/src/fake6502.js
+++ b/src/fake6502.js
@@ -3,22 +3,21 @@
 import { FakeVideo } from "./video.js";
 import { FakeSoundChip } from "./soundchip.js";
 import { TEST_6502, TEST_65C02, TEST_65C12, tubeModelFor } from "./models.js";
-import { buildMachine, machineSpec, nullIo } from "./build-machine.js";
+import { machineSpec, nullIo } from "./machine-spec.js";
 
 const fakeVideo = new FakeVideo();
 const soundChip = new FakeSoundChip();
 
 export function fake6502(model, opts = {}) {
     model = model || TEST_6502;
-    return buildMachine({
-        model,
-        spec: machineSpec({
+    return new model.Cpu(model, {
+        ...nullIo({ video: opts.video ?? fakeVideo, soundChip: opts.soundChip ?? soundChip }),
+        config: machineSpec({
             tube: opts.tube ? tubeModelFor(model) : null,
             tubeCpuMultiplier: opts.tubeCpuMultiplier,
             cpuMultiplier: opts.cpuMultiplier,
             hasTeletextAdaptor: opts.hasTeletextAdaptor,
         }),
-        io: nullIo({ video: opts.video ?? fakeVideo, soundChip: opts.soundChip ?? soundChip }),
         cycleAccurate: opts.cycleAccurate,
     });
 }

--- a/src/keyboard.js
+++ b/src/keyboard.js
@@ -1,4 +1,3 @@
-import { ATOM } from "./keymap-atom.js";
 import { BBC, keyCodes } from "./keymap.js";
 
 const isMac = typeof window !== "undefined" && /^Mac/i.test(window.navigator?.platform || "");
@@ -28,13 +27,9 @@ export class Keyboard extends EventTarget {
         this.inputEnabledFunction = inputEnabledFunction;
         this.dbgr = dbgr;
 
-        // Key interface: routes key events to SysVia (BBC) or PPIA (Atom).
-        // Both provide keyDown, keyUp, keyToggleRaw, setKeyLayout,
-        // clearKeys, disableKeyboard, enableKeyboard.
-        this.keyInterface = processor.model.isAtom ? processor.atomppia : processor.sysvia;
-        // The SHIFT key constant used by stringToMachineKeys in the paste key array.
+        this.keyInterface = processor.model.keyboardOf(processor);
         // Compared by reference in _deliverPasteKey to avoid toggling shift off.
-        this._shiftKey = processor.model.isAtom ? ATOM.SHIFT : BBC.SHIFT;
+        this._shiftKey = processor.model.keys.SHIFT;
 
         // State
         this.emuKeyHandlers = {};
@@ -392,10 +387,7 @@ export class Keyboard extends EventTarget {
             return;
         }
 
-        // Atom ROM polls the keyboard once per VSync (~16ms at 60 Hz).
-        // 80ms gives the ROM ~5 scan cycles to detect, debounce, and
-        // process each keypress.
-        let delayMs = this.processor.model.isAtom ? 80 : 50;
+        let delayMs = this.processor.model.pasteKeyDelayMs;
         if (typeof this._pasteLastChar === "number") {
             delayMs = this._pasteLastChar;
             this._pasteLastChar = undefined;

--- a/src/machine-spec.js
+++ b/src/machine-spec.js
@@ -12,8 +12,6 @@ const NullUserPort = {
     },
 };
 
-const SpecBrand = Symbol("machineSpec");
-
 const SpecDefaults = {
     keyLayout: "physical",
     cpuMultiplier: 1,
@@ -32,30 +30,18 @@ const SpecDefaults = {
 /**
  * What a machine is fitted with and how it is driven, complete and frozen:
  * every field is present, an unknown one is an error, and an undefined
- * override means the default. The CPU takes nothing else.
+ * override means the default. It is the `config` a CPU is built with.
  */
 export function machineSpec(overrides = {}) {
     const unknown = Object.keys(overrides).filter((field) => !Object.hasOwn(SpecDefaults, field));
     if (unknown.length) throw new Error(`Unknown machine spec fields: ${unknown.join(", ")}`);
     const given = Object.fromEntries(Object.entries(overrides).filter(([, value]) => value !== undefined));
     return Object.freeze({
-        [SpecBrand]: true,
         ...SpecDefaults,
         ...given,
         extraRoms: Object.freeze([...(given.extraRoms ?? SpecDefaults.extraRoms)]),
         debugFlags: Object.freeze({ ...SpecDefaults.debugFlags, ...given.debugFlags }),
     });
-}
-
-/** Whether `config` was made by machineSpec(), and so is complete and unchanged. */
-export function isMachineSpec(config) {
-    return config?.[SpecBrand] === true;
-}
-
-/** The processor for `model`, fitted as `spec` says, talking to the peripherals in `io`. */
-export function buildMachine({ model, spec, io, cycleAccurate = true }) {
-    if (!isMachineSpec(spec)) throw new Error("A machine's config must come from machineSpec()");
-    return new model.Cpu(model, { ...io, config: spec, cycleAccurate });
 }
 
 /** Peripherals that go nowhere, for a machine run headless. */

--- a/src/main.js
+++ b/src/main.js
@@ -4,7 +4,6 @@ import "bootswatch/dist/darkly/bootstrap.min.css";
 import "./jsbeeb.css";
 
 import { Debugger } from "./web/debug.js";
-import * as atomKeymap from "./keymap-atom.js";
 import { GamePad } from "./gamepads.js";
 import { initialise as electron } from "./app/electron.js";
 import { AudioHandler } from "./web/audio-handler.js";
@@ -39,7 +38,7 @@ import { RewindUI } from "./web/rewind-ui.js";
 import { DiscVisualiser } from "./web/disc-visualiser.js";
 import { PageActions } from "./web/page-actions.js";
 import { parseMediaParams, processAutobootParams, processDriveTrackParams, processInputParams } from "./url-params.js";
-import { BBC, adaptKeyCodesToBrowser, keyCodes, userKeymap } from "./keymap.js";
+import { adaptKeyCodesToBrowser, keyCodes, userKeymap } from "./keymap.js";
 
 installIcons();
 adaptKeyCodesToBrowser();
@@ -106,13 +105,7 @@ speak(settings.speechOutput);
 settings.on("speechOutput", speak);
 
 // Must come after we know the model, to validate names against those of the hardware.
-const keyMappingWarnings = processInputParams(
-    parsedQuery,
-    model.isAtom ? atomKeymap.ATOM : BBC,
-    keyCodes,
-    userKeymap,
-    gamepad,
-);
+const keyMappingWarnings = processInputParams(parsedQuery, model.keys, keyCodes, userKeymap, gamepad);
 if (keyMappingWarnings.length) {
     toast(`${keyMappingWarnings.join(" ")} The key names are listed in the README.`, {
         title: "Mappings in the URL",

--- a/src/models.js
+++ b/src/models.js
@@ -1,6 +1,9 @@
 import { NoiseAwareWdFdc } from "./wd-fdc.js";
 import { NoiseAwareIntelFdc } from "./intel-fdc.js";
 import * as opcodes from "./6502.opcodes.js";
+import { AtomCpu6502, Cpu6502 } from "./6502.js";
+import { BBC, stringToBBCKeys } from "./keymap.js";
+import { ATOM, stringToATOMKeys } from "./keymap-atom.js";
 
 const CpuModel = Object.freeze({
     MOS6502: 0,
@@ -41,6 +44,16 @@ class Model {
         this._cpuModel = cpuModel;
         this.isMaster = isMaster;
         this.isAtom = !!isAtom;
+        // The one place the two machine families part: everything else asks the model.
+        this.Cpu = this.isAtom ? AtomCpu6502 : Cpu6502;
+        this.keys = this.isAtom ? ATOM : BBC;
+        this.stringToKeys = this.isAtom ? stringToATOMKeys : stringToBBCKeys;
+        // The OS write-character vector, watched to capture what the machine prints.
+        this.wrchvAddress = this.isAtom ? 0x0208 : 0x020e;
+        // Where the machine sits waiting for a key: the Atom kernel's read loop, or BASIC's.
+        this.idleAddress = this.isAtom ? 0xfe94 : isMaster ? 0xe7e6 : 0xe581;
+        // The Atom ROM polls its keyboard once per VSync, so pasted keys need longer apart.
+        this.pasteKeyDelayMs = this.isAtom ? 80 : 50;
         this.Fdc = fdc;
         this.swram = swram;
         this.isTest = false;
@@ -54,6 +67,11 @@ class Model {
      */
     get cyclesPerSecond() {
         return this.clockMhz * 1000 * 1000;
+    }
+
+    /** The chip the keyboard hangs off: the PPIA on an Atom, the system VIA on a BBC. */
+    keyboardOf(processor) {
+        return this.isAtom ? processor.atomppia : processor.sysvia;
     }
 
     get nmos() {

--- a/src/test-machine.js
+++ b/src/test-machine.js
@@ -1,4 +1,4 @@
-import { basicIdleAddr, installBasic } from "./basic-loader.js";
+import { installBasic } from "./basic-loader.js";
 import * as fdc from "./fdc.js";
 import { fake6502 } from "./fake6502.js";
 import { findModel } from "./models.js";
@@ -26,7 +26,7 @@ export class TestMachine {
 
     /** The keyboard interface for this machine (SysVia for BBC, PPIA for Atom). */
     get _keyInterface() {
-        return this.model.isAtom ? this.processor.atomppia : this.processor.sysvia;
+        return this.model.keyboardOf(this.processor);
     }
 
     async initialise() {
@@ -71,7 +71,7 @@ export class TestMachine {
             this._vduListeners = [];
             const cpu = this.processor;
             const ram = cpu.ramRomOs;
-            const wrchvAddr = this.model.isAtom ? 0x0208 : 0x020e;
+            const wrchvAddr = this.model.wrchvAddress;
             cpu.debugInstruction.add((addr) => {
                 if (addr === (ram[wrchvAddr] | (ram[wrchvAddr + 1] << 8))) {
                     for (const listen of this._vduListeners) listen(cpu.a);
@@ -184,24 +184,7 @@ export class TestMachine {
     async runUntilInput(secs) {
         if (!secs) secs = 120;
         console.log("Running until keyboard input requested");
-        if (this.model.isAtom) {
-            // The Atom kernel's keyboard read loop at $FE94 is entered when
-            // BASIC (or the OS) waits for a keypress.  We detect entry to
-            // this routine as the idle point.
-            const atomIdleAddr = 0xfe94;
-            let hit = false;
-            const hook = this.processor.debugInstruction.add((addr) => {
-                if (addr === atomIdleAddr) {
-                    hit = true;
-                    return true;
-                }
-            });
-            await this.runFor(secs * this.model.cyclesPerSecond);
-            hook.remove();
-            assert(hit, "Atom did not reach keyboard input in time");
-            return this.runFor(10 * 1000);
-        }
-        const idleAddr = basicIdleAddr(this.processor.model);
+        const idleAddr = this.model.idleAddress;
         let hit = false;
         const hook = this.processor.debugInstruction.add((addr) => {
             if (addr === idleAddr) {

--- a/src/web/autoboot.js
+++ b/src/web/autoboot.js
@@ -66,7 +66,7 @@ export class Autoboot {
         const tokenised = await t.tokenise(prog);
 
         const { processor } = this;
-        const idleAddr = processor.model.idleAddress;
+        const idleAddr = this.model.idleAddress;
         const hook = processor.debugInstruction.add((addr) => {
             if (addr !== idleAddr) return;
             installBasic(tokenised, {

--- a/src/web/autoboot.js
+++ b/src/web/autoboot.js
@@ -1,8 +1,7 @@
-import * as atomKeymap from "../keymap-atom.js";
 import * as tokeniser from "../basic-tokenise.js";
-import { basicIdleAddr, installBasic } from "../basic-loader.js";
+import { installBasic } from "../basic-loader.js";
 import { noteEvent } from "./analytics.js";
-import { BBC, stringToBBCKeys } from "../keymap.js";
+import { BBC } from "../keymap.js";
 
 /** Booting and typing for the machine at startup: shift-break, *TAPE incantations and BASIC programs. */
 export class Autoboot {
@@ -13,9 +12,8 @@ export class Autoboot {
         this.sendKeys = sendKeys;
     }
 
-    /** Convert text to machine-appropriate key sequences (BBC or Atom) */
     stringToMachineKeys(text) {
-        return this.model.isAtom ? atomKeymap.stringToATOMKeys(text) : stringToBBCKeys(text);
+        return this.model.stringToKeys(text);
     }
 
     boot(image) {
@@ -68,7 +66,7 @@ export class Autoboot {
         const tokenised = await t.tokenise(prog);
 
         const { processor } = this;
-        const idleAddr = basicIdleAddr(processor.model);
+        const idleAddr = processor.model.idleAddress;
         const hook = processor.debugInstruction.add((addr) => {
             if (addr !== idleAddr) return;
             installBasic(tokenised, {

--- a/src/web/machine.js
+++ b/src/web/machine.js
@@ -1,4 +1,4 @@
-import { buildMachine, machineSpec } from "../build-machine.js";
+import { machineSpec } from "../machine-spec.js";
 import { Cmos, localStoragePersistence } from "../cmos.js";
 import { Econet } from "../econet.js";
 import { LoadSD } from "../mmc.js";
@@ -60,7 +60,7 @@ export class Machine {
         video,
         audioHandler,
         dbgr,
-        build = buildMachine,
+        build = (cpuModel, options) => new cpuModel.Cpu(cpuModel, options),
     }) {
         this.model = model;
         this.audioHandler = audioHandler;
@@ -96,19 +96,16 @@ export class Machine {
             printer,
         });
 
-        this.processor = build({
-            model,
-            spec: this.spec,
-            io: {
-                dbgr,
-                video,
-                soundChip: audioHandler.soundChip,
-                ddNoise: audioHandler.ddNoise,
-                relayNoise: audioHandler.relayNoise,
-                music5000: settings.hasMusic5000 ? audioHandler.music5000 : null,
-                cmos: this.cmos,
-                econet: this.econet,
-            },
+        this.processor = build(model, {
+            dbgr,
+            video,
+            soundChip: audioHandler.soundChip,
+            ddNoise: audioHandler.ddNoise,
+            relayNoise: audioHandler.relayNoise,
+            music5000: settings.hasMusic5000 ? audioHandler.music5000 : null,
+            cmos: this.cmos,
+            econet: this.econet,
+            config: this.spec,
         });
 
         printer.attach(this.processor.uservia);

--- a/tests/unit/test-autoboot.js
+++ b/tests/unit/test-autoboot.js
@@ -84,8 +84,8 @@ describe("Autoboot", () => {
         });
 
         it("hooks the Master's idle loop on a Master", async () => {
-            processor.model = findModel("Master");
-            await make().insertBasic(Promise.resolve("10 END"), false);
+            const master = new Autoboot({ model: findModel("Master"), processor, sendKeys });
+            await master.insertBasic(Promise.resolve("10 END"), false);
             processor.debugInstruction.hook(0xe581);
             expect(processor.memory[0x1900]).toBe(0);
             processor.debugInstruction.hook(0xe7e6);

--- a/tests/unit/test-autoboot.js
+++ b/tests/unit/test-autoboot.js
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { Autoboot } from "../../src/web/autoboot.js";
 import * as keymap from "../../src/keymap.js";
 import { BBC } from "../../src/keymap.js";
+import { findModel } from "../../src/models.js";
 
 describe("Autoboot", () => {
     let sendKeys;
@@ -14,7 +15,7 @@ describe("Autoboot", () => {
         const memory = new Uint8Array(0x10000);
         memory[0x18] = 0x19;
         processor = {
-            model: { isMaster: false },
+            model: findModel("B-DFS1.2"),
             memory,
             readmem: (addr) => memory[addr],
             writemem: (addr, value) => (memory[addr] = value),
@@ -32,7 +33,8 @@ describe("Autoboot", () => {
         vi.restoreAllMocks();
     });
 
-    const make = (isAtom = false) => new Autoboot({ model: { isAtom }, processor, sendKeys });
+    const make = (isAtom = false) =>
+        new Autoboot({ model: findModel(isAtom ? "Atom" : "B-DFS1.2"), processor, sendKeys });
 
     it("boots a disc by holding SHIFT through a break", () => {
         make().boot("elite.ssd");
@@ -56,11 +58,10 @@ describe("Autoboot", () => {
     });
 
     it("chains and runs tapes with the right incantations", () => {
-        const spelled = vi.spyOn(keymap, "stringToBBCKeys");
         make().chainTape();
-        expect(spelled).toHaveBeenCalledWith('*TAPE\nCH.""\n');
+        expect(sendKeys.mock.calls.at(-1)[0]).toEqual([1000, ...keymap.stringToBBCKeys('*TAPE\nCH.""\n')]);
         make().runTape();
-        expect(spelled).toHaveBeenCalledWith("*TAPE\n*/\n");
+        expect(sendKeys.mock.calls.at(-1)[0]).toEqual([1000, ...keymap.stringToBBCKeys("*TAPE\n*/\n")]);
     });
 
     describe("insertBasic", () => {
@@ -83,7 +84,7 @@ describe("Autoboot", () => {
         });
 
         it("hooks the Master's idle loop on a Master", async () => {
-            processor.model.isMaster = true;
+            processor.model = findModel("Master");
             await make().insertBasic(Promise.resolve("10 END"), false);
             processor.debugInstruction.hook(0xe581);
             expect(processor.memory[0x1900]).toBe(0);

--- a/tests/unit/test-basic-loader.js
+++ b/tests/unit/test-basic-loader.js
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { basicIdleAddr, installBasic } from "../../src/basic-loader.js";
+import { installBasic } from "../../src/basic-loader.js";
 
 describe("installBasic", () => {
     const machine = (page = 0x19) => {
@@ -23,12 +23,5 @@ describe("installBasic", () => {
         const end = 0x0e00 + 0x105;
         expect(m.memory[0x02] | (m.memory[0x03] << 8)).toBe(end);
         expect(m.memory[0x12] | (m.memory[0x13] << 8)).toBe(end);
-    });
-});
-
-describe("basicIdleAddr", () => {
-    it("names each machine's idle loop", () => {
-        expect(basicIdleAddr({ isMaster: false })).toBe(0xe581);
-        expect(basicIdleAddr({ isMaster: true })).toBe(0xe7e6);
     });
 });

--- a/tests/unit/test-cpu-state.js
+++ b/tests/unit/test-cpu-state.js
@@ -2,14 +2,14 @@ import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { fake6502 } from "../../src/fake6502.js";
 import { Video, FakeVideo } from "../../src/video.js";
 import { SoundChip } from "../../src/soundchip.js";
-import { buildMachine, machineSpec, nullIo } from "../../src/build-machine.js";
+import { machineSpec, nullIo } from "../../src/machine-spec.js";
 import { findModel, TEST_6502 } from "../../src/models.js";
 
 function makeCpu() {
     const fb32 = new Uint32Array(1024 * 768);
     const video = new Video(false, fb32, () => {});
     const soundChip = new SoundChip(() => {});
-    return buildMachine({ model: TEST_6502, spec: machineSpec(), io: nullIo({ video, soundChip }) });
+    return new TEST_6502.Cpu(TEST_6502, { ...nullIo({ video, soundChip }), config: machineSpec() });
 }
 
 describe("Cpu6502 snapshotState / restoreState", () => {

--- a/tests/unit/test-keyboard-setup.js
+++ b/tests/unit/test-keyboard-setup.js
@@ -5,6 +5,7 @@ import { AccessibilitySwitches } from "../../src/web/accessibility-switches.js";
 import { KeyboardSetup } from "../../src/web/keyboard-setup.js";
 import { domFromIndexHtml, teardownDom } from "./helpers.js";
 import { keyCodes } from "../../src/keymap.js";
+import { findModel } from "../../src/models.js";
 
 const keyEvent = (type, which, { alt = false, ctrl = false } = {}) => {
     const event = new KeyboardEvent(type, { altKey: alt, ctrlKey: ctrl, cancelable: true });
@@ -39,7 +40,7 @@ describe("KeyboardSetup", () => {
         };
         accessibilitySwitches = new AccessibilitySwitches();
         processor = {
-            model: { isAtom: false },
+            model: findModel("B-DFS1.2"),
             scheduler: {
                 newTask: () => ({
                     schedule: () => {},

--- a/tests/unit/test-keyboard.js
+++ b/tests/unit/test-keyboard.js
@@ -3,6 +3,7 @@ import { Keyboard } from "../../src/keyboard.js";
 import { Scheduler } from "../../src/scheduler.js";
 import { ATOM, stringToATOMKeys } from "../../src/keymap-atom.js";
 import { BBC, keyCodes } from "../../src/keymap.js";
+import { findModel } from "../../src/models.js";
 
 describe("Keyboard", () => {
     let keyboard;
@@ -39,7 +40,7 @@ describe("Keyboard", () => {
         };
 
         mockProcessor = {
-            model: { isAtom: false },
+            model: findModel("B-DFS1.2"),
             sysvia: mockSysvia,
             setKeyLayout: vi.fn(),
             scheduler: new Scheduler(),
@@ -561,7 +562,7 @@ describe("Keyboard Atom adapter", () => {
         };
 
         mockProcessor = {
-            model: { isAtom: true },
+            model: findModel("Atom"),
             atomppia: mockAtomPPIA,
             setKeyLayout: vi.fn(),
             sysvia: { keyDown: vi.fn(), keyUp: vi.fn() },
@@ -581,7 +582,7 @@ describe("Keyboard Atom adapter", () => {
         keyboard.setRunning(true);
     });
 
-    test("should select atomppia as keyInterface when isAtom is true", () => {
+    test("takes the PPIA as its key interface on an Atom", () => {
         expect(keyboard.keyInterface).toBe(mockAtomPPIA);
     });
 

--- a/tests/unit/test-machine-spec.js
+++ b/tests/unit/test-machine-spec.js
@@ -1,36 +1,20 @@
 import { describe, expect, it, vi } from "vitest";
 
-import { AtomCpu6502, Cpu6502 } from "../../src/6502.js";
-import { buildMachine, isMachineSpec, machineSpec, nullIo } from "../../src/build-machine.js";
-import { TEST_6502, findModel } from "../../src/models.js";
+import { machineSpec, nullIo } from "../../src/machine-spec.js";
+import { TEST_6502 } from "../../src/models.js";
 
-describe("buildMachine", () => {
-    const build = (model, spec = machineSpec()) => buildMachine({ model, spec, io: nullIo() });
+describe("a CPU fitted from a spec", () => {
+    const build = (spec = machineSpec()) => new TEST_6502.Cpu(TEST_6502, { ...nullIo(), config: spec });
 
-    it("builds the processor the model calls for", () => {
-        expect(build(TEST_6502)).toBeInstanceOf(Cpu6502);
-        expect(build(findModel("Atom"))).toBeInstanceOf(AtomCpu6502);
-    });
-
-    it("fits the machine as the spec says", () => {
-        const cpu = build(TEST_6502, machineSpec({ cpuMultiplier: 2, keyLayout: "natural" }));
+    it("is fitted as the spec says", () => {
+        const cpu = build(machineSpec({ cpuMultiplier: 2, keyLayout: "natural" }));
         expect(cpu.cpuMultiplier).toBe(2);
         expect(cpu.keyLayout).toBe("natural");
         expect(cpu.hasTube).toBe(false);
     });
 
-    it("refuses a config that did not come from machineSpec, frozen or missing", () => {
-        expect(() => build(TEST_6502, { keyLayout: "physical" })).toThrow("must come from machineSpec()");
-        expect(() => build(TEST_6502, Object.freeze({ keyLayout: "physical" }))).toThrow(
-            "must come from machineSpec()",
-        );
-        expect(() => buildMachine({ model: TEST_6502, spec: undefined, io: nullIo() })).toThrow(
-            "must come from machineSpec()",
-        );
-    });
-
     it("changes the key layout for the keyboard and for the next reset alike", () => {
-        const cpu = build(TEST_6502);
+        const cpu = build();
         const viaLayout = vi.spyOn(cpu.sysvia, "setKeyLayout");
         cpu.setKeyLayout("gaming");
         expect(cpu.keyLayout).toBe("gaming");
@@ -59,12 +43,6 @@ describe("machineSpec", () => {
     it("refuses a field it does not know, including one every object inherits", () => {
         expect(() => machineSpec({ keylayout: "natural" })).toThrow("Unknown machine spec fields: keylayout");
         expect(() => machineSpec({ toString: () => "" })).toThrow("Unknown machine spec fields: toString");
-    });
-
-    it("can tell its own specs from look-alikes", () => {
-        expect(isMachineSpec(machineSpec())).toBe(true);
-        expect(isMachineSpec(Object.freeze({ keyLayout: "physical" }))).toBe(false);
-        expect(isMachineSpec(undefined)).toBe(false);
     });
 
     it("cannot be changed afterwards", () => {

--- a/tests/unit/test-models.js
+++ b/tests/unit/test-models.js
@@ -2,6 +2,9 @@ import { describe, it, expect } from "vitest";
 import { allModels, basicOnly, DefaultModel, findModel, TEST_6502, TEST_65C02, TEST_65C12 } from "../../src/models.js";
 import { fake6502 } from "../../src/fake6502.js";
 import { guessModelFromHostname } from "../../src/url-params.js";
+import { AtomCpu6502, Cpu6502 } from "../../src/6502.js";
+import { BBC } from "../../src/keymap.js";
+import { ATOM } from "../../src/keymap-atom.js";
 
 describe("Model", () => {
     it("is frozen so per-session settings cannot be stored on it", () => {
@@ -40,6 +43,21 @@ describe("Model", () => {
             Tube65C02: "Tube65C02",
             Tube65C102: "Tube65C102",
         });
+    });
+
+    it("knows the shape of the machine it names", () => {
+        const beeb = findModel("B-DFS1.2");
+        const master = findModel("Master");
+        const atom = findModel("Atom");
+        expect([beeb.Cpu, atom.Cpu]).toEqual([Cpu6502, AtomCpu6502]);
+        expect([beeb.wrchvAddress, atom.wrchvAddress]).toEqual([0x020e, 0x0208]);
+        expect([beeb.idleAddress, master.idleAddress, atom.idleAddress]).toEqual([0xe581, 0xe7e6, 0xfe94]);
+        expect(beeb.keys).toBe(BBC);
+        expect(atom.keys).toBe(ATOM);
+        expect(beeb.stringToKeys("A")).toEqual([BBC.A]);
+        const processor = { sysvia: "via", atomppia: "ppia" };
+        expect([beeb.keyboardOf(processor), atom.keyboardOf(processor)]).toEqual(["via", "ppia"]);
+        expect(atom.pasteKeyDelayMs).toBeGreaterThan(beeb.pasteKeyDelayMs);
     });
 
     it("carries no per-session settings", () => {

--- a/tests/unit/test-rom-loading.js
+++ b/tests/unit/test-rom-loading.js
@@ -1,9 +1,9 @@
 import { describe, it, expect } from "vitest";
 import { TEST_6502 } from "../../src/models.js";
-import { buildMachine, machineSpec, nullIo } from "../../src/build-machine.js";
+import { machineSpec, nullIo } from "../../src/machine-spec.js";
 
 function makeCpu() {
-    return buildMachine({ model: TEST_6502, spec: machineSpec(), io: nullIo() });
+    return new TEST_6502.Cpu(TEST_6502, { ...nullIo(), config: machineSpec() });
 }
 
 // TEST_6502 has eight sideways RAM banks, leaving eight for extra ROMs.

--- a/tests/unit/test-snapshot.js
+++ b/tests/unit/test-snapshot.js
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach } from "vitest";
 import { createSnapshot, restoreSnapshot, snapshotToJSON, snapshotFromJSON, isSameModel } from "../../src/snapshot.js";
 import { Video } from "../../src/video.js";
 import { SoundChip } from "../../src/soundchip.js";
-import { buildMachine, machineSpec, nullIo } from "../../src/build-machine.js";
+import { machineSpec, nullIo } from "../../src/machine-spec.js";
 import { TEST_6502, TubeModel } from "../../src/models.js";
 import { Disc, DiscConfig, loadSsd } from "../../src/disc.js";
 import { discFor } from "../../src/fdc.js";
@@ -15,7 +15,7 @@ function makeCpu(config = {}) {
     const fb32 = new Uint32Array(1024 * 768);
     const video = new Video(false, fb32, () => {});
     const soundChip = new SoundChip(() => {});
-    return buildMachine({ model: TEST_6502, spec: machineSpec(config), io: nullIo({ video, soundChip }) });
+    return new TEST_6502.Cpu(TEST_6502, { ...nullIo({ video, soundChip }), config: machineSpec(config) });
 }
 
 describe("Snapshot coordinator", () => {

--- a/tests/unit/test-web-machine.js
+++ b/tests/unit/test-web-machine.js
@@ -83,12 +83,12 @@ describe("Machine", () => {
     it("builds the processor with everything bolted on and attaches the printer", () => {
         const machine = make();
         expect(machine.processor).toBe(fakeProcessor);
-        const [{ model, spec, io }] = deps.build.mock.calls[0];
+        const [model, fittings] = deps.build.mock.calls[0];
         expect(model).toBe(deps.model);
-        expect(io.cmos).toBe(machine.cmos);
-        expect(spec).toBe(machine.spec);
-        expect(Object.isFrozen(spec)).toBe(true);
-        expect(io.music5000).toBeNull();
+        expect(fittings.cmos).toBe(machine.cmos);
+        expect(fittings.config).toBe(machine.spec);
+        expect(Object.isFrozen(fittings.config)).toBe(true);
+        expect(fittings.music5000).toBeNull();
         expect(deps.printer.attach).toHaveBeenCalledWith(fakeProcessor.uservia);
     });
 


### PR DESCRIPTION
Item 5 of #1072.

**Before.** What a model implies about its machine was re-derived with `isAtom ?` wherever it was needed: the CPU class in `buildMachine`, the WRCHV address in `test-machine.js`, the keyboard chip and shift key in `keyboard.js` and again in `test-machine.js`, the key table in `main.js`, the string-to-keys in `autoboot.js`, the paste cadence in `keyboard.js`, and the wait-for-input address split between `basicIdleAddr` (B or Master) and an Atom-only branch in `TestMachine.runUntilInput`. `basicIdleAddr` showed the right pattern (a fact of the model, in one place) and this extends it.

**After.** `Model` carries `Cpu`, `keys`, `stringToKeys`, `wrchvAddress`, `idleAddress`, `pasteKeyDelayMs` and `keyboardOf(processor)`, all set in its constructor, which is now the one place the two machine families part. The dispatch sites read them; `basicIdleAddr` is gone (the model's `idleAddress` covers the Atom too, so `runUntilInput` has one path); the imports of the Atom key map leave `main.js`, `keyboard.js` and `autoboot.js`. `models.js` gains imports of the CPU classes and the two key maps; nothing on those paths imports `models.js`, so there is no cycle, and the build agrees. With the CPU class on the model, `buildMachine` had nothing left to do but the spec check, so it and the check are gone (review): callers construct `new model.Cpu(model, { ...io, config: machineSpec(...) })`, and the module is `machine-spec.js`, holding `machineSpec` and `nullIo`.

**Left as `isAtom` checks, on purpose:** the VDU decoder's choice of sequence set (an option to a decoder that has no model), the audio worklet's sound chip choice (a class cannot cross the worklet boundary, so a flag must), the session's instrumented sound chip (test instrumentation, not machine shape), and the front panel's tape control (a UI toggle). The tape format code's `isAtom` is about the tape encoding, not the machine.

Tests: `test-models.js` checks each fact for a B, a Master and an Atom; the keyboard, keyboard-setup and autoboot tests use real models where the code now asks the model (their `{ isAtom }` fakes could not answer); the autoboot tape test asserts on the keys sent rather than spying on a function the model now holds by reference; the idle-address test moves from the BASIC loader to the model.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
