### PR TITLE
fix: the media window's phone layout applies, the LED panel fits a phone, and an open menu does not shrink the screen

### DIFF
--- a/index.html
+++ b/index.html
@@ -349,7 +349,7 @@
             <span class="hdr">shift<br />lock</span>
             <span class="led keyboard" id="shiftlight"></span>
           </div>
-          <div class="cell bbc-only" title="Econet activity">
+          <div class="cell bbc-only econet" title="Econet activity">
             <span class="hdr">econet<br />tx/rx</span>
             <span class="led disc" id="networklight"></span>
           </div>

--- a/src/jsbeeb.css
+++ b/src/jsbeeb.css
@@ -2314,7 +2314,7 @@ div.smoothie-chart-tooltip {
     padding-left: 4px;
   }
 
-  #leds .cell[title="Econet activity"] {
+  #leds .cell.econet {
     display: none;
   }
 }

--- a/src/jsbeeb.css
+++ b/src/jsbeeb.css
@@ -1625,150 +1625,6 @@ div.smoothie-chart-tooltip {
   }
 }
 
-/* ----- narrow: a full-screen sheet, the drives above the deck, the list under them ----- */
-
-@media (max-width: 700px) {
-  #media-panel {
-    inset: 0;
-    transform: none;
-    width: auto;
-    max-height: none;
-    border: 0;
-    border-radius: 0;
-  }
-
-  .media-header {
-    cursor: default;
-  }
-
-  .media-deck {
-    grid-template-columns: minmax(0, 1fr);
-    grid-template-rows: auto auto 96px auto auto;
-  }
-
-  .bay {
-    grid-template-columns: 16px 44px minmax(0, 1fr) 62px;
-    grid-template-rows: 22px 42px auto;
-    column-gap: 6px;
-    padding: 5px 6px 5px 5px;
-  }
-
-  .lever-wrap {
-    width: 50px;
-  }
-
-  .lever {
-    width: 40px;
-    height: 15px;
-    transform-origin: 9px 7px;
-  }
-
-  .mouth {
-    padding-left: 56px;
-    height: 42px;
-  }
-
-  .bay-badge {
-    grid-template-columns: 1fr;
-    justify-items: center;
-    height: 34px;
-    padding: 0 4px;
-  }
-
-  .bay-badge .logo,
-  .paper .dfs,
-  .pitch .hwlabel {
-    display: none;
-  }
-
-  .bay-badge .drive-no {
-    text-align: center;
-  }
-
-  .paper .title {
-    font-size: 12px;
-  }
-
-  .bay-line {
-    white-space: normal;
-    flex-wrap: wrap;
-    gap: 2px 6px;
-    padding-top: 3px;
-  }
-
-  .bay-line .spacer {
-    display: none;
-  }
-
-  .deck-window .reel {
-    width: 36px;
-    height: 36px;
-  }
-
-  .deck-window .reels::before {
-    margin-top: 14px;
-  }
-
-  .deck-key {
-    height: 30px;
-  }
-
-  /* The whole sheet scrolls as one, so nothing inside it competes for the height. */
-  #media-panel {
-    overflow-y: auto;
-  }
-
-  #media-panel > * {
-    flex-shrink: 0;
-  }
-
-  .media-list-head {
-    flex-wrap: wrap;
-    gap: 6px 12px;
-  }
-
-  .media-search {
-    flex-basis: 100%;
-  }
-
-  .media-chips {
-    flex-wrap: nowrap;
-    overflow-x: auto;
-    padding-bottom: 4px;
-  }
-
-  .media-list {
-    flex: none;
-  }
-
-  .media-row-main {
-    grid-template-columns: minmax(0, 1fr) auto 26px;
-    grid-template-rows: auto auto;
-    gap: 1px 10px;
-    padding: 7px 8px;
-  }
-
-  .media-row .publisher,
-  .media-row .detail {
-    grid-column: 1;
-    font-size: 11.5px;
-  }
-
-  .media-row .publisher:empty + .detail {
-    grid-column: 1;
-  }
-
-  .media-row .media-source {
-    grid-column: 2;
-    grid-row: 1 / span 3;
-  }
-
-  .media-row .media-keycap {
-    grid-column: 3;
-    grid-row: 1 / span 3;
-  }
-}
-
 /* ----- a slot busy fetching, or left holding a failure ----- */
 
 .bay[data-state="busy"] .mouth {
@@ -2280,5 +2136,185 @@ div.smoothie-chart-tooltip {
     background: Highlight;
     color: HighlightText;
     border-color: Highlight;
+  }
+}
+
+/* ----- narrow: a full-screen sheet, the drives above the deck, the list under them.
+   Last in the file, so it wins over every rule it narrows. ----- */
+
+@media (max-width: 700px) {
+  #media-panel {
+    inset: 0;
+    transform: none;
+    width: auto;
+    max-height: none;
+    border: 0;
+    border-radius: 0;
+  }
+
+  .media-header {
+    cursor: default;
+  }
+
+  .media-deck {
+    grid-template-columns: minmax(0, 1fr);
+    grid-template-rows: auto auto 96px auto auto;
+  }
+
+  .bay {
+    grid-template-columns: 16px 44px minmax(0, 1fr) 62px;
+    grid-template-rows: 22px 42px auto;
+    column-gap: 6px;
+    padding: 5px 6px 5px 5px;
+  }
+
+  .lever-wrap {
+    width: 50px;
+  }
+
+  .lever {
+    width: 40px;
+    height: 15px;
+    transform-origin: 9px 7px;
+  }
+
+  .mouth {
+    padding-left: 56px;
+    height: 42px;
+  }
+
+  .bay-badge {
+    grid-template-columns: 1fr;
+    justify-items: center;
+    height: 34px;
+    padding: 0 4px;
+  }
+
+  .bay-badge .logo,
+  .paper .dfs,
+  .pitch .hwlabel {
+    display: none;
+  }
+
+  .bay-badge .drive-no {
+    text-align: center;
+  }
+
+  .paper .title {
+    font-size: 12px;
+  }
+
+  .bay-line {
+    white-space: normal;
+    flex-wrap: wrap;
+    gap: 2px 6px;
+    padding-top: 3px;
+  }
+
+  .bay-line .spacer {
+    display: none;
+  }
+
+  .deck-window .reel {
+    width: 36px;
+    height: 36px;
+  }
+
+  .deck-window .reels::before {
+    margin-top: 14px;
+  }
+
+  .deck-key {
+    height: 30px;
+  }
+
+  /* The whole sheet scrolls as one, so nothing inside it competes for the height. */
+  #media-panel {
+    overflow-y: auto;
+  }
+
+  #media-panel > * {
+    flex-shrink: 0;
+  }
+
+  .media-list-head {
+    flex-wrap: wrap;
+    gap: 6px 12px;
+  }
+
+  .media-search {
+    flex-basis: 100%;
+  }
+
+  .media-chips {
+    flex-wrap: nowrap;
+    overflow-x: auto;
+    padding-bottom: 4px;
+  }
+
+  .media-list {
+    flex: none;
+  }
+
+  .media-row-main {
+    grid-template-columns: minmax(0, 1fr) auto 26px;
+    grid-template-rows: auto auto;
+    gap: 1px 10px;
+    padding: 7px 8px;
+  }
+
+  .media-row .publisher,
+  .media-row .detail {
+    grid-column: 1;
+    font-size: 11.5px;
+  }
+
+  .media-row .publisher:empty + .detail {
+    grid-column: 1;
+  }
+
+  .media-row .media-source {
+    grid-column: 2;
+    grid-row: 1 / span 3;
+  }
+
+  .media-row .media-keycap {
+    grid-column: 3;
+    grid-row: 1 / span 3;
+  }
+}
+
+/* ----- a phone's LED panel: the slots share the width instead of overflowing it ----- */
+
+@media (max-width: 560px) {
+  #leds {
+    right: 0;
+    margin: 2px;
+    padding: 3px 4px;
+    gap: 4px;
+  }
+
+  #leds .slot-readouts {
+    flex: 1 1 0;
+    min-width: 0;
+    gap: 2px;
+  }
+
+  #leds .slot-readout,
+  #leds .slot-readout[data-slot="tape"] {
+    width: auto;
+    flex: 1 1 0;
+    min-width: 0;
+    padding: 1px 3px;
+    column-gap: 4px;
+  }
+
+  #leds .lights {
+    gap: 3px;
+    padding-left: 4px;
+  }
+
+  #leds .cell[title="Econet activity"] {
+    display: none;
   }
 }

--- a/src/web/layout.js
+++ b/src/web/layout.js
@@ -69,6 +69,16 @@ export function fitMonitor(displayConfig, viewport, canvasNative) {
     };
 }
 
+/**
+ * The height the bar takes from the screen: on a narrow window its menu drops open over the
+ * screen rather than above it, so an open menu does not count.
+ */
+export function navbarHeightOf(header) {
+    if (!header) return 0;
+    const openMenu = header.querySelector(".navbar-collapse.show");
+    return header.offsetHeight - (openMenu?.offsetHeight ?? 0);
+}
+
 /** Keeps the monitor and canvas fitted to the window, and wires the page furniture around them. */
 export class Layout {
     constructor({ screenCanvas, display, embed, sidebars = {} }) {
@@ -120,7 +130,7 @@ export class Layout {
             {
                 innerWidth: window.innerWidth,
                 innerHeight: window.innerHeight,
-                navbarHeight: document.getElementById("header-bar")?.offsetHeight || 0,
+                navbarHeight: navbarHeightOf(document.getElementById("header-bar")),
                 borderReservedSize: this.borderReservedSize,
                 bottomReservedSize: this.bottomReservedSize,
                 devicePixelRatio: window.devicePixelRatio || 1,

--- a/src/web/layout.js
+++ b/src/web/layout.js
@@ -76,7 +76,7 @@ export function fitMonitor(displayConfig, viewport, canvasNative) {
 export function navbarHeightOf(header) {
     if (!header) return 0;
     const openMenu = header.querySelector(".navbar-collapse.show");
-    return header.offsetHeight - (openMenu?.offsetHeight ?? 0);
+    return Math.max(0, header.offsetHeight - (openMenu?.offsetHeight ?? 0));
 }
 
 /** Keeps the monitor and canvas fitted to the window, and wires the page furniture around them. */

--- a/tests/unit/test-layout.js
+++ b/tests/unit/test-layout.js
@@ -30,12 +30,16 @@ const native = { width: 800, height: 600 };
 describe("navbarHeightOf", () => {
     const header = (height, openMenuHeight) => ({
         offsetHeight: height,
-        querySelector: () => (openMenuHeight === undefined ? null : { offsetHeight: openMenuHeight }),
+        querySelector: (selector) =>
+            selector === ".navbar-collapse.show" && openMenuHeight !== undefined
+                ? { offsetHeight: openMenuHeight }
+                : null,
     });
 
-    it("is the bar's height, less a menu dropped open over the screen", () => {
+    it("is the bar's height, less a menu dropped open over the screen, and never less than nothing", () => {
         expect(navbarHeightOf(header(72))).toBe(72);
         expect(navbarHeightOf(header(380, 308))).toBe(72);
+        expect(navbarHeightOf(header(72, 308))).toBe(0);
         expect(navbarHeightOf(null)).toBe(0);
     });
 });

--- a/tests/unit/test-layout.js
+++ b/tests/unit/test-layout.js
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { Layout, fitMonitor } from "../../src/web/layout.js";
+import { Layout, fitMonitor, navbarHeightOf } from "../../src/web/layout.js";
 import { domFromIndexHtml, teardownDom, toasts } from "./helpers.js";
 
 const Config = {
@@ -26,6 +26,19 @@ const viewport = (innerWidth, innerHeight, extra = {}) => ({
 });
 
 const native = { width: 800, height: 600 };
+
+describe("navbarHeightOf", () => {
+    const header = (height, openMenuHeight) => ({
+        offsetHeight: height,
+        querySelector: () => (openMenuHeight === undefined ? null : { offsetHeight: openMenuHeight }),
+    });
+
+    it("is the bar's height, less a menu dropped open over the screen", () => {
+        expect(navbarHeightOf(header(72))).toBe(72);
+        expect(navbarHeightOf(header(380, 308))).toBe(72);
+        expect(navbarHeightOf(null)).toBe(0);
+    });
+});
 
 describe("fitMonitor", () => {
     it("fills the width of a tall window, keeping the picture's aspect", () => {


### PR DESCRIPTION
Fixes #1103, the two regressions on phones since #1091, plus the third thing behind the first screenshot.

- **The sheet layout did not apply.** The rules for widths under 700px sat before the base rules they narrow, so the list head, chips and rows kept their desktop grid on a phone and overflowed it. The block is last in the stylesheet now, and on a phone the Into control, the search box and the count each take a line, the chips scroll sideways, and a row is a title line and a detail line with its badge and targets at the right.
- **The LED panel was wider than a phone.** Its slots now share the width, and the Econet cell is left out below 560px.
- **The screen shrank to its minimum and stayed there.** The monitor is fitted to the window less the top bar's height, and on a phone that height includes the hamburger menu while it is open. Opening the menu (which is where Media lives on a phone) and anything that then fires a resize, such as the keyboard appearing, fitted the screen to a 380px bar and nothing refitted it once the menu closed. An open menu drops over the screen rather than above it, so `navbarHeightOf` leaves it out.

Not touched: the layout viewport on some phones is wider than the screen at load, which predates #1091 and shows as the page zoomed out a little; that is a separate question.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
