### PR TITLE
fix: one typing routine for the page and the headless machine, and the Atom stops dropping pasted keys

### DIFF
--- a/src/machine-session.js
+++ b/src/machine-session.js
@@ -203,10 +203,9 @@ export class MachineSession {
         await this._machine.runFor(cycles);
     }
 
-    /** Emulated cycles since power-on, undoing the per-second rebasing execute() applies */
+    /** Emulated cycles since power-on */
     get elapsedCycles() {
-        const cpu = this._machine.processor;
-        return cpu.cycleSeconds * cpu.model.cyclesPerSecond + cpu.currentCycles;
+        return this._machine.elapsedCycles;
     }
 
     /**

--- a/src/models.js
+++ b/src/models.js
@@ -54,9 +54,9 @@ class Model {
         this.idleAddress = this.isAtom ? 0xfe94 : isMaster ? 0xe7e6 : 0xe581;
         // The Atom ROM polls its keyboard once per VSync, so pasted keys need longer apart.
         this.pasteKeyDelayMs = this.isAtom ? 80 : 50;
-        // The Atom polls its keyboard rather than taking an interrupt, so it
-        // must see each key up before the next key goes down.
-        this.pasteReleaseGapMs = this.isAtom ? 30 : 0;
+        // Two of those 60 Hz scans, 33 ms, with margin: the ROM wants a key seen up
+        // twice before it takes the next.
+        this.pasteReleaseGapMs = this.isAtom ? 40 : 0;
         this.Fdc = fdc;
         this.swram = swram;
         this.isTest = false;

--- a/src/test-machine.js
+++ b/src/test-machine.js
@@ -5,11 +5,10 @@ import { findModel } from "./models.js";
 import assert from "assert";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import * as utils_atom from "./keymap-atom.js";
 import * as Tokeniser from "./basic-tokenise.js";
 import { VduTextCapture } from "./vdu-capture.js";
 import { setNodeBasePath } from "./loader.js";
-import { keyCodes } from "./keymap.js";
+import { Typist } from "./typist.js";
 
 const MaxCyclesPerIter = 100 * 1000;
 const RepoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
@@ -20,6 +19,7 @@ export class TestMachine {
         this.model = findModel(model);
         if (!this.model) throw new Error(`Unknown model "${model}"`);
         this.processor = fake6502(this.model, opts || {});
+        this.typist = new Typist(this.processor);
         this._capturedChars = [];
         this._captureHookInstalled = false;
     }
@@ -143,28 +143,10 @@ export class TestMachine {
         });
     }
 
-    /**
-     * Run until the cursor blink reaches the desired state.
-     * This ensures deterministic screenshots regardless of how many
-     * cycles were consumed by prior type() or runFor() calls.
-     * @param {boolean} on - true for cursor visible, false for hidden
-     */
-    async runToCursorState(on) {
-        const video = this.processor.video;
-        for (let i = 0; i < 100; i++) {
-            if (video.cursorOnThisFrame === on) return;
-            await this.runFor(40000);
-        }
-        throw new Error(`Cursor did not reach state ${on} in time (cursorOnThisFrame=${video.cursorOnThisFrame})`);
-    }
-
-    async runUntilFlashHidden() {
-        const teletext = this.processor.video.teletext;
-        for (let i = 0; i < 100; i++) {
-            if (teletext.hideFlashing) return;
-            await this.runFor(40000);
-        }
-        throw new Error("Flashing text did not reach its hidden phase in time");
+    /** Emulated cycles since power-on, undoing the per-second rebasing execute() applies. */
+    get elapsedCycles() {
+        const cpu = this.processor;
+        return cpu.cycleSeconds * this.model.cyclesPerSecond + cpu.currentCycles;
     }
 
     async runUntilVblank() {
@@ -260,215 +242,16 @@ export class TestMachine {
     }
 
     /**
-     * Convert an ASCII character to a {code, shift} pair for the BBC keyboard.
-     */
-    _charToKey(ch) {
-        switch (ch) {
-            case "\n":
-            case "\r":
-                return { code: 13, shift: false };
-            case '"':
-                return { code: keyCodes.K2, shift: true };
-            case "*":
-                return { code: keyCodes.APOSTROPHE, shift: true };
-            case "!":
-                return { code: keyCodes.K1, shift: true };
-            case ".":
-                return { code: keyCodes.PERIOD, shift: false };
-            case ";":
-                return { code: keyCodes.SEMICOLON, shift: false };
-            case ":":
-                return { code: keyCodes.APOSTROPHE, shift: false };
-            case ",":
-                return { code: keyCodes.COMMA, shift: false };
-            case "&":
-                return { code: keyCodes.K6, shift: true };
-            case " ":
-                return { code: keyCodes.SPACE, shift: false };
-            case "-":
-                return { code: keyCodes.MINUS, shift: false };
-            case "=":
-                return { code: keyCodes.MINUS, shift: true };
-            case "+":
-                return { code: keyCodes.SEMICOLON, shift: true };
-            case "^":
-                return { code: keyCodes.EQUALS, shift: false };
-            case "~":
-                return { code: keyCodes.EQUALS, shift: true };
-            case "[":
-                return { code: keyCodes.LEFT_SQUARE_BRACKET, shift: false };
-            case "]":
-                return { code: keyCodes.RIGHT_SQUARE_BRACKET, shift: false };
-            case "{":
-                return { code: keyCodes.LEFT_SQUARE_BRACKET, shift: true };
-            case "}":
-                return { code: keyCodes.HASH, shift: true };
-            case "\\":
-                return { code: keyCodes.BACKSLASH, shift: false };
-            case "/":
-                return { code: keyCodes.SLASH, shift: false };
-            case "?":
-                return { code: keyCodes.SLASH, shift: true };
-            case "<":
-                return { code: keyCodes.COMMA, shift: true };
-            case ">":
-                return { code: keyCodes.PERIOD, shift: true };
-            case "(":
-                return { code: keyCodes.K8, shift: true };
-            case ")":
-                return { code: keyCodes.K9, shift: true };
-            case "@":
-                return { code: keyCodes.BACK_QUOTE, shift: false };
-            case "#":
-                return { code: keyCodes.K3, shift: true };
-            case "$":
-                return { code: keyCodes.K4, shift: true };
-            case "%":
-                return { code: keyCodes.K5, shift: true };
-            default: {
-                const upper = ch.toUpperCase();
-                const isLetter = (ch >= "a" && ch <= "z") || (ch >= "A" && ch <= "Z");
-                if (isLetter) {
-                    const wantUpper = ch >= "A" && ch <= "Z";
-                    const capsOn = this.processor.sysvia.capsLockLight;
-                    // CAPS LOCK on: unshifted = upper, shifted = lower
-                    // CAPS LOCK off: unshifted = lower, shifted = upper
-                    const needShift = capsOn ? !wantUpper : wantUpper;
-                    return { code: upper.charCodeAt(0), shift: needShift };
-                }
-                return { code: ch.charCodeAt(0), shift: false };
-            }
-        }
-    }
-
-    /**
-     * Type text by installing a debugInstruction hook that presses/releases
-     * keys at timed intervals during CPU execution.  The hook persists across
-     * runFor calls, so breakpoints naturally coexist: if a breakpoint halts
-     * execution mid-typing, the remaining characters are typed when execution
-     * resumes.
+     * Types the text and a RETURN at the machine, running the CPU until the
+     * last key is up. The keys arrive from the scheduler, so a breakpoint that
+     * stops the CPU part way leaves the rest to be typed when it runs again.
      */
     async type(text) {
-        if (this.model.isAtom) {
-            return this._typeAtom(text);
-        }
-        const fullText = text + "\n"; // append RETURN
-        const keys = fullText.split("").map((ch) => this._charToKey(ch));
-        // Key hold is counted in CPU cycles, so scale it to keep the hold constant in
-        // real time: the OS scans the keyboard on a peripheral-rate interrupt.
-        const holdCycles = (40000 * this.processor.cpuMultiplier) | 0;
-        let index = 0;
-        let phase = "idle"; // "idle" → "down" → "idle"
-        let nextEventCycle = 0;
-        let done = false;
-
-        const currentCycle = () =>
-            this.processor.cycleSeconds * this.model.cyclesPerSecond + this.processor.currentCycles;
-
-        const hook = this.processor.debugInstruction.add(() => {
-            if (currentCycle() < nextEventCycle) return;
-
-            if (phase === "down") {
-                // Release current key
-                const key = keys[index];
-                this.processor.sysvia.keyUp(key.code);
-                if (key.shift) this.processor.sysvia.keyUp(16);
-                index++;
-                phase = "idle";
-                nextEventCycle = currentCycle() + holdCycles;
-                return;
-            }
-
-            // phase === "idle"
-            if (index >= keys.length) {
-                hook.remove();
-                done = true;
-                return;
-            }
-
-            // Press next key
-            const key = keys[index];
-            if (key.shift) this.processor.sysvia.keyDown(16);
-            this.processor.sysvia.keyDown(key.code);
-            phase = "down";
-            nextEventCycle = currentCycle() + holdCycles;
-        });
-
-        // Drive execution in chunks until all characters are typed or
-        // a breakpoint halts the CPU.
-        while (!done) {
-            const stopped = await this.runFor(holdCycles);
+        const lines = text.replace(/\r\n?/g, "\n");
+        this.typist.type(this.model.stringToKeys(lines + "\n"), true);
+        while (this.typist.isTyping) {
+            const stopped = await this.runFor(MaxCyclesPerIter);
             if (stopped) break;
-        }
-    }
-
-    /** Type text on the Atom using its key mapping and PPIA interface. */
-    async _typeAtom(text) {
-        // stringToATOMKeys returns a flat array of [col, row] pairs.
-        // SHIFT is held across multiple characters; LOCK is tapped to
-        // toggle the ROM's internal caps lock state.
-        const keySequence = utils_atom.stringToATOMKeys(text + "\n");
-        const ppia = this.processor.atomppia;
-        const holdCycles = (80000 * this.processor.cpuMultiplier) | 0; // Atom at 1 MHz needs longer hold than BBC at 2 MHz
-        const SHIFT = utils_atom.ATOM.SHIFT;
-
-        let index = 0;
-        let phase = "idle";
-        let nextEventCycle = 0;
-        let done = false;
-        let shiftHeld = false;
-
-        const currentCycle = () =>
-            this.processor.cycleSeconds * this.model.cyclesPerSecond + this.processor.currentCycles;
-
-        const isShift = (entry) => entry[0] === SHIFT[0] && entry[1] === SHIFT[1];
-
-        const hook = this.processor.debugInstruction.add(() => {
-            if (currentCycle() < nextEventCycle) return;
-
-            if (phase === "down") {
-                const entry = keySequence[index];
-                if (!isShift(entry)) {
-                    ppia.keyUpRaw(entry);
-                }
-                index++;
-                phase = "idle";
-                nextEventCycle = currentCycle() + holdCycles;
-                return;
-            }
-
-            if (index >= keySequence.length) {
-                if (shiftHeld) ppia.keyUpRaw(SHIFT);
-                hook.remove();
-                done = true;
-                return;
-            }
-
-            const entry = keySequence[index];
-            if (isShift(entry)) {
-                if (shiftHeld) {
-                    ppia.keyUpRaw(SHIFT);
-                    shiftHeld = false;
-                } else {
-                    ppia.keyDownRaw(SHIFT);
-                    shiftHeld = true;
-                }
-                index++;
-                nextEventCycle = currentCycle() + holdCycles;
-            } else {
-                ppia.keyDownRaw(entry);
-                phase = "down";
-                nextEventCycle = currentCycle() + holdCycles;
-            }
-        });
-
-        while (!done) {
-            const stopped = await this.runFor(holdCycles);
-            if (stopped) {
-                hook.remove();
-                if (shiftHeld) ppia.keyUpRaw(SHIFT);
-                break;
-            }
         }
     }
 

--- a/src/typist.js
+++ b/src/typist.js
@@ -1,0 +1,103 @@
+import { BBC } from "./keymap.js";
+
+const RepeatedKeyGapMs = 30;
+
+/**
+ * Types a key sequence into the keyboard matrix from the processor's
+ * scheduler, one key per tick, so the CPU stays on its fast path while the
+ * text arrives. An entry is one of the model's raw keys, or a number of
+ * milliseconds to wait. SHIFT toggles and stays held; any other key is pressed
+ * on one tick and released on the next.
+ */
+export class Typist {
+    constructor(processor) {
+        this.processor = processor;
+        this.keyInterface = processor.keyboardInterface;
+        this._shiftKey = processor.model.keys.SHIFT;
+        this._keys = [];
+        this._lastKey = undefined;
+        this._clocksPerMs = 0;
+        this._task = processor.scheduler.newTask(() => this._deliver());
+    }
+
+    /**
+     * @param {Array} keys raw keys and millisecond delays, consumed as they are sent
+     * @param {boolean} checkCapsAndShiftLocks bracket the keys with a lock toggle when
+     *   the machine's lock lights say the letters would come out in the wrong case
+     */
+    type(keys, checkCapsAndShiftLocks) {
+        if (this.isTyping) this.cancel();
+        this.keyInterface.disableKeyboard();
+        // The task lives on the processor's scheduler, which is polled with peripheral
+        // cycles, so the delays stay in real time whatever the CPU multiplier is.
+        this._clocksPerMs = this.processor.peripheralCyclesPerSecond / 1000;
+
+        if (checkCapsAndShiftLocks) {
+            let toggleKey = null;
+            if (!this.keyInterface.capsLockLight) toggleKey = BBC.CAPSLOCK;
+            else if (this.keyInterface.shiftLockLight) toggleKey = BBC.SHIFTLOCK;
+            if (toggleKey) {
+                keys.unshift(toggleKey);
+                keys.push(toggleKey);
+            }
+        }
+
+        this._keys = keys;
+        this._lastKey = undefined;
+        this._task.schedule(0);
+    }
+
+    cancel() {
+        if (!this.isTyping) return;
+        this._task.cancel();
+        this._releaseLastKey();
+        this._lastKey = undefined;
+        this._keys = [];
+        this.keyInterface.enableKeyboard();
+    }
+
+    get isTyping() {
+        return this._keys.length > 0 || this._task.scheduled();
+    }
+
+    _releaseLastKey() {
+        if (this._lastKey && this._lastKey !== this._shiftKey) this.keyInterface.keyToggleRaw(this._lastKey);
+    }
+
+    _deliver() {
+        this._releaseLastKey();
+
+        if (this._keys.length === 0) {
+            this._lastKey = undefined;
+            this.keyInterface.enableKeyboard();
+            return;
+        }
+
+        const releaseGapMs = this.processor.model.pasteReleaseGapMs;
+        if (this._lastKey && this._lastKey !== this._shiftKey && releaseGapMs) {
+            this._lastKey = undefined;
+            this._task.schedule(releaseGapMs * this._clocksPerMs);
+            return;
+        }
+
+        const key = this._keys[0];
+        const repeated = this._lastKey === key;
+        this._lastKey = key;
+        if (repeated) {
+            this._lastKey = undefined;
+            this._task.schedule(RepeatedKeyGapMs * this._clocksPerMs);
+            return;
+        }
+
+        let delayMs = this.processor.model.pasteKeyDelayMs;
+        if (typeof key === "number") {
+            delayMs = key;
+            this._lastKey = undefined;
+        } else {
+            this.keyInterface.keyToggleRaw(key);
+        }
+
+        this._keys.shift();
+        this._task.schedule(delayMs * this._clocksPerMs);
+    }
+}

--- a/src/web/keyboard.js
+++ b/src/web/keyboard.js
@@ -1,4 +1,5 @@
-import { BBC, keyCodes } from "../keymap.js";
+import { keyCodes } from "../keymap.js";
+import { Typist } from "../typist.js";
 
 const isMac = typeof window !== "undefined" && /^Mac/i.test(window.navigator?.platform || "");
 
@@ -28,8 +29,7 @@ export class Keyboard extends EventTarget {
         this.dbgr = dbgr;
 
         this.keyInterface = processor.keyboardInterface;
-        // Compared by reference in _deliverPasteKey to avoid toggling shift off.
-        this._shiftKey = processor.model.keys.SHIFT;
+        this.typist = new Typist(processor);
 
         // State
         this.emuKeyHandlers = {};
@@ -43,13 +43,6 @@ export class Keyboard extends EventTarget {
         this.lastShiftLocation = 1;
         this.lastCtrlLocation = 1;
         this.lastAltLocation = 1;
-
-        // Paste state — uses a scheduler task instead of a debugInstruction
-        // hook so the CPU can remain on the fast execution path during paste.
-        this._pasteKeys = [];
-        this._pasteLastChar = undefined;
-        this._pasteClocksPerMs = 0;
-        this._pasteTask = this.processor.scheduler.newTask(() => this._deliverPasteKey());
     }
 
     /**
@@ -324,99 +317,17 @@ export class Keyboard extends EventTarget {
         );
     }
 
-    /**
-     * Send raw keyboard input to the emulated machine (for paste/autotype).
-     * @param {Array} keysToSend - Array of machine-specific key codes to send
-     * @param {boolean} checkCapsAndShiftLocks - Whether to check caps and shift locks
-     */
+    /** Sends raw keys, and millisecond delays, to the machine: paste and autoboot come through here. */
     sendRawKeyboard(keysToSend, checkCapsAndShiftLocks) {
-        if (this.isPasting) this.cancelPaste();
-
-        this.keyInterface.disableKeyboard();
-        // The paste task lives on the processor's scheduler, which is polled with peripheral
-        // cycles, so paste delays stay in real time whatever the CPU multiplier is.
-        this._pasteClocksPerMs = this.processor.peripheralCyclesPerSecond / 1000;
-
-        if (checkCapsAndShiftLocks) {
-            let toggleKey = null;
-            if (!this.keyInterface.capsLockLight) toggleKey = BBC.CAPSLOCK;
-            else if (this.keyInterface.shiftLockLight) toggleKey = BBC.SHIFTLOCK;
-            if (toggleKey) {
-                keysToSend.unshift(toggleKey);
-                keysToSend.push(toggleKey);
-            }
-        }
-
-        this._pasteKeys = keysToSend;
-        this._pasteLastChar = undefined;
-        this._pasteTask.schedule(0);
+        this.typist.type(keysToSend, checkCapsAndShiftLocks);
     }
 
-    /**
-     * Scheduler callback that delivers one key per invocation, rescheduling
-     * itself for the next key. Replaces the old debugInstruction hook so the
-     * CPU stays on the fast execution path during paste.
-     * @private
-     */
-    _deliverPasteKey() {
-        if (this._pasteLastChar && this._pasteLastChar !== this._shiftKey) {
-            this.keyInterface.keyToggleRaw(this._pasteLastChar);
-        }
-
-        if (this._pasteKeys.length === 0) {
-            this._pasteLastChar = undefined;
-            this.keyInterface.enableKeyboard();
-            return;
-        }
-
-        const releaseGapMs = this.processor.model.pasteReleaseGapMs;
-        if (this._pasteLastChar && this._pasteLastChar !== this._shiftKey && releaseGapMs) {
-            this._pasteLastChar = undefined;
-            this._pasteTask.schedule(releaseGapMs * this._pasteClocksPerMs);
-            return;
-        }
-
-        const ch = this._pasteKeys[0];
-        const debounce = this._pasteLastChar === ch;
-        this._pasteLastChar = ch;
-        if (debounce) {
-            this._pasteLastChar = undefined;
-            this._pasteTask.schedule(30 * this._pasteClocksPerMs);
-            return;
-        }
-
-        let delayMs = this.processor.model.pasteKeyDelayMs;
-        if (typeof this._pasteLastChar === "number") {
-            delayMs = this._pasteLastChar;
-            this._pasteLastChar = undefined;
-        } else {
-            this.keyInterface.keyToggleRaw(this._pasteLastChar);
-        }
-
-        this._pasteKeys.shift();
-        this._pasteTask.schedule(delayMs * this._pasteClocksPerMs);
-    }
-
-    /**
-     * Cancel any in-progress paste operation.
-     */
     cancelPaste() {
-        if (!this.isPasting) return;
-        this._pasteTask.cancel();
-        if (this._pasteLastChar && this._pasteLastChar !== this._shiftKey) {
-            this.keyInterface.keyToggleRaw(this._pasteLastChar);
-        }
-        this._pasteLastChar = undefined;
-        this._pasteKeys = [];
-        this.keyInterface.enableKeyboard();
+        this.typist.cancel();
     }
 
-    /**
-     * Whether a paste operation is currently in progress.
-     * @returns {boolean}
-     */
     get isPasting() {
-        return this._pasteKeys.length > 0 || this._pasteTask.scheduled();
+        return this.typist.isTyping;
     }
 
     /**

--- a/tests/hardware/teletext/render-page.js
+++ b/tests/hardware/teletext/render-page.js
@@ -11,6 +11,25 @@ export const Pages = ["T1", "T2", "T3", "T4", "T5", "T6", "T7", "T8"];
 // wait for; its BASIC setup is done well inside this.
 const RasterPageFrames = 200;
 
+const FieldCycles = 40000;
+const FlashCycleFields = 64;
+// The OS blanks flashing text for fields 27 to 42 of every 64 it has counted since power-on.
+// T6's reference shows the flashing band blanked; the other pages were taken with it shown.
+const FlashShownField = 10;
+const FlashBlankedField = 35;
+const CaptureField = { T6: FlashBlankedField };
+
+async function runToField(session, field) {
+    while (Math.floor(session.elapsedCycles / FieldCycles) % FlashCycleFields !== field) {
+        await session.runFrames(1);
+    }
+}
+
+// Where T8's boxes sit follows from where in the frame its raster loop caught vsync, which
+// follows from when the program started. Only the widths are the measurement, but the
+// reference pins a position, so start the page from where the reference started it.
+const T8StartCyclesIntoFrame = 12000;
+
 /** Renders one page of the test disc under jsbeeb and returns a PNG of the active display. */
 export async function renderPage(page) {
     const session = new MachineSession("Master");
@@ -18,14 +37,18 @@ export async function renderPage(page) {
         await session.initialise();
         await session.boot();
         session.loadDisc(Disc);
+        if (page === "T8") {
+            await session.runFrames(1);
+            await session.runFor(T8StartCyclesIntoFrame);
+        }
         await session.type(`CHAIN "${page}"`);
         if (page === "T8") {
             await session.runFrames(RasterPageFrames);
         } else {
             // Each page ends at a GET, so the OS reaching the keyboard is the page having
-            // finished drawing. This keeps the flash phase reproducible too.
+            // finished drawing.
             await session.runUntilPrompt();
-            await session.runFrames(1);
+            await runToField(session, CaptureField[page] ?? FlashShownField);
         }
         return await session.screenshotActive();
     } finally {

--- a/tests/integration/teletext.js
+++ b/tests/integration/teletext.js
@@ -46,8 +46,27 @@ async function setupCeefaxTestMachine(video) {
 
 const RefDir = path.join(RepoRoot, "tests/integration/teletext");
 
-async function compare(video, testMachine, expectedName) {
-    const actualPng = await video.capture(testMachine);
+const FieldCycles = 40000;
+const FlashCycleFields = 64;
+// The flash and cursor phases both count fields since power-on, 64 and 32 to a cycle, so a
+// capture at a given field of the flash cycle is the same picture whatever ran before it.
+// Which field each reference was taken at was found by capturing every field and comparing.
+const FlashHiddenField = 56;
+const FlashShownField = 26;
+const CursorJustOnField = 15;
+const CursorOnField = 8;
+const FlashShownCursorOnField = 0;
+
+async function captureAtField(video, testMachine, field) {
+    for (let i = 0; i < 2 * FlashCycleFields; i++) {
+        const png = await video.capture(testMachine);
+        if (Math.floor(testMachine.elapsedCycles / FieldCycles) % FlashCycleFields === field) return png;
+    }
+    throw new Error(`Field ${field} did not come round`);
+}
+
+async function compare(video, testMachine, expectedName, field) {
+    const actualPng = await captureAtField(video, testMachine, field);
     const outputStem = expectedName.replace("expected", "actual").replace(".png", "");
     await expectPngToMatch(actualPng, path.join(RefDir, expectedName), outputStem);
 }
@@ -56,26 +75,24 @@ describe("Test Ceefax test page", () => {
     it("should match the Ceefax test page (no flash)", async () => {
         const video = new CapturingVideo();
         const testMachine = await setupCeefaxTestMachine(video);
-        await compare(video, testMachine, `expected_flash_0.png`);
+        await compare(video, testMachine, `expected_flash_0.png`, FlashHiddenField);
     });
     it("should match the Ceefax test page (flash)", async () => {
         const video = new CapturingVideo();
         const testMachine = await setupCeefaxTestMachine(video);
-        await testMachine.runFor(1500000);
-        await compare(video, testMachine, `expected_flash_1.png`);
+        await compare(video, testMachine, `expected_flash_1.png`, FlashShownField);
     });
     it("should match the Ceefax test page after reveal (no flash)", async () => {
         const video = new CapturingVideo();
         const testMachine = await setupCeefaxTestMachine(video);
         await testMachine.type(" ");
-        await compare(video, testMachine, `expected_reveal_flash_0.png`);
+        await compare(video, testMachine, `expected_reveal_flash_0.png`, FlashHiddenField);
     });
     it("should match the Ceefax test page after reveal (flash)", async () => {
         const video = new CapturingVideo();
         const testMachine = await setupCeefaxTestMachine(video);
         await testMachine.type(" ");
-        await testMachine.runFor(1500000);
-        await compare(video, testMachine, `expected_reveal_flash_1.png`);
+        await compare(video, testMachine, `expected_reveal_flash_1.png`, FlashShownField);
     });
 });
 
@@ -88,8 +105,7 @@ describe("Test other teletext test pages", () => {
         // https://github.com/mattgodbolt/jsbeeb/issues/316
         await testMachine.type("VDU &91,&61,&9E,&92,&93,&94,&81,&91,&91,10,13");
         await testMachine.runUntilInput();
-        await testMachine.runToCursorState(true);
-        await compare(video, testMachine, `expected_hoglet_held_char.png`);
+        await compare(video, testMachine, `expected_hoglet_held_char.png`, CursorJustOnField);
     });
     it("should apply Steady as Set At, not Set After (bug 611)", async () => {
         const video = new CapturingVideo();
@@ -107,9 +123,7 @@ describe("Test other teletext test pages", () => {
         // but pos 5 (Steady+held) and pos 6-7 should show red (Steady applies "Set At").
         await testMachine.type("CLS:VDU &91,&88,&BF,&BF,&9E,&89,&BF,&BF");
         await testMachine.runUntilInput();
-        await testMachine.runUntilFlashHidden();
-        await testMachine.runToCursorState(true);
-        await compare(video, testMachine, `expected_steady_set_at_flash_1.png`);
+        await compare(video, testMachine, `expected_steady_set_at_flash_1.png`, FlashShownCursorOnField);
     });
     it("should work with the alternative engineer test page bug 469", async () => {
         const video = new CapturingVideo();
@@ -122,7 +136,6 @@ describe("Test other teletext test pages", () => {
             "CLS:VDU &81,&80,&81,&A0,&80,&A0,&81,&9E,&A0,&9E,&A0,&97,&AC,&93,&93,&96,&96,&92,&92,&92,&95,&95,&91,&91,&94,&94,&94,&A0,&A0,&94,&80,&81,&80,&81,&80,&81,&80,&81,&B0,&B7",
         );
         await testMachine.runUntilInput();
-        await testMachine.runToCursorState(true);
-        await compare(video, testMachine, `expected_bug_469.png`);
+        await compare(video, testMachine, `expected_bug_469.png`, CursorOnField);
     });
 });

--- a/tests/unit/test-keyboard.js
+++ b/tests/unit/test-keyboard.js
@@ -400,21 +400,6 @@ describe("Keyboard", () => {
         expect(keyboard.isPasting).toBe(true);
     });
 
-    test("sendRawKeyboard should deliver keys via scheduler and re-enable keyboard", () => {
-        keyboard.sendRawKeyboard([BBC.A], false);
-
-        // First scheduler fire: presses the key
-        mockProcessor.scheduler.polltime(1);
-        expect(mockSysvia.keyToggleRaw).toHaveBeenCalledWith(BBC.A);
-        expect(keyboard.isPasting).toBe(true);
-
-        // Second scheduler fire after delay: releases key, sees empty queue, re-enables keyboard
-        const delayCycles = (50 * mockProcessor.peripheralCyclesPerSecond) / 1000;
-        mockProcessor.scheduler.polltime(delayCycles);
-        expect(mockSysvia.enableKeyboard).toHaveBeenCalled();
-        expect(keyboard.isPasting).toBe(false);
-    });
-
     test("cancelPaste should stop paste and re-enable keyboard", () => {
         keyboard.sendRawKeyboard([BBC.A, BBC.B, BBC.C], false);
         mockProcessor.scheduler.polltime(1); // deliver first key
@@ -441,54 +426,6 @@ describe("Keyboard", () => {
 
         expect(keyboard.isPasting).toBe(false);
         expect(mockSysvia.enableKeyboard).toHaveBeenCalled();
-    });
-
-    test("sendRawKeyboard should handle numeric delay entries", () => {
-        keyboard.sendRawKeyboard([1000, BBC.A], false);
-        const clocksPerMs = mockProcessor.peripheralCyclesPerSecond / 1000;
-
-        // First fire: numeric delay consumed, no key toggled yet
-        mockProcessor.scheduler.polltime(1);
-        expect(mockSysvia.keyToggleRaw).not.toHaveBeenCalled();
-        expect(keyboard.isPasting).toBe(true);
-
-        // After 1000ms delay: key A delivered
-        mockProcessor.scheduler.polltime(1000 * clocksPerMs);
-        expect(mockSysvia.keyToggleRaw).toHaveBeenCalledWith(BBC.A);
-    });
-
-    test("sendRawKeyboard should debounce consecutive identical keys", () => {
-        keyboard.sendRawKeyboard([BBC.A, BBC.A], false);
-        const clocksPerMs = mockProcessor.peripheralCyclesPerSecond / 1000;
-
-        // First fire: press A
-        mockProcessor.scheduler.polltime(1);
-        expect(mockSysvia.keyToggleRaw).toHaveBeenCalledTimes(1);
-
-        // Second fire after 50ms: release A, then debounce (same char)
-        mockProcessor.scheduler.polltime(50 * clocksPerMs);
-        // keyToggleRaw called twice: once to release A, once because debounce path
-        // releases previous char then skips pressing
-        expect(mockSysvia.keyToggleRaw).toHaveBeenCalledTimes(2);
-
-        // After 30ms debounce: press A again
-        mockProcessor.scheduler.polltime(30 * clocksPerMs);
-        expect(mockSysvia.keyToggleRaw).toHaveBeenCalledTimes(3);
-    });
-
-    test("sendRawKeyboard while already pasting should cancel previous paste", () => {
-        keyboard.sendRawKeyboard([BBC.A, BBC.B, BBC.C], false);
-        mockProcessor.scheduler.polltime(1); // deliver first key
-
-        // Start a new paste mid-stream
-        keyboard.sendRawKeyboard([BBC.X], false);
-
-        // Old paste should be cancelled, new one in progress
-        expect(keyboard.isPasting).toBe(true);
-
-        // Deliver new paste
-        mockProcessor.scheduler.polltime(1);
-        expect(mockSysvia.keyToggleRaw).toHaveBeenCalledWith(BBC.X);
     });
 
     test("postFrameShouldPause should handle single step", () => {
@@ -601,95 +538,9 @@ describe("Keyboard Atom adapter", () => {
         expect(mockAtomPPIA.keyUp).toHaveBeenCalledWith(65);
     });
 
-    test("sendRawKeyboard should not inject lock toggles for Atom", () => {
-        // PPIA reports capsLockLight=true, shiftLockLight=false,
-        // so the paste logic should not prepend/append any lock keys.
-        mockAtomPPIA.capsLockLight = true;
-        mockAtomPPIA.shiftLockLight = false;
-        const keys = [BBC.A];
-        keyboard.sendRawKeyboard(keys, true);
-        expect(mockAtomPPIA.disableKeyboard).toHaveBeenCalled();
-        // The keys array should not have been modified with lock toggles
-        expect(keys).toEqual([BBC.A]);
-    });
-
     test("setKeyLayout hands the layout to the processor", () => {
         keyboard.setKeyLayout("natural");
         expect(mockProcessor.setKeyLayout).toHaveBeenCalledWith("natural");
-    });
-
-    test("paste should insert debounce gap between key release and next key press", () => {
-        keyboard.sendRawKeyboard([ATOM.A, ATOM.B], false);
-        const clocksPerMs = mockProcessor.peripheralCyclesPerSecond / 1000;
-
-        // First fire: press A
-        mockProcessor.scheduler.polltime(1);
-        expect(mockAtomPPIA.keyToggleRaw).toHaveBeenCalledTimes(1);
-        expect(mockAtomPPIA.keyToggleRaw).toHaveBeenCalledWith(ATOM.A);
-
-        // After 80ms (Atom uses longer hold): release A, then debounce gap
-        mockProcessor.scheduler.polltime(80 * clocksPerMs);
-        expect(mockAtomPPIA.keyToggleRaw).toHaveBeenCalledTimes(2); // release A only
-        expect(mockAtomPPIA.keyToggleRaw).toHaveBeenLastCalledWith(ATOM.A); // toggle off
-
-        // After 30ms debounce: press B
-        mockProcessor.scheduler.polltime(30 * clocksPerMs);
-        expect(mockAtomPPIA.keyToggleRaw).toHaveBeenCalledTimes(3);
-        expect(mockAtomPPIA.keyToggleRaw).toHaveBeenLastCalledWith(ATOM.B);
-    });
-
-    test("paste should not insert debounce gap after SHIFT key", () => {
-        keyboard.sendRawKeyboard([ATOM.SHIFT, ATOM.A], false);
-        const clocksPerMs = mockProcessor.peripheralCyclesPerSecond / 1000;
-
-        // First fire: press SHIFT
-        mockProcessor.scheduler.polltime(1);
-        expect(mockAtomPPIA.keyToggleRaw).toHaveBeenCalledTimes(1);
-
-        // After 80ms: SHIFT is not released (it's the shift key), and A should
-        // be pressed immediately — no debounce gap for SHIFT.
-        mockProcessor.scheduler.polltime(80 * clocksPerMs);
-        expect(mockAtomPPIA.keyToggleRaw).toHaveBeenCalledTimes(2);
-        expect(mockAtomPPIA.keyToggleRaw).toHaveBeenLastCalledWith(ATOM.A);
-    });
-
-    test("paste should handle repeated characters with Atom debounce", () => {
-        keyboard.sendRawKeyboard([ATOM.A, ATOM.A], false);
-        const clocksPerMs = mockProcessor.peripheralCyclesPerSecond / 1000;
-
-        // Press first A
-        mockProcessor.scheduler.polltime(1);
-        expect(mockAtomPPIA.keyToggleRaw).toHaveBeenCalledTimes(1);
-
-        // After 80ms: release A, Atom debounce gap
-        mockProcessor.scheduler.polltime(80 * clocksPerMs);
-        expect(mockAtomPPIA.keyToggleRaw).toHaveBeenCalledTimes(2); // release only
-
-        // After 30ms Atom debounce: same-key debounce fires (not a double press)
-        mockProcessor.scheduler.polltime(30 * clocksPerMs);
-        // The Atom debounce cleared _pasteLastChar, so same-key debounce
-        // doesn't trigger — second A is pressed directly.
-        expect(mockAtomPPIA.keyToggleRaw).toHaveBeenCalledTimes(3);
-        expect(mockAtomPPIA.keyToggleRaw).toHaveBeenLastCalledWith(ATOM.A);
-    });
-
-    test("paste should debounce LOCK key like regular keys", () => {
-        keyboard.sendRawKeyboard([ATOM.LOCK, ATOM.A, ATOM.LOCK], false);
-        const clocksPerMs = mockProcessor.peripheralCyclesPerSecond / 1000;
-
-        // Press LOCK
-        mockProcessor.scheduler.polltime(1);
-        expect(mockAtomPPIA.keyToggleRaw).toHaveBeenCalledTimes(1);
-        expect(mockAtomPPIA.keyToggleRaw).toHaveBeenLastCalledWith(ATOM.LOCK);
-
-        // After 80ms: release LOCK, Atom debounce (LOCK is not SHIFT)
-        mockProcessor.scheduler.polltime(80 * clocksPerMs);
-        expect(mockAtomPPIA.keyToggleRaw).toHaveBeenCalledTimes(2);
-
-        // After 30ms debounce: press A
-        mockProcessor.scheduler.polltime(30 * clocksPerMs);
-        expect(mockAtomPPIA.keyToggleRaw).toHaveBeenCalledTimes(3);
-        expect(mockAtomPPIA.keyToggleRaw).toHaveBeenLastCalledWith(ATOM.A);
     });
 });
 

--- a/tests/unit/test-models.js
+++ b/tests/unit/test-models.js
@@ -56,7 +56,7 @@ describe("Model", () => {
         expect(atom.keys).toBe(ATOM);
         expect(beeb.stringToKeys("A")).toEqual([BBC.A]);
         expect(atom.pasteKeyDelayMs).toBeGreaterThan(beeb.pasteKeyDelayMs);
-        expect([beeb.pasteReleaseGapMs, atom.pasteReleaseGapMs]).toEqual([0, 30]);
+        expect([beeb.pasteReleaseGapMs, atom.pasteReleaseGapMs]).toEqual([0, 40]);
     });
 
     it("carries no per-session settings", () => {

--- a/tests/unit/test-typist.js
+++ b/tests/unit/test-typist.js
@@ -1,0 +1,160 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { Typist } from "../../src/typist.js";
+import { findModel } from "../../src/models.js";
+import { Scheduler } from "../../src/scheduler.js";
+import { BBC } from "../../src/keymap.js";
+import { ATOM } from "../../src/keymap-atom.js";
+
+function typistFor(modelName) {
+    const model = findModel(modelName);
+    const keyboard = {
+        keyToggleRaw: vi.fn(),
+        disableKeyboard: vi.fn(),
+        enableKeyboard: vi.fn(),
+        capsLockLight: true,
+        shiftLockLight: false,
+    };
+    const scheduler = new Scheduler();
+    const typist = new Typist({
+        model,
+        scheduler,
+        peripheralCyclesPerSecond: model.cyclesPerSecond,
+        keyboardInterface: keyboard,
+    });
+    const fire = () => scheduler.polltime(1);
+    const tick = (ms) => scheduler.polltime((ms * model.cyclesPerSecond) / 1000);
+    const toggles = () => keyboard.keyToggleRaw.mock.calls.map(([key]) => key);
+    const finish = () => {
+        for (let ticks = 0; typist.isTyping && ticks < 100; ++ticks) tick(model.pasteKeyDelayMs);
+        expect(typist.isTyping).toBe(false);
+    };
+    return { typist, keyboard, fire, tick, toggles, finish, model };
+}
+
+describe("Typist", () => {
+    describe("on a BBC", () => {
+        it("presses a key on one tick and releases it on the next, then gives the keyboard back", () => {
+            const { typist, keyboard, fire, tick, toggles } = typistFor("B-DFS1.2");
+            typist.type([BBC.A], false);
+            expect(keyboard.disableKeyboard).toHaveBeenCalled();
+            fire();
+            expect(toggles()).toEqual([BBC.A]);
+            expect(typist.isTyping).toBe(true);
+            tick(50);
+            expect(toggles()).toEqual([BBC.A, BBC.A]);
+            expect(keyboard.enableKeyboard).toHaveBeenCalled();
+            expect(typist.isTyping).toBe(false);
+        });
+
+        it("holds SHIFT across the keys that need it", () => {
+            const { typist, toggles, finish } = typistFor("B-DFS1.2");
+            typist.type([BBC.SHIFT, BBC.K1, BBC.SHIFT], false);
+            finish();
+            expect(toggles()).toEqual([BBC.SHIFT, BBC.K1, BBC.K1, BBC.SHIFT]);
+        });
+
+        it("waits out a number instead of pressing it", () => {
+            const { typist, fire, tick, toggles } = typistFor("B-DFS1.2");
+            typist.type([1000, BBC.A], false);
+            fire();
+            expect(toggles()).toEqual([]);
+            expect(typist.isTyping).toBe(true);
+            tick(1000);
+            expect(toggles()).toEqual([BBC.A]);
+        });
+
+        it("leaves a gap between two presses of the same key", () => {
+            const { typist, fire, tick, toggles } = typistFor("B-DFS1.2");
+            typist.type([BBC.A, BBC.A], false);
+            fire();
+            tick(50);
+            expect(toggles()).toEqual([BBC.A, BBC.A]);
+            tick(30);
+            expect(toggles()).toEqual([BBC.A, BBC.A, BBC.A]);
+        });
+
+        it("brackets the keys with CAPS LOCK when the light says lower case", () => {
+            const { typist, keyboard, toggles, finish } = typistFor("B-DFS1.2");
+            keyboard.capsLockLight = false;
+            typist.type([BBC.A], true);
+            finish();
+            expect(toggles()).toEqual([BBC.CAPSLOCK, BBC.CAPSLOCK, BBC.A, BBC.A, BBC.CAPSLOCK, BBC.CAPSLOCK]);
+        });
+
+        it("brackets them with SHIFT LOCK when that light is on", () => {
+            const { typist, keyboard, toggles, finish } = typistFor("B-DFS1.2");
+            keyboard.shiftLockLight = true;
+            typist.type([BBC.A], true);
+            finish();
+            expect(toggles()[0]).toBe(BBC.SHIFTLOCK);
+            expect(toggles().at(-1)).toBe(BBC.SHIFTLOCK);
+        });
+
+        it("leaves the locks alone when the lights are right", () => {
+            const { typist, toggles, finish } = typistFor("B-DFS1.2");
+            typist.type([BBC.A], true);
+            finish();
+            expect(toggles()).toEqual([BBC.A, BBC.A]);
+        });
+
+        it("cancelling releases the key in flight and gives the keyboard back", () => {
+            const { typist, keyboard, fire, toggles } = typistFor("B-DFS1.2");
+            typist.type([BBC.A, BBC.B, BBC.C], false);
+            fire();
+            typist.cancel();
+            expect(toggles()).toEqual([BBC.A, BBC.A]);
+            expect(keyboard.enableKeyboard).toHaveBeenCalled();
+            expect(typist.isTyping).toBe(false);
+        });
+
+        it("typing again replaces what was in flight", () => {
+            const { typist, fire, toggles } = typistFor("B-DFS1.2");
+            typist.type([BBC.A, BBC.B, BBC.C], false);
+            fire();
+            typist.type([BBC.X], false);
+            fire();
+            expect(toggles()).toEqual([BBC.A, BBC.A, BBC.X]);
+        });
+    });
+
+    describe("on an Atom", () => {
+        it("leaves a gap after each release for the polled keyboard", () => {
+            const { typist, fire, tick, toggles } = typistFor("Atom");
+            typist.type([ATOM.A, ATOM.B], false);
+            fire();
+            expect(toggles()).toEqual([ATOM.A]);
+            tick(80);
+            expect(toggles()).toEqual([ATOM.A, ATOM.A]);
+            tick(40);
+            expect(toggles()).toEqual([ATOM.A, ATOM.A, ATOM.B]);
+        });
+
+        it("does not gap after SHIFT, which stays held", () => {
+            const { typist, fire, tick, toggles } = typistFor("Atom");
+            typist.type([ATOM.SHIFT, ATOM.A], false);
+            fire();
+            tick(80);
+            expect(toggles()).toEqual([ATOM.SHIFT, ATOM.A]);
+        });
+
+        it("treats LOCK as a key like any other", () => {
+            const { typist, fire, tick, toggles } = typistFor("Atom");
+            typist.type([ATOM.LOCK, ATOM.A, ATOM.LOCK], false);
+            fire();
+            tick(80);
+            expect(toggles()).toEqual([ATOM.LOCK, ATOM.LOCK]);
+            tick(40);
+            expect(toggles()).toEqual([ATOM.LOCK, ATOM.LOCK, ATOM.A]);
+        });
+
+        it("presses a repeated key again after its gap", () => {
+            const { typist, fire, tick, toggles } = typistFor("Atom");
+            typist.type([ATOM.A, ATOM.A], false);
+            fire();
+            tick(80);
+            tick(40);
+            expect(toggles()).toEqual([ATOM.A, ATOM.A, ATOM.A]);
+        });
+    });
+});


### PR DESCRIPTION
Second of the two `isAtom` clean-ups, stacked on #1081 (it needs `processor.keyboardInterface`). The web keyboard's paste delivery and `TestMachine.type()` become one routine, and doing that found and fixed a real bug in the browser's Atom paste.

## What changes

- **`Typist` (`src/typist.js`)** is the paste delivery that lived in `Keyboard._deliverPasteKey`, moved verbatim into core: raw keys and millisecond delays from the processor's scheduler, SHIFT held across the keys that need it, a 30 ms gap between repeats of a key, and the model's `pasteReleaseGapMs` after each release. `Keyboard.sendRawKeyboard`, `cancelPaste` and `isPasting` delegate to it, so main.js and the paste tests are untouched.
- **`TestMachine.type()`** feeds `model.stringToKeys(text)` to the same Typist and runs the CPU until the last key is up. Its own BBC character table (`_charToKey`), the separate `_typeAtom` path and the `keymap-atom` import go. A carriage return in the text is a RETURN, as before, so the MCP's `"command\r"` habit still works.
- **The Atom drops pasted letters today.** Typing the Atom integration tests through the shared path lost a `T` here and an `o` there. The Atom ROM scans its keyboard once per 60 Hz field and only takes a new key after seeing the matrix empty on two scans, 33 ms; the tuned 30 ms release gap covers one or two scans depending on phase. Measured headlessly with both the real 6847 vsync and TestMachine's fake one: 30 ms drops, 35 ms and above is clean. It is now 40 ms. Paste on an Atom goes from 110 ms to 120 ms per character.

## The screenshot tests

Changing the typing rhythm broke seven teletext screenshot tests, and forcing the old rhythm back broke a different one, which showed what they were really testing: the flash and cursor phase at capture, inherited from how long typing happened to take since power-on. Both phases count fields (64 and 32 to a cycle), so a capture at a stated field of the flash cycle is the same picture whatever ran before. Each reference's field was found by capturing every field of a cycle and comparing:

| reference | matching fields | pinned at |
| --- | --- | --- |
| Ceefax, reveal (no flash) | 50 to 0 | 56 |
| Ceefax, reveal (flash) | 4 to 48 | 26 |
| bug 469 | cursor on, 0 to 14 and 32 to 46 | 8 |
| hoglet held char | 15 and 47 only | 15 |
| steady set-at | 0 only | 0 |
| T2, T7 | flash shown, 43 to 26 | 10 |
| T6 | flash blanked, 28 to 42 | 35 |

T8 is different: its raster loop catches vsync wherever the program happens to be in the frame, so the box position (not the widths, which are the measurement) depends on when `CHAIN` ran. It now starts from a stated point in the frame, the one that reproduces the reference. `TestMachine` gains `elapsedCycles` for this and `MachineSession` delegates to it; `runToCursorState`, `runUntilFlashHidden` and the fixed `runFor` waits those tests used go.

## Tests

`test-typist.js` takes the delivery tests over from `test-keyboard.js` (which keeps its facade and Escape tests), plus lock bracketing and the Atom gap. Unit and integration suites pass; the Atom integration tests now type through the same code the browser does.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
