### PR TITLE
refactor: disc code tidy-ups from the TODO notes

### DIFF
--- a/src/disc-drive.js
+++ b/src/disc-drive.js
@@ -6,6 +6,36 @@ import { Scheduler } from "./scheduler.js";
 import { Disc } from "./disc.js";
 import { IbmDiscFormat } from "./disc.js";
 
+const SpinDebounceMs = 2;
+
+/**
+ * Plays the spin and seek noises for a set of drives.
+ * @param {BaseDiscDrive[]} drives
+ * @param {import("./ddnoise.js").DdNoise|import("./ddnoise.js").FakeDdNoise} ddNoise
+ */
+export function attachDriveNoise(drives, ddNoise) {
+    let nextSeekTime = 0;
+    let numSpinning = 0;
+    const updateSpinStatus = () => {
+        if (numSpinning) ddNoise.spinUp();
+        else ddNoise.spinDown();
+    };
+    for (const drive of drives) {
+        drive.addEventListener("startSpinning", () => {
+            numSpinning++;
+            setTimeout(updateSpinStatus, SpinDebounceMs);
+        });
+        drive.addEventListener("stopSpinning", () => {
+            numSpinning--;
+            setTimeout(updateSpinStatus, SpinDebounceMs);
+        });
+        drive.addEventListener("step", (evt) => {
+            const now = Date.now();
+            if (now > nextSeekTime) nextSeekTime = now + ddNoise.seek(evt.stepAmount) * 1000;
+        });
+    }
+}
+
 class StepEvent extends Event {
     constructor(stepAmount) {
         super("step");

--- a/src/disc-surface.js
+++ b/src/disc-surface.js
@@ -1,9 +1,8 @@
 // Pure geometry and colour mapping, free of the DOM; disc-visualiser.js owns the canvases.
 
-import { IbmDiscFormat } from "./disc.js";
+import { IbmDiscFormat, PulsesPerWord } from "./disc.js";
 
 /** One FM byte, or two MFM bytes; 2us a slot. */
-export const PulsesPerWord = 32;
 
 /**
  * Both FM and MFM put between eight and sixteen flux transitions in a formatted word, so the ramp
@@ -118,7 +117,7 @@ export function trackRegions(track, warn) {
     };
 
     for (const sector of track.findSectors(warn)) {
-        const pulsesPerByte = sector.isMfm ? PulsesPerWord / 2 : PulsesPerWord;
+        const { pulsesPerByte } = sector;
         const noteError = (kind, startBit, endBit) =>
             errors.push({
                 firstWord: Math.floor(startBit / PulsesPerWord) % track.length,

--- a/src/disc.js
+++ b/src/disc.js
@@ -3,6 +3,9 @@
 
 import { crc32 } from "./archive.js";
 import { hexbyte } from "./hex.js";
+
+export const PulsesPerWord = 32;
+
 class TrackBuilder {
     /**
      * @param {Track} track
@@ -13,6 +16,7 @@ class TrackBuilder {
         this._index = 0;
         this._pulsesIndex = 0;
         this._lastMfmBit = 0;
+        this._isMfm = false;
         this._crc = 0;
     }
 
@@ -36,6 +40,7 @@ class TrackBuilder {
         if (this._index >= this._track.pulses2Us.length)
             throw new Error(`Track buffer overflow in ${this._track.description}`);
         this._track.pulses2Us[this._index++] = IbmDiscFormat.fmTo2usPulses(clocks, data);
+        this._isMfm = false;
         this._crc = IbmDiscFormat.crcAddByte(this._crc, data);
         return this;
     }
@@ -69,12 +74,10 @@ class TrackBuilder {
         return this;
     }
 
-    appendCrc(isMfm) {
-        // TODO(#1061) consider remembering isMfm if nothing else needs to know;
-        // could then break this into MFM and FM builder
+    appendCrc() {
         const firstByte = (this._crc >>> 8) & 0xff;
         const secondByte = this._crc & 0xff;
-        if (isMfm) {
+        if (this._isMfm) {
             this.appendMfmByte(firstByte);
             this.appendMfmByte(secondByte);
         } else {
@@ -92,6 +95,7 @@ class TrackBuilder {
         this._pulsesIndex = (this._pulsesIndex + 16) & 31;
         this._track.pulses2Us[this._index] = (existingPulses & mask) | (pulses << this._pulsesIndex);
         if (this._pulsesIndex === 0) this._index++;
+        this._isMfm = true;
         return this;
     }
 
@@ -135,6 +139,7 @@ class TrackBuilder {
      * @param {boolean} isMfm whether this is an MFM track
      */
     buildFromPulses(pulseDeltas, isMfm) {
+        this._isMfm = isMfm;
         let hasWarned = false;
         for (const pulse of pulseDeltas) {
             if (!IbmDiscFormat.checkPulse(pulse, isMfm)) {
@@ -203,6 +208,10 @@ class MfmReader {
         this._rawReader = rawReader;
     }
 
+    static get pulsesPerByte() {
+        return 16;
+    }
+
     read(numBytes) {
         const data = new Uint8Array(numBytes);
         let pulses = 0;
@@ -214,7 +223,7 @@ class MfmReader {
             }
             data[offset] = IbmDiscFormat._2usPulsesToMfm(pulses >>> 16);
         }
-        return { data, clocks: null, iffyPulses: false };
+        return { data, iffyPulses: false };
     }
 
     get initialCrc() {
@@ -234,18 +243,20 @@ class FmReader {
         this._rawReader = rawReader;
     }
 
+    static get pulsesPerByte() {
+        return 32;
+    }
+
     read(numBytes) {
         const data = new Uint8Array(numBytes);
-        const clocks = new Uint8Array(numBytes);
         let iffyPulses = false;
         for (let offset = 0; offset < numBytes; ++offset) {
             const pulses = this._rawReader.readPulses();
-            const { data: dataByte, clock: clockByte, iffyPulses: iffy } = IbmDiscFormat._2usPulsesToFm(pulses);
+            const { data: dataByte, iffyPulses: iffy } = IbmDiscFormat._2usPulsesToFm(pulses);
             data[offset] = dataByte;
-            clocks[offset] = clockByte;
             iffyPulses |= iffy;
         }
-        return { data, clocks, iffyPulses };
+        return { data, iffyPulses };
     }
 
     get initialCrc() {
@@ -263,6 +274,7 @@ class Sector {
     constructor(track, isMfm, idPosBitOffset, warn = console.log) {
         this.track = track;
         this.isMfm = isMfm;
+        this._readerType = isMfm ? MfmReader : FmReader;
         this._warn = warn;
         this.idPosBitOffset = idPosBitOffset;
         this.dataPosBitOffset = null;
@@ -285,8 +297,11 @@ class Sector {
     }
 
     _readerAt(bitOffset) {
-        const rawReader = new RawDiscReader(this.track, bitOffset);
-        return this.isMfm ? new MfmReader(rawReader) : new FmReader(rawReader);
+        return new this._readerType(new RawDiscReader(this.track, bitOffset));
+    }
+
+    get pulsesPerByte() {
+        return this._readerType.pulsesPerByte;
     }
 
     get trackNumber() {
@@ -305,18 +320,20 @@ class Sector {
      * @param {Sector|undefined} nextSector
      */
     read(nextSector) {
-        const pulsesPerByte = this.isMfm ? 16 : 32; // TODO(#1061) put in reader
         if (this.dataPosBitOffset === null) {
             this._warn(`Sector header without data ${this.description}`);
             return;
         }
 
+        const { pulsesPerByte } = this;
         const dataMarker = this.isDeleted
             ? IbmDiscFormat.deletedDataMarkDataPattern
             : IbmDiscFormat.dataMarkDataPattern;
         const sectorStartByte = (this.dataPosBitOffset / pulsesPerByte) | 0;
         const sectorEndByte =
-            (nextSector ? nextSector.idPosBitOffset / pulsesPerByte : (this.track.length * 32) / pulsesPerByte) | 0;
+            (nextSector
+                ? nextSector.idPosBitOffset / pulsesPerByte
+                : (this.track.length * PulsesPerWord) / pulsesPerByte) | 0;
         // Account for CRC and sync bytes.
         let sectorSize = Sector.toSectorSize(sectorEndByte - sectorStartByte - 5);
 
@@ -537,15 +554,9 @@ export const DiscLayout = Object.freeze({
 
 export class DiscConfig {
     constructor() {
-        // TODO(#1061) is this even useful?
-        this.logProtection = false;
-        this.logIffyPulses = false;
         this.expandTo80 = false;
-        this.isQuantizeFm = false;
         this.isSkipOddTracks = false;
         this.isSkipUpperSide = false;
-        this.rev = 0;
-        this.revSpec = "";
     }
 }
 
@@ -712,7 +723,7 @@ export function loadSsd(disc, data, isDsd, onChange) {
                     .appendFmByte(0)
                     .appendFmByte(sector)
                     .appendFmByte(1)
-                    .appendCrc(false);
+                    .appendCrc();
 
                 // Sync pattern between sector header and sector data, aka GAP 2.
                 trackBuilder
@@ -727,7 +738,7 @@ export function loadSsd(disc, data, isDsd, onChange) {
                     .resetCrc()
                     .appendFmDataAndClocks(IbmDiscFormat.dataMarkDataPattern, IbmDiscFormat.markClockPattern)
                     .appendFmChunk(sectorData)
-                    .appendCrc(false);
+                    .appendCrc();
 
                 if (sector !== SsdFormat.sectorsPerTrack - 1) {
                     // Sync pattern between sectors, aka GAP 3.
@@ -808,7 +819,7 @@ export function loadAdf(disc, data, isDsd) {
                     .appendMfmByte(0)
                     .appendMfmByte(sector)
                     .appendMfmByte(1)
-                    .appendCrc(true);
+                    .appendCrc();
 
                 // Sync pattern between sector header and sector data, aka GAP 2.
                 trackBuilder.appendRepeatMfmByte(0x4e, 22).appendRepeatMfmByte(0x00, 12);
@@ -822,7 +833,7 @@ export function loadAdf(disc, data, isDsd) {
                     .appendMfm3xA1Sync()
                     .appendMfmByte(IbmDiscFormat.dataMarkDataPattern)
                     .appendMfmChunk(sectorData)
-                    .appendCrc(true);
+                    .appendCrc();
 
                 // Sync pattern between sectors, aka GAP 3.
                 trackBuilder.appendRepeatMfmByte(0x4e, 24);
@@ -1087,8 +1098,6 @@ export class Disc {
         this._snapshotDirtyTracks.add(dirtyKey);
         this._everDirtyTracks.add(dirtyKey);
         trackObj.pulses2Us[position] = pulses;
-        // TODO(#1061) a debug log flag for this
-        // console.log(`wrote to ${track}:${position * 32}`);
     }
 
     /** @returns {?{isSideUpper: boolean, trackNum: Number}} the track written, if there was one */
@@ -1250,7 +1259,6 @@ export class Disc {
                             console.log(`Non-standard FM sector count ${track.description} count ${sectors.length}`);
                         }
                     }
-                    /// MG stuff
                     for (const sector of sectors) {
                         if (sector.hasHeaderCrcError) console.log(`${sector.description} has bad header crc`);
                         if (sector.trackNumber !== trackNum) console.log(`${sector.description} has bad track id`);
@@ -1260,7 +1268,6 @@ export class Disc {
                     console.log(`"Unformatted track ${track.description}"`);
                 }
             }
-            // TODO(#1061) add fingerprinting, catalog etc
         }
     }
 }

--- a/src/intel-fdc.js
+++ b/src/intel-fdc.js
@@ -6,7 +6,7 @@ import { Cpu6502 } from "./6502.js";
 import { Disc, IbmDiscFormat } from "./disc.js";
 
 // eslint-disable-next-line no-unused-vars
-import { BaseDiscDrive, DiscDrive } from "./disc-drive.js";
+import { attachDriveNoise, BaseDiscDrive, DiscDrive } from "./disc-drive.js";
 // eslint-disable-next-line no-unused-vars
 import { Scheduler } from "./scheduler.js";
 import { hexbyte, hexword } from "./hex.js";
@@ -1750,26 +1750,6 @@ export class IntelFdc {
 export class NoiseAwareIntelFdc extends IntelFdc {
     constructor(cpu, ddNoise, scheduler, debugFlags) {
         super(cpu, scheduler, undefined, debugFlags);
-        let nextSeekTime = 0;
-        let numSpinning = 0;
-        // Update the spin status shortly after the drive state changes to debounce it slightly.
-        const updateSpinStatus = () => {
-            if (numSpinning) ddNoise.spinUp();
-            else ddNoise.spinDown();
-        };
-        for (const drive of this.drives) {
-            drive.addEventListener("startSpinning", () => {
-                numSpinning++;
-                setTimeout(updateSpinStatus, 2);
-            });
-            drive.addEventListener("stopSpinning", () => {
-                --numSpinning;
-                setTimeout(updateSpinStatus, 2);
-            });
-            drive.addEventListener("step", (evt) => {
-                const now = Date.now();
-                if (now > nextSeekTime) nextSeekTime = now + ddNoise.seek(evt.stepAmount) * 1000;
-            });
-        }
+        attachDriveNoise(this.drives, ddNoise);
     }
 }

--- a/src/wd-fdc.js
+++ b/src/wd-fdc.js
@@ -3,7 +3,7 @@
 // eslint-disable-next-line no-unused-vars
 import { Cpu6502 } from "./6502.js";
 // eslint-disable-next-line no-unused-vars
-import { BaseDiscDrive, DiscDrive } from "./disc-drive.js";
+import { attachDriveNoise, BaseDiscDrive, DiscDrive } from "./disc-drive.js";
 import { IbmDiscFormat } from "./disc.js";
 // eslint-disable-next-line no-unused-vars
 import { Scheduler } from "./scheduler.js";
@@ -1449,29 +1449,8 @@ export class WdFdc {
 }
 
 export class NoiseAwareWdFdc extends WdFdc {
-    // TODO(#1061) consider deduplicating with the IntelFdc equivalent.
     constructor(cpu, ddNoise, scheduler, debugFlags) {
         super(cpu, scheduler, undefined, debugFlags);
-        let nextSeekTime = 0;
-        let numSpinning = 0;
-        // Update the spin status shortly after the drive state changes to debounce it slightly.
-        const updateSpinStatus = () => {
-            if (numSpinning) ddNoise.spinUp();
-            else ddNoise.spinDown();
-        };
-        for (const drive of this.drives) {
-            drive.addEventListener("startSpinning", () => {
-                numSpinning++;
-                setTimeout(updateSpinStatus, 2);
-            });
-            drive.addEventListener("stopSpinning", () => {
-                --numSpinning;
-                setTimeout(updateSpinStatus, 2);
-            });
-            drive.addEventListener("step", (evt) => {
-                const now = Date.now();
-                if (now > nextSeekTime) nextSeekTime = now + ddNoise.seek(evt.stepAmount) * 1000;
-            });
-        }
+        attachDriveNoise(this.drives, ddNoise);
     }
 }

--- a/tests/unit/test-disc-drive.js
+++ b/tests/unit/test-disc-drive.js
@@ -1,7 +1,7 @@
 import { afterEach, describe, it, expect, vi } from "vitest";
 
 import { Disc, DiscConfig, IbmDiscFormat, loadSsd } from "../../src/disc.js";
-import { DiscDrive } from "../../src/disc-drive.js";
+import { attachDriveNoise, DiscDrive } from "../../src/disc-drive.js";
 import { Scheduler } from "../../src/scheduler.js";
 
 const SectorsPerTrack = 10;
@@ -210,5 +210,69 @@ describe("40 track discs", () => {
 
         // Ten of the tracks the controller counts in, which is twenty of the surface's.
         expect(steps).toEqual([20]);
+    });
+});
+
+describe("drive noise", () => {
+    afterEach(() => vi.useRealTimers());
+
+    function noisyDrives(seekSeconds = 0) {
+        const calls = [];
+        const ddNoise = {
+            spinUp: () => calls.push("spinUp"),
+            spinDown: () => calls.push("spinDown"),
+            seek: (amount) => {
+                calls.push(`seek ${amount}`);
+                return seekSeconds;
+            },
+        };
+        const scheduler = new Scheduler();
+        const drives = [new DiscDrive(0, scheduler), new DiscDrive(1, scheduler)];
+        attachDriveNoise(drives, ddNoise);
+        return { drives, calls };
+    }
+
+    it("spins up with the first drive to start, stays up over a handover, and spins down with the last to stop", () => {
+        vi.useFakeTimers();
+        const { drives, calls } = noisyDrives();
+
+        drives[0].startSpinning();
+        vi.runAllTimers();
+        expect(calls).toEqual(["spinUp"]);
+
+        drives[0].stopSpinning();
+        drives[1].startSpinning();
+        vi.runAllTimers();
+        expect(calls).not.toContain("spinDown");
+
+        drives[1].stopSpinning();
+        vi.runAllTimers();
+        expect(calls.at(-1)).toBe("spinDown");
+        expect(calls.filter((call) => call === "spinDown")).toHaveLength(1);
+    });
+
+    it("seeks by the tracks the head crosses", () => {
+        vi.useFakeTimers();
+        const { drives, calls } = noisyDrives(0.5);
+
+        drives[0].notifySeekAmount(5);
+        vi.advanceTimersByTime(600);
+        drives[1].notifySeekAmount(-3);
+
+        expect(calls).toEqual(["seek 5", "seek -3"]);
+    });
+
+    it("lets one seek noise finish before starting another", () => {
+        vi.useFakeTimers();
+        const { drives, calls } = noisyDrives(0.5);
+
+        drives[0].notifySeekAmount(1);
+        vi.advanceTimersByTime(400);
+        drives[0].notifySeekAmount(1);
+        expect(calls).toEqual(["seek 1"]);
+
+        vi.advanceTimersByTime(200);
+        drives[0].notifySeekAmount(1);
+        expect(calls).toEqual(["seek 1", "seek 1"]);
     });
 });

--- a/tests/unit/test-disc-hfe.js
+++ b/tests/unit/test-disc-hfe.js
@@ -254,13 +254,13 @@ describe("HFE export tests", function () {
             .appendFmByte(0)
             .appendFmByte(0) // sector
             .appendFmByte(1)
-            .appendCrc(false)
+            .appendCrc()
             .appendRepeatFmByte(0xff, IbmDiscFormat.stdGap2FFs)
             .appendRepeatFmByte(0x00, IbmDiscFormat.stdSync00s)
             .resetCrc()
             .appendFmDataAndClocks(IbmDiscFormat.dataMarkDataPattern, IbmDiscFormat.markClockPattern)
             .appendFmChunk(sectorData)
-            .appendCrc(false)
+            .appendCrc()
             .fillFmByte(0xff);
 
         const hfeData = toHfe(disc);
@@ -360,14 +360,14 @@ describe("HFE export tests", function () {
             .appendMfmByte(0)
             .appendMfmByte(0) // sector
             .appendMfmByte(1)
-            .appendCrc(true)
+            .appendCrc()
             .appendRepeatMfmByte(0x4e, 22)
             .appendRepeatMfmByte(0x00, 12)
             .resetCrc()
             .appendMfm3xA1Sync()
             .appendMfmByte(IbmDiscFormat.dataMarkDataPattern)
             .appendMfmChunk(sectorData)
-            .appendCrc(true)
+            .appendCrc()
             .appendRepeatMfmByte(0x4e, 24)
             .fillMfmByte(0x4e);
 

--- a/tests/unit/test-disc.js
+++ b/tests/unit/test-disc.js
@@ -168,7 +168,7 @@ describe("IBM disc format tests", function () {
 describe("Disc builder tests", () => {
     const someData = new Uint8Array(256);
     someData.fill(0x33);
-    it("should write a simple FM track without blowing up", () => {
+    it("builds an FM track whose CRCs check", () => {
         const disc = new Disc(true, new DiscConfig(), "test.ssd");
         const builder = disc.buildTrack(false, 0);
         builder
@@ -180,17 +180,22 @@ describe("Disc builder tests", () => {
             .appendFmByte(0)
             .appendFmByte(0) // sector
             .appendFmByte(1)
-            .appendCrc(false)
+            .appendCrc()
             .appendRepeatFmByte(0xff, IbmDiscFormat.stdGap2FFs)
             .appendRepeatFmByte(0x00, IbmDiscFormat.stdSync00s)
             .resetCrc()
             .appendFmDataAndClocks(IbmDiscFormat.dataMarkDataPattern, IbmDiscFormat.markClockPattern)
             .appendFmChunk(someData)
-            .appendCrc(false)
+            .appendCrc()
             .fillFmByte(0xff);
+
+        const sectors = disc.getTrack(false, 0).findSectors();
+        expect(sectors).toHaveLength(1);
+        expect(sectors[0].hasHeaderCrcError).toBe(false);
+        expect(sectors[0].hasDataCrcError).toBe(false);
     });
 
-    it("should write a simple MFM track without blowing up", () => {
+    it("builds an MFM track whose CRCs check", () => {
         const disc = new Disc(true, new DiscConfig());
         const builder = disc.buildTrack(false, 0);
         builder
@@ -203,16 +208,21 @@ describe("Disc builder tests", () => {
             .appendMfmByte(0)
             .appendMfmByte(0) // sector
             .appendMfmByte(1)
-            .appendCrc(true)
+            .appendCrc()
             .appendRepeatMfmByte(0x4e, 22)
             .appendRepeatMfmByte(0x00, 12)
             .resetCrc()
             .appendMfm3xA1Sync()
             .appendMfmByte(IbmDiscFormat.dataMarkDataPattern)
             .appendMfmChunk(someData)
-            .appendCrc(true)
+            .appendCrc()
             .appendRepeatMfmByte(0x4e, 24)
             .fillMfmByte(0x4e);
+
+        const sectors = disc.getTrack(false, 0).findSectors();
+        expect(sectors).toHaveLength(1);
+        expect(sectors[0].hasHeaderCrcError).toBe(false);
+        expect(sectors[0].hasDataCrcError).toBe(false);
     });
 
     it("should note how much disc is being used", () => {


### PR DESCRIPTION
Fixes #1061. Stacked on #1115, which it depends on: the FM pulse tests here have no fudge only because that fix makes the encoder and decoder inverses. Merge #1115 first.

The seven notes from the issue, in order:

- `TrackBuilder.appendCrc()` takes no density argument: the builder records the density of whatever it last appended (every FM append goes through `appendFmDataAndClocks`, every MFM append through `appendMfmPulses`, and `buildFromPulses` records the one it is given). The two builder tests now assert the FM and MFM CRCs check instead of asserting nothing.
- `pulsesPerByte` lives on `FmReader` and `MfmReader`; `Sector` holds the reader class it will use and exposes `pulsesPerByte`, which `Sector.read` and the disc surface view use instead of restating 16 or 32. `PulsesPerWord` moves from the surface module into `disc.js`, where the other pulse constants are.
- `DiscConfig` keeps `expandTo80`, `isSkipOddTracks` and `isSkipUpperSide`, the three fields something reads; `logProtection`, `logIffyPulses`, `isQuantizeFm`, `rev` and `revSpec` were only ever assigned.
- The commented-out per-pulse `console.log` in `writePulses` is gone rather than promoted to a debug flag.
- The "add fingerprinting, catalog" wishlist and the stray `/// MG stuff` marker in `logSummary` are gone.
- `NoiseAwareWdFdc` and `NoiseAwareIntelFdc` share `attachDriveNoise(drives, ddNoise)` in `disc-drive.js`, which owns the events it listens to and which both controllers already import; the classes and their constructor signatures are unchanged. Tests cover spin-up with the first drive, no spin-down over a handover between drives, spin-down with the last, seek amounts passed through, and one seek noise finishing before the next starts.
- The `_2usPulsesToFm` tests no longer shift their input by a "deliberate fudge" bit; the reason they needed to is #1115.

Also picked up on the way: `FmReader.read` built a `clocks` array from a key the decoder does not return, so it was always zero, and nothing read it; it is gone.

No behaviour changes beyond those in #1115.

🤖 Generated with [Claude Code](https://claude.com/claude-code)