### PR TITLE
fix: a phone lays the page out at its own width, the monitor takes all of it, and the LED bar reads down

### DIFF
--- a/src/jsbeeb.css
+++ b/src/jsbeeb.css
@@ -2,6 +2,13 @@ body {
   overflow: hidden;
   visibility: visible !important; /* see index.html */
 }
+/* The monitor's side pictures and the canvas before it is fitted reach past the window's edge; a
+   phone would otherwise widen its layout to take them in and shrink the whole page to fit. */
+html,
+body {
+  overflow-x: hidden;
+}
+
 #outer {
   display: block;
 }
@@ -155,6 +162,7 @@ span.accesskey {
 #leds .lights {
   border-left: 1px solid #444;
   padding-left: 8px;
+  align-items: flex-end;
 }
 
 #leds .hdr {
@@ -176,15 +184,16 @@ span.accesskey {
   margin-top: 2px;
 }
 
-/* A slot's line: the header sits over its LED, and the name runs to the right of both. */
+/* A slot reads down: its header, the name of what it holds, then its LED with the tape counter beside. */
 #leds .slot-readout {
   display: grid;
-  grid-template-columns: auto minmax(0, 1fr) auto;
-  grid-template-rows: auto auto;
+  grid-template-columns: auto auto;
+  grid-template-rows: auto auto auto;
+  justify-items: center;
   align-items: center;
-  column-gap: 6px;
-  row-gap: 3px;
-  width: 10em;
+  gap: 3px 4px;
+  min-width: 6.5em;
+  max-width: 9em;
   padding: 1px 6px;
   border: 1px solid transparent;
   border-radius: 4px;
@@ -194,46 +203,47 @@ span.accesskey {
   cursor: pointer;
 }
 
-#leds .slot-readout[data-slot="tape"] {
-  width: 13.5em;
-}
-
 #leds .slot-readout:hover,
 #leds .slot-readout:focus-visible {
   background: rgba(255, 255, 255, 0.06);
   border-color: #444;
 }
 
-#leds .slot-readout .hdr {
-  grid-column: 1;
-  grid-row: 1;
-}
-
 #leds .slot-readout .line {
   display: contents;
 }
 
-#leds .slot-readout .led {
-  grid-column: 1;
-  grid-row: 2;
-  justify-self: center;
+#leds .slot-readout .hdr {
+  grid-row: 1;
+  grid-column: 1 / -1;
 }
 
 #leds .slot-readout .name {
-  grid-column: 2;
   grid-row: 2;
-  min-width: 0;
+  grid-column: 1 / -1;
+  max-width: 100%;
   overflow: hidden;
   text-overflow: ellipsis;
-  text-align: left;
   font-family: var(--bs-font-monospace);
   font-size: 10px;
   white-space: nowrap;
 }
 
+#leds .slot-readout .led {
+  grid-row: 3;
+  grid-column: 1 / -1;
+}
+
+/* The tape's lamp shares its line with the counter. */
+#leds .slot-readout[data-slot="tape"] .led {
+  grid-column: 1;
+  justify-self: end;
+}
+
 #leds .slot-readout .counter {
-  grid-column: 3;
-  grid-row: 2;
+  grid-row: 3;
+  grid-column: 2;
+  justify-self: start;
   font-family: var(--bs-font-monospace);
   font-size: 10px;
   white-space: nowrap;

--- a/src/web/layout.js
+++ b/src/web/layout.js
@@ -3,6 +3,10 @@ import { errorText } from "./reporting.js";
 
 /** Steps the drawing buffer grows in, as a multiple of the base canvas size. */
 const CanvasScaleStep = 0.25;
+/** Below this width the side pictures are not worth a border; the monitor takes the whole width. */
+const NarrowWindow = 700;
+/** Clearance between the monitor and the LED panel below it. */
+const LedPanelGap = 10;
 
 /**
  * Where everything goes for a given window: the monitor picture, the canvas
@@ -122,6 +126,12 @@ export class Layout {
         }
     }
 
+    /** What the LED panel needs below the monitor: its own height, which its layout decides. */
+    ledPanelRoom() {
+        const panel = document.getElementById("leds");
+        return Math.max(this.bottomReservedSize, (panel?.offsetHeight ?? 0) + LedPanelGap);
+    }
+
     resize() {
         // The display config can change when the display mode switches.
         const displayConfig = this.display.filterClass.getDisplayConfig();
@@ -131,8 +141,8 @@ export class Layout {
                 innerWidth: window.innerWidth,
                 innerHeight: window.innerHeight,
                 navbarHeight: navbarHeightOf(document.getElementById("header-bar")),
-                borderReservedSize: this.borderReservedSize,
-                bottomReservedSize: this.bottomReservedSize,
+                borderReservedSize: window.innerWidth <= NarrowWindow ? 0 : this.borderReservedSize,
+                bottomReservedSize: this.bottomReservedSize && this.ledPanelRoom(),
                 devicePixelRatio: window.devicePixelRatio || 1,
             },
             { width: this.screenCanvas.getAttribute("width"), height: this.screenCanvas.getAttribute("height") },

--- a/tests/unit/test-layout.js
+++ b/tests/unit/test-layout.js
@@ -168,6 +168,15 @@ describe("Layout", () => {
             expect(monitor.style.height).toBe("618px");
         });
 
+        it("gives the monitor a narrow window's whole width, with no border for side pictures", () => {
+            vi.spyOn(window, "innerWidth", "get").mockReturnValue(412);
+            vi.spyOn(window, "innerHeight", "get").mockReturnValue(780);
+            make({ embed: false });
+            resize();
+            expect(document.getElementById("cub-monitor").style.width).toBe("412px");
+            vi.restoreAllMocks();
+        });
+
         it("takes two more looks shortly after load, when the page has settled", () => {
             make();
             expect(display.filterClass.getDisplayConfig).not.toHaveBeenCalled();


### PR DESCRIPTION
Fixes #1107, and the rest of what #1103 reported.

- **The page widened a phone's layout viewport.** The monitor's side pictures and its canvas, before the page has fitted them, reach past the window's edge, and Chrome on a phone widens the layout to take them in: the whole page renders shrunk, the LED bar sits at the bottom of a taller layout than the screen shows, and a tap that fires a resize refits everything to that layout. Hiding horizontal overflow on the page stops it, and the layout comes out at the phone's real width. This predates the media window; the taller LED bar made it visible.
- **The monitor came out at its minimum on a phone** once the width was right, because the window reserves 100px each side for the side pictures whatever its width. A narrow window reserves nothing.
- **The room under the monitor** is now what the LED bar actually needs, measured, rather than a fixed 68px the three-line bar had outgrown.
- **Each LED slot reads down** (#1107): header, the name of what it holds, then the lamp, with the tape counter beside its lamp. The bar is about a third narrower on a desktop and fits a phone with room to spare.

Checked in headless Chrome emulating a 412px phone: the layout viewport is 412 wide, the monitor fills it, the bar sits inside the viewport, and nothing scrolls sideways.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
