### PR TITLE
fix: FM pulses are written in the phase the decoder samples, so fuzzy bits read as fuzzy

### DIFF
--- a/src/disc.js
+++ b/src/disc.js
@@ -1348,6 +1348,7 @@ export class IbmDiscFormat {
             clocks = (clocks << 1) & 0xff;
             data = (data << 1) & 0xff;
         }
+        // Bit 7's clock lands in bit 31, so back to unsigned.
         return ret >>> 0;
     }
 

--- a/src/disc.js
+++ b/src/disc.js
@@ -1343,12 +1343,12 @@ export class IbmDiscFormat {
         let ret = 0;
         for (let i = 0; i < 8; ++i) {
             ret <<= 4;
-            if (clocks & 0x80) ret |= 0x04;
-            if (data & 0x80) ret |= 0x01;
+            if (clocks & 0x80) ret |= 0x08;
+            if (data & 0x80) ret |= 0x02;
             clocks = (clocks << 1) & 0xff;
             data = (data << 1) & 0xff;
         }
-        return ret;
+        return ret >>> 0;
     }
 
     static _2usPulsesToFm(pulses) {

--- a/tests/unit/test-disc-drive.js
+++ b/tests/unit/test-disc-drive.js
@@ -72,6 +72,18 @@ describe("Disc drive tests", function () {
         scheduler.polltime(1000000);
         expect(called).toBe(true);
     });
+    it("makes quasi random pulses the FM decoder reads as clean data that changes over time", () => {
+        const scheduler = new Scheduler();
+        const drive = new DiscDrive(0, scheduler);
+        const first = IbmDiscFormat._2usPulsesToFm(drive.getQuasiRandomPulses());
+        expect(first).toMatchObject({ clocks: 0xff, iffyPulses: false });
+        const seen = new Set();
+        for (let i = 0; i < 8; ++i) {
+            scheduler.polltime(1000);
+            seen.add(IbmDiscFormat._2usPulsesToFm(drive.getQuasiRandomPulses()).data);
+        }
+        expect(seen.size).toBeGreaterThan(1);
+    });
     it("asserts index all the time with no disc", () => {
         const scheduler = new Scheduler();
         const drive = new DiscDrive(0, scheduler);

--- a/tests/unit/test-disc.js
+++ b/tests/unit/test-disc.js
@@ -82,33 +82,45 @@ describe("IBM disc format tests", function () {
         expect(crc).toBe(0x9d39);
     });
     it("converts to FM pulses", () => {
-        expect(IbmDiscFormat.fmTo2usPulses(0xff, 0x00)).toBe(0x44444444);
-        expect(IbmDiscFormat.fmTo2usPulses(0xff, 0xff)).toBe(0x55555555);
-        expect(IbmDiscFormat.fmTo2usPulses(0xc7, 0xfe)).toBe(0x55111554);
+        expect(IbmDiscFormat.fmTo2usPulses(0xff, 0x00)).toBe(0x88888888);
+        expect(IbmDiscFormat.fmTo2usPulses(0xff, 0xff)).toBe(0xaaaaaaaa);
+        expect(IbmDiscFormat.fmTo2usPulses(0xc7, 0xfe)).toBe(0xaa222aa8);
     });
     it("converts from FM pulses", () => {
-        // TODO(#1061) either fix these or understand why beebjit doesn't use same bit posn for bits.
-        const deliberateFudge = 1;
-        expect(IbmDiscFormat._2usPulsesToFm(0x44444444 << deliberateFudge)).toEqual({
+        expect(IbmDiscFormat._2usPulsesToFm(0x88888888)).toEqual({
             clocks: 0xff,
             data: 0x00,
             iffyPulses: false,
         });
-        expect(IbmDiscFormat._2usPulsesToFm(0x55555555 << deliberateFudge)).toEqual({
+        expect(IbmDiscFormat._2usPulsesToFm(0xaaaaaaaa)).toEqual({
             clocks: 0xff,
             data: 0xff,
             iffyPulses: false,
         });
-        expect(IbmDiscFormat._2usPulsesToFm(0x55111554 << deliberateFudge)).toEqual({
+        expect(IbmDiscFormat._2usPulsesToFm(0xaa222aa8)).toEqual({
             clocks: 0xc7,
             data: 0xfe,
             iffyPulses: false,
         });
-        expect(IbmDiscFormat._2usPulsesToFm((0x55111554 << deliberateFudge) | 0x05)).toEqual({
+        expect(IbmDiscFormat._2usPulsesToFm(0xaa222aa8 | 0x05)).toEqual({
             clocks: 0xc7,
             data: 0xfe,
             iffyPulses: true,
         });
+    });
+    it("reads back what it wrote in FM", () => {
+        for (const [clocks, data] of [
+            [0xff, 0x00],
+            [0xff, 0xff],
+            [IbmDiscFormat.markClockPattern, IbmDiscFormat.idMarkDataPattern],
+            [0x00, 0x00],
+        ]) {
+            expect(IbmDiscFormat._2usPulsesToFm(IbmDiscFormat.fmTo2usPulses(clocks, data))).toEqual({
+                clocks,
+                data,
+                iffyPulses: false,
+            });
+        }
     });
     it("converts to MFM pulses", () => {
         expect(IbmDiscFormat.mfmTo2usPulses(false, 0x00)).toEqual({ lastBit: false, pulses: 0xaaaa });


### PR DESCRIPTION
Found while working on #1061, whose test for the FM pulse conversion had to shift its input by a "deliberate fudge" of one bit to pass.

An FM bit cell is four 2 us slots. `IbmDiscFormat.fmTo2usPulses` wrote the clock pulse in the second slot and the data pulse in the fourth, while `_2usPulsesToFm` samples the first and third and treats the other two as off-clock ("iffy") pulses. Every reader in the codebase locks on to the decoder's phase for itself (the sliding mark detectors in `disc.js` and the 1770, and the 8271's bit-serial state machine), so the mismatch did nothing on ordinary tracks. beebjit has the same pair of functions with the same mismatch.

It was not harmless for the 1770's fuzzy-bit path. When an FM byte arrives with off-clock pulses (MFM data read as FM, the classic weak-bit protection), `_bitReceived` substitutes a decode of the drive's quasi-random pulses, which the comment there says should give a non-stable read. Those pulses come from the same encoder, so under the old phase they decoded as data 0x00 with the iffy flag set, every time: the "fuzzy" bits were a stable zero.

The encoder now writes the phase the decoder samples, so the two are exact inverses; the unit tests assert that directly and the fudge is gone. A new test checks the drive's quasi-random pulses decode cleanly and change over time, and fails on main.

Two knock-on effects, both corrections rather than regressions:

- Fuzzy bits on the 1770 (Master, B+) now read as varying bytes. The 8271 has no such path, so the copy-protection integration tests (which run on the B with DFS 1.2) do not depend on the old stable zero; the full integration suite passes.
- `Track.findSectorIds` now reports FM `idPosBitOffset` and `dataPosBitOffset` on the word boundary rather than one bit past it, so the disc surface view's `fill` no longer spills one word into the following gap for FM sectors. MFM offsets were already exact.

The same encoder change is also on the #1061 branch, which depends on it; the branches merge cleanly in either order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)