### PR TITLE
fix: each device drives its own NMI line and the CPU takes the OR of them

### DIFF
--- a/docs/snapshot-format.md
+++ b/docs/snapshot-format.md
@@ -104,7 +104,7 @@ The `type` field is the constructor name: `Uint8Array`, `Uint16Array`, `Uint32Ar
 | `s`                | number     | Stack pointer (0-255)                                                                             |
 | `pc`               | number     | Program counter (0-65535)                                                                         |
 | `p`                | number     | Processor flags byte (bits 4-5 always set)                                                        |
-| `nmiLevel`         | boolean    | NMI line level                                                                                    |
+| `nmiLevel`         | boolean    | NMI line level, the OR of every device's line (see below)                                         |
 | `nmiEdge`          | boolean    | NMI edge detected (pending)                                                                       |
 | `halted`           | boolean    | CPU halted state                                                                                  |
 | `takeInt`          | boolean    | Interrupt pending                                                                                 |
@@ -121,6 +121,8 @@ The `type` field is the constructor name: `Uint8Array`, `Uint16Array`, `Uint32Ar
 | `roms`             | Uint8Array | _(Optional)_ ROM contents (256KB, 16 x 16KB banks). Only present in snapshots imported from b-em. |
 
 **Note:** `interrupt` is not saved — it is reconstructed from the VIA and ACIA state, which reasserts their interrupt lines.
+
+The NMI level is rebuilt the same way: the CPU clears every device's line and each device re-drives its own, the FDC from its restored registers and econet from its live state (econet state itself is not saved). `nmiLevel` is read back only when the snapshot carries no FDC state (v1 and imported snapshots), where it stands in for the disc controller's line. `nmiEdge` is applied after the devices have re-driven their lines, so a line coming back up on restore is not mistaken for a fresh edge.
 
 ### Scheduler (`state.scheduler`)
 
@@ -445,7 +447,7 @@ Present only when a co-processor was fitted.
 
 The IRQ and reset lines are not saved: they follow from the status registers and FIFO counts above, in the same way the host's `interrupt` follows from the VIA and ACIA state.
 
-The parasite's NMI does not. The ULA latches its request rather than presenting the register 3 condition as a level, so once the parasite takes an NMI the request is retired while the condition that raised it may still hold. `parasiteNmi` is therefore real state and cannot be recomputed. Snapshots written before it existed fall back to the register 3 condition on restore, which is what the emulator used to derive the line from. `nmiLevel` and `nmiEdge` on the parasite itself are saved for the same reason: an edge already taken leaves no trace in the ULA.
+The parasite's NMI does not. The ULA latches its request rather than presenting the register 3 condition as a level, so once the parasite takes an NMI the request is retired while the condition that raised it may still hold. `parasiteNmi` is therefore real state and cannot be recomputed. Snapshots written before it existed fall back to the register 3 condition on restore, which is what the emulator used to derive the line from. `nmiLevel` and `nmiEdge` on the parasite itself are saved for the same reason: an edge already taken leaves no trace in the ULA. The ULA is the parasite's only NMI source, so unlike the host's `nmiLevel` the parasite's is restored as saved, before the ULA re-drives the line.
 
 ## Known limitations (v3)
 

--- a/src/6502.js
+++ b/src/6502.js
@@ -14,11 +14,17 @@ import { unzipRomImage } from "./archive.js";
 import { signExtend } from "./binary.js";
 import { hexbyte, hexword } from "./hex.js";
 import { loadData } from "./loader.js";
-import { NmiSource } from "./nmi-source.js";
 
 function _set(byte, mask, set) {
     return (byte & ~mask) | (set ? mask : 0);
 }
+
+/** One bit per device that can drive the NMI line; the CPU takes the OR of them all. */
+export const NmiSource = Object.freeze({
+    fdc: 0x01,
+    econet: 0x02,
+    tube: 0x04,
+});
 
 class Flags {
     constructor() {

--- a/src/6502.js
+++ b/src/6502.js
@@ -14,6 +14,7 @@ import { unzipRomImage } from "./archive.js";
 import { signExtend } from "./binary.js";
 import { hexbyte, hexword } from "./hex.js";
 import { loadData } from "./loader.js";
+import { NmiSource } from "./nmi-source.js";
 
 function _set(byte, mask, set) {
     return (byte & ~mask) | (set ? mask : 0);
@@ -114,7 +115,7 @@ class Base6502 {
         this.forceTracing = false;
         this.runner = this.opcodes.runInstruction;
         this.interrupt = 0;
-        this._nmiLevel = false;
+        this._nmiSources = 0;
         this._nmiEdge = false;
 
         if (model.nmos) {
@@ -204,13 +205,18 @@ class Base6502 {
     }
 
     get nmi() {
-        return this._nmiLevel;
+        return this._nmiSources !== 0;
     }
 
-    NMI(nmi) {
-        const prevLevel = this._nmiLevel;
-        this._nmiLevel = !!nmi;
-        if (this._nmiLevel && !prevLevel) this._nmiEdge = true;
+    nmiAsserted(source) {
+        return (this._nmiSources & source) !== 0;
+    }
+
+    setNmi(source, level) {
+        const wasAsserted = this._nmiSources !== 0;
+        if (level) this._nmiSources |= source;
+        else this._nmiSources &= ~source;
+        if (!wasAsserted && this._nmiSources) this._nmiEdge = true;
     }
 
     /** Called as the NMI vector is taken, for devices that withdraw their request at that point. */
@@ -433,7 +439,8 @@ class Tube6502 extends Base6502 {
         this.s = (this.s - 3) & 0xff; // Simulate 3 dummy pushes during reset
         // A latched NMI would otherwise survive the reset and be taken on the first instruction
         // after it, defeating the empty R3 FIFO the ULA seeds for exactly that reason.
-        this._nmiLevel = this._nmiEdge = false;
+        this._nmiSources = 0;
+        this._nmiEdge = false;
         this.takeInt = false;
         this.tube.reset(hard);
     }
@@ -505,7 +512,7 @@ class Tube6502 extends Base6502 {
             s: this.s,
             pc: this.pc,
             p: this.p.asByte(),
-            nmiLevel: this._nmiLevel,
+            nmiLevel: this.nmi,
             nmiEdge: this._nmiEdge,
             takeInt: this.takeInt,
             // The parasite has no scheduler of its own, so this is not relative to any epoch.
@@ -524,7 +531,7 @@ class Tube6502 extends Base6502 {
         this.s = state.s;
         this.pc = state.pc;
         this.p.setFromByte(state.p);
-        this._nmiLevel = state.nmiLevel;
+        this._nmiSources = state.nmiLevel ? NmiSource.tube : 0;
         this._nmiEdge = state.nmiEdge;
         this.takeInt = state.takeInt;
         this.cycles = state.cycles;
@@ -817,20 +824,22 @@ export class Cpu6502 extends Base6502 {
 
     handleEconetStationId() {
         if (!this.econet) return 0xff;
-        this.econet.econetNMIEnabled = false;
+        this.setEconetNmiEnabled(false);
         return this.econet.stationId;
     }
 
-    handleEconetNMIEnable() {
-        if (this.econet && !this.econet.econetNMIEnabled) {
-            // was off
-            this.econet.econetNMIEnabled = true;
-            if (this.econet.ADLC.status1 & 128) {
-                // irq pending
-                this.NMI(true); // delayed NMI asserted
-            }
-        }
+    handleEconetNmiEnable() {
+        if (this.econet) this.setEconetNmiEnabled(true);
         return 0xff;
+    }
+
+    setEconetNmiEnabled(enabled) {
+        this.econet.econetNMIEnabled = enabled;
+        this.updateEconetNmi();
+    }
+
+    updateEconetNmi() {
+        this.setNmi(NmiSource.econet, this.econet.nmi);
     }
 
     readDevice(addr) {
@@ -879,7 +888,7 @@ export class Cpu6502 extends Base6502 {
             case 0xfe18:
                 return this.model.isMaster ? this.adconverter.read(addr) : this.handleEconetStationId();
             case 0xfe20:
-                if (!this.model.isMaster) return this.handleEconetNMIEnable();
+                if (!this.model.isMaster) return this.handleEconetNmiEnable();
                 break;
             case 0xfe24:
             case 0xfe28:
@@ -895,7 +904,7 @@ export class Cpu6502 extends Base6502 {
                 if (this.model.isMaster) return this.handleEconetStationId();
                 break;
             case 0xfe3c:
-                if (this.model.isMaster) return this.handleEconetNMIEnable();
+                if (this.model.isMaster) return this.handleEconetNmiEnable();
                 break;
             case 0xfe40:
             case 0xfe44:
@@ -1054,7 +1063,7 @@ export class Cpu6502 extends Base6502 {
                 return this.serial.write(addr, b);
             case 0xfe18:
                 if (this.model.isMaster) return this.adconverter.write(addr, b);
-                if (!this.model.isMaster && this.econet) this.econet.econetNMIEnabled = false;
+                if (!this.model.isMaster && this.econet) this.setEconetNmiEnabled(false);
                 break;
             case 0xfe20:
                 return this.ula.write(addr, b);
@@ -1077,7 +1086,7 @@ export class Cpu6502 extends Base6502 {
                 }
                 return this.romSelect(b);
             case 0xfe38:
-                if (this.model.isMaster && this.econet) this.econet.econetNMIEnabled = false;
+                if (this.model.isMaster && this.econet) this.setEconetNmiEnabled(false);
                 break;
             case 0xfe3c:
                 if (!this.model.isMaster) {
@@ -1199,7 +1208,7 @@ export class Cpu6502 extends Base6502 {
             s: this.s,
             pc: this.pc,
             p: this.p.asByte(),
-            nmiLevel: this._nmiLevel,
+            nmiLevel: this.nmi,
             nmiEdge: this._nmiEdge,
             halted: this.halted,
             takeInt: this.takeInt,
@@ -1246,8 +1255,7 @@ export class Cpu6502 extends Base6502 {
         this.p.setFromByte(state.p);
         // interrupt is rebuilt by sub-component restores (VIA updateIFR, ACIA updateIrq)
         this.interrupt = 0;
-        this._nmiLevel = state.nmiLevel;
-        this._nmiEdge = state.nmiEdge;
+        this._nmiSources = 0;
         this.halted = state.halted;
         this.takeInt = state.takeInt;
 
@@ -1291,10 +1299,16 @@ export class Cpu6502 extends Base6502 {
         // touchscreen keeps its current state, unpolled.
         if (state.touchScreen) this.touchScreen.restoreState(state.touchScreen);
 
-        // FDC state (v2+). If absent (v1 snapshot), FDC keeps its current state.
+        // FDC state (v2+). If absent (v1 snapshot), FDC keeps its current state, and the saved
+        // level is the only record of its line.
         if (state.fdc) {
             this.fdc.restoreState(state.fdc);
+        } else {
+            this.setNmi(NmiSource.fdc, state.nmiLevel);
         }
+        if (this.econet) this.updateEconetNmi();
+        // After the devices have re-driven their lines, so a line coming back up is not an edge.
+        this._nmiEdge = state.nmiEdge;
 
         // Tube state (v3+). Rather than leave the parasite running on state the host knows
         // nothing about, reset it; restoreSnapshot() rejects such a pairing before reaching here.
@@ -1379,7 +1393,7 @@ export class Cpu6502 extends Base6502 {
         this.p.i = true;
         this.s = (this.s - 3) & 0xff; // Simulate 3 dummy pushes during reset
         this._nmiEdge = false;
-        this._nmiLevel = false;
+        this._nmiSources = 0;
         this.halted = false;
         this.breakpointResume = false;
         this.music5000PageSel = 0;
@@ -1428,10 +1442,9 @@ export class Cpu6502 extends Base6502 {
         const musicStuff = this.music5000 ? (cycles) => this.music5000.polltime(cycles) : nop;
         const econetStuff = this.econet
             ? (cycles) => {
-                  const donmi = this.econet.polltime(cycles);
-                  if (donmi && this.econet.econetNMIEnabled) {
-                      this.NMI(true);
-                  }
+                  const retrigger = this.econet.polltime(cycles);
+                  if (retrigger) this.setNmi(NmiSource.econet, false);
+                  this.updateEconetNmi();
                   this.filestore.polltime(cycles);
               }
             : nop;

--- a/src/econet.js
+++ b/src/econet.js
@@ -650,9 +650,14 @@ export class Econet {
         }
     }
 
+    /** The ADLC's IRQ output as the NMI line sees it, gated by the station-id/NMI-enable latch. */
+    get nmi() {
+        return this.econetNMIEnabled && !!(this.ADLC.status1 & 128);
+    }
+
+    /** Whether the ADLC wants a fresh NMI edge while its IRQ flag stays set. */
     checkForNMI() {
-        // Do we need to flag an interrupt?
-        let raiseNMI = false;
+        let retriggerNMI = false;
         if (this.ADLC.status1 !== this.ADLCprev.status1 || this.ADLC.status2 !== this.ADLCprev.status2) {
             // something changed
             let tempcause, temp2;
@@ -689,7 +694,6 @@ export class Econet {
 
             if (tempcause) {
                 //something got set
-                raiseNMI = true;
                 this.irqcause = this.irqcause | tempcause; // remember which bit went high to flag irq
                 // SR1b7 IRQ flag
                 this.ADLC.status1 |= 128;
@@ -707,12 +711,12 @@ export class Econet {
                 } else {
                     // interrupt again because still have flags set
                     if (this.ADLC.control2 & 1) {
-                        raiseNMI = true;
+                        retriggerNMI = true;
                     }
                 }
             }
         }
 
-        return raiseNMI;
+        return retriggerNMI;
     }
 }

--- a/src/intel-fdc.js
+++ b/src/intel-fdc.js
@@ -1,8 +1,7 @@
 // Translated from beebjit by Chris Evans.
 // https://github.com/scarybeasts/beebjit
 // eslint-disable-next-line no-unused-vars
-import { Cpu6502 } from "./6502.js";
-import { NmiSource } from "./nmi-source.js";
+import { Cpu6502, NmiSource } from "./6502.js";
 // eslint-disable-next-line no-unused-vars
 import { Disc, IbmDiscFormat } from "./disc.js";
 

--- a/src/intel-fdc.js
+++ b/src/intel-fdc.js
@@ -2,6 +2,7 @@
 // https://github.com/scarybeasts/beebjit
 // eslint-disable-next-line no-unused-vars
 import { Cpu6502 } from "./6502.js";
+import { NmiSource } from "./nmi-source.js";
 // eslint-disable-next-line no-unused-vars
 import { Disc, IbmDiscFormat } from "./disc.js";
 
@@ -343,8 +344,7 @@ export class IntelFdc {
         // aka. late DMA, which will abort the command while NMI is asserted. We
         // therefore need to de-assert NMI so that the NMI for command completion
         // isn't lost.
-        // TODO(#1058) we don't model NMIs properly here, each device should have its own nmi line
-        this._cpu.NMI(false);
+        this._cpu.setNmi(NmiSource.fdc, false);
     }
 
     powerOnReset() {
@@ -1025,12 +1025,11 @@ export class IntelFdc {
     }
 
     _updateNmi() {
-        const status = this.internalStatus;
-        const level = !!(status & StatusFlag.nmi);
-        if (this._cpu.nmi && level) {
+        const level = !!(this.internalStatus & StatusFlag.nmi);
+        if (level && this._cpu.nmiAsserted(NmiSource.fdc)) {
             this._log("edge triggered NMI already high");
         }
-        this._cpu.NMI(level);
+        this._cpu.setNmi(NmiSource.fdc, level);
     }
 
     _updateExternalStatus() {
@@ -1729,8 +1728,7 @@ export class IntelFdc {
         this._timerTask.cancel();
         if (state.timerTaskOffset !== null) this._timerTask.schedule(state.timerTaskOffset);
 
-        // NMI level is saved/restored by the CPU snapshot directly,
-        // so we don't reassert it here.
+        this._updateNmi();
     }
 
     /// jsbeeb compatibility stuff

--- a/src/nmi-source.js
+++ b/src/nmi-source.js
@@ -1,6 +1,0 @@
-/** One bit per device that can drive the NMI line; the CPU takes the OR of them all. */
-export const NmiSource = Object.freeze({
-    fdc: 0x01,
-    econet: 0x02,
-    tube: 0x04,
-});

--- a/src/nmi-source.js
+++ b/src/nmi-source.js
@@ -1,0 +1,6 @@
+/** One bit per device that can drive the NMI line; the CPU takes the OR of them all. */
+export const NmiSource = Object.freeze({
+    fdc: 0x01,
+    econet: 0x02,
+    tube: 0x04,
+});

--- a/src/tube.js
+++ b/src/tube.js
@@ -1,4 +1,4 @@
-import { NmiSource } from "./nmi-source.js";
+import { NmiSource } from "./6502.js";
 import { hexbyte, hexword } from "./hex.js";
 
 //  this one should be declared more globally

--- a/src/tube.js
+++ b/src/tube.js
@@ -1,3 +1,4 @@
+import { NmiSource } from "./nmi-source.js";
 import { hexbyte, hexword } from "./hex.js";
 
 //  this one should be declared more globally
@@ -139,7 +140,7 @@ export class Tube {
         //  each host access to register 3 that gives the parasite something to do raises a request, and
         //  only the parasite can retire one, by servicing the transfer or by taking the NMI. Recomputing
         //  the condition here instead would lose every request raised while an earlier one still stood.
-        this.parasiteCpu.NMI(this.parasiteNmi && this.parasiteNmiEnabled());
+        this.parasiteCpu.setNmi(NmiSource.tube, this.parasiteNmi && this.parasiteNmiEnabled());
         //  parasite CPU RESET held low - not implemented in the CPU - the CPU should be frozen until this signal is released
         this.parasiteCpu.resetHeldLow = this.internalStatusRegister & TUBE_ULA_FLAG_STATUS_PARASITE_RESET_ACTIVE_LOW;
     }

--- a/src/wd-fdc.js
+++ b/src/wd-fdc.js
@@ -1,8 +1,7 @@
 // Translated from beebjit by Chris Evans.
 // https://github.com/scarybeasts/beebjit
 // eslint-disable-next-line no-unused-vars
-import { Cpu6502 } from "./6502.js";
-import { NmiSource } from "./nmi-source.js";
+import { Cpu6502, NmiSource } from "./6502.js";
 // eslint-disable-next-line no-unused-vars
 import { BaseDiscDrive, DiscDrive } from "./disc-drive.js";
 import { IbmDiscFormat } from "./disc.js";

--- a/src/wd-fdc.js
+++ b/src/wd-fdc.js
@@ -2,6 +2,7 @@
 // https://github.com/scarybeasts/beebjit
 // eslint-disable-next-line no-unused-vars
 import { Cpu6502 } from "./6502.js";
+import { NmiSource } from "./nmi-source.js";
 // eslint-disable-next-line no-unused-vars
 import { BaseDiscDrive, DiscDrive } from "./disc-drive.js";
 import { IbmDiscFormat } from "./disc.js";
@@ -218,11 +219,7 @@ export class WdFdc {
     }
 
     _updateNmi() {
-        const newLevel = this._isDrq | (this._isOpus ? false : this._isIntRq);
-        // TODO(#1058) the cpu handling of NMIs is bad here. Should update to handle multiple
-        // NMI/interrupt sources. And when we do go back and implement the checks in the beebjit
-        // source here too.
-        this._cpu.NMI(newLevel);
+        this._cpu.setNmi(NmiSource.fdc, this._isDrq || (!this._isOpus && this._isIntRq));
     }
 
     /**
@@ -1405,8 +1402,7 @@ export class WdFdc {
         this._timerTask.cancel();
         if (state.timerTaskOffset !== null) this._timerTask.schedule(state.timerTaskOffset);
 
-        // NMI level is saved/restored by the CPU snapshot directly,
-        // so we don't reassert it here.
+        this._updateNmi();
     }
 
     /// jsbeeb compatibility stuff

--- a/tests/integration/tube.js
+++ b/tests/integration/tube.js
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { TestMachine } from "../../src/test-machine.js";
-import { NmiSource } from "../../src/nmi-source.js";
+import { NmiSource } from "../../src/6502.js";
 
 // The ULA's M flag, which lets pending R3 data raise the parasite's NMI.
 const TubeStatusEnableParasiteNmiFromR3 = 0x08;

--- a/tests/integration/tube.js
+++ b/tests/integration/tube.js
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { TestMachine } from "../../src/test-machine.js";
+import { NmiSource } from "../../src/nmi-source.js";
 
 // The ULA's M flag, which lets pending R3 data raise the parasite's NMI.
 const TubeStatusEnableParasiteNmiFromR3 = 0x08;
@@ -73,7 +74,7 @@ describe("Tube co-processor", () => {
 
         cpu.restoreState(state);
 
-        expect(cpu.tube._nmiLevel).toBe(true);
+        expect(cpu.tube.nmi).toBe(true);
         expect(cpu.tube._nmiEdge).toBe(true);
     });
 
@@ -92,14 +93,14 @@ describe("Tube co-processor", () => {
         cpu.restoreState(state);
 
         expect(cpu.tube.tube.parasiteNmi).toBe(true);
-        expect(cpu.tube._nmiLevel).toBe(true);
+        expect(cpu.tube.nmi).toBe(true);
     });
 
     it("does not take a latched NMI across a parasite reset", async () => {
         const machine = new TestMachine("Master", { tube: true });
         await machine.initialise();
         const parasite = machine.processor.tube;
-        parasite.NMI(true);
+        parasite.setNmi(NmiSource.tube, true);
         expect(parasite._nmiEdge).toBe(true);
 
         parasite.reset(true);

--- a/tests/unit/test-cpu-state.js
+++ b/tests/unit/test-cpu-state.js
@@ -1,5 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { fake6502 } from "../../src/fake6502.js";
+import { NmiSource } from "../../src/nmi-source.js";
+import { Econet } from "../../src/econet.js";
 import { Video, FakeVideo } from "../../src/video.js";
 import { SoundChip } from "../../src/soundchip.js";
 import { machineSpec, nullIo } from "../../src/machine-spec.js";
@@ -10,6 +12,46 @@ function makeCpu() {
     const video = new Video(false, fb32, () => {});
     const soundChip = new SoundChip(() => {});
     return new TEST_6502.Cpu(TEST_6502, { ...nullIo({ video, soundChip }), config: machineSpec() });
+}
+
+// The 8271 seek command, selecting drive 1. The drive is empty, so it never reports ready and the
+// command completes at once with an error, raising its completion NMI.
+const SeekDrive1 = 0x69;
+const FdcResetRegister = 2;
+
+function sendSeekToMissingDrive(fdc) {
+    fdc.write(0, SeekDrive1);
+    fdc.write(1, 0);
+}
+
+/** Whether the CPU takes an NMI before its next instruction, consuming the edge if so. */
+function takesNmi(cpu) {
+    cpu.p.i = true;
+    cpu.checkInt();
+    if (!cpu.takeInt) return false;
+    cpu.brk(true);
+    return true;
+}
+
+const AdlcControl1 = 0xfea0;
+const AdlcControl2 = 0xfea1;
+const AdlcTxFifo = 0xfea2;
+const RxTxInterruptsEnabled = 0x06;
+const RxTxReset = 0xc0;
+const PrioritisedStatus = 0x01;
+const AdlcIrqFlag = 0x80;
+
+// Releasing the resets with interrupts enabled reports two causes at once: TDRA, and via S2RQ
+// the idle line.
+function raiseAdlcIrq(cpu) {
+    cpu.writeDevice(AdlcControl1, RxTxInterruptsEnabled);
+    cpu.writeDevice(AdlcControl2, PrioritisedStatus);
+    cpu.polltime(1);
+}
+
+function clearAdlcIrq(cpu) {
+    cpu.writeDevice(AdlcControl1, RxTxReset);
+    cpu.polltime(1);
 }
 
 describe("Cpu6502 snapshotState / restoreState", () => {
@@ -41,19 +83,42 @@ describe("Cpu6502 snapshotState / restoreState", () => {
         expect(cpu2.p.asByte()).toBe(0xe5 | 0x30); // bits 4,5 always set
     });
 
-    it("should snapshot and restore interrupt state", () => {
-        cpu._nmiLevel = true;
-        cpu._nmiEdge = true;
+    it("should restore a pending NMI edge, but not a level no device on the restored machine holds", async () => {
+        cpu.setNmi(NmiSource.econet, true);
         cpu.halted = true;
+
+        const snapshot = cpu.snapshotState();
+        const cpu2 = makeCpu();
+        await cpu2.initialise();
+        cpu2.restoreState(snapshot);
+
+        expect(snapshot.nmiLevel).toBe(true);
+        expect(cpu2.nmi).toBe(false);
+        expect(takesNmi(cpu2)).toBe(true);
+        expect(cpu2.halted).toBe(true);
+    });
+
+    it("should reconstruct the NMI level from FDC state", () => {
+        sendSeekToMissingDrive(cpu.fdc);
+        expect(cpu.nmi).toBe(true);
 
         const snapshot = cpu.snapshotState();
         const cpu2 = makeCpu();
         cpu2.restoreState(snapshot);
 
-        // interrupt is rebuilt by sub-component restores (VIA/ACIA), not saved directly
-        expect(cpu2._nmiLevel).toBe(true);
-        expect(cpu2._nmiEdge).toBe(true);
-        expect(cpu2.halted).toBe(true);
+        expect(cpu2.nmi).toBe(true);
+    });
+
+    it("should not raise an NMI edge for a level the FDC restores", () => {
+        sendSeekToMissingDrive(cpu.fdc);
+        takesNmi(cpu);
+
+        const snapshot = cpu.snapshotState();
+        const cpu2 = makeCpu();
+        cpu2.restoreState(snapshot);
+
+        expect(cpu2.nmi).toBe(true);
+        expect(takesNmi(cpu2)).toBe(false);
     });
 
     it("should reconstruct interrupt flags from VIA state", () => {
@@ -178,6 +243,172 @@ describe("Cpu6502 snapshotState / restoreState", () => {
 
         // The scheduler should have tasks registered (VIA timers at minimum)
         expect(cpu2.scheduler.headroom()).toBeLessThan(0xffffffff);
+    });
+});
+
+describe("Cpu6502 NMI lines", () => {
+    let cpu;
+
+    beforeEach(() => {
+        cpu = fake6502();
+    });
+
+    it("takes an NMI when the first source rises", () => {
+        cpu.setNmi(NmiSource.fdc, true);
+
+        expect(cpu.nmi).toBe(true);
+        expect(takesNmi(cpu)).toBe(true);
+    });
+
+    it("does not take a second NMI for a source rising while another is held", () => {
+        cpu.setNmi(NmiSource.fdc, true);
+        takesNmi(cpu);
+
+        cpu.setNmi(NmiSource.econet, true);
+
+        expect(takesNmi(cpu)).toBe(false);
+    });
+
+    it("holds the line until every source has dropped", () => {
+        cpu.setNmi(NmiSource.fdc, true);
+        cpu.setNmi(NmiSource.econet, true);
+
+        cpu.setNmi(NmiSource.fdc, false);
+        expect(cpu.nmi).toBe(true);
+
+        cpu.setNmi(NmiSource.econet, false);
+        expect(cpu.nmi).toBe(false);
+    });
+
+    it("does not take an NMI for a source pulsing while another is held", () => {
+        cpu.setNmi(NmiSource.fdc, true);
+        cpu.setNmi(NmiSource.econet, true);
+        takesNmi(cpu);
+
+        cpu.setNmi(NmiSource.fdc, false);
+        cpu.setNmi(NmiSource.fdc, true);
+
+        expect(takesNmi(cpu)).toBe(false);
+    });
+
+    it("takes another NMI once every source has dropped and one rises again", () => {
+        cpu.setNmi(NmiSource.fdc, true);
+        cpu.setNmi(NmiSource.econet, true);
+        takesNmi(cpu);
+        cpu.setNmi(NmiSource.fdc, false);
+        cpu.setNmi(NmiSource.econet, false);
+
+        cpu.setNmi(NmiSource.econet, true);
+
+        expect(takesNmi(cpu)).toBe(true);
+    });
+
+    it("tells each source whether its own line is up", () => {
+        cpu.setNmi(NmiSource.econet, true);
+
+        expect(cpu.nmiAsserted(NmiSource.econet)).toBe(true);
+        expect(cpu.nmiAsserted(NmiSource.fdc)).toBe(false);
+    });
+
+    it("drops every source on reset", () => {
+        cpu.setNmi(NmiSource.fdc, true);
+        cpu.setNmi(NmiSource.econet, true);
+
+        cpu.reset(true);
+
+        expect(cpu.nmi).toBe(false);
+        expect(takesNmi(cpu)).toBe(false);
+    });
+
+    it("leaves another device's line up when the 8271 aborts a command", () => {
+        cpu.setNmi(NmiSource.econet, true);
+        sendSeekToMissingDrive(cpu.fdc);
+
+        cpu.fdc.write(FdcResetRegister, 1);
+
+        expect(cpu.nmiAsserted(NmiSource.fdc)).toBe(false);
+        expect(cpu.nmi).toBe(true);
+    });
+});
+
+describe("Cpu6502 econet NMI line", () => {
+    const StationIdRegister = 0xfe18;
+    const NmiEnableRegister = 0xfe20;
+    let cpu;
+    let econet;
+
+    beforeEach(async () => {
+        econet = new Econet(1, TEST_6502.cyclesPerSecond);
+        cpu = new TEST_6502.Cpu(TEST_6502, { ...nullIo(), econet, config: machineSpec() });
+        await cpu.initialise();
+    });
+
+    it("follows the ADLC's IRQ flag", () => {
+        raiseAdlcIrq(cpu);
+        expect(econet.ADLC.status1 & AdlcIrqFlag).toBe(AdlcIrqFlag);
+        expect(cpu.nmi).toBe(true);
+        expect(takesNmi(cpu)).toBe(true);
+
+        clearAdlcIrq(cpu);
+        expect(econet.ADLC.status1 & AdlcIrqFlag).toBe(0);
+        expect(cpu.nmi).toBe(false);
+    });
+
+    it("takes an NMI for each of two requests in turn", () => {
+        raiseAdlcIrq(cpu);
+        takesNmi(cpu);
+        clearAdlcIrq(cpu);
+
+        raiseAdlcIrq(cpu);
+
+        expect(takesNmi(cpu)).toBe(true);
+    });
+
+    it("takes a second NMI when one prioritised cause clears while another stays", () => {
+        raiseAdlcIrq(cpu);
+        expect(takesNmi(cpu)).toBe(true);
+
+        // Filling the transmit FIFO withdraws TDRA, leaving the S2RQ cause.
+        for (let i = 0; i < 3; i++) cpu.writeDevice(AdlcTxFifo, 0x55);
+        cpu.polltime(1);
+
+        expect(econet.ADLC.status1 & AdlcIrqFlag).toBe(AdlcIrqFlag);
+        expect(takesNmi(cpu)).toBe(true);
+    });
+
+    it("does not take a new NMI for a request restored with it", () => {
+        raiseAdlcIrq(cpu);
+        takesNmi(cpu);
+        const snapshot = cpu.snapshotState();
+
+        cpu.restoreState(snapshot);
+        cpu.polltime(1);
+
+        expect(cpu.nmi).toBe(true);
+        expect(takesNmi(cpu)).toBe(false);
+    });
+
+    it("drops the line while reading the station id disables it, and raises it again on enable", () => {
+        raiseAdlcIrq(cpu);
+        takesNmi(cpu);
+
+        cpu.readDevice(StationIdRegister);
+        expect(cpu.nmi).toBe(false);
+
+        cpu.readDevice(NmiEnableRegister);
+        expect(cpu.nmi).toBe(true);
+        expect(takesNmi(cpu)).toBe(true);
+    });
+
+    it("does not touch the disc controller's line", () => {
+        cpu.setNmi(NmiSource.fdc, true);
+        takesNmi(cpu);
+
+        raiseAdlcIrq(cpu);
+        expect(takesNmi(cpu)).toBe(false);
+
+        cpu.readDevice(StationIdRegister);
+        expect(cpu.nmi).toBe(true);
     });
 });
 

--- a/tests/unit/test-cpu-state.js
+++ b/tests/unit/test-cpu-state.js
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { fake6502 } from "../../src/fake6502.js";
-import { NmiSource } from "../../src/nmi-source.js";
+import { NmiSource } from "../../src/6502.js";
 import { Econet } from "../../src/econet.js";
 import { Video, FakeVideo } from "../../src/video.js";
 import { SoundChip } from "../../src/soundchip.js";

--- a/tests/unit/test-snapshot.js
+++ b/tests/unit/test-snapshot.js
@@ -285,7 +285,7 @@ describe("Snapshot coordinator", () => {
     describe("WD1770 FDC snapshot", () => {
         it("should round-trip WD1770 state including BigInt markDetector", () => {
             const scheduler = new Scheduler();
-            const mockCpu = { model: { isMaster: true }, NMI: () => {} };
+            const mockCpu = { model: { isMaster: true }, setNmi: () => {} };
             const fdc = new WdFdc(mockCpu, scheduler, undefined, {});
 
             // Set markDetector to a non-zero BigInt to verify serialization

--- a/tests/unit/test-tube.js
+++ b/tests/unit/test-tube.js
@@ -18,7 +18,7 @@ function fakeCpu() {
         resetHeldLow: false,
         nmiLevel: false,
         nmiEdges: 0,
-        NMI(nmi) {
+        setNmi(source, nmi) {
             if (nmi && !this.nmiLevel) this.nmiEdges++;
             this.nmiLevel = !!nmi;
         },


### PR DESCRIPTION
Fixes #1058.

Both disc controllers called `cpu.NMI(level)` directly, so whichever device spoke last set the CPU's single NMI flag, and the two TODO comments in the controllers said so. Econet was worse off than the comments let on: it only ever raised the line and never lowered it, so after the first econet NMI a second could only be seen once some disc activity happened to lower the CPU's level for it. The tube ULA drove the parasite the same way.

The fix is the shape the IRQ side already has (`cpu.interrupt` is a bitmask each device ORs its own bit into and clears):

- `NmiSource`, exported from `6502.js`, names one bit per device: disc controller, econet, tube. `tube.js` importing it makes a `6502.js` and `tube.js` import cycle, which is benign because each only uses the other's export inside a function.
- `Base6502` keeps a `_nmiSources` mask; `setNmi(source, level)` sets or clears that source and sets the edge only when the OR goes from zero to non-zero; `nmi` reports the OR; `nmiAsserted(source)` reports one line, which the 8271 uses for its "already high" diagnostic. `NMI()` is gone, no shim.
- The 8271 and 1770 drive the disc controller line only, so the 8271's late-DMA abort no longer lowers anyone else's line.
- Econet's line is derived: NMI enable latch AND the ADLC's IRQ flag. The CPU applies it after every econet poll and on the FE18/FE20 (Model B) and FE38/FE3C (Master) enable and disable accesses, and drops and re-asserts it when the ADLC reports a retrigger (a prioritised cause cleared while another stays), which is the one case that needs a fresh edge with the flag still set.
- The tube drives the parasite's line.

Snapshots keep their format. On the host the level is rebuilt the way the IRQ mask is: the sources are cleared, the FDC and econet re-drive their lines from their restored state, and only then is the saved edge applied, so a line coming back up on restore is not mistaken for a fresh edge. Snapshots with no FDC state (v1 and the BeebEm and UEF imports) apply the saved level as the disc controller's line. The parasite keeps its existing contract: its saved level seeds the tube source before the ULA restore, so the ULA's restore can still produce the edge it is owed. `docs/snapshot-format.md` updated.

Tests, in `test-cpu-state.js`: the edge rules for two sources in every order; the econet line following the ADLC flag through the real register path (control registers written at FEA0/FEA1, the transmit FIFO to withdraw a cause), two requests in turn each getting an edge, the station-id read dropping the line and the enable read raising it again, the retrigger giving a second NMI with the flag still set, a restore over a live econet request not manufacturing an NMI, the 8271's abort leaving econet's line up, and the snapshot round trip of a pending edge. Edges are observed through `checkInt` and `brk`, the path `execute` uses, with the I flag set so only an NMI counts.

User-visible change: econet only. Successive econet interrupts are now each taken without needing disc activity in between, and a station-id read visibly drops the line. Disc controller and tube behaviour is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)