### PR TITLE
feat: MachineSession reads and writes a chosen sideways bank or shadow RAM, and reports what is paged in

### DIFF
--- a/src/machine-session.js
+++ b/src/machine-session.js
@@ -28,6 +28,9 @@ import { setNodeBasePath } from "./loader.js";
 const FB_WIDTH = 1024;
 const FB_HEIGHT = 625;
 
+// Bit X of ACCCON: shadow RAM in place of main at &3000 to &7FFF.
+const AcconShadowBit = 4;
+
 // Five times a frame, so only a machine that has stopped painting hits it.
 const BackstopSecondsPerFrame = 0.1;
 
@@ -392,20 +395,72 @@ export class MachineSession {
         };
     }
 
-    /** Read `length` bytes from emulator memory starting at `address` */
-    readMemory(address, length = 16) {
-        const bytes = [];
-        for (let i = 0; i < length; i++) {
-            bytes.push(this._machine.readbyte(address + i));
-        }
-        return bytes;
+    /**
+     * What the memory map has paged in: `romsel`, the sideways bank at
+     * &8000 to &BFFF, and on a Master `acccon`, whose bit 2 puts shadow
+     * RAM at &3000 to &7FFF.
+     * @returns {{romsel: number, acccon?: number}}
+     */
+    pagingState() {
+        const cpu = this._machine.processor;
+        const state = { romsel: cpu.romsel };
+        if (cpu.model.isMaster) state.acccon = cpu.acccon;
+        return state;
     }
 
-    /** Write an array of byte values into emulator memory at `address` */
-    writeMemory(address, bytes) {
-        for (let i = 0; i < bytes.length; i++) {
-            this._machine.writebyte(address + i, bytes[i]);
+    /**
+     * Runs `fn` with `bank` paged at &8000, or shadow RAM paged (or not)
+     * at &3000, putting the map back afterwards. Either left undefined
+     * leaves the map as the machine has it.
+     */
+    _withPaging({ bank, shadow }, fn) {
+        const cpu = this._machine.processor;
+        const { romsel, acccon } = cpu;
+        if (bank !== undefined) {
+            if (!Number.isInteger(bank) || bank < 0 || bank > 15) throw new Error(`Bank ${bank} is not 0 to 15`);
+            cpu.romSelect(bank);
         }
+        if (shadow !== undefined) {
+            if (!cpu.model.isMaster) throw new Error("Only a Master has shadow RAM");
+            cpu.writeAcccon(shadow ? acccon | AcconShadowBit : acccon & ~AcconShadowBit);
+        }
+        try {
+            return fn();
+        } finally {
+            if (bank !== undefined) cpu.romSelect(romsel);
+            if (shadow !== undefined) cpu.writeAcccon(acccon);
+        }
+    }
+
+    /**
+     * Read `length` bytes from emulator memory starting at `address`, from
+     * whatever is paged in unless `bank` or `shadow` says otherwise.
+     * @param {number} address
+     * @param {number} [length=16]
+     * @param {Object} [opts]
+     * @param {number} [opts.bank] sideways bank to read at &8000 to &BFFF
+     * @param {boolean} [opts.shadow] on a Master, read shadow RAM (true) or main RAM (false) at &3000 to &7FFF
+     */
+    readMemory(address, length = 16, { bank, shadow } = {}) {
+        return this._withPaging({ bank, shadow }, () => {
+            const bytes = [];
+            for (let i = 0; i < length; i++) {
+                bytes.push(this._machine.readbyte(address + i));
+            }
+            return bytes;
+        });
+    }
+
+    /**
+     * Write an array of byte values into emulator memory at `address`;
+     * `bank` and `shadow` pick where, as for readMemory.
+     */
+    writeMemory(address, bytes, { bank, shadow } = {}) {
+        this._withPaging({ bank, shadow }, () => {
+            for (let i = 0; i < bytes.length; i++) {
+                this._machine.writebyte(address + i, bytes[i]);
+            }
+        });
     }
 
     /** Read the current 6502 CPU registers */

--- a/src/machine-session.js
+++ b/src/machine-session.js
@@ -29,7 +29,7 @@ const FB_WIDTH = 1024;
 const FB_HEIGHT = 625;
 
 // Bit X of ACCCON: shadow RAM in place of main at &3000 to &7FFF.
-const AcconShadowBit = 4;
+const AccconShadowBit = 4;
 
 // Five times a frame, so only a machine that has stopped painting hits it.
 const BackstopSecondsPerFrame = 0.1;
@@ -422,7 +422,7 @@ export class MachineSession {
         }
         if (shadow !== undefined) {
             if (!cpu.model.isMaster) throw new Error("Only a Master has shadow RAM");
-            cpu.writeAcccon(shadow ? acccon | AcconShadowBit : acccon & ~AcconShadowBit);
+            cpu.writeAcccon(shadow ? acccon | AccconShadowBit : acccon & ~AccconShadowBit);
         }
         try {
             return fn();

--- a/tests/integration/machine-session.js
+++ b/tests/integration/machine-session.js
@@ -139,6 +139,71 @@ describe("MachineSession running for cycles", () => {
     });
 });
 
+describe("MachineSession paged memory", () => {
+    let session;
+    const SidewaysRamBank = 4; // one of the Master's four
+    const OtherSidewaysRamBank = 5;
+
+    beforeAll(async () => {
+        session = new MachineSession("Master");
+        await session.initialise();
+        await session.boot(30);
+    }, BootTimeout);
+
+    afterAll(() => session.destroy());
+
+    it("reports what is paged in, agreeing with the OS's copy of ROMSEL", () => {
+        const [romselCopy] = session.readMemory(0xf4, 1);
+
+        expect(session.pagingState()).toEqual({ romsel: romselCopy, acccon: expect.any(Number) });
+    });
+
+    it("reads and writes a sideways bank other than the one paged in", () => {
+        const before = session.pagingState();
+
+        session.writeMemory(0x8000, [1, 2, 3], { bank: SidewaysRamBank });
+        session.writeMemory(0x8000, [9, 9, 9], { bank: OtherSidewaysRamBank });
+
+        expect(session.readMemory(0x8000, 3, { bank: SidewaysRamBank })).toEqual([1, 2, 3]);
+        expect(session.readMemory(0x8000, 3, { bank: OtherSidewaysRamBank })).toEqual([9, 9, 9]);
+        expect(session.readMemory(0x8000, 3)).not.toEqual([1, 2, 3]);
+        expect(session.pagingState()).toEqual(before);
+    });
+
+    it("reads and writes shadow RAM apart from main RAM", () => {
+        const before = session.pagingState();
+
+        session.writeMemory(0x3000, [10, 20], { shadow: true });
+        session.writeMemory(0x3000, [30, 40], { shadow: false });
+
+        expect(session.readMemory(0x3000, 2, { shadow: true })).toEqual([10, 20]);
+        expect(session.readMemory(0x3000, 2, { shadow: false })).toEqual([30, 40]);
+        expect(session.pagingState()).toEqual(before);
+    });
+
+    it("refuses a bank that does not exist", () => {
+        expect(() => session.readMemory(0x8000, 1, { bank: 16 })).toThrow(/0 to 15/);
+    });
+});
+
+describe("MachineSession paged memory on a machine without shadow RAM", () => {
+    let session;
+
+    beforeAll(async () => {
+        session = await bootedSession();
+    }, BootTimeout);
+
+    afterAll(() => session.destroy());
+
+    it("reports ROMSEL alone", () => {
+        expect(session.pagingState()).toEqual({ romsel: expect.any(Number) });
+    });
+
+    it("refuses to page shadow RAM", () => {
+        expect(() => session.readMemory(0x3000, 1, { shadow: true })).toThrow(/Master/);
+    });
+});
+
 describe("MachineSession frame stepping across a hard reset", () => {
     let session;
 

--- a/tests/integration/machine-session.js
+++ b/tests/integration/machine-session.js
@@ -166,7 +166,7 @@ describe("MachineSession paged memory", () => {
 
         expect(session.readMemory(0x8000, 3, { bank: SidewaysRamBank })).toEqual([1, 2, 3]);
         expect(session.readMemory(0x8000, 3, { bank: OtherSidewaysRamBank })).toEqual([9, 9, 9]);
-        expect(session.readMemory(0x8000, 3)).not.toEqual([1, 2, 3]);
+        expect(session.readMemory(0x8000, 3)).toEqual(session.readMemory(0x8000, 3, { bank: before.romsel & 15 }));
         expect(session.pagingState()).toEqual(before);
     });
 


### PR DESCRIPTION
The jsbeeb half of [jsbeeb-mcp#28](https://github.com/mattgodbolt/jsbeeb-mcp/issues/28): `read_memory` returns whatever bank is paged in at that instant and does not say which, which cost the reporter a misdiagnosis when a sample of a sprite buffer came from an empty sideways bank.

**Changes to `MachineSession`:**
- `pagingState()` reports `romsel`, and on a Master `acccon` too.
- `readMemory(address, length, { bank, shadow })` and `writeMemory(address, bytes, { bank, shadow })` page the chosen sideways bank at &8000, or shadow versus main RAM at &3000 on a Master, for the access, and put the map back afterwards. Either option left undefined leaves that part of the map as the machine has it. A bank outside 0 to 15, or `shadow` on anything but a Master, throws.

Paging goes through the CPU's own `romSelect` and `writeAcccon`, so the access sees exactly the map the CPU would, and restoring the old values restores everything they drive (the video display page included).

Tests: on a Master, `pagingState` agrees with the OS's RAM copy of ROMSEL at &F4; writes to sideways RAM banks 4 and 5 read back from the right bank and not from the bank paged in; shadow and main RAM at &3000 hold different values; the map is unchanged afterwards; a bad bank is refused. On a BBC B, only ROMSEL is reported and `shadow` is refused. ci-checks, unit and integration suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TL2MpWUn5RmZkrFvLdWdBW
