### PR TITLE
fix: the headless Atom gets its field sync from its stand-in video, not from TestMachine

### DIFF
--- a/src/fake6502.js
+++ b/src/fake6502.js
@@ -1,6 +1,6 @@
 // Fakes out various 6502s for testing purposes.
 
-import { FakeVideo } from "./video.js";
+import { FakeAtomVideo, FakeVideo } from "./video.js";
 import { FakeSoundChip } from "./soundchip.js";
 import { TEST_6502, TEST_65C02, TEST_65C12, tubeModelFor } from "./models.js";
 import { machineSpec, nullIo } from "./machine-spec.js";
@@ -11,7 +11,10 @@ const soundChip = new FakeSoundChip();
 export function fake6502(model, opts = {}) {
     model = model || TEST_6502;
     return new model.Cpu(model, {
-        ...nullIo({ video: opts.video ?? fakeVideo, soundChip: opts.soundChip ?? soundChip }),
+        ...nullIo({
+            video: opts.video ?? (model.isAtom ? new FakeAtomVideo() : fakeVideo),
+            soundChip: opts.soundChip ?? soundChip,
+        }),
         config: machineSpec({
             tube: opts.tube ? tubeModelFor(model) : null,
             tubeCpuMultiplier: opts.tubeCpuMultiplier,

--- a/src/test-machine.js
+++ b/src/test-machine.js
@@ -32,32 +32,6 @@ export class TestMachine {
     async initialise() {
         setNodeBasePath(RepoRoot);
         await this.processor.initialise();
-        if (this.model.isAtom) this._startAtomVSync();
-    }
-
-    /**
-     * The Atom ROM's main loop waits for VSync (bit 7 of Port C) to
-     * toggle before scanning the keyboard.  The MC6847 video chip drives
-     * this in the real emulator, but fake6502 doesn't create one, so we
-     * simulate it with a scheduler task at ~60 Hz (NTSC).
-     */
-    _startAtomVSync() {
-        const ppia = this.processor.atomppia;
-        const VsyncPeriod = 16667; // 1 MHz / 60 Hz (NTSC 262-line frame)
-        const VsyncPulse = 800;
-        let inVsync = false;
-        const task = this.processor.scheduler.newTask(() => {
-            if (!inVsync) {
-                ppia.setVBlankInt(1);
-                inVsync = true;
-                task.reschedule(VsyncPulse);
-            } else {
-                ppia.setVBlankInt(0);
-                inVsync = false;
-                task.reschedule(VsyncPeriod - VsyncPulse);
-            }
-        });
-        task.schedule(VsyncPeriod);
     }
 
     /**

--- a/src/video.js
+++ b/src/video.js
@@ -1254,3 +1254,29 @@ export class FakeVideo {
 
     restoreState() {}
 }
+
+// The 6847's field as the PPIA sees it: 262 lines at 60Hz, with field sync low
+// for the 32 lines of flyback (see 6847.js).
+const AtomFieldCycles = 16667;
+const AtomFlybackCycles = Math.round((AtomFieldCycles * 32) / 262);
+
+/** No picture, but the field sync the Atom ROM waits on before each keyboard scan. */
+export class FakeAtomVideo extends FakeVideo {
+    reset(cpu) {
+        this.ppia = cpu.atomppia;
+        this.cycles = 0;
+        this.inFlyback = false;
+    }
+
+    polltime(cycles) {
+        this.cycles += cycles;
+        if (!this.inFlyback && this.cycles >= AtomFieldCycles - AtomFlybackCycles) {
+            this.inFlyback = true;
+            this.ppia.setVBlankInt(1);
+        } else if (this.inFlyback && this.cycles >= AtomFieldCycles) {
+            this.inFlyback = false;
+            this.cycles -= AtomFieldCycles;
+            this.ppia.setVBlankInt(0);
+        }
+    }
+}

--- a/tests/unit/test-video.js
+++ b/tests/unit/test-video.js
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach, vi, afterEach } from "vitest";
 import {
+    FakeAtomVideo,
     Video,
     HDISPENABLE,
     VDISPENABLE,
@@ -1257,5 +1258,42 @@ describe("Video", () => {
 
             expect(snapshot.ulaPal[0]).toBe(0xdeadbeef);
         });
+    });
+});
+
+describe("FakeAtomVideo", () => {
+    const Field = 16667;
+    const FlybackStart = Field - (Field * 32) / 262;
+    const Step = 7;
+
+    const runAField = (video, ppia) => {
+        const edges = [];
+        let polled = 0;
+        ppia.setVBlankInt.mockImplementation((level) => edges.push({ level, at: polled }));
+        for (; polled < Field; polled += Step) video.polltime(Step);
+        return edges;
+    };
+
+    it("pulses the PPIA's field sync once a field, low for the flyback lines", () => {
+        const ppia = { setVBlankInt: vi.fn() };
+        const video = new FakeAtomVideo();
+        video.reset({ atomppia: ppia });
+        const [start, end] = runAField(video, ppia);
+        expect(start.level).toBe(1);
+        expect(start.at).toBeGreaterThanOrEqual(FlybackStart - Step);
+        expect(start.at).toBeLessThanOrEqual(FlybackStart);
+        expect(end.level).toBe(0);
+        expect(end.at).toBeGreaterThanOrEqual(Field - Step);
+        expect(end.at).toBeLessThanOrEqual(Field);
+    });
+
+    it("keeps the same period field after field", () => {
+        const ppia = { setVBlankInt: vi.fn() };
+        const video = new FakeAtomVideo();
+        video.reset({ atomppia: ppia });
+        runAField(video, ppia);
+        const [start, end] = runAField(video, ppia);
+        expect([start.level, end.level]).toEqual([1, 0]);
+        expect(ppia.setVBlankInt).toHaveBeenCalledTimes(4);
     });
 });


### PR DESCRIPTION
Fixes #1085.

`fake6502` gives an Atom a `FakeAtomVideo`: no picture, but the PPIA's field sync pulsed the way the 6847 does it, once per 262-line field and low for the 32 lines of flyback (the numbers are the 6847's, as `6847.js` has them). That is what the Atom ROM waits on before each keyboard scan, so a headless Atom types without any help from the harness.

`TestMachine._startAtomVSync` and its scheduler task go. They ran whenever the model was an Atom, real `Video` or not, so a `MachineSession` Atom (the MCP's) had the 6847 and the stand-in both pulsing the same bit at unrelated phases. Now only the fake video pulses it, and only when there is no real one.

Tests: a unit test on `FakeAtomVideo` checks the pulse's position and period from the cycles polled; the Atom integration tests, which type through this sync, pass unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
