### PR TITLE
feat: the whole page takes a dropped disc, tape or save state

### DIFF
--- a/index.html
+++ b/index.html
@@ -257,8 +257,8 @@
               class="form-control"
               type="text"
               maxlength="0"
-              placeholder="Paste / drop here"
-              aria-label="Paste text or drop files here"
+              placeholder="Paste here"
+              aria-label="Paste text here"
             />
           </form>
         </div>
@@ -357,6 +357,12 @@
             <span class="hdr" id="virtual-mhz-header">virtual<br />MHz</span>
             <span class="virtualMHz"></span>
           </div>
+        </div>
+      </div>
+      <div id="drop-zone" class="drop-zone" hidden aria-hidden="true">
+        <div class="drop-zone-card">
+          <b>Drop a disc, tape or save state</b>
+          <span class="drop-zone-into"></span>
         </div>
       </div>
       <div id="media-panel" hidden role="dialog" aria-labelledby="media-title">

--- a/src/jsbeeb.css
+++ b/src/jsbeeb.css
@@ -264,6 +264,9 @@ span.accesskey {
 
 /* One LED, coloured by what it reports; change a kind's colour here. */
 :root {
+  --aim: #4d8be0;
+  --muted: #9aa3ad;
+  --rule: #3a3f44;
   --led-keyboard: #e81414;
   --led-power: #e81414;
   --led-tape: #e81414;
@@ -712,9 +715,6 @@ div.smoothie-chart-tooltip {
 /* ------------------------------------------------------------------ */
 
 #media-panel {
-  --aim: #4d8be0;
-  --muted: #9aa3ad;
-  --rule: #3a3f44;
   --beige: #d9d0ba;
   --beige-hi: #ece5d2;
   --beige-lo: #b9ae95;
@@ -2281,4 +2281,35 @@ div.smoothie-chart-tooltip {
     color: HighlightText;
     border-color: Highlight;
   }
+}
+
+/* ----- the whole page as a drop zone, said so while a file is over it ----- */
+
+.drop-zone {
+  position: fixed;
+  inset: 0;
+  z-index: 20;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(0, 0, 0, 0.55);
+  pointer-events: none;
+}
+
+.drop-zone-card {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 6px;
+  padding: 28px 40px;
+  border: 3px dashed var(--aim);
+  border-radius: 12px;
+  background: rgba(0, 0, 0, 0.8);
+  color: #eee;
+  font-size: 18px;
+}
+
+.drop-zone-card span {
+  font-size: 14px;
+  color: var(--muted);
 }

--- a/src/media-resolver.js
+++ b/src/media-resolver.js
@@ -8,6 +8,30 @@ export function splitImage(image) {
     return { schema: match[2] || match[1] || "", image: match[3] };
 }
 
+/**
+ * Every schema a reference can start with: how it is served (`route`) and where the page says it
+ * came from, as a media-catalogue source key (`source`) or as words (`phrase`). A reference
+ * with no schema is a bare name from the built-in folder.
+ */
+export const Schemas = Object.freeze({
+    "": { route: "folder", source: "builtin" },
+    sth: { route: "sth", source: "sth" },
+    "|": { route: "sth", source: "sth" },
+    hfe: { route: "hfe", source: "hfe" },
+    gd: { route: "drive", source: "gdrive" },
+    local: { route: "browser", source: "browser" },
+    "!": { route: "browser", source: "browser" },
+    session: { route: "session", source: "session" },
+    data: { route: "zipped-inline", phrase: "the URL" },
+    b64data: { route: "inline", phrase: "the URL" },
+    http: { route: "url", phrase: "the web" },
+    https: { route: "url", phrase: "the web" },
+    file: { route: "url", phrase: "a file" },
+});
+
+/** How a reference is served; a schema this page does not know is read as a folder name. */
+export const routeOf = (ref) => (Schemas[splitImage(ref).schema] ?? Schemas[""]).route;
+
 // Where a bare name is looked for, and which registered source serves the archive.
 const Kinds = {
     disc: { folder: "discs", sth: "sth" },
@@ -38,23 +62,20 @@ export class MediaResolver {
     }
 
     async resolve(kind, ref) {
-        const { schema, image } = splitImage(ref);
+        const { image } = splitImage(ref);
         const { folder, sth } = Kinds[kind];
-        switch (schema) {
-            case "|":
+        switch (routeOf(ref)) {
             case "sth":
                 return this.source(sth)(image);
             case "hfe":
                 return { name: image, data: await this.source("hfe")(image), ignored: [] };
             case "session":
                 return this.source("session")(image);
-            case "b64data":
+            case "inline":
                 return { name: "disk.ssd", data: stringToUint8Array(atob(image)), ignored: [] };
-            case "data":
+            case "zipped-inline":
                 return unzipDiscImage(stringToUint8Array(atob(image)));
-            case "http":
-            case "https":
-            case "file":
+            case "url":
                 // The URL may end in query parameters, which would upset the extension check.
                 return openIfZip(new URL(ref).pathname.split("/").pop(), await this.load(ref));
             default:

--- a/src/web/media-catalogue.js
+++ b/src/web/media-catalogue.js
@@ -1,5 +1,5 @@
 import { Provenance, describe as describeHfe } from "../bbcdiscs.js";
-import { splitImage } from "../media-resolver.js";
+import { Schemas, splitImage } from "../media-resolver.js";
 
 /**
  * One shape for everything the media window can list, whichever source it
@@ -39,24 +39,11 @@ export const Sources = Object.freeze({
 
 export const sourceName = (source) => Sources[source]?.name ?? source;
 
-// The source behind each URL schema the list knows, and words for the schemas it does not.
-const SchemaSources = {
-    "": "builtin",
-    sth: "sth",
-    "|": "sth",
-    hfe: "hfe",
-    gd: "gdrive",
-    local: "browser",
-    "!": "browser",
-    session: "session",
-};
-const OtherSchemaPhrases = { http: "the web", https: "the web", file: "a file", data: "the URL", b64data: "the URL" };
-
 /** Where a URL reference came from, in words, or null when the URL names nothing. */
 export function sourceOf(ref) {
     if (!ref) return null;
-    const { schema } = splitImage(ref);
-    return Sources[SchemaSources[schema]]?.phrase ?? OtherSchemaPhrases[schema] ?? null;
+    const schema = Schemas[splitImage(ref).schema];
+    return Sources[schema?.source]?.phrase ?? schema?.phrase ?? null;
 }
 
 /** A descriptor for a bare reference, as the URL or the desktop menu gives one: known by its file name. */
@@ -68,7 +55,7 @@ export function describeRef(ref, kind) {
         title: image.split("/").pop(),
         publisher: "",
         detail: "",
-        source: SchemaSources[schema] ?? OtherSchemaPhrases[schema] ?? schema,
+        source: Schemas[schema]?.source ?? Schemas[schema]?.phrase ?? schema,
         savesChanges: false,
     };
 }

--- a/src/web/media-loader.js
+++ b/src/web/media-loader.js
@@ -4,7 +4,7 @@ import { DiscLayout } from "../disc.js";
 import { loadTapeFromData } from "../tapes.js";
 import { toast } from "./toast.js";
 import { errorText, reportIgnoredFiles, reportLoadFailure } from "./reporting.js";
-import { MediaResolver, openIfZip, splitImage } from "../media-resolver.js";
+import { MediaResolver, openIfZip, routeOf, splitImage } from "../media-resolver.js";
 import { MediaSlots } from "./media-slots.js";
 import { stringToUint8Array } from "../binary.js";
 import { noteEvent } from "./analytics.js";
@@ -93,24 +93,6 @@ export class MediaLoader extends EventTarget {
             }
             evt.target.value = ""; // clear so if the user picks the same file again after a reset we get a "change"
         });
-
-        const pastetext = document.getElementById("paste-text");
-        pastetext.addEventListener("dragover", (event) => {
-            event.preventDefault();
-            event.stopPropagation();
-            event.dataTransfer.dropEffect = "copy";
-        });
-        pastetext.addEventListener("drop", async (event) => {
-            noteEvent("local", "drop");
-            const file = event.dataTransfer.files[0];
-            if (!file) return;
-            try {
-                const outcome = await this.openFile(file);
-                if (outcome) toast(outcome, { title: "Dropped" });
-            } catch (error) {
-                reportLoadFailure(file.name, error);
-            }
-        });
     }
 
     get params() {
@@ -157,22 +139,24 @@ export class MediaLoader extends EventTarget {
      * A file from this computer, into whatever it is for: a save state is
      * restored, a tape goes in the deck, anything else into the named drive.
      *
-     * @returns {Promise<?string>} what happened, for a toast, or null when it was reported already
+     * @returns {Promise<?{kind: string, name: string, driveIndex?: number, words: string}>} what
+     *   happened, with words for a toast; null when a restore failed and has been reported already
      */
     async openFile(file, driveIndex = 0) {
         const arrayBuffer = await file.arrayBuffer();
         if (this.isSnapshotFile(file.name, arrayBuffer)) {
-            return (await this.loadSnapshot(file, arrayBuffer)) ? `Restored the state saved in ${file.name}.` : null;
+            if (!(await this.loadSnapshot(file, arrayBuffer))) return null;
+            return { kind: "snapshot", name: file.name, words: `Restored the state saved in ${file.name}.` };
         }
         // What a zip holds decides whether it is a tape or a disc, so it is opened first.
         const { name, data, ignored } = await openIfZip(file.name, new Uint8Array(arrayBuffer));
         reportIgnoredFiles(name, ignored);
         if (isTapeName(name)) {
             await this.loadTapeFile(name, data);
-            return `Loaded ${name} as the tape.`;
+            return { kind: "tape", name, words: `Loaded ${name} as the tape.` };
         }
         this.loadDiscFile(name, data, driveIndex);
-        return `Loaded ${name} into drive ${driveIndex}.`;
+        return { kind: "disc", name, driveIndex, words: `Loaded ${name} into drive ${driveIndex}.` };
     }
 
     setAutoboot(on) {
@@ -221,8 +205,9 @@ export class MediaLoader extends EventTarget {
 
     async loadDiscImage(discImage, layout = DiscLayout.auto) {
         if (!discImage) return null;
-        const { schema, image } = splitImage(discImage);
-        if (schema[0] === "!" || schema === "local") {
+        const { image } = splitImage(discImage);
+        const route = routeOf(discImage);
+        if (route === "browser") {
             return localDisc(image, layout, (error) =>
                 toast(
                     `Browser storage would not take changes to ${image} (${errorText(error)}). Use the drive's Save button to keep a copy.`,
@@ -230,7 +215,7 @@ export class MediaLoader extends EventTarget {
                 ),
             );
         }
-        if (schema === "gd") {
+        if (route === "drive") {
             const [, id, name = "(unknown)"] = image.match(/([^/]+)\/?(.*)/) ?? [null, image];
             return this.driveSource({ name, id }, layout);
         }
@@ -243,7 +228,7 @@ export class MediaLoader extends EventTarget {
         const { name, data, ignored } = await this.resolver.resolve("disc", discImage);
         reportIgnoredFiles(name, ignored);
         const loaded = disc.discFor(name, data, undefined, layout);
-        if (schema === "session") loaded.setOriginalImage(data);
+        if (route === "session") loaded.setOriginalImage(data);
         return loaded;
     }
 

--- a/src/web/media-window.js
+++ b/src/web/media-window.js
@@ -195,7 +195,7 @@ export class MediaWindow {
         );
     }
 
-    /** Takes the window's listeners off the page, for a page that builds another. */
+    /** Takes the window's drop-zone listeners off the page, for a page that builds another window. */
     dispose() {
         this.pageListeners.abort();
     }

--- a/src/web/media-window.js
+++ b/src/web/media-window.js
@@ -109,6 +109,8 @@ export class MediaWindow {
             if (this.isOpen) this.refreshList();
         });
         loop.addEventListener("tick", () => this.tick());
+        this.pageListeners = new AbortController();
+        this.bindDropZone();
         // The Atom has no disc drives: only the deck, and only the deck to aim at.
         if (model.isAtom) {
             this.panel.querySelector(".media-case").hidden = true;
@@ -133,6 +135,93 @@ export class MediaWindow {
 
     get isOpen() {
         return this.floating.isOpen;
+    }
+
+    /**
+     * The whole page takes a dropped file: a disc goes into the aimed drive, a tape into the
+     * deck, a save state is restored. An overlay says so while a file is over the page.
+     */
+    bindDropZone() {
+        const zone = document.getElementById("drop-zone");
+        const words = zone.querySelector(".drop-zone-into");
+        // dragenter and dragleave fire for every element crossed, so the depth says when the page is left.
+        let depth = 0;
+        const hasFiles = (e) => [...(e.dataTransfer?.types ?? [])].includes("Files");
+        const { signal } = this.pageListeners;
+        document.addEventListener(
+            "dragenter",
+            (e) => {
+                if (!hasFiles(e)) return;
+                e.preventDefault();
+                if (depth++ === 0) {
+                    words.textContent = this.model.isAtom
+                        ? "a tape goes in the deck"
+                        : `a disc goes into ${this.targetName}`;
+                    zone.hidden = false;
+                }
+            },
+            { signal },
+        );
+        document.addEventListener(
+            "dragover",
+            (e) => {
+                if (!hasFiles(e)) return;
+                e.preventDefault();
+                e.dataTransfer.dropEffect = "copy";
+            },
+            { signal },
+        );
+        document.addEventListener(
+            "dragleave",
+            (e) => {
+                if (!hasFiles(e)) return;
+                if (--depth === 0) zone.hidden = true;
+            },
+            { signal },
+        );
+        document.addEventListener(
+            "drop",
+            async (e) => {
+                if (!hasFiles(e)) return;
+                e.preventDefault();
+                depth = 0;
+                zone.hidden = true;
+                const file = e.dataTransfer.files[0];
+                if (!file) return;
+                noteEvent("local", "drop");
+                await this.openFile(file, "Dropped");
+            },
+            { signal },
+        );
+    }
+
+    /** Takes the window's listeners off the page, for a page that builds another. */
+    dispose() {
+        this.pageListeners.abort();
+    }
+
+    /** Where a disc from this computer goes, in words. */
+    get targetName() {
+        return `drive ${this.targetDrive}`;
+    }
+
+    /**
+     * Opens a file from this computer into the aimed drive, the deck or the machine's state, says
+     * so, boots a disc that went into drive 0 if Autoboot is ticked, and gets out of the way.
+     */
+    async openFile(file, title) {
+        try {
+            const opened = await this.media.openFile(file, this.targetDrive);
+            if (!opened) return;
+            toast(opened.words, { title });
+            if (opened.kind === "disc" && opened.driveIndex === 0 && this.media.params.autoboot !== undefined) {
+                this.processor.reset(true);
+                this.autoboot(opened.name);
+            }
+            this.close();
+        } catch (error) {
+            reportLoadFailure(file.name, error);
+        }
     }
 
     /** Opens with the list, aimed at drive 0 (the deck, on the Atom). */
@@ -340,15 +429,7 @@ export class MediaWindow {
             const file = evt.target.files[0];
             if (!file) return;
             noteEvent("local", "clickWindow");
-            try {
-                const outcome = await this.media.openFile(file, this.targetDrive);
-                if (outcome) {
-                    toast(outcome, { title: "Opened" });
-                    this.close();
-                }
-            } catch (error) {
-                reportLoadFailure(file.name, error);
-            }
+            await this.openFile(file, "Opened");
             evt.target.value = "";
         });
         list.connect.addEventListener("click", async () => {

--- a/src/web/page-actions.js
+++ b/src/web/page-actions.js
@@ -29,10 +29,12 @@ export class PageActions {
         );
         window.addEventListener("focus", () => loop.setEmulationLead(audioHandler.setWindowFocused(true)), { signal });
 
-        // To lower the chance of data loss, only the drop zone in the menu bar accepts drops.
+        // Files are the media window's to take; anything else dropped on the page would replace it.
+        const carriesFiles = (event) => [...(event.dataTransfer?.types ?? [])].includes("Files");
         document.addEventListener(
             "dragover",
             (event) => {
+                if (carriesFiles(event)) return;
                 event.preventDefault();
                 event.dataTransfer.dropEffect = "none";
             },

--- a/src/web/url-state.js
+++ b/src/web/url-state.js
@@ -94,10 +94,17 @@ export class UrlState {
      * history entry for the lot.
      */
     set(changes, { settle = false } = {}) {
+        let changed = false;
         for (const [key, value] of Object.entries(changes)) {
-            if (value === undefined) delete this.params[key];
-            else this.params[key] = value;
+            if (value === undefined) {
+                if (key in this.params) changed = true;
+                delete this.params[key];
+            } else {
+                if (this.params[key] !== value) changed = true;
+                this.params[key] = value;
+            }
         }
+        if (!changed) return;
         if (settle) this.updateUrlOnceSettled();
         else this.updateUrl();
     }

--- a/tests/integration/media-window.js
+++ b/tests/integration/media-window.js
@@ -43,6 +43,7 @@ describe("the media window against a real machine", () => {
             "econetfs",
             "paste-text",
             "leds",
+            "drop-zone",
             "media-panel",
             "drive-bay-template",
             "save-state",
@@ -105,10 +106,10 @@ describe("the media window against a real machine", () => {
     const expectRowDetail = (title, matcher) =>
         vi.waitFor(() => expect(text(rowDetail(title) ?? { textContent: "(no row)" })).toMatch(matcher));
     const publicFile = (relative) => readFileSync(path.join(RepoRoot, "public", relative));
-    const dropOnPasteBox = (name, bytes) => {
+    const dropOnPage = (name, bytes) => {
         const event = new Event("drop", { bubbles: true, cancelable: true });
-        Object.defineProperty(event, "dataTransfer", { value: { files: [new File([bytes], name)] } });
-        document.getElementById("paste-text").dispatchEvent(event);
+        Object.defineProperty(event, "dataTransfer", { value: { types: ["Files"], files: [new File([bytes], name)] } });
+        document.body.dispatchEvent(event);
     };
 
     it("loads the built-in Elite into drive 0 from the list, names it in the URL and catalogues it", async () => {
@@ -166,7 +167,7 @@ describe("the media window against a real machine", () => {
         document.querySelector("#media-list .media-row-main").click();
         await vi.waitFor(() => expect(document.querySelector('.bay[data-drive="0"]').dataset.state).toBe("busy"));
 
-        dropOnPasteBox("Welcome.ssd", publicFile("discs/Welcome.ssd"));
+        dropOnPage("Welcome.ssd", publicFile("discs/Welcome.ssd"));
         await vi.waitFor(() => expect(machine.processor.fdc.drives[0].disc?.name).toBe("Welcome.ssd"));
         finishSlow({ name: "Slow.ssd", data: publicFile("discs/elite.ssd"), ignored: [] });
         await new Promise((resolve) => setTimeout(resolve, 20));

--- a/tests/playwright/smoke.spec.js
+++ b/tests/playwright/smoke.spec.js
@@ -265,3 +265,23 @@ test("every display mode and sound output on the bar can be picked", async ({ be
     }
     await beeb.expectScreenText(">");
 });
+
+test("a drive bay shows one thing at a time: the note when empty, the jacket when loaded, neither twice while busy", async ({
+    beeb,
+    page,
+}) => {
+    await beeb.open();
+    await beeb.expectScreenText(">");
+    await page.click("#navbarMedia");
+    await expect(page.locator("#media-panel")).toBeVisible();
+    const visible = (selector) => page.locator(`.bay[data-drive="0"] ${selector}`).isVisible();
+    const shown = async () => ({ note: await visible(".empty-note"), jacket: await visible(".jacket") });
+    // The page boots with a disc in drive 0; ejecting it is the empty state.
+    await page.click('.bay[data-drive="0"] .bay-eject');
+    await expect(page.locator('.bay[data-drive="0"]')).toHaveAttribute("data-state", "empty");
+    expect(await shown()).toEqual({ note: true, jacket: false });
+    await page.evaluate(() => (document.querySelector('.bay[data-drive="0"]').dataset.state = "busy"));
+    expect(await shown()).toEqual({ note: false, jacket: true });
+    await page.evaluate(() => (document.querySelector('.bay[data-drive="0"]').dataset.state = "loaded"));
+    expect(await shown()).toEqual({ note: false, jacket: true });
+});

--- a/tests/unit/test-analogue-inputs.js
+++ b/tests/unit/test-analogue-inputs.js
@@ -64,6 +64,7 @@ describe("AnalogueInputs", () => {
 
         it("refuses a channel that does not exist, says so, and clears the setting", () => {
             deps.settings.microphoneChannel = 5;
+            deps.settings.urlState.params.microphoneChannel = 5;
             const inputs = make();
             inputs.updateAdcSources(false, 5);
             for (let ch = 0; ch < 4; ch++) expect(channels[ch]).toBe(inputs.gamepadSource);
@@ -114,6 +115,7 @@ describe("AnalogueInputs", () => {
     describe("a microphone that cannot start", () => {
         it("reports, clears the setting and takes it out of the URL", async () => {
             deps.settings.microphoneChannel = 2;
+            deps.settings.urlState.params.microphoneChannel = 2;
             const inputs = make();
             vi.spyOn(inputs.microphoneInput, "initialise").mockResolvedValue(false);
             vi.spyOn(inputs.microphoneInput, "getErrorMessage").mockReturnValue("denied");

--- a/tests/unit/test-media-loader.js
+++ b/tests/unit/test-media-loader.js
@@ -140,36 +140,29 @@ describe("MediaLoader", () => {
         });
     });
 
-    describe("the drop zone", () => {
-        const drop = (file) => {
-            const event = new Event("drop", { bubbles: true, cancelable: true });
-            Object.defineProperty(event, "dataTransfer", { value: { files: file ? [file] : [] } });
-            document.getElementById("paste-text").dispatchEvent(event);
-        };
-
+    describe("opening a file", () => {
         it("hands a save state to the snapshot loader, and says so only if it was restored", async () => {
             deps.loadSnapshot.mockResolvedValue(true);
             const media = make();
-            drop(fileFor("state.snp", new Uint8Array([1])));
-            await vi.waitFor(() => expect(deps.loadSnapshot).toHaveBeenCalled());
+            expect(await media.openFile(fileFor("state.snp", new Uint8Array([1])))).toEqual({
+                kind: "snapshot",
+                name: "state.snp",
+                words: "Restored the state saved in state.snp.",
+            });
             expect(deps.drives.putDiscIn).not.toHaveBeenCalled();
-            await vi.waitFor(() => expect(toasts()).toEqual([expect.stringContaining("Restored")]));
             deps.loadSnapshot.mockResolvedValue(false);
             expect(await media.openFile(fileFor("bad.snp", new Uint8Array([1])))).toBeNull();
         });
 
-        it("puts a dropped disc in drive 0 and says so", async () => {
-            make();
-            drop(fileFor("dropped.ssd", ssdImage()));
-            await vi.waitFor(() => expect(deps.drives.putDiscIn).toHaveBeenCalled());
-            expect(toasts()).toEqual([expect.stringContaining("Loaded dropped.ssd into drive 0.")]);
-        });
-
-        it("does nothing when nothing was dropped", async () => {
-            make();
-            drop(null);
-            expect(deps.drives.putDiscIn).not.toHaveBeenCalled();
-            expect(deps.loadSnapshot).not.toHaveBeenCalled();
+        it("puts a disc in the drive it was given and says so", async () => {
+            const media = make();
+            expect(await media.openFile(fileFor("mine.ssd", ssdImage()), 1)).toEqual({
+                kind: "disc",
+                name: "mine.ssd",
+                driveIndex: 1,
+                words: "Loaded mine.ssd into drive 1.",
+            });
+            expect(deps.drives.putDiscIn).toHaveBeenCalledWith(1, expect.objectContaining({ name: "mine.ssd" }));
         });
     });
 
@@ -177,7 +170,9 @@ describe("MediaLoader", () => {
         it("remembers a disc file, lists it, and can put it in either drive again by reference", async () => {
             deps.urlState.params.disc2 = "old.ssd";
             const media = make();
-            expect(await media.openFile(fileFor("mine.ssd", ssdImage()), 1)).toBe("Loaded mine.ssd into drive 1.");
+            expect((await media.openFile(fileFor("mine.ssd", ssdImage()), 1)).words).toBe(
+                "Loaded mine.ssd into drive 1.",
+            );
             expect(deps.drives.putDiscIn).toHaveBeenCalledWith(1, expect.objectContaining({ name: "mine.ssd" }));
             expect(deps.urlState.params.disc2).toBeUndefined();
             const { descriptors } = await media.listAll();
@@ -207,7 +202,11 @@ describe("MediaLoader", () => {
             const zipped = new Uint8Array(await createZipBlob([{ name: "Chuckie.uef", data: uef }]).arrayBuffer());
             deps.urlState.params.tape = "sth:old.zip";
             const media = make();
-            expect(await media.openFile(fileFor("chuckie_egg.zip", zipped))).toBe("Loaded Chuckie.uef as the tape.");
+            expect(await media.openFile(fileFor("chuckie_egg.zip", zipped))).toEqual({
+                kind: "tape",
+                name: "Chuckie.uef",
+                words: "Loaded Chuckie.uef as the tape.",
+            });
             expect(deps.urlState.params.tape).toBeUndefined();
             expect(deps.processor.tapeInterface.setTape).toHaveBeenCalledWith(
                 expect.objectContaining({ name: "Chuckie.uef" }),

--- a/tests/unit/test-media-window.js
+++ b/tests/unit/test-media-window.js
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { MediaWindow, shortName } from "../../src/web/media-window.js";
 import { describeRef, sourceOf } from "../../src/web/media-catalogue.js";
+import { Schemas } from "../../src/media-resolver.js";
 import { MediaSlots } from "../../src/web/media-slots.js";
 import { Drives } from "../../src/web/drives.js";
 import { DriveTracks } from "../../src/url-params.js";
@@ -27,7 +28,7 @@ describe("MediaWindow", () => {
     let urlState;
 
     beforeEach(() => {
-        domFromIndexHtml("navbarSupportedContent", "leds", "media-panel", "drive-bay-template");
+        domFromIndexHtml("navbarSupportedContent", "leds", "drop-zone", "media-panel", "drive-bay-template");
         document.querySelector(".media-header").setPointerCapture = () => {};
         fdc = fakeFdc();
         tapeInterface = {
@@ -78,9 +79,14 @@ describe("MediaWindow", () => {
         };
     });
 
-    afterEach(teardownDom);
+    let made;
+    afterEach(() => {
+        made?.dispose();
+        made = null;
+        return teardownDom();
+    });
 
-    const make = () => new MediaWindow(deps);
+    const make = () => (made = new MediaWindow(deps));
     const panel = () => document.getElementById("media-panel");
     const bay = (driveIndex) => document.querySelector(`.bay[data-drive="${driveIndex}"]`);
     const text = (el) => el.textContent.replace(/\s+/g, " ").trim();
@@ -905,7 +911,12 @@ describe("MediaWindow", () => {
         });
 
         it("opens a file into the aimed drive from the footer, and connects Google Drive", async () => {
-            deps.media.openFile.mockResolvedValue("Loaded mine.ssd into drive 1.");
+            deps.media.openFile.mockResolvedValue({
+                kind: "disc",
+                name: "mine.ssd",
+                driveIndex: 1,
+                words: "Loaded mine.ssd into drive 1.",
+            });
             await openWith([]);
             bay(1).querySelector(".bay-slot").click();
             const input = document.getElementById("media-open");
@@ -981,6 +992,94 @@ describe("MediaWindow", () => {
             expect(text(document.getElementById("media-count"))).toBe("showing 100 of 120; keep typing to narrow it");
             search("Disc 11");
             expect(text(document.getElementById("media-count"))).toBe("11 of 120");
+        });
+    });
+
+    describe("the page as a drop zone", () => {
+        const dragEvent = (type, target = document.body) => {
+            const event = new Event(type, { bubbles: true, cancelable: true });
+            Object.defineProperty(event, "dataTransfer", { value: { types: ["Files"], files: [], dropEffect: "" } });
+            target.dispatchEvent(event);
+            return event;
+        };
+        const dropFile = (file) => {
+            const event = new Event("drop", { bubbles: true, cancelable: true });
+            Object.defineProperty(event, "dataTransfer", { value: { types: ["Files"], files: [file] } });
+            document.body.dispatchEvent(event);
+        };
+        const zone = () => document.getElementById("drop-zone");
+
+        it("shows where a file will go while one is over the page, and hides when it leaves", () => {
+            make();
+            expect(zone().hidden).toBe(true);
+            dragEvent("dragenter");
+            expect(zone().hidden).toBe(false);
+            expect(text(zone())).toContain("a disc goes into drive 0");
+            dragEvent("dragenter", document.getElementById("leds"));
+            dragEvent("dragleave", document.getElementById("leds"));
+            expect(zone().hidden).toBe(false);
+            dragEvent("dragleave");
+            expect(zone().hidden).toBe(true);
+        });
+
+        it("ignores a drag that carries no files", () => {
+            make();
+            const event = new Event("dragenter", { bubbles: true, cancelable: true });
+            Object.defineProperty(event, "dataTransfer", { value: { types: ["text/plain"], files: [] } });
+            document.body.dispatchEvent(event);
+            expect(zone().hidden).toBe(true);
+            expect(event.defaultPrevented).toBe(false);
+        });
+
+        it("opens a dropped file into the aimed drive and says so", async () => {
+            deps.media.openFile.mockResolvedValue({
+                kind: "disc",
+                name: "mine.ssd",
+                driveIndex: 1,
+                words: "Loaded mine.ssd into drive 1.",
+            });
+            const window = await openWith([]);
+            document.querySelector('#media-into [data-target="1"]').click();
+            dragEvent("dragenter");
+            dropFile(new File([new Uint8Array(4)], "mine.ssd"));
+            await vi.waitFor(() => expect(deps.media.openFile).toHaveBeenCalledWith(expect.anything(), 1));
+            await vi.waitFor(() =>
+                expect(toasts()).toEqual([expect.stringContaining("Loaded mine.ssd into drive 1.")]),
+            );
+            expect(zone().hidden).toBe(true);
+            expect(window.isOpen).toBe(false);
+            expect(deps.processor.reset).not.toHaveBeenCalled();
+        });
+
+        it("boots a disc dropped into drive 0 when Autoboot is ticked", async () => {
+            deps.media.params.autoboot = "";
+            deps.media.openFile.mockResolvedValue({
+                kind: "disc",
+                name: "game.ssd",
+                driveIndex: 0,
+                words: "Loaded game.ssd into drive 0.",
+            });
+            make();
+            dropFile(new File([new Uint8Array(4)], "game.ssd"));
+            await vi.waitFor(() => expect(deps.autoboot).toHaveBeenCalledWith("game.ssd"));
+            expect(deps.processor.reset).toHaveBeenCalledWith(true);
+        });
+
+        it("does not boot a tape or a restored state, whatever the tick says", async () => {
+            deps.media.params.autoboot = "";
+            deps.media.openFile.mockResolvedValue({ kind: "tape", name: "t.uef", words: "Loaded t.uef as the tape." });
+            make();
+            dropFile(new File([new Uint8Array(4)], "t.uef"));
+            await vi.waitFor(() => expect(toasts()).toHaveLength(1));
+            expect(deps.processor.reset).not.toHaveBeenCalled();
+        });
+
+        it("reports a file that could not be opened", async () => {
+            vi.spyOn(console, "error").mockImplementation(() => {});
+            deps.media.openFile.mockRejectedValue(new Error("not a disc"));
+            make();
+            dropFile(new File([new Uint8Array(4)], "junk.bin"));
+            await vi.waitFor(() => expect(toasts()).toEqual([expect.stringContaining("not a disc")]));
         });
     });
 
@@ -1192,6 +1291,13 @@ describe("MediaWindow", () => {
             expect(sourceOf("elite.ssd")).toBe("built in");
             expect(sourceOf("session:mine.ssd")).toBe("a file opened this session");
             expect(sourceOf(undefined)).toBeNull();
+        });
+
+        it("has words for every schema a reference can take", () => {
+            for (const schema of Object.keys(Schemas)) {
+                const ref = schema === "" ? "x.ssd" : schema.length === 1 ? `${schema}x.ssd` : `${schema}:x.ssd`;
+                expect(sourceOf(ref), schema).toBeTruthy();
+            }
         });
     });
 });

--- a/tests/unit/test-page-actions.js
+++ b/tests/unit/test-page-actions.js
@@ -122,16 +122,28 @@ describe("PageActions", () => {
     });
 
     describe("drops", () => {
-        it("refuses drops anywhere but the drop zone", () => {
-            make();
+        const dragOver = (types) => {
             const over = new Event("dragover", { cancelable: true, bubbles: true });
-            over.dataTransfer = { dropEffect: "copy" };
+            over.dataTransfer = { dropEffect: "copy", types };
             document.body.dispatchEvent(over);
+            return over;
+        };
+
+        it("refuses a drag that carries no file, so a dropped link cannot replace the page", () => {
+            make();
+            const over = dragOver(["text/uri-list"]);
             expect(over.defaultPrevented).toBe(true);
             expect(over.dataTransfer.dropEffect).toBe("none");
             const drop = new Event("drop", { cancelable: true, bubbles: true });
             document.body.dispatchEvent(drop);
             expect(drop.defaultPrevented).toBe(true);
+        });
+
+        it("leaves a drag that carries files to the media window", () => {
+            make();
+            const over = dragOver(["Files"]);
+            expect(over.defaultPrevented).toBe(false);
+            expect(over.dataTransfer.dropEffect).toBe("copy");
         });
     });
 

--- a/tests/unit/test-url-state.js
+++ b/tests/unit/test-url-state.js
@@ -62,6 +62,14 @@ describe("UrlState", () => {
         }
     });
 
+    it("makes no history for a change that changes nothing", () => {
+        const state = new UrlState(location("?disc1=a.ssd"), history);
+        state.set({ disc1: "a.ssd", tape: undefined });
+        expect(history.pushState).not.toHaveBeenCalled();
+        state.set({ disc1: "b.ssd" });
+        expect(history.pushState).toHaveBeenCalledTimes(1);
+    });
+
     it("deletes a parameter set to undefined", () => {
         const state = new UrlState(location("?model=B&disc=elite.ssd"), history);
         state.set({ disc: undefined });


### PR DESCRIPTION
The first three follow-ups from #1091.

- **A page-wide drop zone** (the rest of #629). Drop a file anywhere: an overlay says where a disc will go while a file is over the page, a disc goes into the aimed drive, a tape into the deck, a save state is restored, and a disc dropped into drive 0 boots when Autoboot is ticked, as one from the list does. The paste box is a paste box again.
- **One schema table.** The resolver's routing and the catalogue's "where it came from" both read `Schemas` in `media-resolver.js`, so a schema cannot be served without a source or a phrase; the `sourceOf` test walks the table rather than a list of its own. This is the fix for the dropped `session` row Copilot found in #1091.
- **No history for a no-op.** `UrlState.set` pushes nothing when the parameters did not change, which the media slots were sidestepping and the settings were not.
- **A browser check of the bay's states**: which of the empty note and the jacket show for empty, busy and loaded, the class of bug a unit test cannot see.

Closes #629.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
