### PR TITLE
refactor: the 8271 status register is composed from what the host can see

### DIFF
--- a/src/intel-fdc.js
+++ b/src/intel-fdc.js
@@ -304,7 +304,6 @@ export class IntelFdc {
 
         this._regs = new Uint8Array(IntelFdc.NumRegisters);
         this._isResultReady = false;
-        // Derived from one of the regs plus _isResultReady.
         this._status = 0;
         this._mmioData = 0;
         this._mmioClocks = 0;
@@ -1046,27 +1045,11 @@ export class IntelFdc {
         // READ DRIVE STATUS:                        188us
         // write $35 to parameter register:           31us
         // write 3rd SPECIFY parameter:               27us
-        let status = this.internalStatus;
-        // The internal status register appears to be shared with some mode bits that
-        // must be masked out.
-        status &= ~0x03;
-        // Current best thinking is that the internal register uses bit value 0x10 for
-        // something different, and that "result ready" is maintained by the external
-        // register logic.
-        status &= ~StatusFlag.resultReady;
-        if (this._isResultReady) {
-            status |= StatusFlag.resultReady;
-        }
-
-        // TODO(#1060) "command register full", bit value 0x40, isn't understood. In
-        // particular, the mode register (shared with the status register we
-        // believe) is set to 0xC1 in typical operation. This would seem to raise
-        // 0x40 after it has been lowered at command register acceptance. However,
-        // the bit is not returned.
-        // Don't return it, ever, for now.
-        // Also avoid "parameter register full".
-        status &= ~0x60;
-
+        // Command register full and parameter register full are set by the host's write and cleared
+        // when the 8271's microcontroller accepts the byte, which here is the same instant. The mode
+        // register shares this byte; result ready is kept by the external register logic.
+        let status = this.internalStatus & (StatusFlag.busy | StatusFlag.nmi | StatusFlag.needData);
+        if (this._isResultReady) status |= StatusFlag.resultReady;
         this._status = status;
     }
 

--- a/src/intel-fdc.js
+++ b/src/intel-fdc.js
@@ -1045,9 +1045,14 @@ export class IntelFdc {
         // READ DRIVE STATUS:                        188us
         // write $35 to parameter register:           31us
         // write 3rd SPECIFY parameter:               27us
-        // Command register full and parameter register full are set by the host's write and cleared
-        // when the 8271's microcontroller accepts the byte, which here is the same instant. The mode
-        // register shares this byte; result ready is kept by the external register logic.
+        // EMU NOTE: command register full and parameter register full are set by the host's write
+        // and cleared when the 8271's microcontroller accepts the byte; see Chris Evans's ROM
+        // reverse engineering, https://scarybeastsecurity.blogspot.com/2020/11/reverse-engineering-forgotten-1970s.html
+        // On the real chip acceptance takes the tens of microseconds listed above; here it happens
+        // in the same write, so neither bit is ever reported. Software only polls for them to
+        // clear, so nothing waits on them being set, and the latency is left unmodelled rather
+        // than guessed from two measurements. The mode register shares this byte; result ready
+        // is kept by the external register logic.
         let status = this.internalStatus & (StatusFlag.busy | StatusFlag.nmi | StatusFlag.needData);
         if (this._isResultReady) status |= StatusFlag.resultReady;
         this._status = status;

--- a/tests/unit/test-intel-fdc.js
+++ b/tests/unit/test-intel-fdc.js
@@ -45,13 +45,13 @@ describe("Intel 8271 tests", function () {
     const paramFull = 0x20;
     const resultReady = 0x10;
     const loadHead = 0x08;
-    const select1 = 0x40;
+    const driveSelect1 = 0x40;
     const writeRegCmd = 0x3a;
     const readDriveStatusCmd = 0x2c;
     const mmioWrite = 0x23;
-    const seekCmd = (0x0a << 2) | select1 | 1;
+    const seekCmd = (0x0a << 2) | driveSelect1 | 1;
 
-    it("should contruct and start out idle", () => {
+    it("should construct and start out idle", () => {
         const fakeCpu = fake6502();
         const scheduler = new Scheduler();
         const fdc = new IntelFdc(fakeCpu, scheduler);
@@ -74,7 +74,7 @@ describe("Intel 8271 tests", function () {
         const fdc = new IntelFdc(fakeCpu, scheduler, [fakeDrive]);
         expect(fdc._driveOut & loadHead).toBe(0);
         expect(fakeDrive.spinning).toBe(false);
-        sendCommand(fdc, writeRegCmd, mmioWrite, loadHead | select1);
+        sendCommand(fdc, writeRegCmd, mmioWrite, loadHead | driveSelect1);
         expect(fdc._driveOut & loadHead).toBe(loadHead);
         expect(fakeDrive.spinning).toBe(true);
     });
@@ -83,7 +83,7 @@ describe("Intel 8271 tests", function () {
         const scheduler = new Scheduler();
         const fakeDrive = new FakeDrive();
         const fdc = new IntelFdc(fakeCpu, scheduler, [fakeDrive]);
-        sendCommand(fdc, writeRegCmd, mmioWrite, loadHead | select1);
+        sendCommand(fdc, writeRegCmd, mmioWrite, loadHead | driveSelect1);
         // nb will seek two more due to bad track nonsense
         sendCommand(fdc, seekCmd, 2);
         expect(fakeDrive.track).toBe(1);

--- a/tests/unit/test-intel-fdc.js
+++ b/tests/unit/test-intel-fdc.js
@@ -40,6 +40,17 @@ function sendCommand(fdc, command, ...params) {
 }
 
 describe("Intel 8271 tests", function () {
+    const busy = 0x80;
+    const commandFull = 0x40;
+    const paramFull = 0x20;
+    const resultReady = 0x10;
+    const loadHead = 0x08;
+    const select1 = 0x40;
+    const writeRegCmd = 0x3a;
+    const readDriveStatusCmd = 0x2c;
+    const mmioWrite = 0x23;
+    const seekCmd = (0x0a << 2) | select1 | 1;
+
     it("should contruct and start out idle", () => {
         const fakeCpu = fake6502();
         const scheduler = new Scheduler();
@@ -52,15 +63,9 @@ describe("Intel 8271 tests", function () {
         const fakeCpu = fake6502();
         const scheduler = new Scheduler();
         const fdc = new IntelFdc(fakeCpu, scheduler);
-        fdc.write(0, 0x3a);
-        expect(fdc.internalStatus).toBe(0x80); // 0x80 = busy
+        fdc.write(0, writeRegCmd);
+        expect(fdc.internalStatus).toBe(busy);
     });
-
-    const loadHead = 0x08;
-    const select1 = 0x40;
-    const writeRegCmd = 0x3a;
-    const mmioWrite = 0x23;
-    const seekCmd = (0x0a << 2) | select1 | 1;
 
     it("should spin up when poked", () => {
         const fakeCpu = fake6502();
@@ -89,5 +94,46 @@ describe("Intel 8271 tests", function () {
         // We should reach and stop at track 4.
         scheduler.polltime(6000 * 10);
         expect(fakeDrive.track).toBe(4);
+    });
+
+    describe("status register", () => {
+        const statusAddr = 0;
+        const resultAddr = 1;
+        const readSpecialRegisterCmd = 0x3d;
+        const modeRegister = 0x17;
+        const dfsMode = 0xc1;
+
+        function makeFdc() {
+            return new IntelFdc(fake6502(), new Scheduler(), [new FakeDrive()]);
+        }
+
+        it("does not report command or parameter register full after the mode register is written", () => {
+            const fdc = makeFdc();
+            sendCommand(fdc, writeRegCmd, modeRegister, dfsMode);
+            expect(fdc.read(statusAddr)).toBe(0);
+            sendCommand(fdc, readDriveStatusCmd);
+            expect(fdc.read(statusAddr)).toBe(resultReady);
+        });
+
+        it("keeps the mode bits in the shared internal byte where read special register sees them", () => {
+            const fdc = makeFdc();
+            sendCommand(fdc, writeRegCmd, modeRegister, dfsMode);
+            sendCommand(fdc, readSpecialRegisterCmd, modeRegister);
+            expect(fdc.read(resultAddr)).toBe(dfsMode & ~commandFull);
+        });
+
+        it("shows busy but not command register full once a command taking parameters is written", () => {
+            const fdc = makeFdc();
+            sendCommand(fdc, writeRegCmd);
+            expect(fdc.read(statusAddr) & (busy | commandFull)).toBe(busy);
+        });
+
+        it("does not report parameter register full after any parameter write", () => {
+            const fdc = makeFdc();
+            sendCommand(fdc, writeRegCmd, modeRegister);
+            expect(fdc.read(statusAddr) & (busy | paramFull)).toBe(busy);
+            sendCommand(fdc, writeRegCmd, modeRegister, dfsMode);
+            expect(fdc.read(statusAddr) & (busy | paramFull)).toBe(0);
+        });
     });
 });


### PR DESCRIPTION
Refs #1060.

The 8271's status register read used to mask 0x60 out of the shared internal status/mode byte under a TODO saying "command register full" was not understood. It is understood now, from the datasheet's command-phase flowchart and Chris Evans's (@scarybeasts) 8271 ROM reverse engineering, written up in [Reverse engineering a forgotten 1970s Intel dual core beast: 8271, a new ISA](https://scarybeastsecurity.blogspot.com/2020/11/reverse-engineering-forgotten-1970s.html):

- Command register full (0x40) is set by the host's write to the command register and cleared by the 8271's microcontroller when it accepts the command. The ROM's `.wakeup_COMMAND` handler in that post clears it in its first instructions (`AND I7,#$BF` on R23, the shared byte).
- Parameter register full (0x20) works the same way: set by the host's parameter write, cleared when the ROM's parameter callback consumes it.
- The datasheet's flowchart has the host loop while command busy before writing a command and loop while parameter full before each parameter. DFS does exactly that.

The emulation accepts commands and parameters in the same instant as the host's write, so neither bit is ever observable, and that is why they were "never reported". DFS's write of 0xC1 to the mode register lands in the shared byte but the external bit is the host-write latch, not that byte, so it must not show through; that is what the old mask was protecting.

This change composes the external status from the bits that can show (busy, interrupt request, data request) plus the existing external result-ready latch, and deletes the TODO. No behaviour changes. Tests pin the contract: the mode write leaves status at zero, a parameter write never shows 0x20, a command with parameters shows busy without 0x40, and read special register 0x17 still sees the shared byte internally (0x81: the ROM's clear of bit 6 has happened, the mode bits remain).

### What this deliberately does not do

Making the bits observable means deferring acceptance on the scheduler. The EMU NOTE above `_updateExternalStatus` already records measurements from a real machine ("write $35 to parameter register: 31us", "write 3rd SPECIFY parameter: 27us"), so parameter acceptance could be modelled as a ~30 us window during which 0x20 reads set and a second parameter write overwrites the first, as the datasheet says. I did not do that here because the benefit is only visible to software that waits for the bit to be *set*, which the datasheet's flowchart never does, while the cost is a new class of failure for any loader that writes parameters back to back faster than the real chip accepts them, and the two measurements may not be the general case. If you would like that modelled, it is a small follow-up (pending parameter, a scheduler task, and the snapshot gains that state); you may also know what the 31 us actually measured.

🤖 Generated with [Claude Code](https://claude.com/claude-code)