### PR TITLE
fix: a tape at its end no longer freezes the machine, and other tape, key and Drive fixes

### DIFF
--- a/src/acia.js
+++ b/src/acia.js
@@ -72,12 +72,16 @@ export class Acia extends EventTarget {
             this.runTape();
             this.relayNoise.motorOn();
         } else if (!on && this.motorOn) {
-            this.toneGen.mute();
-            this.runTapeTask.cancel();
-            this.setTapeCarrier(false);
+            this.stopRunning();
             this.relayNoise.motorOff();
         }
         this.motorOn = on;
+    }
+
+    stopRunning() {
+        this.toneGen.mute();
+        this.runTapeTask.cancel();
+        this.setTapeCarrier(false);
     }
 
     read(addr) {
@@ -271,15 +275,20 @@ export class Acia extends EventTarget {
         if (state.runRs423TaskOffset !== null) this.runRs423Task.schedule(state.runRs423TaskOffset);
     }
 
+    /** A tape put in, or taken out, while the motor is on starts or stops at once. */
     setTape(tape) {
         this.tape = tape;
+        if (!this.motorOn) return;
+        if (tape) this.runTape();
+        else this.stopRunning();
     }
 
     rewindTape() {
-        if (this.tape) {
-            console.log("rewinding tape");
-            this.tape.rewind();
-        }
+        if (!this.tape) return;
+        console.log("rewinding tape");
+        this.tape.rewind();
+        // A tape that had run out stopped being polled; rewound, it has something to play again.
+        if (this.motorOn) this.runTape();
     }
 
     // Byte times are held in CPU cycles because that's what the scheduler counts.
@@ -343,8 +352,12 @@ export class Acia extends EventTarget {
         this.serialTransmitCyclesPerByte = this.secondsToCycles(this.numBitsPerByte() / rate);
     }
 
+    /** Polls the tape and books the next poll; a tape that has run out is left alone. */
     runTape() {
-        if (this.tape) this.runTapeTask.reschedule(this.tape.poll(this));
+        if (!this.tape) return;
+        const delay = this.tape.poll(this);
+        if (delay === undefined) this.stopRunning();
+        else this.runTapeTask.reschedule(delay);
     }
 
     runRs423() {

--- a/src/ppia.js
+++ b/src/ppia.js
@@ -410,7 +410,9 @@ export class AtomPPIA extends PPIA {
     // nothing on ATOM
     receive(/*_byte*/) {}
 
+    /** A tape put in starts stopped, whatever the last one was doing. */
     setTape(tape) {
+        this.stopTape();
         this.tape = tape;
     }
 
@@ -436,8 +438,12 @@ export class AtomPPIA extends PPIA {
         }
     }
 
+    /** Polls the tape and books the next poll; the Atom's PLAY is its motor, so a tape that runs out stops. */
     runTape() {
-        if (this.tape) this.runTapeTask.reschedule(this.tape.poll(this));
+        if (!this.tape) return;
+        const delay = this.tape.poll(this);
+        if (delay === undefined) this.stopTape();
+        else this.runTapeTask.reschedule(delay);
     }
 
     updateIrq() {}

--- a/src/tapes.js
+++ b/src/tapes.js
@@ -29,8 +29,6 @@ class UefTape {
         this.isAtom = model.isAtom;
         this.cpuSpeed = model.cyclesPerSecond;
         this.rewind();
-
-        this.curChunk = this.readChunk();
     }
 
     rewind() {
@@ -54,6 +52,8 @@ class UefTape {
         const minor = this.stream.readByte();
         const major = this.stream.readByte();
         if (major !== 0x00) throw "Unsupported UEF version " + major + "." + minor;
+        // No chunk yet: the first poll reads one. null, later, means the tape has run off the end.
+        this.curChunk = undefined;
     }
 
     readChunk() {
@@ -68,7 +68,7 @@ class UefTape {
     // On BBC, acia is the ACIA (6850); on Atom, it's the PPIA (8255).
     // Both provide setTapeCarrier(), tone(), and receive/receiveBit().
     poll(acia) {
-        if (!this.curChunk) return;
+        if (this.curChunk === null) return;
 
         // Atom: deliver one wavebit per poll.
         if (this.isAtom && this.atomWavebitsLeft > 0) {
@@ -242,7 +242,6 @@ class UefTape {
                 return secsToClocks(gap, this.cpuSpeed);
             default:
                 console.log("Skipping unknown chunk " + hexword(this.curChunk.id));
-                this.curChunk = this.readChunk();
                 break;
         }
         return this.cycles(1);

--- a/src/web/google-drive.js
+++ b/src/web/google-drive.js
@@ -87,10 +87,14 @@ export class GoogleDriveLoader {
     }
 
     async listFiles() {
-        let response = await this.driveClient.files.list({ q: `mimeType = '${MIME_TYPE}' and trashed = false` });
+        const query = {
+            q: `mimeType = '${MIME_TYPE}' and trashed = false`,
+            fields: `nextPageToken, files(${FILE_FIELDS})`,
+        };
+        let response = await this.driveClient.files.list(query);
         let result = response.result.files;
         while (response.result.nextPageToken) {
-            response = await this.driveClient.files.list({ pageToken: response.result.nextPageToken });
+            response = await this.driveClient.files.list({ ...query, pageToken: response.result.nextPageToken });
             result = result.concat(response.result.files);
         }
         return result;

--- a/src/web/keyboard.js
+++ b/src/web/keyboard.js
@@ -259,12 +259,12 @@ export class Keyboard extends EventTarget {
      * @param {KeyboardEvent} evt - The keyboard event
      */
     keyUp(evt) {
-        // Early return for text input
-        if (this.inputEnabledFunction()) return;
-
-        // Always let the key ups come through to avoid sticky keys in the debugger
+        // Always let the key ups come through to avoid sticky keys: a key held while focus
+        // moved into a text field still has to be released in the machine.
         const code = this.keyCode(evt);
         this.keyInterface.keyUp(code);
+
+        if (this.inputEnabledFunction()) return;
 
         // No further special handling needed if not running
         if (!this.running) return;

--- a/src/web/snapshot-ui.js
+++ b/src/web/snapshot-ui.js
@@ -232,10 +232,8 @@ export class SnapshotUI {
             }
 
             this.drives.putDiscIn(driveIndex, loadedDisc);
-            // Only update the URL/query for URL-sourced discs. For embedded
-            // (local-file) discs, setting parsedQuery would put a bogus source
-            // in the URL and break subsequent saves/reloads.
-            if (savedMedia[discKey]) this.media.setDiscImage(driveIndex, savedMedia[discKey]);
+            // An embedded disc has no source, which takes whatever the URL named before out of it.
+            this.media.setDiscImage(driveIndex, savedMedia[discKey]);
         }
     }
 }

--- a/tests/unit/test-acia.js
+++ b/tests/unit/test-acia.js
@@ -68,6 +68,48 @@ describe("Acia", () => {
         });
     });
 
+    describe("the tape and the relay", () => {
+        const withTape = () => {
+            const relayNoise = { motorOn: vi.fn(), motorOff: vi.fn() };
+            const acia = createMockAcia(relayNoise);
+            const tape = { poll: vi.fn(() => 100), rewind: vi.fn() };
+            acia.setTape(tape);
+            vi.spyOn(acia.runTapeTask, "reschedule");
+            vi.spyOn(acia.runTapeTask, "cancel");
+            return { acia, tape };
+        };
+
+        it("starts a tape put in while the relay is on, and stops when it is taken out", () => {
+            const { acia } = withTape();
+            acia.setMotor(true);
+            acia.runTapeTask.reschedule.mockClear();
+            const another = { poll: vi.fn(() => 100), rewind: vi.fn() };
+            acia.setTape(another);
+            expect(acia.runTapeTask.reschedule).toHaveBeenCalled();
+            expect(another.poll).toHaveBeenCalled();
+            acia.setTape(undefined);
+            expect(acia.runTapeTask.cancel).toHaveBeenCalled();
+        });
+
+        it("leaves a tape put in with the relay off until the relay comes on", () => {
+            const { acia } = withTape();
+            expect(acia.runTapeTask.reschedule).not.toHaveBeenCalled();
+            acia.setMotor(true);
+            expect(acia.runTapeTask.reschedule).toHaveBeenCalledWith(100);
+        });
+
+        it("stops polling a tape that has run out, and picks it up again once rewound", () => {
+            const { acia, tape } = withTape();
+            tape.poll.mockReturnValueOnce(undefined);
+            acia.setMotor(true);
+            expect(acia.runTapeTask.reschedule).not.toHaveBeenCalled();
+            expect(acia.runTapeTask.cancel).toHaveBeenCalled();
+            acia.rewindTape();
+            expect(tape.rewind).toHaveBeenCalled();
+            expect(acia.runTapeTask.reschedule).toHaveBeenCalledWith(100);
+        });
+    });
+
     describe("receive overrun", () => {
         it("should raise one notice for a burst of overruns", () => {
             const acia = createMockAcia();

--- a/tests/unit/test-google-drive.js
+++ b/tests/unit/test-google-drive.js
@@ -35,6 +35,22 @@ describe("GoogleDriveLoader", () => {
         });
     });
 
+    it("lists every page of disc images, asking each time for the fields the rows read", async () => {
+        const loader = new GoogleDriveLoader();
+        const list = vi
+            .fn()
+            .mockResolvedValueOnce({ result: { files: [{ id: "1" }], nextPageToken: "more" } })
+            .mockResolvedValueOnce({ result: { files: [{ id: "2" }] } });
+        loader.driveClient = { files: { list } };
+        expect(await loader.listFiles()).toEqual([{ id: "1" }, { id: "2" }]);
+        expect(list).toHaveBeenCalledTimes(2);
+        for (const [query] of list.mock.calls) {
+            expect(query.q).toContain("trashed = false");
+            expect(query.fields).toContain("capabilities");
+        }
+        expect(list.mock.calls[1][0].pageToken).toBe("more");
+    });
+
     it("gives up when the Google script cannot be fetched", async () => {
         const loader = new GoogleDriveLoader();
 

--- a/tests/unit/test-keyboard.js
+++ b/tests/unit/test-keyboard.js
@@ -214,7 +214,7 @@ describe("Keyboard", () => {
         expect(event.preventDefault).toHaveBeenCalled();
     });
 
-    test("keyUp should not proceed when input is enabled", () => {
+    test("keyUp still releases the key when input is enabled, but leaves the event to the page", () => {
         const event = {
             which: keyCodes.A,
             location: 0,
@@ -222,14 +222,12 @@ describe("Keyboard", () => {
             altKey: false,
         };
 
-        // Set input enabled to true
         mockInputEnabledFunction.mockReturnValueOnce(true);
 
         keyboard.setRunning(true);
         keyboard.keyUp(event);
 
-        expect(mockInputEnabledFunction).toHaveBeenCalled();
-        expect(mockSysvia.keyUp).not.toHaveBeenCalled();
+        expect(mockSysvia.keyUp).toHaveBeenCalledWith(keyCodes.A);
         expect(event.preventDefault).not.toHaveBeenCalled();
     });
 

--- a/tests/unit/test-ppia.js
+++ b/tests/unit/test-ppia.js
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { AtomPPIA } from "../../src/ppia.js";
 import { Scheduler } from "../../src/scheduler.js";
 
@@ -190,6 +190,28 @@ describe("AtomPPIA", () => {
             };
             ppia.setTape(fakeTape);
             expect(ppia.tape).toBe(fakeTape);
+        });
+
+        it("starts a new tape stopped, whatever the last one was doing", () => {
+            const { ppia } = makePPIA();
+            ppia.setTape({ rewind() {}, poll: () => 100 });
+            ppia.playTape();
+            ppia.setTape({ rewind() {}, poll: () => 100 });
+            expect(ppia.motorOn).toBe(false);
+            ppia.setTape(undefined);
+            expect(ppia.motorOn).toBe(false);
+        });
+
+        it("stops, motor and all, when the tape runs out", () => {
+            const { ppia } = makePPIA();
+            let polls = 0;
+            ppia.setTape({ rewind() {}, poll: () => (++polls > 1 ? undefined : 100) });
+            vi.spyOn(ppia.runTapeTask, "reschedule");
+            ppia.playTape();
+            expect(ppia.motorOn).toBe(true);
+            ppia.runTape();
+            expect(ppia.runTapeTask.reschedule).toHaveBeenCalledTimes(1);
+            expect(ppia.motorOn).toBe(false);
         });
 
         it("stops the motor when rewinding", () => {

--- a/tests/unit/test-snapshot-ui.js
+++ b/tests/unit/test-snapshot-ui.js
@@ -280,7 +280,7 @@ describe("SnapshotUI", () => {
             expect(driveIndex).toBe(0);
             expect(loadedDisc.name).toBe("mine.ssd");
             expect(loadedDisc.originalImageData).toBeTruthy();
-            expect(deps.media.setDiscImage).not.toHaveBeenCalled();
+            expect(deps.media.setDiscImage).toHaveBeenCalledWith(0, undefined);
         });
 
         it("rebuilds image data that was serialised as a plain object", async () => {

--- a/tests/unit/test-tapes.js
+++ b/tests/unit/test-tapes.js
@@ -6,7 +6,6 @@ const BbcModel = findModel("B-DFS1.2");
 const AtomModel = findModel("Atom");
 
 // Build a minimal UEF file: "UEF File!\0" + version (minor, major) + chunks.
-// UefTape constructor reads the first chunk, so at least one must be present.
 function makeUef(chunks) {
     const header = [
         // "UEF File!\0"
@@ -116,11 +115,14 @@ describe("tapes", () => {
                 { id: 0x0116, data: [0x00, 0x00, 0x80, 0x3f] },
             ]);
 
+        // The first poll takes the origin chunk; the second is the gap.
         it("turns a one second gap into one second of CPU cycles", async () => {
             const bbc = await loadTapeFromData("test.uef", oneSecondGap(), BbcModel);
+            bbc.poll(mockAcia());
             expect(bbc.poll(mockAcia())).toBe(2 * 1000 * 1000);
 
             const atom = await loadTapeFromData("test.uef", oneSecondGap(), AtomModel);
+            atom.poll(mockAcia());
             expect(atom.poll(mockAcia())).toBe(1 * 1000 * 1000);
         });
 
@@ -152,6 +154,17 @@ describe("tapes", () => {
             expect(pollUntilReceived(tape)).toBe(0x41);
         });
 
+        it("skips a chunk it does not know without losing the one after it", async () => {
+            const uef = makeUef([
+                { id: 0x0100, data: [0x41] },
+                { id: 0x0120, data: [0x01, 0x00] },
+                { id: 0x0100, data: [0x42] },
+            ]);
+            const tape = await loadTapeFromData("test.uef", uef, BbcModel);
+            expect(pollUntilReceived(tape)).toBe(0x41);
+            expect(pollUntilReceived(tape)).toBe(0x42);
+        });
+
         it("should support rewind and replay", async () => {
             const uef = makeUef([
                 { id: 0x0110, data: [0x01, 0x00] },
@@ -159,6 +172,18 @@ describe("tapes", () => {
             ]);
             const tape = await loadTapeFromData("test.uef", uef, BbcModel);
             expect(pollUntilReceived(tape)).toBe(0x41);
+
+            tape.rewind();
+            expect(pollUntilReceived(tape)).toBe(0x41);
+        });
+
+        it("plays again from the start after running off the end", async () => {
+            const uef = makeUef([{ id: 0x0100, data: [0x41] }]);
+            const tape = await loadTapeFromData("test.uef", uef, BbcModel);
+            expect(pollUntilReceived(tape)).toBe(0x41);
+            const acia = { setTapeCarrier() {}, tone() {}, receive() {} };
+            let polls = 0;
+            while (tape.poll(acia) !== undefined) expect(++polls).toBeLessThan(20);
 
             tape.rewind();
             expect(pollUntilReceived(tape)).toBe(0x41);


### PR DESCRIPTION
Fixes found while reviewing the media window branch (#1091), all present on main today and none depending on that branch. Pulled out so they can land on their own.

- **A UEF tape running off its end froze the machine.** Its poll returned nothing, and rescheduling on nothing put a task at the head of the scheduler's queue that never expires, so no timer fired again. Both tape interfaces now stop polling; the ACIA restarts on rewind, the Atom's PLAY drops as a real recorder's would.
- **A UEF's first chunk was never played.** It was read at construction and read over again on the first poll. Real tapes start with an origin chunk, so this only cost a log line; a tape starting with data lost it. Rewind and construction now do the same thing.
- **An unknown UEF chunk swallowed the chunk after it**, and threw when it was the last chunk in the file.
- **A tape put in while the motor relay was on never started**; one taken out left the tone playing. On the Atom a new tape inherited a running motor.
- **A key held while focus moved into a text field was never released in the machine**: key-ups were dropped whenever typing was enabled.
- **Google Drive's listing** did not ask for the capabilities its callers read, and its second page dropped the query filter.
- **A restored save state with an embedded disc** left the URL naming the disc that was in the drive before.

Each has a test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
