### PR TITLE
fix: media loads go through the drive funnels, and the URL names only what is in the drive

### DIFF
--- a/src/app/electron.js
+++ b/src/app/electron.js
@@ -1,20 +1,31 @@
 // Electron integration for jsbeeb desktop application.
 // Handles IPC communication for loading disc/tape images and showing modals from Electron's main process.
 
+import { reportLoadFailure } from "../web/reporting.js";
+
 function init(args) {
-    const { loadDiscImage, loadTapeImage, loadStateFile, processor, modals, actions, settings, media } = args;
+    const { loadStateFile, modals, actions, settings, media, drives } = args;
     const api = window.electronAPI;
 
     api.onLoadDisc(async (message) => {
         const { drive, path } = message;
-        const image = await loadDiscImage(path);
-        processor.fdc.loadDisc(drive, image);
+        try {
+            drives.putDiscIn(drive, await media.loadDiscImage(path, drives.layoutForDrive(drive)));
+            if (drive === 0) media.setDisc1Image(path);
+            else media.setDisc2Image(path);
+        } catch (error) {
+            reportLoadFailure(`disc ${path}`, error);
+        }
     });
 
     api.onLoadTape(async (message) => {
         const { path } = message;
-        const tape = await loadTapeImage(path);
-        processor.tapeInterface.setTape(tape);
+        try {
+            media.setProcessorTape(await media.loadTapeImage(path));
+            media.setTapeImage(path);
+        } catch (error) {
+            reportLoadFailure(`tape ${path}`, error);
+        }
     });
 
     api.onShowModal((message) => {

--- a/src/app/electron.js
+++ b/src/app/electron.js
@@ -11,8 +11,7 @@ function init(args) {
         const { drive, path } = message;
         try {
             drives.putDiscIn(drive, await media.loadDiscImage(path, drives.layoutForDrive(drive)));
-            if (drive === 0) media.setDisc1Image(path);
-            else media.setDisc2Image(path);
+            media.setDiscImage(drive, path);
         } catch (error) {
             reportLoadFailure(`disc ${path}`, error);
         }

--- a/src/disc.js
+++ b/src/disc.js
@@ -604,6 +604,39 @@ export function sniffDfsLayout(data, isDsd) {
     return { is40Track: true, reason };
 }
 
+// The title is split across the two catalogue sectors, and the cycle number follows its second half.
+const DfsTitleFirstHalf = 8;
+const DfsTitleSecondHalf = 4;
+const DfsCycleOffset = 4;
+const DfsEntryCountInSector1 = DfsEntryCountOffset - SsdFormat.sectorSize;
+
+const isPrintableAscii = (byte) => byte >= 0x20 && byte < 0x7f;
+
+/**
+ * What the DFS catalogue on one side of a loaded disc says it is called, and how many times it
+ * has been written to, which between them are what was on the sticker.
+ *
+ * @param {Disc} disc
+ * @param {boolean} [isSideUpper]
+ * @returns {{title: string, cycle: string}|null} null when the side holds no DFS catalogue
+ */
+export function dfsCatalogue(disc, isSideUpper = false) {
+    const sectors = new Map();
+    for (const sector of disc.getTrack(isSideUpper, 0).findSectors(() => {})) {
+        const usable =
+            !sector.hasHeaderCrcError && !sector.hasDataCrcError && sector.sectorData?.length === SsdFormat.sectorSize;
+        if (usable && !sectors.has(sector.sectorNumber)) sectors.set(sector.sectorNumber, sector.sectorData);
+    }
+    const sector0 = sectors.get(0);
+    const sector1 = sectors.get(1);
+    if (!sector0 || !sector1) return null;
+    const entryBytes = sector1[DfsEntryCountInSector1];
+    if (entryBytes % DfsEntrySize !== 0 || entryBytes > DfsMaxEntries * DfsEntrySize) return null;
+    const titleBytes = [...sector0.subarray(0, DfsTitleFirstHalf), ...sector1.subarray(0, DfsTitleSecondHalf)];
+    const title = String.fromCharCode(...titleBytes.filter(isPrintableAscii)).trimEnd();
+    return { title, cycle: hexbyte(sector1[DfsCycleOffset]) };
+}
+
 // One track could match by luck; a disc's worth of them could not.
 const MinDoubleSteppedTracks = 4;
 

--- a/src/main.js
+++ b/src/main.js
@@ -389,11 +389,9 @@ exposeConsoleSurface(window, { loop, processor, video, audioHandler });
 
 // Hooks for electron.
 electron({
-    loadDiscImage: media.loadDiscImage.bind(media),
-    loadTapeImage: media.loadTapeImage.bind(media),
-    processor,
     settings,
     media,
+    drives,
     modals: {
         show: (modalId, sthType) => {
             if (modalId === "sth" && sthType) {

--- a/src/web/drives.js
+++ b/src/web/drives.js
@@ -36,7 +36,7 @@ export class Drives extends EventTarget {
         }
 
         document.getElementById("download-drive-link").addEventListener("click", async () => {
-            const disc = this.discToDownload();
+            const disc = this.discToDownload(0);
             if (!disc) return;
             const save = (options) =>
                 downloadDriveData(toSsdOrDsd(disc, options), disc.name, disc.isDoubleSided ? ".dsd" : ".ssd");
@@ -49,16 +49,16 @@ export class Drives extends EventTarget {
         });
 
         document.getElementById("download-drive-hfe-link").addEventListener("click", () => {
-            const disc = this.discToDownload();
+            const disc = this.discToDownload(0);
             if (!disc) return;
             downloadDriveData(toHfe(disc), disc.name, ".hfe");
         });
     }
 
-    /** @returns {import("../disc.js").Disc|null} the disc in drive 0, saying so when there is nothing to download */
-    discToDownload() {
-        const disc = this.fdc?.drives[0].disc;
-        if (!disc) toast("There is no disc in drive 0 to download.", { title: "Disc" });
+    /** @returns {import("../disc.js").Disc|null} the disc in the drive, saying so when there is nothing to download */
+    discToDownload(driveIndex) {
+        const disc = this.fdc?.drives[driveIndex].disc;
+        if (!disc) toast(`There is no disc in drive ${driveIndex} to download.`, { title: "Disc" });
         return disc ?? null;
     }
 

--- a/src/web/drives.js
+++ b/src/web/drives.js
@@ -7,11 +7,13 @@ import { DriveTracks } from "../url-params.js";
 const tracksPerStepFor = (tracks) => (tracks === "40" ? 2 : 1);
 
 /**
- * The disc drives as the page sees them: putting a disc in, the 40/80 track
- * switches on the Discs menu, and downloading what is in drive 0.
+ * The disc drives as the page sees them: putting a disc in and taking it out,
+ * the 40/80 track switches on the Discs menu, and downloading what is in drive 0.
+ * Raises "disc-changed" with the drive index and what it now holds.
  */
-export class Drives {
+export class Drives extends EventTarget {
     constructor({ fdc, driveTracks, confirm }) {
+        super();
         this.fdc = fdc;
         this.driveTracks = driveTracks;
         this.saidWritesAreNotKept = false;
@@ -80,6 +82,13 @@ export class Drives {
         this.noteUnsavedWrites(loadedDisc);
         // A switch the user fixed does not move, so anything it does is not news.
         if (fixed === undefined && drive.tracksPerStep !== was) this.noteDriveTracks(driveIndex, loadedDisc.name);
+        this.dispatchEvent(new CustomEvent("disc-changed", { detail: { driveIndex, disc: loadedDisc } }));
+    }
+
+    eject(driveIndex) {
+        this.fdc.loadDisc(driveIndex, undefined, this.tracksPerStepForDrive(driveIndex));
+        this.showDriveTracks(driveIndex);
+        this.dispatchEvent(new CustomEvent("disc-changed", { detail: { driveIndex, disc: undefined } }));
     }
 
     noteUnsavedWrites(loadedDisc) {

--- a/src/web/google-drive-picker.js
+++ b/src/web/google-drive-picker.js
@@ -189,7 +189,7 @@ export class GoogleDrivePicker {
         }
 
         try {
-            const result = await this.googleDrive.create(name, data);
+            const result = await this.googleDrive.create(name, data, this.drives.layoutForDrive(0));
             this.media.setDisc1Image("gd:" + result.fileId + "/" + name);
             this.drives.putDiscIn(0, result.disc);
             this.modals.loadingFinished();

--- a/src/web/google-drive-picker.js
+++ b/src/web/google-drive-picker.js
@@ -139,11 +139,13 @@ export class GoogleDrivePicker {
             row.querySelector(".name").textContent = item.name;
             row.addEventListener("click", async () => {
                 noteEvent("google-drive", "click", item.name);
-                this.media.setDisc1Image(`gd:${item.id}/${item.name}`);
                 this.modal.hide();
                 try {
                     const ssd = await this.load(item, this.drives.layoutForDrive(0));
-                    if (ssd) this.drives.putDiscIn(0, ssd);
+                    if (ssd) {
+                        this.drives.putDiscIn(0, ssd);
+                        this.media.setDisc1Image(`gd:${item.id}/${item.name}`);
+                    }
                 } catch (error) {
                     toast(`Unable to load ${item.name} from Google Drive: ${errorText(error)}`, {
                         title: "Google Drive",
@@ -190,8 +192,8 @@ export class GoogleDrivePicker {
 
         try {
             const result = await this.googleDrive.create(name, data, this.drives.layoutForDrive(0));
-            this.media.setDisc1Image("gd:" + result.fileId + "/" + name);
             this.drives.putDiscIn(0, result.disc);
+            this.media.setDisc1Image("gd:" + result.fileId + "/" + name);
             this.modals.loadingFinished();
         } catch (error) {
             console.error(`Error creating Google Drive disc: ${error}`, error);

--- a/src/web/google-drive-picker.js
+++ b/src/web/google-drive-picker.js
@@ -144,7 +144,7 @@ export class GoogleDrivePicker {
                     const ssd = await this.load(item, this.drives.layoutForDrive(0));
                     if (ssd) {
                         this.drives.putDiscIn(0, ssd);
-                        this.media.setDisc1Image(`gd:${item.id}/${item.name}`);
+                        this.media.setDiscImage(0, `gd:${item.id}/${item.name}`);
                     }
                 } catch (error) {
                     toast(`Unable to load ${item.name} from Google Drive: ${errorText(error)}`, {
@@ -193,7 +193,7 @@ export class GoogleDrivePicker {
         try {
             const result = await this.googleDrive.create(name, data, this.drives.layoutForDrive(0));
             this.drives.putDiscIn(0, result.disc);
-            this.media.setDisc1Image("gd:" + result.fileId + "/" + name);
+            this.media.setDiscImage(0, "gd:" + result.fileId + "/" + name);
             this.modals.loadingFinished();
         } catch (error) {
             console.error(`Error creating Google Drive disc: ${error}`, error);

--- a/src/web/google-drive.js
+++ b/src/web/google-drive.js
@@ -137,11 +137,11 @@ export class GoogleDriveLoader {
         });
     }
 
-    async create(name, data) {
+    async create(name, data, layout) {
         console.log(`Google Drive: creating disc image: '${name}'`);
         const response = await this.saveFile(name, data);
         const meta = response.result;
-        return { fileId: meta.id, disc: this.makeDisc(data, meta) };
+        return { fileId: meta.id, disc: this.makeDisc(data, meta, layout) };
     }
 
     makeDisc(data, meta, layout) {

--- a/src/web/hfe-picker.js
+++ b/src/web/hfe-picker.js
@@ -59,7 +59,6 @@ export class HfePicker {
     async pick(file) {
         noteEvent("hfe", "click", file.path);
         const image = "hfe:" + file.path;
-        this.media.setDisc1Image(image);
         const needsAutoboot = this.urlState.params.autoboot !== undefined;
         if (needsAutoboot) this.processor.reset(true);
 
@@ -68,6 +67,7 @@ export class HfePicker {
         try {
             const loaded = await this.media.loadDiscImage(image, this.drives.layoutForDrive(0));
             this.drives.putDiscIn(0, loaded);
+            this.media.setDisc1Image(image);
             this.modals.loadingFinished();
             if (needsAutoboot) this.autoboot(name);
         } catch (err) {

--- a/src/web/hfe-picker.js
+++ b/src/web/hfe-picker.js
@@ -67,7 +67,7 @@ export class HfePicker {
         try {
             const loaded = await this.media.loadDiscImage(image, this.drives.layoutForDrive(0));
             this.drives.putDiscIn(0, loaded);
-            this.media.setDisc1Image(image);
+            this.media.setDiscImage(0, image);
             this.modals.loadingFinished();
             if (needsAutoboot) this.autoboot(name);
         } catch (err) {

--- a/src/web/media-loader.js
+++ b/src/web/media-loader.js
@@ -144,10 +144,10 @@ export class MediaLoader extends EventTarget {
             elem.querySelector(".description").textContent = image.desc;
             elem.addEventListener("click", async () => {
                 noteEvent("images", "click", image.file);
-                this.setDisc1Image(image.file);
                 modals.hide("discs");
                 try {
-                    drives.putDiscIn(0, await this.loadDiscImage(this.params.disc1, drives.layoutForDrive(0)));
+                    drives.putDiscIn(0, await this.loadDiscImage(image.file, drives.layoutForDrive(0)));
+                    this.setDisc1Image(image.file);
                 } catch (error) {
                     reportLoadFailure(`${image.name} (${image.file})`, error);
                 }

--- a/src/web/media-loader.js
+++ b/src/web/media-loader.js
@@ -165,8 +165,21 @@ export class MediaLoader extends EventTarget {
         else this.resolver.addSource(schema, fetcher);
     }
 
+    /** Puts a tape in the deck, or empties it; raises "tape-changed" with what the deck now holds. */
     setProcessorTape(tape) {
         this.processor.tapeInterface.setTape(tape);
+        this.dispatchEvent(new CustomEvent("tape-changed", { detail: { tape } }));
+    }
+
+    ejectDisc(driveIndex) {
+        this.drives.eject(driveIndex);
+        if (driveIndex === 0) this.setDisc1Image(undefined);
+        else this.setDisc2Image(undefined);
+    }
+
+    ejectTape() {
+        this.setProcessorTape(undefined);
+        this.setTapeImage(undefined);
     }
 
     setDisc1Image(name) {

--- a/src/web/media-loader.js
+++ b/src/web/media-loader.js
@@ -147,7 +147,7 @@ export class MediaLoader extends EventTarget {
                 modals.hide("discs");
                 try {
                     drives.putDiscIn(0, await this.loadDiscImage(image.file, drives.layoutForDrive(0)));
-                    this.setDisc1Image(image.file);
+                    this.setDiscImage(0, image.file);
                 } catch (error) {
                     reportLoadFailure(`${image.name} (${image.file})`, error);
                 }
@@ -173,8 +173,7 @@ export class MediaLoader extends EventTarget {
 
     ejectDisc(driveIndex) {
         this.drives.eject(driveIndex);
-        if (driveIndex === 0) this.setDisc1Image(undefined);
-        else this.setDisc2Image(undefined);
+        this.setDiscImage(driveIndex, undefined);
     }
 
     ejectTape() {
@@ -182,14 +181,13 @@ export class MediaLoader extends EventTarget {
         this.setTapeImage(undefined);
     }
 
-    setDisc1Image(name) {
-        this.urlState.set({ disc: undefined, disc1: name });
-        this.dispatchEvent(new CustomEvent("media-changed", { detail: { disc1: name } }));
-    }
-
-    setDisc2Image(name) {
-        this.urlState.set({ disc2: name });
-        this.dispatchEvent(new CustomEvent("media-changed", { detail: { disc2: name } }));
+    /** Names the disc in a drive for the URL and the settings store, or unnames it. */
+    setDiscImage(driveIndex, name) {
+        // The URL has always called the drives disc1 and disc2, and a bare disc means disc1.
+        const changes = driveIndex === 0 ? { disc: undefined, disc1: name } : { disc2: name };
+        this.urlState.set(changes);
+        const detail = driveIndex === 0 ? { disc1: name } : { disc2: name };
+        this.dispatchEvent(new CustomEvent("media-changed", { detail }));
     }
 
     setTapeImage(name) {

--- a/src/web/snapshot-ui.js
+++ b/src/web/snapshot-ui.js
@@ -235,10 +235,7 @@ export class SnapshotUI {
             // Only update the URL/query for URL-sourced discs. For embedded
             // (local-file) discs, setting parsedQuery would put a bogus source
             // in the URL and break subsequent saves/reloads.
-            if (savedMedia[discKey]) {
-                if (driveIndex === 0) this.media.setDisc1Image(savedMedia[discKey]);
-                else this.media.setDisc2Image(savedMedia[discKey]);
-            }
+            if (savedMedia[discKey]) this.media.setDiscImage(driveIndex, savedMedia[discKey]);
         }
     }
 }

--- a/src/web/sth-picker.js
+++ b/src/web/sth-picker.js
@@ -71,7 +71,6 @@ export class SthPicker {
     async pickDisc(item) {
         noteEvent("sth", "click", item);
         const image = "sth:" + item;
-        this.media.setDisc1Image(image);
         const needsAutoboot = this.urlState.params.autoboot !== undefined;
         if (needsAutoboot) {
             this.processor.reset(true);
@@ -81,6 +80,7 @@ export class SthPicker {
         try {
             const loaded = await this.media.loadDiscImage(image, this.drives.layoutForDrive(0));
             this.drives.putDiscIn(0, loaded);
+            this.media.setDisc1Image(image);
             this.modals.loadingFinished();
 
             if (needsAutoboot) {
@@ -95,12 +95,11 @@ export class SthPicker {
     async pickTape(item) {
         noteEvent("sth", "clickTape", item);
         const image = "sth:" + item;
-        this.media.setTapeImage(image);
-
         this.modals.popupLoading("Loading " + item);
         try {
             const tape = await this.media.loadTapeImage(image);
             this.media.setProcessorTape(tape);
+            this.media.setTapeImage(image);
             this.modals.loadingFinished();
         } catch (err) {
             console.error("Error loading tape image:", err);

--- a/src/web/sth-picker.js
+++ b/src/web/sth-picker.js
@@ -80,7 +80,7 @@ export class SthPicker {
         try {
             const loaded = await this.media.loadDiscImage(image, this.drives.layoutForDrive(0));
             this.drives.putDiscIn(0, loaded);
-            this.media.setDisc1Image(image);
+            this.media.setDiscImage(0, image);
             this.modals.loadingFinished();
 
             if (needsAutoboot) {

--- a/tests/unit/helpers.js
+++ b/tests/unit/helpers.js
@@ -27,7 +27,7 @@ export function makeWebDeps() {
     return {
         media: {
             addSource: vi.fn(),
-            setDisc1Image: vi.fn(),
+            setDiscImage: vi.fn(),
             setTapeImage: vi.fn(),
             loadDiscImage: vi.fn(),
             loadTapeImage: vi.fn(),

--- a/tests/unit/test-disc.js
+++ b/tests/unit/test-disc.js
@@ -5,6 +5,7 @@ import {
     Disc,
     DiscConfig,
     IbmDiscFormat,
+    dfsCatalogue,
     loadSsd,
     loadAdf,
     sniffDfsLayout,
@@ -446,6 +447,63 @@ function eraseDataField(track, sectorNumber) {
     const start = Math.floor(sector.dataPosBitOffset / 32) - 1;
     for (let word = start; word < start + 256; ++word) track.pulses2Us[word] = IbmDiscFormat.fmTo2usPulses(0xff, 0xff);
 }
+
+describe("reading the sticker off a disc", () => {
+    const loaded = (data, isDsd = false) => loadSsd(new Disc(true, new DiscConfig(), "test.ssd"), data, isDsd);
+    const titled = (title, cycle, { sectors = 800, side = 0, isDsd = false } = {}) => {
+        const data = ssdImage(sectors, { length: 80 * TrackSize * (isDsd ? 2 : 1) });
+        const base = side * TrackSize;
+        data.set(new TextEncoder().encode(title.slice(0, 8)), base);
+        data.set(new TextEncoder().encode(title.slice(8, 12)), base + SectorSize);
+        data[base + SectorSize + 4] = cycle;
+        return data;
+    };
+
+    it("reads the title and cycle number Acornsoft put on Elite", () => {
+        const disc = loaded(fs.readFileSync("public/discs/elite.ssd"));
+        expect(dfsCatalogue(disc)).toEqual({ title: "Elite", cycle: "05" });
+    });
+
+    it("joins the title's two halves and reads the cycle as the BCD it is", () => {
+        expect(dfsCatalogue(loaded(titled("WELCOME-DISK", 0x12)))).toEqual({ title: "WELCOME-DISK", cycle: "12" });
+    });
+
+    it("drops the padding and anything unprintable", () => {
+        const data = titled("GAMES", 0x01);
+        data[5] = 0;
+        data[6] = 0xff;
+        expect(dfsCatalogue(loaded(data))).toEqual({ title: "GAMES", cycle: "01" });
+    });
+
+    it("reads each side of a double sided disc for itself", () => {
+        const data = titled("SIDE 0", 0x01, { isDsd: true });
+        const upper = titled("SIDE 2", 0x02, { isDsd: true, side: 1 });
+        data.set(upper.subarray(TrackSize, 2 * TrackSize), TrackSize);
+        const disc = loaded(data, true);
+        expect(dfsCatalogue(disc, false)).toEqual({ title: "SIDE 0", cycle: "01" });
+        expect(dfsCatalogue(disc, true)).toEqual({ title: "SIDE 2", cycle: "02" });
+    });
+
+    it("reads a freshly formatted disc as untitled and never written", () => {
+        expect(dfsCatalogue(unobservedDisc())).toEqual({ title: "", cycle: "00" });
+    });
+
+    it("finds no catalogue on a surface nobody has formatted", () => {
+        expect(dfsCatalogue(Disc.createBlank())).toBeNull();
+    });
+
+    it("finds no catalogue where the entry count is not a DFS one", () => {
+        const data = titled("NOT DFS", 0x01);
+        data[0x105] = 3;
+        expect(dfsCatalogue(loaded(data))).toBeNull();
+    });
+
+    it("finds no catalogue when a catalogue sector cannot be read", () => {
+        const disc = loaded(titled("LOST", 0x01));
+        eraseDataField(disc.getTrack(false, 0), 1);
+        expect(dfsCatalogue(disc)).toBeNull();
+    });
+});
 
 describe("flushWrites marks the surface used", () => {
     it("notices a write to the upper side of a disc loaded as single sided", () => {

--- a/tests/unit/test-drives.js
+++ b/tests/unit/test-drives.js
@@ -168,6 +168,15 @@ describe("Drives", () => {
     describe("the drive 0 downloads", () => {
         const download = (id) => document.getElementById(id).click();
 
+        it("find the disc in whichever drive is asked for", () => {
+            const drives = make();
+            const disc = fakeDisc();
+            drives.putDiscIn(1, disc);
+            expect(drives.discToDownload(1)).toBe(disc);
+            expect(drives.discToDownload(0)).toBeNull();
+            expect(toasts()).toEqual([expect.stringContaining("no disc in drive 0")]);
+        });
+
         it("say so instead of saving when drive 0 is empty", () => {
             make();
             download("download-drive-link");

--- a/tests/unit/test-drives.js
+++ b/tests/unit/test-drives.js
@@ -16,7 +16,7 @@ function fakeFdc() {
         drives,
         loadDisc: vi.fn((driveIndex, disc, fixed) => {
             drives[driveIndex].disc = disc;
-            drives[driveIndex].tracksPerStep = fixed ?? (disc.is40Track ? 2 : 1);
+            drives[driveIndex].tracksPerStep = fixed ?? (disc?.is40Track ? 2 : 1);
         }),
     };
 }
@@ -92,6 +92,47 @@ describe("Drives", () => {
         it("says nothing about a switch the user fixed, whatever the disc", () => {
             make([DriveTracks.forty, DriveTracks.auto]).putDiscIn(0, fakeDisc({ is40Track: false }));
             expect(toasts()).toEqual([]);
+        });
+    });
+
+    describe("what the drives hold", () => {
+        const changes = (drives) => {
+            const seen = [];
+            drives.addEventListener("disc-changed", (e) => seen.push(e.detail));
+            return seen;
+        };
+
+        it("says which drive took which disc", () => {
+            const drives = make();
+            const seen = changes(drives);
+            const disc = fakeDisc();
+            drives.putDiscIn(1, disc);
+            expect(seen).toEqual([{ driveIndex: 1, disc }]);
+        });
+
+        it("ejects a disc, leaving the drive empty and saying so", () => {
+            const drives = make();
+            drives.putDiscIn(0, fakeDisc());
+            const seen = changes(drives);
+            drives.eject(0);
+            expect(fdc.drives[0].disc).toBeUndefined();
+            expect(seen).toEqual([{ driveIndex: 0, disc: undefined }]);
+        });
+
+        it("keeps a fixed switch where the user put it across an eject", () => {
+            const drives = make([DriveTracks.forty, DriveTracks.auto]);
+            drives.putDiscIn(0, fakeDisc({ is40Track: false }));
+            drives.eject(0);
+            expect(fdc.loadDisc).toHaveBeenLastCalledWith(0, undefined, 2);
+            expect(activeTracks(0)).toEqual(["40"]);
+        });
+
+        it("lets an unfixed switch rest at 80 track once the drive is empty", () => {
+            const drives = make();
+            drives.putDiscIn(1, fakeDisc({ is40Track: true }));
+            drives.eject(1);
+            expect(fdc.drives[1].tracksPerStep).toBe(1);
+            expect(activeTracks(1)).toEqual(["80"]);
         });
     });
 

--- a/tests/unit/test-electron.js
+++ b/tests/unit/test-electron.js
@@ -24,8 +24,7 @@ describe("the Electron hooks", () => {
                 loadDiscImage: vi.fn(),
                 loadTapeImage: vi.fn(),
                 setProcessorTape: vi.fn(),
-                setDisc1Image: vi.fn(),
-                setDisc2Image: vi.fn(),
+                setDiscImage: vi.fn(),
                 setTapeImage: vi.fn(),
                 addEventListener: vi.fn(),
             },
@@ -59,14 +58,14 @@ describe("the Electron hooks", () => {
         await loadDisc({ drive: 1, path: "file:///discs/b.ssd" });
         expect(deps.media.loadDiscImage).toHaveBeenCalledWith("file:///discs/b.ssd", "layout1");
         expect(deps.drives.putDiscIn).toHaveBeenCalledWith(1, loaded);
-        expect(deps.media.setDisc2Image).toHaveBeenCalledWith("file:///discs/b.ssd");
-        expect(deps.media.setDisc1Image).not.toHaveBeenCalled();
+        expect(deps.media.setDiscImage).toHaveBeenCalledWith(1, "file:///discs/b.ssd");
+        expect(deps.media.setDiscImage).toHaveBeenCalledTimes(1);
     });
 
     it("names drive 0's disc as disc1", async () => {
         deps.media.loadDiscImage.mockResolvedValue({});
         await loadDisc({ drive: 0, path: "file:///discs/a.ssd" });
-        expect(deps.media.setDisc1Image).toHaveBeenCalledWith("file:///discs/a.ssd");
+        expect(deps.media.setDiscImage).toHaveBeenCalledWith(0, "file:///discs/a.ssd");
     });
 
     it("reports a disc that will not load and leaves the drive and the URL alone", async () => {
@@ -74,7 +73,7 @@ describe("the Electron hooks", () => {
         deps.media.loadDiscImage.mockRejectedValue(new Error("no such file"));
         await loadDisc({ drive: 0, path: "file:///discs/missing.ssd" });
         expect(deps.drives.putDiscIn).not.toHaveBeenCalled();
-        expect(deps.media.setDisc1Image).not.toHaveBeenCalled();
+        expect(deps.media.setDiscImage).not.toHaveBeenCalled();
         expect(toasts()).toEqual([expect.stringContaining("Could not load disc file:///discs/missing.ssd")]);
     });
 

--- a/tests/unit/test-electron.js
+++ b/tests/unit/test-electron.js
@@ -1,0 +1,96 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { initialise } from "../../src/app/electron.js";
+import { teardownDom, toasts } from "./helpers.js";
+
+describe("the Electron hooks", () => {
+    let api;
+    let deps;
+
+    beforeEach(() => {
+        api = {
+            onLoadDisc: vi.fn(),
+            onLoadTape: vi.fn(),
+            onShowModal: vi.fn(),
+            onAction: vi.fn(),
+            onLoadState: vi.fn(),
+            setTitle: vi.fn(),
+            saveSettings: vi.fn(),
+        };
+        window.electronAPI = api;
+        deps = {
+            media: {
+                loadDiscImage: vi.fn(),
+                loadTapeImage: vi.fn(),
+                setProcessorTape: vi.fn(),
+                setDisc1Image: vi.fn(),
+                setDisc2Image: vi.fn(),
+                setTapeImage: vi.fn(),
+                addEventListener: vi.fn(),
+            },
+            drives: { layoutForDrive: (driveIndex) => `layout${driveIndex}`, putDiscIn: vi.fn() },
+        };
+    });
+
+    afterEach(() => {
+        delete window.electronAPI;
+        return teardownDom();
+    });
+
+    const loadDisc = (message) => {
+        initialise(deps);
+        return api.onLoadDisc.mock.calls[0][0](message);
+    };
+    const loadTape = (message) => {
+        initialise(deps);
+        return api.onLoadTape.mock.calls[0][0](message);
+    };
+
+    it("does nothing outside Electron", () => {
+        delete window.electronAPI;
+        initialise(deps);
+        expect(api.onLoadDisc).not.toHaveBeenCalled();
+    });
+
+    it("puts a disc in the drive the menu named, laid out for that drive, and names it in the URL", async () => {
+        const loaded = {};
+        deps.media.loadDiscImage.mockResolvedValue(loaded);
+        await loadDisc({ drive: 1, path: "file:///discs/b.ssd" });
+        expect(deps.media.loadDiscImage).toHaveBeenCalledWith("file:///discs/b.ssd", "layout1");
+        expect(deps.drives.putDiscIn).toHaveBeenCalledWith(1, loaded);
+        expect(deps.media.setDisc2Image).toHaveBeenCalledWith("file:///discs/b.ssd");
+        expect(deps.media.setDisc1Image).not.toHaveBeenCalled();
+    });
+
+    it("names drive 0's disc as disc1", async () => {
+        deps.media.loadDiscImage.mockResolvedValue({});
+        await loadDisc({ drive: 0, path: "file:///discs/a.ssd" });
+        expect(deps.media.setDisc1Image).toHaveBeenCalledWith("file:///discs/a.ssd");
+    });
+
+    it("reports a disc that will not load and leaves the drive and the URL alone", async () => {
+        vi.spyOn(console, "error").mockImplementation(() => {});
+        deps.media.loadDiscImage.mockRejectedValue(new Error("no such file"));
+        await loadDisc({ drive: 0, path: "file:///discs/missing.ssd" });
+        expect(deps.drives.putDiscIn).not.toHaveBeenCalled();
+        expect(deps.media.setDisc1Image).not.toHaveBeenCalled();
+        expect(toasts()).toEqual([expect.stringContaining("Could not load disc file:///discs/missing.ssd")]);
+    });
+
+    it("routes a tape to the machine and names it in the URL", async () => {
+        const tape = {};
+        deps.media.loadTapeImage.mockResolvedValue(tape);
+        await loadTape({ path: "file:///tapes/t.uef" });
+        expect(deps.media.setProcessorTape).toHaveBeenCalledWith(tape);
+        expect(deps.media.setTapeImage).toHaveBeenCalledWith("file:///tapes/t.uef");
+    });
+
+    it("reports a tape that will not load", async () => {
+        vi.spyOn(console, "error").mockImplementation(() => {});
+        deps.media.loadTapeImage.mockRejectedValue(new Error("not a UEF"));
+        await loadTape({ path: "file:///tapes/bad.uef" });
+        expect(deps.media.setProcessorTape).not.toHaveBeenCalled();
+        expect(toasts()).toEqual([expect.stringContaining("Could not load tape file:///tapes/bad.uef")]);
+    });
+});

--- a/tests/unit/test-google-drive-picker.js
+++ b/tests/unit/test-google-drive-picker.js
@@ -160,9 +160,10 @@ describe("GoogleDrivePicker", () => {
             document.querySelector("#google-drive .disc-name").value = "fresh.ssd";
             submit();
             await vi.waitFor(() => expect(deps.drives.putDiscIn).toHaveBeenCalled());
-            const [name, data] = loader.create.mock.calls[0];
+            const [name, data, layout] = loader.create.mock.calls[0];
             expect(name).toBe("fresh.ssd");
             expect(data.length).toBeGreaterThan(0);
+            expect(layout).toBe("auto");
             expect(deps.media.setDisc1Image).toHaveBeenCalledWith("gd:xyz/fresh.ssd");
         });
 

--- a/tests/unit/test-google-drive-picker.js
+++ b/tests/unit/test-google-drive-picker.js
@@ -18,7 +18,7 @@ describe("GoogleDrivePicker", () => {
             create: vi.fn(),
         };
         deps = {
-            media: { addSource: vi.fn(), setDisc1Image: vi.fn() },
+            media: { addSource: vi.fn(), setDiscImage: vi.fn() },
             drives: { layoutForDrive: () => "auto", putDiscIn: vi.fn() },
             modals: { popupLoading: vi.fn(), loadingFinished: vi.fn() },
             processor: { fdc: { drives: [{ disc: null }, {}] } },
@@ -119,7 +119,7 @@ describe("GoogleDrivePicker", () => {
             );
             document.querySelector("#google-drive li:not(.template)").click();
             await vi.waitFor(() => expect(deps.drives.putDiscIn).toHaveBeenCalledWith(0, ssd));
-            expect(deps.media.setDisc1Image).toHaveBeenCalledWith("gd:abc/mine.ssd");
+            expect(deps.media.setDiscImage).toHaveBeenCalledWith(0, "gd:abc/mine.ssd");
         });
 
         it("reports a failed load once and leaves the drive alone", async () => {
@@ -136,7 +136,7 @@ describe("GoogleDrivePicker", () => {
                 expect(toasts()).toEqual([expect.stringContaining("Unable to load mine.ssd from Google Drive: boom")]),
             );
             expect(deps.drives.putDiscIn).not.toHaveBeenCalled();
-            expect(deps.media.setDisc1Image).not.toHaveBeenCalled();
+            expect(deps.media.setDiscImage).not.toHaveBeenCalled();
         });
 
         it("says when the list cannot be fetched", async () => {
@@ -165,7 +165,7 @@ describe("GoogleDrivePicker", () => {
             expect(name).toBe("fresh.ssd");
             expect(data.length).toBeGreaterThan(0);
             expect(layout).toBe("auto");
-            expect(deps.media.setDisc1Image).toHaveBeenCalledWith("gd:xyz/fresh.ssd");
+            expect(deps.media.setDiscImage).toHaveBeenCalledWith(0, "gd:xyz/fresh.ssd");
         });
 
         it("reports a drive 0 disc that cannot be saved in the named format", async () => {

--- a/tests/unit/test-google-drive-picker.js
+++ b/tests/unit/test-google-drive-picker.js
@@ -136,6 +136,7 @@ describe("GoogleDrivePicker", () => {
                 expect(toasts()).toEqual([expect.stringContaining("Unable to load mine.ssd from Google Drive: boom")]),
             );
             expect(deps.drives.putDiscIn).not.toHaveBeenCalled();
+            expect(deps.media.setDisc1Image).not.toHaveBeenCalled();
         });
 
         it("says when the list cannot be fetched", async () => {

--- a/tests/unit/test-google-drive.js
+++ b/tests/unit/test-google-drive.js
@@ -17,11 +17,9 @@ describe("GoogleDriveLoader", () => {
             loader.parentFolderId = "folder";
             loader.gapi = {
                 client: {
-                    request: vi
-                        .fn()
-                        .mockResolvedValue({
-                            result: { id: "xyz", name: "fresh.ssd", capabilities: { canEdit: true } },
-                        }),
+                    request: vi.fn().mockResolvedValue({
+                        result: { id: "xyz", name: "fresh.ssd", capabilities: { canEdit: true } },
+                    }),
                 },
             };
             return loader;

--- a/tests/unit/test-google-drive.js
+++ b/tests/unit/test-google-drive.js
@@ -2,12 +2,40 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { GoogleDriveLoader } from "../../src/web/google-drive.js";
-import { teardownDom } from "./helpers.js";
+import { DiscLayout } from "../../src/disc.js";
+import { ssdImage, teardownDom } from "./helpers.js";
 
 describe("GoogleDriveLoader", () => {
     beforeEach(() => vi.spyOn(console, "log").mockImplementation(() => {}));
 
     afterEach(teardownDom);
+
+    describe("creating a disc", () => {
+        const fortyTrackSectors = 400;
+        const makeSignedIn = () => {
+            const loader = new GoogleDriveLoader();
+            loader.parentFolderId = "folder";
+            loader.gapi = {
+                client: {
+                    request: vi
+                        .fn()
+                        .mockResolvedValue({
+                            result: { id: "xyz", name: "fresh.ssd", capabilities: { canEdit: true } },
+                        }),
+                },
+            };
+            return loader;
+        };
+
+        it("lays the new disc out as the drive it is for wants", async () => {
+            const loader = makeSignedIn();
+            const detected = await loader.create("fresh.ssd", ssdImage(fortyTrackSectors), DiscLayout.auto);
+            expect(detected.fileId).toBe("xyz");
+            expect(detected.disc.is40Track).toBe(true);
+            const contiguous = await loader.create("fresh.ssd", ssdImage(fortyTrackSectors), DiscLayout.contiguous);
+            expect(contiguous.disc.is40Track).toBe(false);
+        });
+    });
 
     it("gives up when the Google script cannot be fetched", async () => {
         const loader = new GoogleDriveLoader();

--- a/tests/unit/test-hfe-picker.js
+++ b/tests/unit/test-hfe-picker.js
@@ -116,13 +116,16 @@ describe("HfePicker", () => {
             expect(click.defaultPrevented).toBe(true);
         });
 
-        it("names it in the URL, loads it and closes the loading dialog", async () => {
+        it("loads it, then names it in the URL and closes the loading dialog", async () => {
             const loaded = {};
             deps.media.loadDiscImage.mockResolvedValue(loaded);
             await make().pick(entry("Games/ELITE.hfe", "Elite"));
-            expect(deps.media.setDisc1Image).toHaveBeenCalledWith("hfe:Games/ELITE.hfe");
             expect(deps.media.loadDiscImage).toHaveBeenCalledWith("hfe:Games/ELITE.hfe", "auto");
             expect(deps.drives.putDiscIn).toHaveBeenCalledWith(0, loaded);
+            expect(deps.media.setDisc1Image).toHaveBeenCalledWith("hfe:Games/ELITE.hfe");
+            expect(deps.media.setDisc1Image.mock.invocationCallOrder[0]).toBeGreaterThan(
+                deps.drives.putDiscIn.mock.invocationCallOrder[0],
+            );
             expect(deps.modals.loadingFinished).toHaveBeenCalledWith();
         });
 
@@ -139,6 +142,7 @@ describe("HfePicker", () => {
             deps.media.loadDiscImage.mockRejectedValue(new Error("404"));
             await make().pick(entry("A.hfe", "Elite"));
             expect(deps.drives.putDiscIn).not.toHaveBeenCalled();
+            expect(deps.media.setDisc1Image).not.toHaveBeenCalled();
             expect(deps.modals.loadingFinished).toHaveBeenCalledWith(
                 expect.stringContaining("Unable to load Elite from the HFE archive: 404"),
             );

--- a/tests/unit/test-hfe-picker.js
+++ b/tests/unit/test-hfe-picker.js
@@ -122,8 +122,8 @@ describe("HfePicker", () => {
             await make().pick(entry("Games/ELITE.hfe", "Elite"));
             expect(deps.media.loadDiscImage).toHaveBeenCalledWith("hfe:Games/ELITE.hfe", "auto");
             expect(deps.drives.putDiscIn).toHaveBeenCalledWith(0, loaded);
-            expect(deps.media.setDisc1Image).toHaveBeenCalledWith("hfe:Games/ELITE.hfe");
-            expect(deps.media.setDisc1Image.mock.invocationCallOrder[0]).toBeGreaterThan(
+            expect(deps.media.setDiscImage).toHaveBeenCalledWith(0, "hfe:Games/ELITE.hfe");
+            expect(deps.media.setDiscImage.mock.invocationCallOrder[0]).toBeGreaterThan(
                 deps.drives.putDiscIn.mock.invocationCallOrder[0],
             );
             expect(deps.modals.loadingFinished).toHaveBeenCalledWith();
@@ -142,7 +142,7 @@ describe("HfePicker", () => {
             deps.media.loadDiscImage.mockRejectedValue(new Error("404"));
             await make().pick(entry("A.hfe", "Elite"));
             expect(deps.drives.putDiscIn).not.toHaveBeenCalled();
-            expect(deps.media.setDisc1Image).not.toHaveBeenCalled();
+            expect(deps.media.setDiscImage).not.toHaveBeenCalled();
             expect(deps.modals.loadingFinished).toHaveBeenCalledWith(
                 expect.stringContaining("Unable to load Elite from the HFE archive: 404"),
             );

--- a/tests/unit/test-media-loader.js
+++ b/tests/unit/test-media-loader.js
@@ -110,7 +110,7 @@ describe("MediaLoader", () => {
 
         it("names drive 0's disc, displacing any bare disc parameter", () => {
             deps.urlState.params.disc = "old.ssd";
-            makeWatched().setDisc1Image("sth:ELITE.zip");
+            makeWatched().setDiscImage(0, "sth:ELITE.zip");
             expect(deps.urlState.params).toEqual({ disc1: "sth:ELITE.zip" });
             expect(deps.urlState.updateUrl).toHaveBeenCalledTimes(1);
             expect(mediaEvents).toEqual([{ disc1: "sth:ELITE.zip" }]);
@@ -118,7 +118,7 @@ describe("MediaLoader", () => {
 
         it("names drive 1's disc and the tape", () => {
             const media = makeWatched();
-            media.setDisc2Image("b.ssd");
+            media.setDiscImage(1, "b.ssd");
             media.setTapeImage("sth:Chuckie.zip");
             expect(deps.urlState.params).toEqual({ disc2: "b.ssd", tape: "sth:Chuckie.zip" });
             expect(mediaEvents).toEqual([{ disc2: "b.ssd" }, { tape: "sth:Chuckie.zip" }]);

--- a/tests/unit/test-media-loader.js
+++ b/tests/unit/test-media-loader.js
@@ -133,6 +133,26 @@ describe("MediaLoader", () => {
             );
             expect(names).toEqual(BuiltInImages.map((image) => image.name));
         });
+
+        it("puts the clicked image in drive 0, then names it in the URL", async () => {
+            const media = make();
+            const loaded = {};
+            vi.spyOn(media, "loadDiscImage").mockResolvedValue(loaded);
+            document.querySelector("#disc-list li:not(.template)").click();
+            await vi.waitFor(() => expect(deps.drives.putDiscIn).toHaveBeenCalledWith(0, loaded));
+            expect(media.loadDiscImage).toHaveBeenCalledWith("elite.ssd", DiscLayout.auto);
+            expect(deps.urlState.params).toEqual({ disc1: "elite.ssd" });
+            expect(deps.modals.hide).toHaveBeenCalledWith("discs");
+        });
+
+        it("leaves the URL alone when the image will not load", async () => {
+            const media = make();
+            vi.spyOn(console, "error").mockImplementation(() => {});
+            vi.spyOn(media, "loadDiscImage").mockRejectedValue(new Error("offline"));
+            document.querySelector("#disc-list li:not(.template)").click();
+            await vi.waitFor(() => expect(toasts()).toEqual([expect.stringContaining("Could not load Elite")]));
+            expect(deps.urlState.params).toEqual({});
+        });
     });
 
     describe("the local disc input", () => {

--- a/tests/unit/test-media-loader.js
+++ b/tests/unit/test-media-loader.js
@@ -230,10 +230,36 @@ describe("MediaLoader", () => {
     });
 
     describe("setProcessorTape", () => {
-        it("hands the tape to the machine's tape interface", () => {
+        it("hands the tape to the machine's tape interface and says the deck changed", () => {
             const tape = {};
-            make().setProcessorTape(tape);
+            const media = make();
+            const seen = [];
+            media.addEventListener("tape-changed", (e) => seen.push(e.detail));
+            media.setProcessorTape(tape);
             expect(deps.processor.tapeInterface.setTape).toHaveBeenCalledWith(tape);
+            expect(seen).toEqual([{ tape }]);
+        });
+    });
+
+    describe("ejecting", () => {
+        it("empties a drive and takes its disc out of the URL", () => {
+            deps.drives.eject = vi.fn();
+            deps.urlState.params.disc1 = "sth:ELITE.zip";
+            deps.urlState.params.disc2 = "b.ssd";
+            const media = make();
+            media.ejectDisc(0);
+            expect(deps.drives.eject).toHaveBeenCalledWith(0);
+            expect(deps.urlState.params).toEqual({ disc2: "b.ssd" });
+            media.ejectDisc(1);
+            expect(deps.drives.eject).toHaveBeenLastCalledWith(1);
+            expect(deps.urlState.params).toEqual({});
+        });
+
+        it("empties the deck and takes the tape out of the URL", () => {
+            deps.urlState.params.tape = "sth:Chuckie.zip";
+            make().ejectTape();
+            expect(deps.processor.tapeInterface.setTape).toHaveBeenCalledWith(undefined);
+            expect(deps.urlState.params).toEqual({});
         });
     });
 });

--- a/tests/unit/test-snapshot-ui.js
+++ b/tests/unit/test-snapshot-ui.js
@@ -97,7 +97,7 @@ describe("SnapshotUI", () => {
             processor: { fdc: { drives: [{ disc: null }, { disc: null }] }, hasTube: false, execute: vi.fn() },
             model: { name: "B-DFS1.2" },
             video: { paint: vi.fn() },
-            media: { loadDiscImage: vi.fn(), setDisc1Image: vi.fn(), setDisc2Image: vi.fn() },
+            media: { loadDiscImage: vi.fn(), setDiscImage: vi.fn() },
             drives: { putDiscIn: vi.fn() },
             urlState: { params: {}, urlWith: vi.fn() },
             modals: { showError: vi.fn() },
@@ -217,7 +217,7 @@ describe("SnapshotUI", () => {
             await make().reloadSnapshotMedia({ disc1: "sth:ELITE.zip", disc1Crc32: 0x1234 });
             expect(deps.media.loadDiscImage).toHaveBeenCalledWith("sth:ELITE.zip", DiscLayout.contiguous);
             expect(deps.drives.putDiscIn).toHaveBeenCalledWith(0, loaded);
-            expect(deps.media.setDisc1Image).toHaveBeenCalledWith("sth:ELITE.zip");
+            expect(deps.media.setDiscImage).toHaveBeenCalledWith(0, "sth:ELITE.zip");
             expect(toasts()).toEqual([]);
         });
 
@@ -280,7 +280,7 @@ describe("SnapshotUI", () => {
             expect(driveIndex).toBe(0);
             expect(loadedDisc.name).toBe("mine.ssd");
             expect(loadedDisc.originalImageData).toBeTruthy();
-            expect(deps.media.setDisc1Image).not.toHaveBeenCalled();
+            expect(deps.media.setDiscImage).not.toHaveBeenCalled();
         });
 
         it("rebuilds image data that was serialised as a plain object", async () => {
@@ -297,7 +297,7 @@ describe("SnapshotUI", () => {
             deps.media.loadDiscImage.mockResolvedValue(loaded);
             await make().reloadSnapshotMedia({ disc2: "b.ssd" });
             expect(deps.drives.putDiscIn).toHaveBeenCalledWith(1, loaded);
-            expect(deps.media.setDisc2Image).toHaveBeenCalledWith("b.ssd");
+            expect(deps.media.setDiscImage).toHaveBeenCalledWith(1, "b.ssd");
         });
     });
 

--- a/tests/unit/test-sth-picker.js
+++ b/tests/unit/test-sth-picker.js
@@ -80,13 +80,16 @@ describe("SthPicker", () => {
     });
 
     describe("picking a disc", () => {
-        it("names it in the URL, loads it into drive 0 and closes the loading dialog", async () => {
+        it("loads it into drive 0, then names it in the URL and closes the loading dialog", async () => {
             const loaded = {};
             deps.media.loadDiscImage.mockResolvedValue(loaded);
             await make().pickDisc("ELITE.zip");
-            expect(deps.media.setDisc1Image).toHaveBeenCalledWith("sth:ELITE.zip");
             expect(deps.media.loadDiscImage).toHaveBeenCalledWith("sth:ELITE.zip", "auto");
             expect(deps.drives.putDiscIn).toHaveBeenCalledWith(0, loaded);
+            expect(deps.media.setDisc1Image).toHaveBeenCalledWith("sth:ELITE.zip");
+            expect(deps.media.setDisc1Image.mock.invocationCallOrder[0]).toBeGreaterThan(
+                deps.drives.putDiscIn.mock.invocationCallOrder[0],
+            );
             expect(deps.modals.loadingFinished).toHaveBeenCalledWith();
             expect(deps.processor.reset).not.toHaveBeenCalled();
             expect(deps.autoboot).not.toHaveBeenCalled();
@@ -105,6 +108,7 @@ describe("SthPicker", () => {
             deps.media.loadDiscImage.mockRejectedValue(new Error("404"));
             await make().pickDisc("ELITE.zip");
             expect(deps.drives.putDiscIn).not.toHaveBeenCalled();
+            expect(deps.media.setDisc1Image).not.toHaveBeenCalled();
             expect(deps.modals.loadingFinished).toHaveBeenCalledWith(
                 expect.stringContaining("Unable to load ELITE.zip from the STH archive: 404"),
             );
@@ -112,14 +116,16 @@ describe("SthPicker", () => {
     });
 
     describe("picking a tape", () => {
-        it("names it in the URL and routes it to the machine", async () => {
+        it("routes it to the machine, then names it in the URL", async () => {
             const tape = {};
-            deps.media.setTapeImage.mockImplementation((name) => (deps.urlState.params.tape = name));
             deps.media.loadTapeImage.mockResolvedValue(tape);
             await make().pickTape("CHUCKIE.zip");
-            expect(deps.media.setTapeImage).toHaveBeenCalledWith("sth:CHUCKIE.zip");
             expect(deps.media.loadTapeImage).toHaveBeenCalledWith("sth:CHUCKIE.zip");
             expect(deps.media.setProcessorTape).toHaveBeenCalledWith(tape);
+            expect(deps.media.setTapeImage).toHaveBeenCalledWith("sth:CHUCKIE.zip");
+            expect(deps.media.setTapeImage.mock.invocationCallOrder[0]).toBeGreaterThan(
+                deps.media.setProcessorTape.mock.invocationCallOrder[0],
+            );
         });
 
         it("reports a failure through the loading dialog", async () => {
@@ -127,6 +133,7 @@ describe("SthPicker", () => {
             deps.media.loadTapeImage.mockRejectedValue(new Error("410"));
             await make().pickTape("CHUCKIE.zip");
             expect(deps.media.setProcessorTape).not.toHaveBeenCalled();
+            expect(deps.media.setTapeImage).not.toHaveBeenCalled();
             expect(deps.modals.loadingFinished).toHaveBeenCalledWith(
                 expect.stringContaining("Unable to load CHUCKIE.zip from the STH archive: 410"),
             );

--- a/tests/unit/test-sth-picker.js
+++ b/tests/unit/test-sth-picker.js
@@ -86,8 +86,8 @@ describe("SthPicker", () => {
             await make().pickDisc("ELITE.zip");
             expect(deps.media.loadDiscImage).toHaveBeenCalledWith("sth:ELITE.zip", "auto");
             expect(deps.drives.putDiscIn).toHaveBeenCalledWith(0, loaded);
-            expect(deps.media.setDisc1Image).toHaveBeenCalledWith("sth:ELITE.zip");
-            expect(deps.media.setDisc1Image.mock.invocationCallOrder[0]).toBeGreaterThan(
+            expect(deps.media.setDiscImage).toHaveBeenCalledWith(0, "sth:ELITE.zip");
+            expect(deps.media.setDiscImage.mock.invocationCallOrder[0]).toBeGreaterThan(
                 deps.drives.putDiscIn.mock.invocationCallOrder[0],
             );
             expect(deps.modals.loadingFinished).toHaveBeenCalledWith();
@@ -108,7 +108,7 @@ describe("SthPicker", () => {
             deps.media.loadDiscImage.mockRejectedValue(new Error("404"));
             await make().pickDisc("ELITE.zip");
             expect(deps.drives.putDiscIn).not.toHaveBeenCalled();
-            expect(deps.media.setDisc1Image).not.toHaveBeenCalled();
+            expect(deps.media.setDiscImage).not.toHaveBeenCalled();
             expect(deps.modals.loadingFinished).toHaveBeenCalledWith(
                 expect.stringContaining("Unable to load ELITE.zip from the STH archive: 404"),
             );


### PR DESCRIPTION
The plumbing fixes ahead of the #824 media window, each a bug on main today and small enough to read alone. Nothing here changes what the page looks like.

- **The desktop app's File menu loads go through the funnels.** Electron's Load disc 0/1 called `fdc.loadDisc` directly, skipping the drive's 40/80 switch, the unsaved-writes notice and the URL, and a file that would not load failed silently. Tape loads likewise bypassed `setProcessorTape` and never named the tape in the URL. Both now report failures like every web route.
- **A disc is named in the URL only once it is in the drive.** The STH, HFE, Google Drive and built-in routes wrote `disc1` (or `tape`) before fetching, so a failed load left the URL naming a disc the drive did not hold.
- **A disc created on Google Drive is laid out for the drive it goes into.** `create()` dropped the layout, so a drive fixed at 80 track still had a 40 track catalogue sniffed and double stepped.
- **The drives and the deck say what they hold, and can be emptied.** `Drives` raises `disc-changed` from `putDiscIn` and the new `eject`; `MediaLoader` raises `tape-changed` and gains `ejectDisc` and `ejectTape`, which also clear the slot's URL parameter. Nothing calls eject yet.
- **`discToDownload` takes the drive.** Both menu links still ask for drive 0.
- **`dfsCatalogue(disc, side)` reads the DFS title and cycle number** off the two catalogue sectors of track 0, which is what was on the sticker.

The Electron hooks had no unit test; they have one now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)