### PR TITLE
fix: a run stopped short by a breakpoint no longer lengthens the next one

### DIFF
--- a/src/machine-session.js
+++ b/src/machine-session.js
@@ -196,8 +196,9 @@ export class MachineSession {
     }
 
     /**
-     * Run for an exact number of emulated CPU cycles, or until a breakpoint
-     * fires. `completed` is false if one did.
+     * Run for an exact number of emulated CPU cycles, or until something stops
+     * the CPU first: a breakpoint, or the paint runFrames stops at. `completed`
+     * is false if it was stopped short.
      * @returns {Promise<{cyclesRun: number, completed: boolean}>}
      */
     async runFor(cycles) {

--- a/src/machine-session.js
+++ b/src/machine-session.js
@@ -196,11 +196,14 @@ export class MachineSession {
     }
 
     /**
-     * Run for an exact number of emulated CPU cycles.
-     * Useful for timing-sensitive code.
+     * Run for an exact number of emulated CPU cycles, or until a breakpoint
+     * fires. `completed` is false if one did.
+     * @returns {Promise<{cyclesRun: number, completed: boolean}>}
      */
     async runFor(cycles) {
-        await this._machine.runFor(cycles);
+        const startCycles = this.elapsedCycles;
+        const stopped = await this._machine.runFor(cycles);
+        return { cyclesRun: this.elapsedCycles - startCycles, completed: !stopped };
     }
 
     /** Emulated cycles since power-on */
@@ -226,25 +229,15 @@ export class MachineSession {
         const cpu = this._machine.processor;
         const backstop = maxCycles ?? count * BackstopSecondsPerFrame * cpu.model.cyclesPerSecond;
         const startFrame = this._frameCount;
-        const startCycles = this.elapsedCycles;
-        // execute() adds each request to a running targetCycles, so budget left
-        // unspent by an early stop would silently lengthen the caller's next run.
-        const unspentBefore = cpu.targetCycles - cpu.currentCycles;
 
         this._stopAtFrame = startFrame + count;
         try {
-            await this._machine.runFor(backstop);
+            const { cyclesRun } = await this.runFor(backstop);
+            const framesRun = this._frameCount - startFrame;
+            return { framesRun, cyclesRun, completed: framesRun >= count };
         } finally {
             this._stopAtFrame = Infinity;
-            cpu.targetCycles = cpu.currentCycles + unspentBefore;
         }
-
-        const framesRun = this._frameCount - startFrame;
-        return {
-            framesRun,
-            cyclesRun: this.elapsedCycles - startCycles,
-            completed: framesRun >= count,
-        };
     }
 
     /** Frames painted since the session was created; a hard reset does not zero it */

--- a/src/models.js
+++ b/src/models.js
@@ -50,9 +50,10 @@ class Model {
         this.stringToKeys = this.isAtom ? stringToATOMKeys : stringToBBCKeys;
         // The OS write-character vector, watched to capture what the machine prints.
         this.wrchvAddress = this.isAtom ? 0x0208 : 0x020e;
-        // Where the machine sits waiting for a key: the Atom kernel's keyboard scan, which its
-        // line editor calls straight (the OSRDCH entry at $FE94 is only passed at boot), or BASIC's.
-        this.idleAddress = this.isAtom ? 0xfe71 : isMaster ? 0xe7e6 : 0xe581;
+        // Where the machine sits waiting for a key: BASIC's read loop, or on the Atom the kernel's
+        // wait-for-key scan at $FEA7. The scan before it at $FE9F only checks every key is up, and a
+        // 100 ms debounce delay follows, during which a key pressed is not seen.
+        this.idleAddress = this.isAtom ? 0xfea7 : isMaster ? 0xe7e6 : 0xe581;
         // The Atom ROM polls its keyboard once per VSync, so pasted keys need longer apart.
         this.pasteKeyDelayMs = this.isAtom ? 80 : 50;
         // Two of those 60 Hz scans, 33 ms, with margin: the ROM wants a key seen up

--- a/src/test-machine.js
+++ b/src/test-machine.js
@@ -95,16 +95,24 @@ export class TestMachine {
             .join("");
     }
 
+    /**
+     * Run for `cycles` emulated cycles, or until something stops the CPU.
+     * Resolves true if it was stopped short.
+     */
     runFor(cycles) {
         let left = cycles;
         let stopped = false;
+        const cpu = this.processor;
         return new Promise((resolve) => {
             const runAnIter = () => {
                 const todo = Math.max(0, Math.min(left, MaxCyclesPerIter));
                 if (todo) {
-                    stopped = !this.processor.execute(todo);
+                    stopped = !cpu.execute(todo);
                     left -= todo;
                 }
+                // execute() adds each request to a running targetCycles, so budget
+                // left unspent by an early stop would silently lengthen the next run.
+                if (stopped) cpu.targetCycles = cpu.currentCycles;
                 // Not truthiness: a negative or NaN request clamps todo to zero,
                 // so left would never move and the loop never end.
                 if (left > 0 && !stopped) {

--- a/tests/hardware/teletext/render-page.js
+++ b/tests/hardware/teletext/render-page.js
@@ -27,7 +27,9 @@ async function runToField(session, field) {
 
 // Where T8's boxes sit follows from where in the frame its raster loop caught vsync, which
 // follows from when the program started. Only the widths are the measurement, but the
-// reference pins a position, so start the page from where the reference started it.
+// reference pins a position, so start the page from where the reference started it:
+// three frames and 12000 cycles after the prompt.
+const T8StartFramesAfterPrompt = 3;
 const T8StartCyclesIntoFrame = 12000;
 
 /** Renders one page of the test disc under jsbeeb and returns a PNG of the active display. */
@@ -38,7 +40,7 @@ export async function renderPage(page) {
         await session.boot();
         session.loadDisc(Disc);
         if (page === "T8") {
-            await session.runFrames(1);
+            await session.runFrames(T8StartFramesAfterPrompt);
             await session.runFor(T8StartCyclesIntoFrame);
         }
         await session.type(`CHAIN "${page}"`);

--- a/tests/integration/machine-session.js
+++ b/tests/integration/machine-session.js
@@ -94,6 +94,51 @@ describe("MachineSession frame stepping", () => {
     });
 });
 
+describe("MachineSession running for cycles", () => {
+    let session;
+
+    beforeAll(async () => {
+        session = await bootedSession();
+    }, BootTimeout);
+
+    afterAll(() => session.destroy());
+
+    function breakOnNextInterrupt() {
+        const [lo, hi] = session.readMemory(0x204, 2); // IRQ1V, entered every interrupt
+        return session.addBreakpoint("execute", lo | (hi << 8));
+    }
+
+    it("reports the cycles it ran", async () => {
+        const before = session.elapsedCycles;
+
+        const result = await session.runFor(1000);
+
+        expect(result.completed).toBe(true);
+        expect(result.cyclesRun).toBe(session.elapsedCycles - before);
+        expectCyclesNear(result.cyclesRun, 1000);
+    });
+
+    it("stops short when a breakpoint fires and reports only the cycles run", async () => {
+        const id = breakOnNextInterrupt();
+        const before = session.elapsedCycles;
+
+        const result = await session.runFor(600000);
+        session.removeBreakpoint(id);
+
+        expect(result.completed).toBe(false);
+        expect(result.cyclesRun).toBe(session.elapsedCycles - before);
+        expect(result.cyclesRun).toBeLessThan(CyclesPerInterlacedFrame);
+    });
+
+    it("leaves no unspent cycles behind after a breakpoint stop", async () => {
+        const id = breakOnNextInterrupt();
+        await session.runFor(600000);
+        session.removeBreakpoint(id);
+
+        expectCyclesNear((await session.runFor(1000)).cyclesRun, 1000);
+    });
+});
+
 describe("MachineSession frame stepping across a hard reset", () => {
     let session;
 

--- a/tests/unit/test-models.js
+++ b/tests/unit/test-models.js
@@ -51,7 +51,7 @@ describe("Model", () => {
         const atom = findModel("Atom");
         expect([beeb.Cpu, atom.Cpu]).toEqual([Cpu6502, AtomCpu6502]);
         expect([beeb.wrchvAddress, atom.wrchvAddress]).toEqual([0x020e, 0x0208]);
-        expect([beeb.idleAddress, master.idleAddress, atom.idleAddress]).toEqual([0xe581, 0xe7e6, 0xfe71]);
+        expect([beeb.idleAddress, master.idleAddress, atom.idleAddress]).toEqual([0xe581, 0xe7e6, 0xfea7]);
         expect(beeb.keys).toBe(BBC);
         expect(atom.keys).toBe(ATOM);
         expect(beeb.stringToKeys("A")).toEqual([BBC.A]);


### PR DESCRIPTION
`TestMachine.runFor` hands the CPU its request in 100000-cycle chunks, and `execute()` adds each chunk to a running target. When a breakpoint (or any stop) ended a chunk early, the unspent remainder stayed on the target and was silently run at the start of the next call: after a stop 25000 cycles into a chunk, a request for 1000 cycles ran 75987. `runFrames` had a local workaround for this; the fix now lives in `runFor`, so every caller gets it, and `MachineSession.runFor` reports `{ cyclesRun, completed }` the way `runFrames` does, so a caller stopped by a breakpoint can see how far it got.

This is the jsbeeb half of [jsbeeb-mcp#25](https://github.com/mattgodbolt/jsbeeb-mcp/issues/25), where `run_for_cycles` reports the cycles requested rather than run, and then overruns on the following call.

Two tests were relying on the accident, and both turned out to be real findings:

- **Atom idle address.** The Atom keyboard tests typed straight after `runUntilInput`, which worked only because the leftover budget happened to carry the machine through the kernel's debounce. The idle address was the scan at `$FE71`, but OSRDCH's first call to it (from `$FE9F`) only checks every key is up, and a 100 ms delay follows in which the keyboard is ignored; a key pressed then is lost. The idle address is now the wait-for-key scan at `$FEA7`, which is reached only once the kernel is actually polling for a key. Measured: with the old address and an exact 10000-cycle settle, `PRINT 42` arrives as `RINT 42`; with the new one it works with the same settle.
- **T8 teletext reference.** The reference pins where the raster loop caught vsync, which follows from when the program started; the leftover budget had put that start two frames later than the test said. The test now starts the page where the reference did.

Tests: `MachineSession running for cycles` covers the reported count, a breakpoint stop, and that no budget is left behind (the last fails without the fix). ci-checks, unit, integration (with submodules) and CPU suites all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TL2MpWUn5RmZkrFvLdWdBW
