### PR TITLE
fix: the Atom's idle address is its keyboard scan, so waiting for the prompt works after boot

### DIFF
--- a/src/models.js
+++ b/src/models.js
@@ -50,8 +50,9 @@ class Model {
         this.stringToKeys = this.isAtom ? stringToATOMKeys : stringToBBCKeys;
         // The OS write-character vector, watched to capture what the machine prints.
         this.wrchvAddress = this.isAtom ? 0x0208 : 0x020e;
-        // Where the machine sits waiting for a key: the Atom kernel's read loop, or BASIC's.
-        this.idleAddress = this.isAtom ? 0xfe94 : isMaster ? 0xe7e6 : 0xe581;
+        // Where the machine sits waiting for a key: the Atom kernel's keyboard scan, which its
+        // line editor calls straight (the OSRDCH entry at $FE94 is only passed at boot), or BASIC's.
+        this.idleAddress = this.isAtom ? 0xfe71 : isMaster ? 0xe7e6 : 0xe581;
         // The Atom ROM polls its keyboard once per VSync, so pasted keys need longer apart.
         this.pasteKeyDelayMs = this.isAtom ? 80 : 50;
         // Two of those 60 Hz scans, 33 ms, with margin: the ROM wants a key seen up

--- a/tests/integration/atom-keyboard.js
+++ b/tests/integration/atom-keyboard.js
@@ -18,6 +18,13 @@ describe("Atom keyboard", () => {
         return machine.drainText();
     }
 
+    it("reaches the prompt again after a command, so runUntilInput can wait for it", async () => {
+        await bootAtom();
+        await machine.type("PRINT 6*7");
+        await machine.runUntilInput(10);
+        expect(machine.drainText()).toContain("42");
+    });
+
     it("should type uppercase text", async () => {
         await bootAtom();
         const output = await typeAndCapture("PRINT 42");

--- a/tests/unit/test-models.js
+++ b/tests/unit/test-models.js
@@ -51,7 +51,7 @@ describe("Model", () => {
         const atom = findModel("Atom");
         expect([beeb.Cpu, atom.Cpu]).toEqual([Cpu6502, AtomCpu6502]);
         expect([beeb.wrchvAddress, atom.wrchvAddress]).toEqual([0x020e, 0x0208]);
-        expect([beeb.idleAddress, master.idleAddress, atom.idleAddress]).toEqual([0xe581, 0xe7e6, 0xfe94]);
+        expect([beeb.idleAddress, master.idleAddress, atom.idleAddress]).toEqual([0xe581, 0xe7e6, 0xfe71]);
         expect(beeb.keys).toBe(BBC);
         expect(atom.keys).toBe(ATOM);
         expect(beeb.stringToKeys("A")).toEqual([BBC.A]);


### PR DESCRIPTION
Fixes #1084.

`Model.idleAddress` for the Atom was `$FE94`, the OSRDCH entry. The cold start passes it once; the line editor never does, since at the prompt the kernel calls the keyboard scan at `$FE71` straight (and the OSRDCH vector at `$208` points at `$FE52` besides). So `TestMachine.runUntilInput`, and `MachineSession.runUntilPrompt` through it, worked at boot and timed out after every command.

Measured on the kernel: idle at the prompt, `$FE71` is hit about 750 times a second and `$FE94` never; while a `FOR` loop runs, none of `$FE52`, `$FE66`, `$FE6B`, `$FE71` or `$FE94` is touched for the loop's whole 60 seconds plus. So `$FE71` is the address that means "waiting for a key" and nothing else, and it is the idle address now. (On the Atom `$FE71` is kernel ROM; I/O is at `$B000` to `$BFFF`, unlike the BBC's SHEILA.)

Tests: the Atom keyboard integration suite gains a case that types a command and then waits for the prompt, which is what failed before; the model shape test carries the new address.

With this and #1086 in, jsbeeb-mcp can offer the Atom in `create_machine`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
