### PR TITLE
fix: a save state restores over a disc kept in the browser or on Drive, and other restore and Drive fixes

### DIFF
--- a/src/disc.js
+++ b/src/disc.js
@@ -1222,6 +1222,8 @@ export class Disc {
                 trackObj.pulses2Us.set(trackData.pulses2Us);
                 trackObj.length = trackData.length;
                 this._everDirtyTracks.add(trackNum | (isSideUpper ? 0x100 : 0));
+                // A disc that keeps its changes at its source takes the overlay there too.
+                for (const listener of this._trackWriteListeners) listener(isSideUpper, trackNum, trackObj);
             }
         }
     }

--- a/src/url-params.js
+++ b/src/url-params.js
@@ -298,13 +298,14 @@ export function guessModelFromHostname(hostname) {
  * Parse disc images from the query parameters
  * @param {Object} parsedQuery - The query parameters
  * @returns {Object} Object containing disc information
- *   - discImage: disc image URL (?disc= or ?disc1=)
+ *   - discImage: disc image URL (?disc1= or, failing that, ?disc=)
  *   - secondDiscImage: second disc URL (?disc2=)
  *   - mmcImage: MMC/SD card image URL (?mmc=, Atom only)
  */
 export function parseMediaParams(parsedQuery) {
     const { disc, disc1, disc2, mmc } = parsedQuery;
-    const discImage = disc || disc1;
+    // disc1 is the name the drives use; a bare disc is the older spelling, and gives way to it.
+    const discImage = disc1 || disc;
 
     return { discImage, secondDiscImage: disc2, mmcImage: mmc };
 }

--- a/src/web/google-drive.js
+++ b/src/web/google-drive.js
@@ -73,7 +73,7 @@ export class GoogleDriveLoader {
         return new Promise((resolve, reject) => {
             console.log("Authorizing...");
             this.tokenClient.callback = (resp) => {
-                if (resp.error !== undefined) reject(resp);
+                if (resp.error !== undefined) return reject(new Error(resp.error_description ?? resp.error));
                 console.log("Authorized OK");
                 this.authorized = true;
                 resolve(true);

--- a/src/web/snapshot-ui.js
+++ b/src/web/snapshot-ui.js
@@ -221,7 +221,10 @@ export class SnapshotUI {
                 continue;
             }
 
+            // A disc that keeps its changes at its source has moved on by design; the state's own
+            // dirty tracks go back over it.
             if (
+                !loadedDisc.savesChanges &&
                 savedMedia[crcKey] != null &&
                 loadedDisc.originalImageCrc32 != null &&
                 loadedDisc.originalImageCrc32 !== savedMedia[crcKey]

--- a/tests/unit/test-disc.js
+++ b/tests/unit/test-disc.js
@@ -13,6 +13,7 @@ import {
 } from "../../src/disc.js";
 import * as fs from "node:fs";
 import { ssdImage } from "./helpers.js";
+import { discFor } from "../../src/fdc.js";
 
 afterEach(() => vi.restoreAllMocks());
 
@@ -676,5 +677,23 @@ describe("sector decoding warnings", () => {
         track.findSectors();
 
         expect(console).toHaveBeenCalled();
+    });
+});
+
+describe("restoring a state's written tracks", () => {
+    it("tells the disc's write listeners, so a disc kept at its source takes them there", () => {
+        const disc = discFor("kept.ssd", ssdImage());
+        const written = [];
+        disc.addTrackWriteListener((isSideUpper, trackNum) => written.push([isSideUpper, trackNum]), true);
+        const track = disc.getTrack(false, 3);
+        disc.restoreState({
+            tracksUsed: disc.tracksUsed,
+            isDoubleSided: false,
+            isWriteable: true,
+            name: "kept.ssd",
+            tracks: {},
+            dirtyTracks: { "false:3": { pulses2Us: track.pulses2Us.slice(), length: track.length } },
+        });
+        expect(written).toEqual([[false, 3]]);
     });
 });

--- a/tests/unit/test-google-drive.js
+++ b/tests/unit/test-google-drive.js
@@ -51,6 +51,17 @@ describe("GoogleDriveLoader", () => {
         expect(list.mock.calls[1][0].pageToken).toBe("more");
     });
 
+    it("does not count a refused token as a connection, and says why in words", async () => {
+        const loader = new GoogleDriveLoader();
+        loader.tokenClient = {
+            requestAccessToken() {
+                this.callback({ error: "access_denied", error_description: "The user did not consent" });
+            },
+        };
+        await expect(loader.authorize(false)).rejects.toThrow("The user did not consent");
+        expect(loader.authorized).toBe(false);
+    });
+
     it("gives up when the Google script cannot be fetched", async () => {
         const loader = new GoogleDriveLoader();
 

--- a/tests/unit/test-snapshot-ui.js
+++ b/tests/unit/test-snapshot-ui.js
@@ -221,6 +221,13 @@ describe("SnapshotUI", () => {
             expect(toasts()).toEqual([]);
         });
 
+        it("restores over a disc that keeps its changes at its source, however its bytes have moved on", async () => {
+            const loaded = { name: "mine.ssd", originalImageCrc32: 0x9999, savesChanges: true };
+            deps.media.loadDiscImage.mockResolvedValue(loaded);
+            await make().reloadSnapshotMedia({ disc1: "local:mine.ssd", disc1Crc32: 0x1234 });
+            expect(deps.drives.putDiscIn).toHaveBeenCalledWith(0, loaded);
+        });
+
         it("refuses to restore when the source has changed under the state", async () => {
             deps.media.loadDiscImage.mockResolvedValue({ name: "ELITE.ssd", originalImageCrc32: 0x9999 });
             await expect(make().reloadSnapshotMedia({ disc1: "sth:ELITE.zip", disc1Crc32: 0x1234 })).rejects.toThrow(

--- a/tests/unit/test-url-params.js
+++ b/tests/unit/test-url-params.js
@@ -344,6 +344,8 @@ describe("URL Parameters", () => {
                 secondDiscImage: undefined,
                 mmcImage: undefined,
             });
+            // disc1 is what the drives are named by; a bare disc gives way to it, as it does everywhere else.
+            expect(parseMediaParams({ disc: "old.ssd", disc1: "disc1.ssd" }).discImage).toBe("disc1.ssd");
         });
 
         it("should extract mmc image for Atom", () => {


### PR DESCRIPTION
Pre-existing bugs found while reviewing the media window branch (#1091), pulled out so they land on their own as #1095 did.

- **A save state could not be restored over a browser-local or Google Drive disc once the machine had written to it.** Those discs keep their changes at the source by design, so the bytes there no longer match the CRC the state recorded. Such a disc is now restored and the state's own written tracks go back over it.
- **A restore's written tracks never reached the disc's source.** `restoreState` overlaid them in memory only, so the saved copy kept the newer bytes and the next write pushed them back. The overlay now goes through the disc's write listeners like any other write.
- **A refused Google sign-in counted as a connection**: the rejection did not `return`, so `authorized` was set anyway. It also surfaced as "[object Object]"; the rejection now carries Google's description.
- **`?disc=A&disc1=B` loaded A while the snapshot manifest named B.** `disc1` is what the drives are named by everywhere else, so it wins here too.

Each has a test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
