### PR TITLE
fix: restore paging when a session read validates a bank and shadow together

### DIFF
--- a/src/machine-session.js
+++ b/src/machine-session.js
@@ -484,15 +484,12 @@ export class MachineSession {
     _withPaging({ bank, shadow }, fn) {
         const cpu = this._machine.processor;
         const { romsel, acccon } = cpu;
-        if (bank !== undefined) {
-            if (!Number.isInteger(bank) || bank < 0 || bank > 15) throw new Error(`Bank ${bank} is not 0 to 15`);
-            cpu.romSelect(bank);
-        }
-        if (shadow !== undefined) {
-            if (!cpu.model.isMaster) throw new Error("Only a Master has shadow RAM");
-            cpu.writeAcccon(shadow ? acccon | AccconShadowBit : acccon & ~AccconShadowBit);
-        }
+        if (bank !== undefined && (!Number.isInteger(bank) || bank < 0 || bank > 15))
+            throw new Error(`Bank ${bank} is not 0 to 15`);
+        if (shadow !== undefined && !cpu.model.isMaster) throw new Error("Only a Master has shadow RAM");
         try {
+            if (bank !== undefined) cpu.romSelect(bank);
+            if (shadow !== undefined) cpu.writeAcccon(shadow ? acccon | AccconShadowBit : acccon & ~AccconShadowBit);
             return fn();
         } finally {
             if (bank !== undefined) cpu.romSelect(romsel);

--- a/tests/integration/machine-session.js
+++ b/tests/integration/machine-session.js
@@ -279,6 +279,14 @@ describe("MachineSession paged memory on a machine without shadow RAM", () => {
     it("refuses to page shadow RAM", () => {
         expect(() => session.readMemory(0x3000, 1, { shadow: true })).toThrow(/Master/);
     });
+
+    it("leaves the map alone when it refuses a bank and shadow together", () => {
+        const before = session.pagingState();
+
+        expect(() => session.readMemory(0x8000, 1, { bank: 5, shadow: true })).toThrow(/Master/);
+
+        expect(session.pagingState()).toEqual(before);
+    });
 });
 
 describe("MachineSession frame stepping across a hard reset", () => {


### PR DESCRIPTION
`MachineSession._withPaging` paged the sideways bank in before checking that the machine has shadow RAM, so a call passing both options on a machine without shadow RAM threw from the second guard with ROMSEL left on the requested bank. Every later read or write through the session then saw the wrong bank.

Both guards now run before anything is changed, and the two paging writes moved inside the `try` whose `finally` puts the map back.

The new integration test fails on the old code with ROMSEL stuck at 5 instead of 15.

Fixes #1105

🤖 Generated with [Claude Code](https://claude.com/claude-code)