### PR TITLE
fix: fast tape and the hidden-tab hold see the Atom's cassette motor

### DIFF
--- a/src/6502.js
+++ b/src/6502.js
@@ -690,6 +690,8 @@ export class Cpu6502 extends Base6502 {
         this.uservia = new via.UserVia(this, this.scheduler, this.model.isMaster, this.config.userPort);
         this.acia = new Acia(this, this.soundChip.toneGenerator, this.scheduler, this.relayNoise);
         this.serial = new Serial(this.acia);
+        this.keyboardInterface = this.sysvia;
+        this.tapeInterface = this.acia;
         this.adconverter = new Adc(this.sysvia, this.scheduler);
         this.touchScreen = new TouchScreen(this.scheduler, this.model.cyclesPerSecond);
         this.soundChip.setScheduler(this.scheduler);
@@ -1612,6 +1614,8 @@ export class AtomCpu6502 extends Cpu6502 {
         // Atom peripherals
         this.atomppia = new AtomPPIA(this, this.keyLayout, this.scheduler);
         this.atommc = new AtomMMC2(this);
+        this.keyboardInterface = this.atomppia;
+        this.tapeInterface = this.atomppia;
 
         // Branquart bank selection
         this.branquartLatch = 0;

--- a/src/app/electron.js
+++ b/src/app/electron.js
@@ -14,7 +14,7 @@ function init(args) {
     api.onLoadTape(async (message) => {
         const { path } = message;
         const tape = await loadTapeImage(path);
-        processor.acia.setTape(tape);
+        processor.tapeInterface.setTape(tape);
     });
 
     api.onShowModal((message) => {

--- a/src/models.js
+++ b/src/models.js
@@ -54,6 +54,9 @@ class Model {
         this.idleAddress = this.isAtom ? 0xfe94 : isMaster ? 0xe7e6 : 0xe581;
         // The Atom ROM polls its keyboard once per VSync, so pasted keys need longer apart.
         this.pasteKeyDelayMs = this.isAtom ? 80 : 50;
+        // The Atom polls its keyboard rather than taking an interrupt, so it
+        // must see each key up before the next key goes down.
+        this.pasteReleaseGapMs = this.isAtom ? 30 : 0;
         this.Fdc = fdc;
         this.swram = swram;
         this.isTest = false;
@@ -67,11 +70,6 @@ class Model {
      */
     get cyclesPerSecond() {
         return this.clockMhz * 1000 * 1000;
-    }
-
-    /** The chip the keyboard hangs off: the PPIA on an Atom, the system VIA on a BBC. */
-    keyboardOf(processor) {
-        return this.isAtom ? processor.atomppia : processor.sysvia;
     }
 
     get nmos() {

--- a/src/ppia.js
+++ b/src/ppia.js
@@ -415,9 +415,8 @@ export class AtomPPIA extends PPIA {
     }
 
     rewindTape() {
-        if (this.tape) {
-            this.tape.rewind();
-        }
+        this.stopTape();
+        if (this.tape) this.tape.rewind();
     }
 
     playTape() {

--- a/src/test-machine.js
+++ b/src/test-machine.js
@@ -26,7 +26,7 @@ export class TestMachine {
 
     /** The keyboard interface for this machine (SysVia for BBC, PPIA for Atom). */
     get _keyInterface() {
-        return this.model.keyboardOf(this.processor);
+        return this.processor.keyboardInterface;
     }
 
     async initialise() {

--- a/src/web/emulation-loop.js
+++ b/src/web/emulation-loop.js
@@ -177,7 +177,7 @@ export class EmulationLoop extends EventTarget {
         const now = performance.now();
 
         const { processor, display, audioHandler } = this;
-        const motorOn = processor.acia.motorOn;
+        const motorOn = processor.tapeInterface.motorOn;
         const speedy = this.fastAsPossible || (this.fastTape && motorOn);
 
         display.setSpeedy(speedy);
@@ -253,7 +253,7 @@ export class EmulationLoop extends EventTarget {
         const { processor } = this;
         if (document.visibilityState === "hidden") {
             const keepRunningWhenHidden =
-                processor.acia.motorOn || processor.fdc.motorOn[0] || processor.fdc.motorOn[1];
+                processor.tapeInterface.motorOn || processor.fdc.motorOn[0] || processor.fdc.motorOn[1];
             if (!keepRunningWhenHidden && !this.resumeOnVisible) this.resumeOnVisible = this.pause("the hidden tab");
         } else if (this.resumeOnVisible) {
             this.resumeOnVisible();

--- a/src/web/front-panel.js
+++ b/src/web/front-panel.js
@@ -40,13 +40,8 @@ export class FrontPanel {
 
                 if (type === "rewind") {
                     console.log("Rewinding tape to the start");
-                    if (model.isAtom) {
-                        processor.atomppia.stopTape();
-                        processor.atomppia.rewindTape();
-                        this.updateTapeButton();
-                    } else {
-                        processor.acia.rewindTape();
-                    }
+                    processor.tapeInterface.rewindTape();
+                    this.updateTapeButton();
                 }
             });
         }
@@ -100,14 +95,12 @@ export class FrontPanel {
 
     syncLights() {
         const { processor } = this;
-        if (this.model.isAtom) {
-            this.cassette.update(processor.atomppia.motorOn);
-        } else {
+        this.cassette.update(processor.tapeInterface.motorOn);
+        if (!this.model.isAtom) {
             this.caps.update(processor.sysvia.capsLockLight);
             this.shift.update(processor.sysvia.shiftLockLight);
             this.drive0.update(processor.fdc.motorOn[0]);
             this.drive1.update(processor.fdc.motorOn[1]);
-            this.cassette.update(processor.acia.motorOn);
             if (processor.econet) {
                 this.network.update(processor.econet.activityLight());
             }

--- a/src/web/keyboard.js
+++ b/src/web/keyboard.js
@@ -27,7 +27,7 @@ export class Keyboard extends EventTarget {
         this.inputEnabledFunction = inputEnabledFunction;
         this.dbgr = dbgr;
 
-        this.keyInterface = processor.model.keyboardOf(processor);
+        this.keyInterface = processor.keyboardInterface;
         // Compared by reference in _deliverPasteKey to avoid toggling shift off.
         this._shiftKey = processor.model.keys.SHIFT;
 
@@ -369,12 +369,10 @@ export class Keyboard extends EventTarget {
             return;
         }
 
-        // Atom's PPIA keyboard is polled, not interrupt-driven like the BBC's
-        // SysVIA. Insert a debounce gap after every key release so the ROM
-        // sees the key-up before the next key-down arrives.
-        if (this._pasteLastChar && this._pasteLastChar !== this._shiftKey && this.processor.model.isAtom) {
+        const releaseGapMs = this.processor.model.pasteReleaseGapMs;
+        if (this._pasteLastChar && this._pasteLastChar !== this._shiftKey && releaseGapMs) {
             this._pasteLastChar = undefined;
-            this._pasteTask.schedule(30 * this._pasteClocksPerMs);
+            this._pasteTask.schedule(releaseGapMs * this._pasteClocksPerMs);
             return;
         }
 

--- a/src/web/media-loader.js
+++ b/src/web/media-loader.js
@@ -165,13 +165,8 @@ export class MediaLoader extends EventTarget {
         else this.resolver.addSource(schema, fetcher);
     }
 
-    /** Route tape to the correct interface (ACIA for BBC, PPIA for Atom) */
     setProcessorTape(tape) {
-        if (this.model.isAtom) {
-            this.processor.atomppia.setTape(tape);
-        } else {
-            this.processor.acia.setTape(tape);
-        }
+        this.processor.tapeInterface.setTape(tape);
     }
 
     setDisc1Image(name) {

--- a/tests/unit/test-cpu-state.js
+++ b/tests/unit/test-cpu-state.js
@@ -277,3 +277,17 @@ describe("cycle counter rollover", () => {
         expect(absolute).toBeLessThan(2 * 1000 * 1000);
     });
 });
+
+describe("the chips a machine names", () => {
+    it("puts the keyboard and tape on the system VIA and ACIA of a BBC", () => {
+        const cpu = fake6502(findModel("B-DFS1.2"));
+        expect(cpu.keyboardInterface).toBe(cpu.sysvia);
+        expect(cpu.tapeInterface).toBe(cpu.acia);
+    });
+
+    it("puts both on the PPIA of an Atom", () => {
+        const cpu = fake6502(findModel("Atom"));
+        expect(cpu.keyboardInterface).toBe(cpu.atomppia);
+        expect(cpu.tapeInterface).toBe(cpu.atomppia);
+    });
+});

--- a/tests/unit/test-emulation-loop.js
+++ b/tests/unit/test-emulation-loop.js
@@ -19,7 +19,7 @@ describe("EmulationLoop", () => {
                 execute: vi.fn(() => true),
                 stop: vi.fn(),
                 pc: 0x1234,
-                acia: { motorOn: false },
+                tapeInterface: { motorOn: false },
                 fdc: { motorOn: [false, false] },
                 sysvia: {},
                 snapshotState: vi.fn(() => ({})),
@@ -110,7 +110,7 @@ describe("EmulationLoop", () => {
     it("speeds up for a tape motor only when told fast tape", () => {
         deps.fastTape = true;
         const loop = started();
-        deps.processor.acia.motorOn = true;
+        deps.processor.tapeInterface.motorOn = true;
         vi.advanceTimersByTime(10);
         expect(cyclesExecuted().at(-1)).toBe(ClocksPerSecond / 50);
         expect(loop.isRunning()).toBe(true);

--- a/tests/unit/test-front-panel.js
+++ b/tests/unit/test-front-panel.js
@@ -24,8 +24,10 @@ describe("FrontPanel", () => {
 
     afterEach(teardownDom);
 
-    const make = (isAtom = false, printer = new Printer()) =>
-        new FrontPanel({ processor, model: { isAtom }, printer, loop });
+    const make = (isAtom = false, printer = new Printer()) => {
+        processor.tapeInterface = isAtom ? processor.atomppia : processor.acia;
+        return new FrontPanel({ processor, model: { isAtom }, printer, loop });
+    };
     const lit = (id) => document.getElementById(id).classList.contains("on");
 
     describe("the lights", () => {
@@ -89,11 +91,13 @@ describe("FrontPanel", () => {
             expect(processor.atomppia.rewindTape).not.toHaveBeenCalled();
         });
 
-        it("stops the Atom's tape before rewinding it", () => {
+        it("rewinds the Atom's tape and shows play as what comes next", () => {
             make(true);
+            processor.atomppia.motorOn = true;
+            processor.atomppia.rewindTape.mockImplementation(() => (processor.atomppia.motorOn = false));
             document.querySelector('#tape-menu a[data-id="rewind"]').click();
-            expect(processor.atomppia.stopTape).toHaveBeenCalled();
             expect(processor.atomppia.rewindTape).toHaveBeenCalled();
+            expect(document.getElementById("tape-play-stop").textContent).toBe("▶");
         });
 
         it("ignores menu links it does not handle", () => {

--- a/tests/unit/test-keyboard-setup.js
+++ b/tests/unit/test-keyboard-setup.js
@@ -59,6 +59,7 @@ describe("KeyboardSetup", () => {
                 keyboardEnabled: true,
             },
         };
+        processor.keyboardInterface = processor.sysvia;
         setup = new KeyboardSetup({ actions, accessibilitySwitches, processor, dbgr: {}, keyLayout: "physical" });
         setup.keyboard.setRunning(true);
     });

--- a/tests/unit/test-keyboard.js
+++ b/tests/unit/test-keyboard.js
@@ -42,6 +42,7 @@ describe("Keyboard", () => {
         mockProcessor = {
             model: findModel("B-DFS1.2"),
             sysvia: mockSysvia,
+            keyboardInterface: mockSysvia,
             setKeyLayout: vi.fn(),
             scheduler: new Scheduler(),
             setReset: vi.fn(),
@@ -564,6 +565,7 @@ describe("Keyboard Atom adapter", () => {
         mockProcessor = {
             model: findModel("Atom"),
             atomppia: mockAtomPPIA,
+            keyboardInterface: mockAtomPPIA,
             setKeyLayout: vi.fn(),
             sysvia: { keyDown: vi.fn(), keyUp: vi.fn() },
             scheduler: new Scheduler(),

--- a/tests/unit/test-media-loader.js
+++ b/tests/unit/test-media-loader.js
@@ -26,8 +26,7 @@ describe("MediaLoader", () => {
         deps = {
             processor: {
                 fdc: null,
-                acia: { setTape: vi.fn() },
-                atomppia: { setTape: vi.fn() },
+                tapeInterface: { setTape: vi.fn() },
                 filestore: {},
                 econet: {},
             },
@@ -187,8 +186,8 @@ describe("MediaLoader", () => {
             deps.urlState.params.tape = "old.uef";
             make();
             await pickFile("tape_load", fileFor("mine.uef", uefImage()));
-            await vi.waitFor(() => expect(deps.processor.acia.setTape).toHaveBeenCalled());
-            expect(deps.processor.acia.setTape.mock.calls[0][0]).toBeTruthy();
+            await vi.waitFor(() => expect(deps.processor.tapeInterface.setTape).toHaveBeenCalled());
+            expect(deps.processor.tapeInterface.setTape.mock.calls[0][0]).toBeTruthy();
             expect(deps.urlState.params.tape).toBeUndefined();
             expect(deps.modals.hide).toHaveBeenCalledWith("tapes");
         });
@@ -197,7 +196,7 @@ describe("MediaLoader", () => {
             make();
             await pickFile("tape_load", fileFor("noise.uef", new Uint8Array(12)));
             await vi.waitFor(() => expect(toasts()).toEqual([expect.stringContaining("Could not load noise.uef")]));
-            expect(deps.processor.acia.setTape).not.toHaveBeenCalled();
+            expect(deps.processor.tapeInterface.setTape).not.toHaveBeenCalled();
         });
     });
 
@@ -231,13 +230,10 @@ describe("MediaLoader", () => {
     });
 
     describe("setProcessorTape", () => {
-        it("routes the tape to the ACIA on a BBC and the PPIA on an Atom", () => {
+        it("hands the tape to the machine's tape interface", () => {
             const tape = {};
             make().setProcessorTape(tape);
-            expect(deps.processor.acia.setTape).toHaveBeenCalledWith(tape);
-            deps.model.isAtom = true;
-            make().setProcessorTape(tape);
-            expect(deps.processor.atomppia.setTape).toHaveBeenCalledWith(tape);
+            expect(deps.processor.tapeInterface.setTape).toHaveBeenCalledWith(tape);
         });
     });
 });

--- a/tests/unit/test-models.js
+++ b/tests/unit/test-models.js
@@ -55,9 +55,8 @@ describe("Model", () => {
         expect(beeb.keys).toBe(BBC);
         expect(atom.keys).toBe(ATOM);
         expect(beeb.stringToKeys("A")).toEqual([BBC.A]);
-        const processor = { sysvia: "via", atomppia: "ppia" };
-        expect([beeb.keyboardOf(processor), atom.keyboardOf(processor)]).toEqual(["via", "ppia"]);
         expect(atom.pasteKeyDelayMs).toBeGreaterThan(beeb.pasteKeyDelayMs);
+        expect([beeb.pasteReleaseGapMs, atom.pasteReleaseGapMs]).toEqual([0, 30]);
     });
 
     it("carries no per-session settings", () => {

--- a/tests/unit/test-ppia.js
+++ b/tests/unit/test-ppia.js
@@ -192,6 +192,22 @@ describe("AtomPPIA", () => {
             expect(ppia.tape).toBe(fakeTape);
         });
 
+        it("stops the motor when rewinding", () => {
+            const { ppia } = makePPIA();
+            const fakeTape = {
+                rewound: false,
+                rewind() {
+                    this.rewound = true;
+                },
+                poll: () => 100,
+            };
+            ppia.setTape(fakeTape);
+            ppia.playTape();
+            ppia.rewindTape();
+            expect(ppia.motorOn).toBe(false);
+            expect(fakeTape.rewound).toBe(true);
+        });
+
         it("should receive bits into port C", () => {
             const { ppia } = makePPIA();
             ppia.receiveBit(1);


### PR DESCRIPTION
First of the two `isAtom` clean-ups: the tape interface gets the treatment the keyboard got in #1079, and the paste path's Atom gap becomes a model field.

## What changes

- **The CPU names its chips.** `Cpu6502` sets `keyboardInterface` and `tapeInterface` to the system VIA and ACIA as it constructs them; `AtomCpu6502` points both at the PPIA. The dispatch lives where the chips are built, so `Model.keyboardOf(processor)` is no longer needed and goes.
- **Five sites stop asking `isAtom` to find a chip:** `MediaLoader.setProcessorTape`, the front panel's rewind handler and cassette light, the Electron tape loader, and the web `Keyboard`'s key interface.
- **A fix that fell out:** the emulation loop read `processor.acia.motorOn` for fast tape and for keeping a hidden tab running. On an Atom that is the base class's unused ACIA, so neither ever noticed the cassette. Both now read `tapeInterface.motorOn`.
- **Rewinding the Atom's tape stops the motor in the PPIA**, not in the front panel; the panel just rewinds and refreshes its play/stop button, which is already a no-op on a BBC.
- **`Model.pasteReleaseGapMs`** (0 on a BBC, 30 on an Atom) replaces the `isAtom` branch and its comment in `_deliverPasteKey`, matching `pasteKeyDelayMs` beside it.

## Tests

Mocked processors name their interfaces the way the real ones do. New checks: a real `fake6502` B and Atom expose the expected chips; the PPIA stops its motor on rewind; the front panel's rewind refreshes the Atom button; the model carries the release gap.

The next PR unifies `TestMachine.type()` over the same interface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
