### PR TITLE
chore: keep Vitest's transformed modules between runs

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -18,8 +18,6 @@ export default defineConfig({
     },
     test: {
         testTimeout: 15000,
-        // Transformed modules persist in node_modules/.vitest-cache, so each run reuses the last
-        // one's work rather than transforming the graph again. Reinstalling deps clears it.
         fsModuleCache: true,
         ...(JobSummaryTitle
             ? { reporters: ["default", ["github-actions", { jobSummary: { title: JobSummaryTitle } }]] }

--- a/vite.config.js
+++ b/vite.config.js
@@ -18,6 +18,9 @@ export default defineConfig({
     },
     test: {
         testTimeout: 15000,
+        // Transformed modules persist in node_modules/.vitest-cache, so each run reuses the last
+        // one's work rather than transforming the graph again. Reinstalling deps clears it.
+        fsModuleCache: true,
         ...(JobSummaryTitle
             ? { reporters: ["default", ["github-actions", { jobSummary: { title: JobSummaryTitle } }]] }
             : {}),


### PR DESCRIPTION
Vitest 5 can keep transformed modules on disk and reuse them across separate runs, so a cold start skips work the last run already did. The cache lives in `node_modules/.vitest-cache` and is thrown away whenever dependencies are reinstalled.

Measured on this machine, three runs each way, all of them cold processes:

| Run | Before | After |
| --- | --- | --- |
| Unit suite | 13.5s | 13.1s |
| `vitest related` for one source file, as the pre-commit hook runs it | 21.1s | 20.0s |
| A single test file | 4.1s | 4.0s |

That is three to five percent, for 41MB under `node_modules`. It is a local benefit only: CI installs from scratch each time, so its cache is always empty. Worth having or not depending on whether the disk matters more than the seconds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
