### PR TITLE
feat: MachineSession presses keys by matrix position, reports what is held, and refuses to drop a key while interrupted typing owns the keyboard

### DIFF
--- a/src/machine-session.js
+++ b/src/machine-session.js
@@ -115,19 +115,88 @@ export class MachineSession {
         return this.drainOutput();
     }
 
+    get _keyboard() {
+        return this._machine.processor.keyboardInterface;
+    }
+
+    /**
+     * The keyboard is the typist's until everything from type() has been
+     * delivered, and a key pressed meanwhile would be silently dropped.
+     */
+    _requireKeyboard() {
+        if (this.typingPending) {
+            throw new Error(
+                "Text from type() is still being typed (a breakpoint stopped the run part way): " +
+                    "run the machine on to finish it, or cancelTyping() first",
+            );
+        }
+    }
+
     /**
      * Press a key (by browser keyCode).
      * Use utils.keyCodes for named keys, or ASCII charCode for letters/digits.
      */
     keyDown(keyCode, shiftDown = false) {
-        this._machine.processor.sysvia.keyDown(keyCode, shiftDown);
+        this._requireKeyboard();
+        this._keyboard.keyDown(keyCode, shiftDown);
     }
 
     /**
      * Release a key (by browser keyCode).
      */
     keyUp(keyCode) {
-        this._machine.processor.sysvia.keyUp(keyCode);
+        this._requireKeyboard();
+        this._keyboard.keyUp(keyCode);
+    }
+
+    /**
+     * Press a key by its place in the keyboard matrix, as the model's key
+     * table (BBC or ATOM in the keymaps) gives it, with no host key map in
+     * between: a game reading the matrix sees exactly this key.
+     * @param {[number, number]} colRow
+     */
+    keyDownRaw(colRow) {
+        this._requireKeyboard();
+        this._keyboard.keyDownRaw(colRow);
+    }
+
+    /**
+     * Release a key pressed by matrix position.
+     * @param {[number, number]} colRow
+     */
+    keyUpRaw(colRow) {
+        this._requireKeyboard();
+        this._keyboard.keyUpRaw(colRow);
+    }
+
+    /**
+     * Every key currently down, as matrix positions keyDownRaw takes.
+     * @returns {Array<[number, number]>}
+     */
+    heldKeys() {
+        const held = [];
+        this._keyboard.keys.forEach((column, col) => {
+            column.forEach((down, row) => {
+                if (down) held.push([col, row]);
+            });
+        });
+        return held;
+    }
+
+    /** Whether text from type() is still to be delivered, which a breakpoint stopping the run leaves behind. */
+    get typingPending() {
+        return this._machine.typist.isTyping;
+    }
+
+    /** Drop any text from type() still to be delivered, and give the keyboard back. */
+    cancelTyping() {
+        this._machine.typist.cancel();
+    }
+
+    /** Release every key, and drop any typing still pending, so the keyboard is in a known state. */
+    releaseAllKeys() {
+        this.cancelTyping();
+        this._keyboard.clearKeys();
     }
 
     /**

--- a/src/machine-session.js
+++ b/src/machine-session.js
@@ -126,7 +126,7 @@ export class MachineSession {
     _requireKeyboard() {
         if (this.typingPending) {
             throw new Error(
-                "Text from type() is still being typed (a breakpoint stopped the run part way): " +
+                "Text from type() is still being typed: await type(), or if a breakpoint stopped it " +
                     "run the machine on to finish it, or cancelTyping() first",
             );
         }
@@ -134,7 +134,7 @@ export class MachineSession {
 
     /**
      * Press a key (by browser keyCode).
-     * Use utils.keyCodes for named keys, or ASCII charCode for letters/digits.
+     * Use keyCodes from keymap.js for named keys, or ASCII charCode for letters/digits.
      */
     keyDown(keyCode, shiftDown = false) {
         this._requireKeyboard();

--- a/tests/integration/machine-session.js
+++ b/tests/integration/machine-session.js
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeAll, afterAll } from "vitest";
 import { MachineSession } from "../../src/machine-session.js";
+import { BBC, keyCodes } from "../../src/keymap.js";
 
 const CyclesPerInterlacedFrame = 40000;
 const CyclesPerNonInterlacedFrame = 39936;
@@ -136,6 +137,82 @@ describe("MachineSession running for cycles", () => {
         session.removeBreakpoint(id);
 
         expectCyclesNear((await session.runFor(1000)).cyclesRun, 1000);
+    });
+});
+
+describe("MachineSession keyboard", () => {
+    let session;
+    const HoldCycles = 200000; // a tenth of a second, several OS keyboard scans
+
+    beforeAll(async () => {
+        session = await bootedSession();
+    }, BootTimeout);
+
+    afterAll(() => session.destroy());
+
+    async function pressRaw(key) {
+        session.keyDownRaw(key);
+        await session.runFor(HoldCycles);
+        session.keyUpRaw(key);
+        await session.runFor(HoldCycles);
+    }
+
+    it("types a key pressed by matrix position", async () => {
+        await pressRaw(BBC.A);
+        await pressRaw(BBC.RETURN);
+
+        expect((await session.runUntilPrompt()).screenText).toContain("A");
+    });
+
+    it("reports the keys held, however they were pressed", () => {
+        session.keyDownRaw(BBC.A);
+        session.keyDown(keyCodes.SHIFT);
+        expect(session.heldKeys()).toEqual(expect.arrayContaining([BBC.A, BBC.SHIFT]));
+
+        session.keyUpRaw(BBC.A);
+        session.keyUp(keyCodes.SHIFT);
+        expect(session.heldKeys()).toEqual([]);
+    });
+
+    it("refuses a key while typing a breakpoint interrupted still owns the keyboard", async () => {
+        const id = session.addBreakpoint("execute", 0xffee); // OSWRCH, echoing the first character
+        await session.type("X");
+        session.removeBreakpoint(id);
+
+        expect(session.typingPending).toBe(true);
+        expect(() => session.keyDown(keyCodes.SHIFT)).toThrow(/cancelTyping/);
+        expect(() => session.keyDownRaw(BBC.SHIFT)).toThrow(/cancelTyping/);
+
+        session.cancelTyping();
+        expect(session.typingPending).toBe(false);
+        session.keyDown(keyCodes.SHIFT);
+        expect(session.heldKeys()).toEqual([BBC.SHIFT]);
+        session.keyUp(keyCodes.SHIFT);
+
+        await pressRaw(BBC.RETURN);
+        await session.runUntilPrompt();
+    });
+
+    it("releases every key held", () => {
+        session.keyDownRaw(BBC.SHIFT);
+        session.keyDownRaw(BBC.A);
+
+        session.releaseAllKeys();
+
+        expect(session.heldKeys()).toEqual([]);
+    });
+
+    it("releasing every key drops pending typing too", async () => {
+        const id = session.addBreakpoint("execute", 0xffee);
+        await session.type("X");
+        session.removeBreakpoint(id);
+
+        session.releaseAllKeys();
+
+        expect(session.typingPending).toBe(false);
+        expect(session.heldKeys()).toEqual([]);
+        await pressRaw(BBC.RETURN);
+        await session.runUntilPrompt();
     });
 });
 


### PR DESCRIPTION
The jsbeeb half of [jsbeeb-mcp#29](https://github.com/mattgodbolt/jsbeeb-mcp/issues/29) (autoboot silently losing SHIFT in long sessions) and [jsbeeb-mcp#27](https://github.com/mattgodbolt/jsbeeb-mcp/issues/27) (pressing keys by internal key number).

**The #29 mechanism, reproduced.** `type()` hands the keyboard to the typist until the last key is delivered, and a breakpoint stopping the run part way leaves it that way: the system VIA's `set()` returns early while the keyboard is disabled. A `keyDown` made then was silently dropped, so a SHIFT+BREAK autoboot after an interrupted `type()` reset without SHIFT, and the leftover text was then typed into the freshly reset machine.

**Changes to `MachineSession`:**
- `keyDown`, `keyUp` and the new raw presses throw while `typingPending` is true, with a message saying what to do, rather than dropping the key.
- `typingPending` says whether text from `type()` is still to be delivered; `cancelTyping()` drops it and gives the keyboard back.
- `keyDownRaw(colRow)` / `keyUpRaw(colRow)` press a key by its place in the matrix, as `BBC` / `ATOM` in the keymaps give it, with no host key map between: a game's own keyboard scan sees exactly that key. (Internal key number to matrix is `[n & 15, n >> 4]`; that mapping will live in the MCP.)
- `heldKeys()` lists every key down as matrix positions; `releaseAllKeys()` releases them all and drops pending typing.

Both keyboard interfaces (system VIA and the Atom's PPIA) already had the raw calls and the same matrix shape, so this is the session surface over them.

Tests: `MachineSession keyboard` in the integration suite covers a raw press reaching BASIC, the held-key readout for raw and mapped presses, the refusal and recovery after an interrupted `type()`, and `releaseAllKeys`. ci-checks, unit and integration suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TL2MpWUn5RmZkrFvLdWdBW
