### PR TITLE
fix: each LED slot's header is one line, and the bar is the same on a phone as on a desktop

### DIFF
--- a/index.html
+++ b/index.html
@@ -326,15 +326,15 @@
       <div id="leds">
         <div class="slot-readouts" role="group" aria-label="What is loaded">
           <button type="button" class="slot-readout media-window-open bbc-only" data-slot="0">
-            <span class="hdr">drive<br />0/2</span>
+            <span class="hdr">drive 0/2</span>
             <span class="line"><span class="led disc" id="drive0"></span><span class="name"></span></span>
           </button>
           <button type="button" class="slot-readout media-window-open bbc-only" data-slot="1">
-            <span class="hdr">drive<br />1/3</span>
+            <span class="hdr">drive 1/3</span>
             <span class="line"><span class="led disc" id="drive1"></span><span class="name"></span></span>
           </button>
           <button type="button" class="slot-readout media-window-open" data-slot="tape">
-            <span class="hdr">cassette<br />motor</span>
+            <span class="hdr">cassette motor</span>
             <span class="line"
               ><span class="led tape" id="motorlight"></span><span class="name"></span><span class="counter"></span
             ></span>

--- a/src/jsbeeb.css
+++ b/src/jsbeeb.css
@@ -147,6 +147,7 @@ span.accesskey {
   left: 0;
   position: fixed;
   display: flex;
+  flex-wrap: wrap;
   align-items: stretch;
   gap: 8px;
   color: #ddd;
@@ -2322,40 +2323,5 @@ div.smoothie-chart-tooltip {
   .media-row .media-keycap {
     grid-column: 3;
     grid-row: 1 / span 3;
-  }
-}
-
-/* ----- a phone's LED panel: the slots share the width instead of overflowing it ----- */
-
-@media (max-width: 560px) {
-  #leds {
-    right: 0;
-    margin: 2px;
-    padding: 3px 4px;
-    gap: 4px;
-  }
-
-  #leds .slot-readouts {
-    flex: 1 1 0;
-    min-width: 0;
-    gap: 2px;
-  }
-
-  #leds .slot-readout,
-  #leds .slot-readout[data-slot="tape"] {
-    width: auto;
-    flex: 1 1 0;
-    min-width: 0;
-    padding: 1px 3px;
-    column-gap: 4px;
-  }
-
-  #leds .lights {
-    gap: 3px;
-    padding-left: 4px;
-  }
-
-  #leds .cell.econet {
-    display: none;
   }
 }


### PR DESCRIPTION
The rest of #1107, from testing on a phone: each slot's header ("drive 0/2", "drive 1/3", "cassette motor") is one line over the name and the lamp, and the bar has one layout everywhere. The phone-only rules from #1104 are gone; the bar as it now is fits a 412px phone, and wraps rather than overflowing on anything narrower.

Not merged; ready for you.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
