### PR TITLE
feat: the 1770 accepts the address marks the WD1772 specification lists, syncs to C2 in read track, and can be a 1772 or Opus-wired

### DIFF
--- a/src/wd-fdc.js
+++ b/src/wd-fdc.js
@@ -141,23 +141,35 @@ const TimerState = Object.freeze({
     done: 4,
 });
 
+/**
+ * Which controller, and how it is wired. The Master Compact's WD1772 steps faster than the WD1770; the
+ * Opus Challenger's WD1770 sits at the other half of the page and keeps INTRQ off the NMI line.
+ *
+ * @readonly
+ * @enum {string}
+ */
+export const WdFdcVariant = Object.freeze({
+    wd1770: "wd1770",
+    wd1772: "wd1772",
+    opusChallenger: "opusChallenger",
+});
+
 export class WdFdc {
     /**
      * @param {Cpu6502} cpu
      * @param {Scheduler} scheduler
      * @param {BaseDiscDrive[] | undefined} drives
      * @param {*} debugFlags
-     * @param {{is1772?: boolean, isOpus?: boolean}} [variant] a WD1772 rather than a WD1770, as in the Master
-     *   Compact, and the Opus Challenger's wiring, which swaps the register halves and keeps INTRQ off the NMI line
+     * @param {WdFdcVariant} [variant]
      */
-    constructor(cpu, scheduler, drives, debugFlags, { is1772 = false, isOpus = false } = {}) {
+    constructor(cpu, scheduler, drives, debugFlags, variant = WdFdcVariant.wd1770) {
         this._cpu = cpu;
         if (drives) this._drives = drives;
         else this._drives = [new DiscDrive(0, scheduler), new DiscDrive(1, scheduler)];
 
         this._isMaster = cpu.model.isMaster;
-        this._is1772 = is1772;
-        this._isOpus = isOpus;
+        this._is1772 = variant === WdFdcVariant.wd1772;
+        this._isOpus = variant === WdFdcVariant.opusChallenger;
 
         this._controlRegister = 0;
         /** @type {Status|Number} */

--- a/src/wd-fdc.js
+++ b/src/wd-fdc.js
@@ -57,6 +57,13 @@ const ForceInterruptBits = Object.freeze({
     immediate: 0x08,
 });
 
+// The datasheet names one byte for each address mark; the WD1772 accepts the whole range
+// (Jean Louis-Guerin's WD1772 specification, "Type II commands").
+const isIdMark = (data) => data >= 0xfc && data <= 0xff;
+const isDataMark = (data) => data === 0xfa || data === 0xfb;
+const isDeletedDataMark = (data) => data === 0xf8 || data === 0xf9;
+const FmIndexMark = 0xfc;
+
 /**
  * The drive control register is documented here:
  * https://www.cloud9.co.uk/james/BBCMicro/Documentation/wd1770.html
@@ -108,17 +115,17 @@ const State = Object.freeze({
     inId: 6,
     searchData: 7,
     inData: 8,
-    inReadTrack: 8,
-    writeSectorDelay: 9,
-    writeSectorLeadInFm: 10,
-    writeSectorLeadInMfm: 11,
-    writeSectorMarkerFm: 12,
-    writeSectorMarkerMfm: 13,
-    writeSectorBody: 14,
-    writeTrackSetup: 15,
-    inWriteTrack: 16,
-    checkMulti: 17,
-    done: 18,
+    inReadTrack: 9,
+    writeSectorDelay: 10,
+    writeSectorLeadInFm: 11,
+    writeSectorLeadInMfm: 12,
+    writeSectorMarkerFm: 13,
+    writeSectorMarkerMfm: 14,
+    writeSectorBody: 15,
+    writeTrackSetup: 16,
+    inWriteTrack: 17,
+    checkMulti: 18,
+    done: 19,
 });
 
 /**
@@ -140,15 +147,17 @@ export class WdFdc {
      * @param {Scheduler} scheduler
      * @param {BaseDiscDrive[] | undefined} drives
      * @param {*} debugFlags
+     * @param {{is1772?: boolean, isOpus?: boolean}} [variant] a WD1772 rather than a WD1770, as in the Master
+     *   Compact, and the Opus Challenger's wiring, which swaps the register halves and keeps INTRQ off the NMI line
      */
-    constructor(cpu, scheduler, drives, debugFlags) {
+    constructor(cpu, scheduler, drives, debugFlags, { is1772 = false, isOpus = false } = {}) {
         this._cpu = cpu;
         if (drives) this._drives = drives;
         else this._drives = [new DiscDrive(0, scheduler), new DiscDrive(1, scheduler)];
 
         this._isMaster = cpu.model.isMaster;
-        this._is1772 = false; // TODO(#1059) if we ever support Master Compact
-        this._isOpus = false; // TODO(#1059) if we ever support Opus
+        this._is1772 = is1772;
+        this._isOpus = isOpus;
 
         this._controlRegister = 0;
         /** @type {Status|Number} */
@@ -265,10 +274,9 @@ export class WdFdc {
         // Only remap control register values.
         if (addr >= 4) return val;
         let remapped = Control.reset;
-        if (val & 0x01) remapped |= Control.drive0;
-        else remapped |= Control.drive1;
+        remapped |= val & 0x01 ? Control.drive1 : Control.drive0;
         if (val & 0x02) remapped |= Control.side;
-        if (val & 0x40) remapped |= Control.density;
+        if (!(val & 0x40)) remapped |= Control.density;
         return remapped;
     }
 
@@ -739,7 +747,7 @@ export class WdFdc {
             case State.inId:
             case State.searchData:
             case State.inData:
-            case State.readTrack:
+            case State.inReadTrack:
                 this._bitstreamReceived(pulses, count, isIndexPulsePositiveEdge);
                 if (this._indexPulseCount >= 6) {
                     this._statusRegister |= Status.recordNotFound;
@@ -959,39 +967,36 @@ export class WdFdc {
 
     _markDetectorTriggered() {
         if (this._isDoubleDensity(this._controlRegister)) {
-            // EMU NOTE: unsure as to exactly when MFM sync bytes are spotted. Here we look for MFM 0x00 then MFM 0xa1 (sync).
-            // The documented sequence is 12 0x00, 3x 0xa1 (sync).
-            if ((this._markDetector & 0xffffffffn) === 0xaaaa4489n) {
+            // EMU NOTE: unsure as to exactly when MFM sync bytes are spotted. Here we look for MFM 0x00 then an MFM
+            // sync, 0xa1 or 0xc2. The documented sequences are 12 0x00, 3x 0xa1 (sync) and 12 0x00, 3x 0xc2 (index).
+            const lastWord = this._markDetector & 0xffffffffn;
+            if (lastWord === 0xaaaa4489n) {
                 this._deliverData = 0xa1;
                 return true;
             }
-            // TODO(#1059) sync to c2 (5224).
-            // Note that an early, naive attempt had it triggered in the middle of the sector data,
-            // so we'll need to study how it actually works in detail.
-            // Tag the byte after 3 sync bytes as a marker.
+            // Ordinary data can encode this pattern too (01 fe 29 is one such run), so it only resyncs
+            // where the spec says it may, in read track.
+            if (lastWord === 0xaaaa5224n && this._state === State.inReadTrack) {
+                this._deliverData = 0xc2;
+                return true;
+            }
+            // Tag the byte after 3 sync bytes as a marker. The byte after 3 index syncs is the index mark, which
+            // opens no field, so it stays untagged.
             if ((this._markDetector & 0xffffffffffff0000n) === 0x4489448944890000n) {
                 this._deliverIsMarker = true;
             }
-        } else {
-            // The FM mark detector appears to need 4 data bits' worth of zeros, with clock bits set to 1, to be able to trigger.
-            // Tried on @scarybeasts's real 1772-based machine.
-            if ((this._markDetector & 0x0000ffff00000000n) === 0x0000888800000000n) {
-                const { clocks, data, iffyPulses } = IbmDiscFormat._2usPulsesToFm(
-                    Number(this._markDetector & 0xffffffffn),
-                );
-                if (!iffyPulses && clocks === 0xc7) {
-                    // TODO(#1059) see http://info-coach.fr/atari/documents/_mydoc/WD1772-JLG.pdf
-                    // This suggests that a wider range of byte values will function as markers. It may also differ FM vs. MFM.
-                    if (data === 0xf8 || data === 0xfb || data === 0xfe) {
-                        // Resync to marker.
-                        this._deliverData = data;
-                        this._deliverIsMarker = true;
-                        return true;
-                    }
-                }
-            }
+            return false;
         }
-        return false;
+        // The FM mark detector appears to need 4 data bits' worth of zeros, with clock bits set to 1, to be able to trigger.
+        // Tried on @scarybeasts's real 1772-based machine.
+        if ((this._markDetector & 0x0000ffff00000000n) !== 0x0000888800000000n) return false;
+        const { clocks, data, iffyPulses } = IbmDiscFormat._2usPulsesToFm(Number(this._markDetector & 0xffffffffn));
+        // A mark reads back with the clock that write track gives it.
+        const markClocks = this._fmMarkerClocksFor(data);
+        if (iffyPulses || markClocks === undefined || clocks !== markClocks) return false;
+        this._deliverData = data;
+        this._deliverIsMarker = data !== FmIndexMark;
+        return true;
     }
 
     /**
@@ -1066,7 +1071,7 @@ export class WdFdc {
 
     _fmMarkerClocksFor(byte) {
         switch (byte) {
-            case 0xfc:
+            case FmIndexMark:
                 return 0xd7;
             case 0xf8:
             case 0xf9:
@@ -1161,9 +1166,9 @@ export class WdFdc {
 
         switch (this._state) {
             case State.searchId:
-                if (!isMarker || data !== IbmDiscFormat.idMarkDataPattern) break;
+                if (!isMarker || !isIdMark(data)) break;
                 this._setState(State.inId);
-                this._crc = IbmDiscFormat.crcAddByte(IbmDiscFormat.crcInit(isMfm), IbmDiscFormat.idMarkDataPattern);
+                this._crc = IbmDiscFormat.crcAddByte(IbmDiscFormat.crcInit(isMfm), data);
                 break;
             case State.inId:
                 this._byteReceivedInId(data);
@@ -1221,9 +1226,8 @@ export class WdFdc {
             if (isCrcError) this._statusRegister |= Status.crcError;
             // Unlike the 8271, read address returns just a single record. It is also not synchronized
             // to the index pulse.
-            // EMU TODO(#1059) it's likely that timing is generally off for most states,
-            // i.e. the 1770 takes various numbers of internal clock cycles before it
-            // delivers the CRC error, before it goes not busy, etc.
+            // EMU NOTE: the internal clock cycles the 1770 spends between delivering the last
+            // header byte, reporting the CRC error and dropping busy are not modelled.
             // EMU NOTE: must not clear busy flag right away. The 1770 delivers the
             // last header byte DRQ separately from lowering the busy flag.
             this._setState(State.done);
@@ -1261,10 +1265,8 @@ export class WdFdc {
             this._setState(State.searchId);
             return;
         }
-        if (!isMarker) return;
-        if (data === IbmDiscFormat.dataMarkDataPattern) {
-            // Nothing...
-        } else if (data === IbmDiscFormat.deletedDataMarkDataPattern) {
+        if (!isMarker || !(isDataMark(data) || isDeletedDataMark(data))) return;
+        if (isDeletedDataMark(data)) {
             // EMU NOTE: the datasheet is ambiguous on whether the deleted mark is
             // visible in the status register immediately, or at the end of a read.
             // The state machine diagram says "DAM in time" -> "Set Record Type in
@@ -1278,7 +1280,7 @@ export class WdFdc {
             // the bit, but testing on @scarybeasts's 1772, the bit is set and left set even if
             // a non-deleted sector is encountered subsequently.
             this._statusRegister |= Status.typeIIorIIIDeletedMark;
-        } else return;
+        }
         this._setState(State.inData);
         // CRC error is reset here. It's possible to hit a CRC error in a sector header and then find
         // an OK matching sector header.

--- a/tests/unit/test-wd-fdc.js
+++ b/tests/unit/test-wd-fdc.js
@@ -3,44 +3,188 @@ import { describe, it, expect } from "vitest";
 import { Scheduler } from "../../src/scheduler.js";
 import { WdFdc } from "../../src/wd-fdc.js";
 import { DiscDrive } from "../../src/disc-drive.js";
-import { Disc, DiscConfig } from "../../src/disc.js";
+import { Disc, DiscConfig, IbmDiscFormat } from "../../src/disc.js";
 import { fake6502 } from "../../src/fake6502.js";
 
 const ControlRegister = 0;
 const CommandRegister = 4;
 const StatusRegister = 4;
 const TrackRegister = 5;
+const SectorRegister = 6;
 const DataRegister = 7;
 
-// Reset is active low, so 0x20 releases it; 0x01 selects drive 0.
+// Reset is active low, so 0x20 releases it; 0x01 selects drive 0. Density is active low too, so
+// this is double density.
 const ControlRunningDrive0 = 0x21;
+const ControlRunningDrive0Fm = 0x29;
 
 const StatusBusy = 0x01;
+const StatusDrq = 0x02;
+const StatusLostData = 0x04;
+const StatusCrcError = 0x08;
+const StatusRecordNotFound = 0x10;
+const StatusDeletedMark = 0x20;
 
 const ForceInterrupt = 0xd0;
 // The whole low nibble, including the ready line bits the BBC can never exercise.
 const AllFlagCombinations = [...Array(16).keys()];
-// Seek, with the spin-up wait disabled so the seek starts without six revolutions of delay.
+// Type I, II and III commands with the spin-up wait disabled so they start without six
+// revolutions of delay.
 const SeekCommand = 0x18;
+const ReadSectorCommand = 0x88;
+const ReadAddressCommand = 0xc8;
+const ReadTrackCommand = 0xe8;
+// The e flag adds the head settle delay after spin-up.
+const SettleFlag = 0x04;
+const SpinUpWaitFlag = 0x08;
 
+const TicksPerMs = 2000;
+const DoneTimerTicks = 64;
 // Long enough to reach the drive's first pulse callback and to outlast the 32us the controller
 // takes to report a command as complete, but still well inside a seek's first step.
 const ShortWaitTicks = 1000;
+const MfmByteTicks = 64;
+// Well inside the 32us an MFM byte takes, so no byte is lost between polls.
+const PollTicks = 16;
+
+const IdMark = IbmDiscFormat.idMarkDataPattern;
+const DataMark = IbmDiscFormat.dataMarkDataPattern;
+const IndexMark = 0xfc;
+const FmIndexMarkClocks = 0xd7;
+const SectorLengthCode = 1;
+const SectorBytes = 256;
+const IndexMarkGap = 50;
+const SectorGap = 22;
+
+function blankDisc() {
+    return new Disc(true, new DiscConfig(), "test.ssd");
+}
 
 /**
  * A drive with no disc holds its index line permanently asserted, so the controller sees exactly
  * one index pulse edge: the first callback after the motor starts.
  *
- * @param {boolean} withDisc whether to load a blank disc, needed for anything that reads the surface
+ * @param {{disc?: Disc|null, control?: Number, controlRegister?: Number, variant?: {is1772?: boolean, isOpus?: boolean}}} [options]
+ *   the disc in drive 0 if any, the first control register write and where it goes, and the
+ *   controller variant
  */
-function makeFdc(withDisc = false) {
+function makeFdc({
+    disc = null,
+    control = ControlRunningDrive0,
+    controlRegister = ControlRegister,
+    variant = {},
+} = {}) {
     const cpu = fake6502();
     const scheduler = new Scheduler();
     const drives = [new DiscDrive(0, scheduler), new DiscDrive(1, scheduler)];
-    if (withDisc) drives[0].setDisc(new Disc(true, new DiscConfig(), "test.ssd"));
-    const fdc = new WdFdc(cpu, scheduler, drives, {});
-    fdc.write(ControlRegister, ControlRunningDrive0);
+    if (disc) drives[0].setDisc(disc);
+    const fdc = new WdFdc(cpu, scheduler, drives, {}, variant);
+    fdc.write(controlRegister, control);
     return { cpu, scheduler, fdc };
+}
+
+/**
+ * Issues a command and polls until the controller drops busy, taking every byte it offers.
+ *
+ * @returns {{bytes: Number[], status: Number, ticks: Number}} the bytes read, the final status and
+ *   how long the command took
+ */
+function runCommand(fdc, scheduler, command, { commandRegister = CommandRegister, dataRegister = DataRegister } = {}) {
+    const bytes = [];
+    const takeByte = () => {
+        if (fdc.read(commandRegister) & StatusDrq) bytes.push(fdc.read(dataRegister));
+    };
+    const start = scheduler.epoch;
+    fdc.write(commandRegister, command);
+    do {
+        takeByte();
+        scheduler.polltime(PollTicks);
+    } while (fdc.read(commandRegister) & StatusBusy);
+    takeByte();
+    return { bytes, status: fdc.read(commandRegister), ticks: scheduler.epoch - start };
+}
+
+function hex(bytes) {
+    return bytes.map((b) => b.toString(16).padStart(2, "0")).join("");
+}
+
+function sectorData() {
+    return new Uint8Array(SectorBytes).map((_, i) => i & 0xff);
+}
+
+// Runs whose MFM encoding contains the 0x00 then 0xc2 sync pattern at some bit offset.
+const DataMimickingC2Sync = [0x01, 0xfe, 0x29, 0x07, 0xf8, 0xa4];
+
+function appendFmSector(builder, { idMark = IdMark, dataMark = DataMark, sector = 0 }) {
+    return builder
+        .appendRepeatFmByte(0xff, IbmDiscFormat.stdGap1FFs)
+        .appendRepeatFmByte(0x00, IbmDiscFormat.stdSync00s)
+        .resetCrc()
+        .appendFmDataAndClocks(idMark, IbmDiscFormat.markClockPattern)
+        .appendFmByte(0)
+        .appendFmByte(0)
+        .appendFmByte(sector)
+        .appendFmByte(SectorLengthCode)
+        .appendCrc(false)
+        .appendRepeatFmByte(0xff, IbmDiscFormat.stdGap2FFs)
+        .appendRepeatFmByte(0x00, IbmDiscFormat.stdSync00s)
+        .resetCrc()
+        .appendFmDataAndClocks(dataMark, IbmDiscFormat.markClockPattern)
+        .appendFmChunk(sectorData())
+        .appendCrc(false);
+}
+
+function appendMfmSector(builder, { idMark = IdMark, dataMark = DataMark, sector = 0, data = sectorData() }) {
+    return builder
+        .appendRepeatMfmByte(0x4e, SectorGap)
+        .appendRepeatMfmByte(0x00, 12)
+        .resetCrc()
+        .appendMfm3xA1Sync()
+        .appendMfmByte(idMark)
+        .appendMfmByte(0)
+        .appendMfmByte(0)
+        .appendMfmByte(sector)
+        .appendMfmByte(SectorLengthCode)
+        .appendCrc(true)
+        .appendRepeatMfmByte(0x4e, SectorGap)
+        .appendRepeatMfmByte(0x00, 12)
+        .resetCrc()
+        .appendMfm3xA1Sync()
+        .appendMfmByte(dataMark)
+        .appendMfmChunk(data)
+        .appendCrc(true);
+}
+
+function appendMfmIndexMark(builder) {
+    builder.appendRepeatMfmByte(0x4e, 60).appendRepeatMfmByte(0x00, 12);
+    for (let i = 0; i < 3; ++i) builder.appendMfmPulses(IbmDiscFormat.mfmC2Sync);
+    return builder.appendMfmByte(IndexMark).appendRepeatMfmByte(0x4e, IndexMarkGap);
+}
+
+function fmDiscWithSector(marks) {
+    const disc = blankDisc();
+    appendFmSector(disc.buildTrack(false, 0), marks).fillFmByte(0xff);
+    return disc;
+}
+
+function mfmDiscWithSector(marks) {
+    const disc = blankDisc();
+    appendMfmSector(disc.buildTrack(false, 0).appendRepeatMfmByte(0x4e, 60), marks).fillMfmByte(0x4e);
+    return disc;
+}
+
+/**
+ * The head reads the surface in aligned 16 or 32 bit words, so a track built a word at a time is
+ * byte-aligned from the moment the motor starts. Rotating its bits leaves the controller no
+ * alignment it did not find for itself.
+ */
+function rotateTrackBits(track, bits) {
+    const words = track.pulses2Us.subarray(0, track.length);
+    const rotated = words.map((word, i) => {
+        const next = words[(i + 1) % words.length];
+        return ((word << bits) | (next >>> (32 - bits))) >>> 0;
+    });
+    words.set(rotated);
 }
 
 describe("WD1770 FDC tests", () => {
@@ -58,7 +202,7 @@ describe("WD1770 FDC tests", () => {
         });
 
         it("aborts a seek in progress and interrupts for &D8", () => {
-            const { cpu, scheduler, fdc } = makeFdc(true);
+            const { cpu, scheduler, fdc } = makeFdc({ disc: blankDisc() });
             fdc.write(TrackRegister, 0);
             fdc.write(DataRegister, 40);
             fdc.write(CommandRegister, SeekCommand);
@@ -111,13 +255,195 @@ describe("WD1770 FDC tests", () => {
 
         it("accepts every combination of flags during a seek", () => {
             for (const bits of AllFlagCombinations) {
-                const { scheduler, fdc } = makeFdc(true);
+                const { scheduler, fdc } = makeFdc({ disc: blankDisc() });
                 fdc.write(TrackRegister, 0);
                 fdc.write(DataRegister, 40);
                 fdc.write(CommandRegister, SeekCommand);
                 scheduler.polltime(ShortWaitTicks);
                 expect(() => fdc.write(CommandRegister, ForceInterrupt | bits)).not.toThrow();
             }
+        });
+    });
+
+    describe("address marks", () => {
+        it.each([
+            ["FM", fmDiscWithSector, ControlRunningDrive0Fm, IdMark, 0xfa, 0],
+            ["FM", fmDiscWithSector, ControlRunningDrive0Fm, IdMark, 0xf9, StatusDeletedMark],
+            ["MFM", mfmDiscWithSector, ControlRunningDrive0, 0xfc, 0xfa, 0],
+            ["MFM", mfmDiscWithSector, ControlRunningDrive0, 0xff, 0xf9, StatusDeletedMark],
+        ])(
+            "reads an %s sector marked with the alternate values",
+            (_, discWith, control, idMark, dataMark, expected) => {
+                const { scheduler, fdc } = makeFdc({ disc: discWith({ idMark, dataMark }), control });
+                fdc.write(SectorRegister, 0);
+                const { bytes, status } = runCommand(fdc, scheduler, ReadSectorCommand);
+                expect(bytes).toEqual([...sectorData()]);
+                expect(status & (StatusDeletedMark | StatusCrcError | StatusRecordNotFound | StatusLostData)).toBe(
+                    expected,
+                );
+            },
+        );
+
+        it("keeps read track byte-aligned across an MFM index mark", () => {
+            const disc = blankDisc();
+            const builder = appendMfmIndexMark(disc.buildTrack(false, 0));
+            appendMfmSector(builder, {}).fillMfmByte(0x4e);
+            rotateTrackBits(builder.track, 5);
+            const { scheduler, fdc } = makeFdc({ disc });
+            const { bytes } = runCommand(fdc, scheduler, ReadTrackCommand);
+            expect(hex(bytes)).toContain(`c2c2c2fc${"4e".repeat(IndexMarkGap + SectorGap)}0000`);
+            expect(hex(bytes)).toContain(`a1a1a1fe00000001`);
+        });
+
+        it("does not resync on data that looks like an index sync", () => {
+            const data = sectorData();
+            data.set(DataMimickingC2Sync, 100);
+            const { scheduler, fdc } = makeFdc({ disc: mfmDiscWithSector({ data }) });
+            fdc.write(SectorRegister, 0);
+            const { bytes, status } = runCommand(fdc, scheduler, ReadSectorCommand);
+            expect(bytes).toEqual([...data]);
+            expect(status & StatusCrcError).toBe(0);
+        });
+
+        it("does not take an MFM index mark for a sector ID", () => {
+            const disc = blankDisc();
+            appendMfmSector(appendMfmIndexMark(disc.buildTrack(false, 0)), { sector: 3 }).fillMfmByte(0x4e);
+            const { scheduler, fdc } = makeFdc({ disc });
+            const { bytes, status } = runCommand(fdc, scheduler, ReadAddressCommand);
+            expect(bytes.slice(0, 4)).toEqual([0, 0, 3, SectorLengthCode]);
+            expect(status & StatusCrcError).toBe(0);
+        });
+
+        it("does not take an FM index mark for a sector ID", () => {
+            const disc = blankDisc();
+            const builder = disc
+                .buildTrack(false, 0)
+                .appendRepeatFmByte(0xff, IbmDiscFormat.stdGap1FFs)
+                .appendRepeatFmByte(0x00, IbmDiscFormat.stdSync00s)
+                .appendFmDataAndClocks(IndexMark, FmIndexMarkClocks);
+            appendFmSector(builder, { sector: 3 }).fillFmByte(0xff);
+            const { scheduler, fdc } = makeFdc({ disc, control: ControlRunningDrive0Fm });
+            const { bytes, status } = runCommand(fdc, scheduler, ReadAddressCommand);
+            expect(bytes.slice(0, 4)).toEqual([0, 0, 3, SectorLengthCode]);
+            expect(status & StatusCrcError).toBe(0);
+        });
+    });
+
+    describe("variants", () => {
+        describe("step rate", () => {
+            it.each([
+                [{}, 0, 6],
+                [{}, 1, 12],
+                [{}, 2, 20],
+                [{}, 3, 30],
+                [{ is1772: true }, 0, 6],
+                [{ is1772: true }, 1, 12],
+                [{ is1772: true }, 2, 2],
+                [{ is1772: true }, 3, 3],
+            ])("with %o steps one track at rate %i in %i ms", (variant, rate, ms) => {
+                const { scheduler, fdc } = makeFdc({ disc: blankDisc(), variant });
+                fdc.write(TrackRegister, 0);
+                fdc.write(DataRegister, 1);
+                const { ticks } = runCommand(fdc, scheduler, SeekCommand | rate);
+                expect(ticks).toBeGreaterThanOrEqual(ms * TicksPerMs + DoneTimerTicks);
+                expect(ticks).toBeLessThan(ms * TicksPerMs + DoneTimerTicks + 2 * PollTicks);
+            });
+        });
+
+        describe("head settle", () => {
+            // Read address finishes as soon as it sees an ID, so a track of nothing but IDs
+            // shows the settle delay to within one ID's length.
+            function discOfIds() {
+                const disc = blankDisc();
+                const builder = disc.buildTrack(false, 0);
+                for (let sector = 0; sector < 250; ++sector) {
+                    builder
+                        .appendRepeatMfmByte(0x00, 12)
+                        .resetCrc()
+                        .appendMfm3xA1Sync()
+                        .appendMfmByte(IdMark)
+                        .appendMfmByte(0)
+                        .appendMfmByte(0)
+                        .appendMfmByte(sector)
+                        .appendMfmByte(SectorLengthCode)
+                        .appendCrc(true);
+                }
+                builder.fillMfmByte(0x4e);
+                return disc;
+            }
+            const IdTicks = 22 * MfmByteTicks;
+
+            function readAddressTicks(variant, command) {
+                const { scheduler, fdc } = makeFdc({ disc: discOfIds(), variant });
+                return runCommand(fdc, scheduler, command).ticks;
+            }
+
+            it.each([[{}], [{ is1772: true }]])("with %o the e flag delays a type III command by 15 ms", (variant) => {
+                const command = ReadAddressCommand & ~SpinUpWaitFlag;
+                const delay = readAddressTicks(variant, command | SettleFlag) - readAddressTicks(variant, command);
+                expect(delay).toBeGreaterThan(15 * TicksPerMs - IdTicks);
+                expect(delay).toBeLessThan(15 * TicksPerMs + IdTicks);
+            });
+        });
+
+        describe("Opus Challenger", () => {
+            // The Challenger puts the 1770 in the low half of the page and its control register in
+            // the high half; bit 0 picks drive 1, bit 1 the side and bit 6 double density.
+            const OpusControlRegister = 4;
+            const OpusCommandRegister = 0;
+            const OpusStatusRegister = 0;
+            const OpusTrackRegister = 1;
+            const OpusDataRegister = 3;
+            const OpusDoubleDensity = 0x40;
+            const OpusDrive1 = 0x01;
+
+            function makeOpus(control, disc = null) {
+                return makeFdc({ disc, control, controlRegister: OpusControlRegister, variant: { isOpus: true } });
+            }
+
+            it("keeps INTRQ off the NMI line", () => {
+                const { cpu, fdc } = makeOpus(OpusDoubleDensity);
+                fdc.write(OpusCommandRegister, ForceInterrupt | 0x08);
+                expect(cpu.nmi).toBe(false);
+            });
+
+            it("raises the NMI for DRQ", () => {
+                const { cpu, scheduler, fdc } = makeOpus(OpusDoubleDensity);
+                fdc.write(OpusCommandRegister, ReadTrackCommand);
+                scheduler.polltime(ShortWaitTicks);
+                expect(fdc.read(OpusStatusRegister) & StatusDrq).toBe(StatusDrq);
+                expect(cpu.nmi).toBe(true);
+            });
+
+            it("maps the registers to the low half of the page", () => {
+                const { fdc } = makeOpus(OpusDoubleDensity);
+                fdc.write(OpusTrackRegister, 42);
+                expect(fdc.read(OpusTrackRegister)).toBe(42);
+                expect(fdc.read(TrackRegister)).toBe(0xfe);
+            });
+
+            it("selects the drive from bit 0 of the control register", () => {
+                const drive0 = makeOpus(OpusDoubleDensity);
+                drive0.fdc.write(OpusCommandRegister, ForceInterrupt);
+                expect(drive0.fdc.motorOn).toEqual([true, false]);
+
+                const drive1 = makeOpus(OpusDoubleDensity | OpusDrive1);
+                drive1.fdc.write(OpusCommandRegister, ForceInterrupt);
+                expect(drive1.fdc.motorOn).toEqual([false, true]);
+            });
+
+            it.each([
+                [OpusDoubleDensity, 2 * IbmDiscFormat.bytesPerTrack],
+                [0, IbmDiscFormat.bytesPerTrack],
+            ])("with control %i reads a revolution as %i bytes", (control, bytesPerRevolution) => {
+                const { scheduler, fdc } = makeOpus(control, blankDisc());
+                const { bytes } = runCommand(fdc, scheduler, ReadTrackCommand, {
+                    commandRegister: OpusCommandRegister,
+                    dataRegister: OpusDataRegister,
+                });
+                expect(bytes.length).toBeGreaterThan(bytesPerRevolution - 4);
+                expect(bytes.length).toBeLessThanOrEqual(bytesPerRevolution + 4);
+            });
         });
     });
 });

--- a/tests/unit/test-wd-fdc.js
+++ b/tests/unit/test-wd-fdc.js
@@ -46,6 +46,8 @@ const ShortWaitTicks = 1000;
 const MfmByteTicks = 64;
 // Well inside the 32us an MFM byte takes, so no byte is lost between polls.
 const PollTicks = 16;
+// A type II command gives up after five revolutions, so a command still busy after ten has hung.
+const MaxCommandTicks = 10 * DiscDrive.TicksPerRevolution;
 
 const IdMark = IbmDiscFormat.idMarkDataPattern;
 const DataMark = IbmDiscFormat.dataMarkDataPattern;
@@ -99,6 +101,7 @@ function runCommand(fdc, scheduler, command, { commandRegister = CommandRegister
     do {
         takeByte();
         scheduler.polltime(PollTicks);
+        if (scheduler.epoch - start > MaxCommandTicks) throw new Error(`Command ${command} never finished`);
     } while (fdc.read(commandRegister) & StatusBusy);
     takeByte();
     return { bytes, status: fdc.read(commandRegister), ticks: scheduler.epoch - start };

--- a/tests/unit/test-wd-fdc.js
+++ b/tests/unit/test-wd-fdc.js
@@ -1,7 +1,7 @@
 import { describe, it, expect } from "vitest";
 
 import { Scheduler } from "../../src/scheduler.js";
-import { WdFdc } from "../../src/wd-fdc.js";
+import { WdFdc, WdFdcVariant } from "../../src/wd-fdc.js";
 import { DiscDrive } from "../../src/disc-drive.js";
 import { Disc, DiscConfig, IbmDiscFormat } from "../../src/disc.js";
 import { fake6502 } from "../../src/fake6502.js";
@@ -66,7 +66,7 @@ function blankDisc() {
  * A drive with no disc holds its index line permanently asserted, so the controller sees exactly
  * one index pulse edge: the first callback after the motor starts.
  *
- * @param {{disc?: Disc|null, control?: Number, controlRegister?: Number, variant?: {is1772?: boolean, isOpus?: boolean}}} [options]
+ * @param {{disc?: Disc|null, control?: Number, controlRegister?: Number, variant?: WdFdcVariant}} [options]
  *   the disc in drive 0 if any, the first control register write and where it goes, and the
  *   controller variant
  */
@@ -74,7 +74,7 @@ function makeFdc({
     disc = null,
     control = ControlRunningDrive0,
     controlRegister = ControlRegister,
-    variant = {},
+    variant = WdFdcVariant.wd1770,
 } = {}) {
     const cpu = fake6502();
     const scheduler = new Scheduler();
@@ -344,15 +344,15 @@ describe("WD1770 FDC tests", () => {
     describe("variants", () => {
         describe("step rate", () => {
             it.each([
-                [{}, 0, 6],
-                [{}, 1, 12],
-                [{}, 2, 20],
-                [{}, 3, 30],
-                [{ is1772: true }, 0, 6],
-                [{ is1772: true }, 1, 12],
-                [{ is1772: true }, 2, 2],
-                [{ is1772: true }, 3, 3],
-            ])("with %o steps one track at rate %i in %i ms", (variant, rate, ms) => {
+                [WdFdcVariant.wd1770, 0, 6],
+                [WdFdcVariant.wd1770, 1, 12],
+                [WdFdcVariant.wd1770, 2, 20],
+                [WdFdcVariant.wd1770, 3, 30],
+                [WdFdcVariant.wd1772, 0, 6],
+                [WdFdcVariant.wd1772, 1, 12],
+                [WdFdcVariant.wd1772, 2, 2],
+                [WdFdcVariant.wd1772, 3, 3],
+            ])("a %s steps one track at rate %i in %i ms", (variant, rate, ms) => {
                 const { scheduler, fdc } = makeFdc({ disc: blankDisc(), variant });
                 fdc.write(TrackRegister, 0);
                 fdc.write(DataRegister, 1);
@@ -390,12 +390,15 @@ describe("WD1770 FDC tests", () => {
                 return runCommand(fdc, scheduler, command).ticks;
             }
 
-            it.each([[{}], [{ is1772: true }]])("with %o the e flag delays a type III command by 15 ms", (variant) => {
-                const command = ReadAddressCommand & ~SpinUpWaitFlag;
-                const delay = readAddressTicks(variant, command | SettleFlag) - readAddressTicks(variant, command);
-                expect(delay).toBeGreaterThan(15 * TicksPerMs - IdTicks);
-                expect(delay).toBeLessThan(15 * TicksPerMs + IdTicks);
-            });
+            it.each([[WdFdcVariant.wd1770], [WdFdcVariant.wd1772]])(
+                "on a %s the e flag delays a type III command by 15 ms",
+                (variant) => {
+                    const command = ReadAddressCommand & ~SpinUpWaitFlag;
+                    const delay = readAddressTicks(variant, command | SettleFlag) - readAddressTicks(variant, command);
+                    expect(delay).toBeGreaterThan(15 * TicksPerMs - IdTicks);
+                    expect(delay).toBeLessThan(15 * TicksPerMs + IdTicks);
+                },
+            );
         });
 
         describe("Opus Challenger", () => {
@@ -410,7 +413,12 @@ describe("WD1770 FDC tests", () => {
             const OpusDrive1 = 0x01;
 
             function makeOpus(control, disc = null) {
-                return makeFdc({ disc, control, controlRegister: OpusControlRegister, variant: { isOpus: true } });
+                return makeFdc({
+                    disc,
+                    control,
+                    controlRegister: OpusControlRegister,
+                    variant: WdFdcVariant.opusChallenger,
+                });
             }
 
             it("keeps INTRQ off the NMI line", () => {


### PR DESCRIPTION
Fixes #1059. Stacked on #1114 (the Read Track state fix), which the read track tests here need; merge #1114 first.

The five notes from the issue, against Jean Louis-Guerin's WD1772 specification (V1.3) and beebjit:

- **Marker byte range.** The spec says an ID field is opened by an IDAM of $FC to $FF and a data field by $FA/$FB (data) or $F8/$F9 (deleted), and its write-track table gives the FM clocks: C7 for F8 to FB and FE, D7 for FC. The FM detector now accepts a byte as a mark when its clock is the one write track would give it, the ID search accepts FC to FF, the data search FA/FB and F8/F9, and both CRCs are seeded from the mark actually read rather than the constant. The write side already matched the table. Where beebjit is narrower than the spec (F8/FB/FE only), the spec wins. The FM index mark (FC with D7) resyncs the bit stream but is not tagged as a field marker, and neither is the byte after three C2 syncs, otherwise a standard index mark would open a bogus ID field (a Read Address at the index would have returned four gap bytes with a CRC error).
- **C2 sync.** Read Track now resyncs on the C2 index sync (MFM 00 then 0x5224), so its output is byte-aligned across the index mark. The resync is honoured only in the read track state. beebjit's note that a naive attempt fired in the middle of sector data was right: the pattern occurs in ordinary MFM data (`01 fe 29` is one of about a thousand byte triples that encode it at some bit offset), so a resync inside a field corrupts the rest of that sector. The spec itself confines the C2 false-sync caveat to Read Track. A regression test reads an MFM sector whose data contains such triples and checks it comes back intact.
- **1772 and Opus variants.** `WdFdc` takes a `WdFdcVariant` (`wd1770`, the default; `wd1772`; `opusChallenger`, whose board carries a 1770 wired differently). No machine model sets anything but the default, as none is a Master Compact or Opus Challenger. The 1772 step rates were already coded; head settle stays at 15 ms for both, since the 1772 datasheet gives 15 ms and jsbeeb already runs the 1770 at b-em's 15 ms (beebjit halves its 30 ms, which would give 7.5 ms here). The Opus control register remap had drive select and density inverted relative to beebjit's `wd_fdc_opus_remap_val`; it is now ported from beebjit. Tests cover all four step rates on both chips (measured from the scheduler epoch), the settle delay, and the Opus wiring: INTRQ off the NMI, DRQ on it, the register halves swapped, drive select and density polarity.
- **State timing.** Left as a plain EMU NOTE; there is no measurement to base a change on.
- **Read Track itself** never worked on the 1770 before #1114; the tests here depend on that fix, which is merged into this branch.

Test helpers added to `test-wd-fdc.js`: `runCommand` polls a command to completion collecting DRQ bytes; FM and MFM sector and index-mark track builders; and `rotateTrackBits`, which rotates a built track by a few bits so the controller has to find byte alignment itself rather than inheriting it from the word-aligned builder.

User-visible: discs using the non-standard mark bytes now read on the 1770 as on real hardware (only copy-protected titles are likely to notice), and Read Track output is byte-aligned across an MFM index mark.

🤖 Generated with [Claude Code](https://claude.com/claude-code)