### PR TITLE
feat!: identify host keys by physical position, not by key code

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,13 +64,20 @@ And Superior's Hunchback steers with `CAPS LOCK` and `CTRL`, which the arrow key
 
 [`https://bbc.xania.org/?disc1=sth:Superior/Hunchback-Superior.zip&autoboot&KEY.LEFT=CAPSLOCK&KEY.RIGHT=CTRL`](https://bbc.xania.org/?disc1=sth:Superior/Hunchback-Superior.zip&autoboot&KEY.LEFT=CAPSLOCK&KEY.RIGHT=CTRL)
 
-The **host key** names are jsbeeb's names for the keys on your own keyboard. Most are what you'd expect, but note:
+The **host key** names are jsbeeb's names for the keys on your own keyboard. A host key is identified by where it
+sits, not by what it types, so these work the same on a Dvorak, AZERTY or Hungarian layout as on a QWERTY one. Most
+names are what you'd expect, but note:
 
 - `ENTER` (the BBC's `RETURN` key is called `ENTER` on the host side)
 - `K0` to `K9` for the number keys, `NUMPAD0` to `NUMPAD9` for the keypad
-- `SHIFT_LEFT` / `SHIFT_RIGHT`, `CTRL_LEFT` / `CTRL_RIGHT`, `ALT_LEFT` / `ALT_RIGHT` to distinguish the two of each
-- `BACK_QUOTE`, `APOSTROPHE`, `SEMICOLON`, `MINUS`, `EQUALS`, `HASH`, `BACKSLASH`, `LEFT_SQUARE_BRACKET`,
+- `SHIFT_LEFT` / `SHIFT_RIGHT`, `CTRL_LEFT` / `CTRL_RIGHT`, `ALT_LEFT` / `ALT_RIGHT` to distinguish the two of each.
+  Plain `SHIFT`, `CTRL` and `ALT` map both sides at once
+- `WINDOWS` and `WINDOWS_RIGHT` for the Windows or Command keys
+- `BACK_QUOTE`, `APOSTROPHE`, `SEMICOLON`, `MINUS`, `EQUALS`, `BACKSLASH`, `LEFT_SQUARE_BRACKET`,
   `RIGHT_SQUARE_BRACKET` for punctuation
+- `BACKSLASH` is the key left of `Enter` on a UK keyboard (printed `#~`) and the one above it on a US keyboard
+  (printed `\|`); they are the same physical key. `HASH` is accepted as another name for it. `INTL_BACKSLASH` is the
+  extra key between the left shift and the `Z` that only a 102-key keyboard has
 
 The **BBC key** names are:
 
@@ -97,7 +104,8 @@ Some things to know:
   was at fault.
 - On the Atom, use the Atom's own key names (`LOCK`, `UP_DOWN`, `LEFT_RIGHT` and so on) rather than the BBC's.
 
-The definitive lists are `keyCodes` (host) and `BBC` (BBC micro) in [`src/keymap.js`](src/keymap.js), and `ATOM` in
+The definitive lists are `keyCodes` with `keyCodeAliases` (host) and `BBC` (BBC micro) in
+[`src/keymap.js`](src/keymap.js), and `ATOM` in
 [`src/keymap-atom.js`](src/keymap-atom.js).
 
 ### Discs and Tapes

--- a/README.md
+++ b/README.md
@@ -72,7 +72,8 @@ names are what you'd expect, but note:
 - `K0` to `K9` for the number keys, `NUMPAD0` to `NUMPAD9` for the keypad
 - `SHIFT_LEFT` / `SHIFT_RIGHT`, `CTRL_LEFT` / `CTRL_RIGHT`, `ALT_LEFT` / `ALT_RIGHT` to distinguish the two of each.
   Plain `SHIFT`, `CTRL` and `ALT` map both sides at once
-- `WINDOWS` and `WINDOWS_RIGHT` for the Windows or Command keys
+- `WINDOWS` and `WINDOWS_RIGHT` for the Windows or Command keys, and `CLEAR` for the key an Apple
+  keyboard prints that on
 - `BACK_QUOTE`, `APOSTROPHE`, `SEMICOLON`, `MINUS`, `EQUALS`, `BACKSLASH`, `LEFT_SQUARE_BRACKET`,
   `RIGHT_SQUARE_BRACKET` for punctuation
 - `BACKSLASH` is the key left of `Enter` on a UK keyboard (printed `#~`) and the one above it on a US keyboard
@@ -97,6 +98,8 @@ Some things to know:
 
 - Names are case-insensitive, and a remapped key ignores the `SHIFT` state, so `KEY.ENTER=COPY` presses `COPY` whether
   or not shift is held.
+- Any host key can be named here, including ones no layout uses by default, such as `PRINTSCREEN`, `SCROLL_LOCK` and
+  `WINDOWS_RIGHT`. Naming one is the only way to make it press anything.
 - Remapping replaces what that host key normally does; in the Space Invaders example above, `Enter` no longer presses
   `RETURN`.
 - The remapping is applied on top of whichever keyboard layout is selected, and survives changing layout or model.

--- a/src/keymap-atom.js
+++ b/src/keymap-atom.js
@@ -1,4 +1,4 @@
-import { detectKeyboardLayout, keyCodes, userKeymap } from "./keymap.js";
+import { detectKeyboardLayout, hostKeyCodes, keyCodes, userKeymap } from "./keymap.js";
 
 // ATOM
 
@@ -241,11 +241,8 @@ export function getKeyMapAtom(keyLayout) {
 
     // shiftDown undefined -> map both
     function map(s, colRow, shiftDown) {
-        if ((!s && s !== 0) || !colRow) {
+        if (!s || !colRow) {
             console.log("error binding key", s, colRow);
-        }
-        if (typeof s === "string") {
-            s = s.charCodeAt(0);
         }
 
         if (shiftDown === undefined) {
@@ -344,8 +341,6 @@ export function getKeyMapAtom(keyLayout) {
 
         // 3rd row
 
-        map(keyCodes.HASH, ATOM.BACKSLASH); // Atom has no # key; map to nearest
-
         map(keyCodes.MINUS, ATOM.MINUS_EQUALS);
 
         // 2nd row
@@ -364,14 +359,14 @@ export function getKeyMapAtom(keyLayout) {
         map(keyCodes.END, ATOM.COPY);
         map(keyCodes.F11, ATOM.COPY);
 
-        map(keyCodes.CTRL, ATOM.CTRL);
         map(keyCodes.CTRL_LEFT, ATOM.CTRL);
         map(keyCodes.CTRL_RIGHT, ATOM.CTRL);
-        map(keyCodes.SHIFT, ATOM.SHIFT);
         map(keyCodes.SHIFT_LEFT, ATOM.SHIFT);
         map(keyCodes.SHIFT_RIGHT, ATOM.SHIFT);
 
+        // The Atom has no `#` key, so both of the host's backslash keys go to the nearest.
         map(keyCodes.BACKSLASH, ATOM.BACKSLASH);
+        map(keyCodes.INTL_BACKSLASH, ATOM.BACKSLASH);
     } else if (keyLayout === "gaming") {
         // gaming keyboard
 
@@ -409,20 +404,17 @@ export function getKeyMapAtom(keyLayout) {
         map(keyCodes.CAPSLOCK, ATOM.CTRL);
         map(keyCodes.SEMICOLON, ATOM.SEMICOLON_PLUS);
         map(keyCodes.APOSTROPHE, ATOM.COLON_STAR);
-        // UK keyboard (key missing on US)
-        map(keyCodes.HASH, ATOM.RIGHT_SQUARE_BRACKET);
+        // UK prints `#~` on this key, a US board `\|`.
+        map(keyCodes.BACKSLASH, isUKlayout ? ATOM.RIGHT_SQUARE_BRACKET : ATOM.BACKSLASH);
 
-        // UK has extra key \| for SHIFT
+        // Only a 102-key board has a key here, so only there can the left shift be spared.
         map(keyCodes.SHIFT_LEFT, isUKlayout ? ATOM.LOCK : ATOM.SHIFT);
-        // UK: key is between SHIFT and Z
-        // US: key is above ENTER
-        map(keyCodes.BACKSLASH, isUKlayout ? ATOM.SHIFT : ATOM.BACKSLASH);
+        map(keyCodes.INTL_BACKSLASH, ATOM.SHIFT);
 
         // 5th row
 
         // Atom uses CTRL as shift, so map PC Ctrl to Atom's LOCK key
         map(keyCodes.CTRL_LEFT, ATOM.LOCK);
-        map(keyCodes.SHIFT, ATOM.CTRL);
 
         // ATOM.DELETE is covered by the common mapping above
         map(keyCodes.CTRL_RIGHT, ATOM.COPY);
@@ -451,9 +443,7 @@ export function getKeyMapAtom(keyLayout) {
         map(keyCodes.LEFT_SQUARE_BRACKET, ATOM.AT); // maps to @
         map(keyCodes.RIGHT_SQUARE_BRACKET, ATOM.BACKSLASH); // maps to \
 
-        map(keyCodes.SHIFT, ATOM.CTRL);
         map(keyCodes.SHIFT_LEFT, ATOM.CTRL); // using CAPSLOCK for CTRL doesn't work on MAC
-        map(keyCodes.CTRL, ATOM.SHIFT);
         map(keyCodes.CTRL_LEFT, ATOM.SHIFT);
 
         map(keyCodes.CTRL_RIGHT, ATOM.SHIFT);
@@ -462,14 +452,15 @@ export function getKeyMapAtom(keyLayout) {
         // A-L normal
         map(keyCodes.SEMICOLON, ATOM.SEMICOLON_PLUS); // ; / +
         map(keyCodes.APOSTROPHE, ATOM.LEFT_SQUARE_BRACKET);
-        map(keyCodes.BACKSLASH, ATOM.RIGHT_SQUARE_BRACKET); // HASH is \| key on Mac
+        map(keyCodes.BACKSLASH, ATOM.RIGHT_SQUARE_BRACKET);
+        map(keyCodes.INTL_BACKSLASH, ATOM.RIGHT_SQUARE_BRACKET);
 
         // Z - M normal
     }
 
     // `KEY.` URL parameters, applied last so they win. See the equivalent in `getKeyMap`.
     for (const mapping of userKeymap) {
-        remap(keyCodes[mapping.native], ATOM[mapping.key]);
+        for (const code of hostKeyCodes(mapping.native)) remap(code, ATOM[mapping.key]);
     }
 
     return keys2;

--- a/src/keymap.js
+++ b/src/keymap.js
@@ -1,11 +1,5 @@
 import { runningInNode } from "./loader.js";
 
-export function isFirefox() {
-    // With thanks to http://stackoverflow.com/questions/9847580/how-to-detect-safari-chrome-ie-firefox-and-opera-browser
-    // Opera 8.0+ (UA detection to detect Blink/v8-powered Opera)
-    return typeof InstallTrigger !== "undefined"; // Firefox 1.0+
-}
-
 export const userKeymap = [];
 
 export const BBC = {
@@ -251,131 +245,148 @@ export function stringToBBCKeys(str) {
 }
 
 /**
- * Useful references:
- * http://www.cambiaresearch.com/articles/15/javascript-char-codes-key-codes
- * https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent.keyCode
+ * Host keys by physical position, as `KeyboardEvent.code` names them:
+ * https://www.w3.org/TR/uievents-code/
+ *
+ * The names on the left are jsbeeb's own, and the `KEY.` URL parameters use them.
  */
 export const keyCodes = {
-    UNDEFINED: 0,
-    SEMICOLON: 186,
-    HASH: 222,
-    APOSTROPHE: 192,
-    MUTE: 173,
-    MINUS: 189,
-    EQUALS: 187,
-    BACK_QUOTE: 223,
-    BACKSPACE: 8,
-    TAB: 9,
-    CLEAR: 12,
-    ENTER: 13,
-    SHIFT: 16,
-    CTRL: 17,
-    ALT: 18,
-    BREAK: 19,
-    CAPSLOCK: 20,
-    ESCAPE: 27,
-    SPACE: 32,
-    PAGEUP: 33,
-    PAGEDOWN: 34,
-    END: 35,
-    HOME: 36,
-    LEFT: 37,
-    UP: 38,
-    RIGHT: 39,
-    DOWN: 40,
-    PRINTSCREEN: 44,
-    INSERT: 45,
-    DELETE: 46,
-    K0: 48,
-    K1: 49,
-    K2: 50,
-    K3: 51,
-    K4: 52,
-    K5: 53,
-    K6: 54,
-    K7: 55,
-    K8: 56,
-    K9: 57,
-    A: 65,
-    B: 66,
-    C: 67,
-    D: 68,
-    E: 69,
-    F: 70,
-    G: 71,
-    H: 72,
-    I: 73,
-    J: 74,
-    K: 75,
-    L: 76,
-    M: 77,
-    N: 78,
-    O: 79,
-    P: 80,
-    Q: 81,
-    R: 82,
-    S: 83,
-    T: 84,
-    U: 85,
-    V: 86,
-    W: 87,
-    X: 88,
-    Y: 89,
-    Z: 90,
-    /* also META on Mac */
-    WINDOWS: 91,
-    MENU: 93,
-    NUMPAD0: 96,
-    NUMPAD1: 97,
-    NUMPAD2: 98,
-    NUMPAD3: 99,
-    NUMPAD4: 100,
-    NUMPAD5: 101,
-    NUMPAD6: 102,
-    NUMPAD7: 103,
-    NUMPAD8: 104,
-    NUMPAD9: 105,
-    NUMPADASTERISK: 106,
-    NUMPADPLUS: 107,
-    /* on numeric keypad in eg Germany*/
-    NUMPAD_DECIMAL_COMMA: 108,
-    NUMPADMINUS: 109,
-    /* on numeric keypad */
-    NUMPAD_DECIMAL_POINT: 110,
-    NUMPADSLASH: 111,
-    F1: 112,
-    F2: 113,
-    F3: 114,
-    F4: 115,
-    F5: 116,
-    F6: 117,
-    F7: 118,
-    F8: 119,
-    F9: 120,
-    F10: 121,
-    F11: 122,
-    F12: 123,
-    NUMLOCK: 144,
-    SCROLL_LOCK: 145,
-    VOLUMEUP: 174,
-    VOLUMEDOWN: 175,
-    FASTFORWARD: 176,
-    FASTREWIND: 177,
-    PLAYPAUSE: 179,
-    COMMA: 188,
-    PERIOD: 190,
-    SLASH: 191,
-    LEFT_SQUARE_BRACKET: 219,
-    BACKSLASH: 220,
-    RIGHT_SQUARE_BRACKET: 221,
-    NUMPADENTER: 255, // hack, jsbeeb only
-    SHIFT_LEFT: 256, // hack, jsbeeb only
-    SHIFT_RIGHT: 257, // hack, jsbeeb only
-    ALT_LEFT: 258, // hack, jsbeeb only
-    ALT_RIGHT: 259, // hack, jsbeeb only
-    CTRL_LEFT: 260, // hack, jsbeeb only
-    CTRL_RIGHT: 261, // hack, jsbeeb only
+    SEMICOLON: "Semicolon",
+    APOSTROPHE: "Quote",
+    MUTE: "AudioVolumeMute",
+    MINUS: "Minus",
+    EQUALS: "Equal",
+    BACK_QUOTE: "Backquote",
+    BACKSPACE: "Backspace",
+    TAB: "Tab",
+    ENTER: "Enter",
+    BREAK: "Pause",
+    CAPSLOCK: "CapsLock",
+    ESCAPE: "Escape",
+    SPACE: "Space",
+    PAGEUP: "PageUp",
+    PAGEDOWN: "PageDown",
+    END: "End",
+    HOME: "Home",
+    LEFT: "ArrowLeft",
+    UP: "ArrowUp",
+    RIGHT: "ArrowRight",
+    DOWN: "ArrowDown",
+    PRINTSCREEN: "PrintScreen",
+    INSERT: "Insert",
+    DELETE: "Delete",
+    K0: "Digit0",
+    K1: "Digit1",
+    K2: "Digit2",
+    K3: "Digit3",
+    K4: "Digit4",
+    K5: "Digit5",
+    K6: "Digit6",
+    K7: "Digit7",
+    K8: "Digit8",
+    K9: "Digit9",
+    A: "KeyA",
+    B: "KeyB",
+    C: "KeyC",
+    D: "KeyD",
+    E: "KeyE",
+    F: "KeyF",
+    G: "KeyG",
+    H: "KeyH",
+    I: "KeyI",
+    J: "KeyJ",
+    K: "KeyK",
+    L: "KeyL",
+    M: "KeyM",
+    N: "KeyN",
+    O: "KeyO",
+    P: "KeyP",
+    Q: "KeyQ",
+    R: "KeyR",
+    S: "KeyS",
+    T: "KeyT",
+    U: "KeyU",
+    V: "KeyV",
+    W: "KeyW",
+    X: "KeyX",
+    Y: "KeyY",
+    Z: "KeyZ",
+    /* also COMMAND on Mac */
+    WINDOWS: "MetaLeft",
+    WINDOWS_RIGHT: "MetaRight",
+    MENU: "ContextMenu",
+    NUMPAD0: "Numpad0",
+    NUMPAD1: "Numpad1",
+    NUMPAD2: "Numpad2",
+    NUMPAD3: "Numpad3",
+    NUMPAD4: "Numpad4",
+    NUMPAD5: "Numpad5",
+    NUMPAD6: "Numpad6",
+    NUMPAD7: "Numpad7",
+    NUMPAD8: "Numpad8",
+    NUMPAD9: "Numpad9",
+    NUMPADASTERISK: "NumpadMultiply",
+    NUMPADPLUS: "NumpadAdd",
+    NUMPAD_DECIMAL_COMMA: "NumpadComma",
+    NUMPADMINUS: "NumpadSubtract",
+    NUMPAD_DECIMAL_POINT: "NumpadDecimal",
+    NUMPADSLASH: "NumpadDivide",
+    NUMPADENTER: "NumpadEnter",
+    F1: "F1",
+    F2: "F2",
+    F3: "F3",
+    F4: "F4",
+    F5: "F5",
+    F6: "F6",
+    F7: "F7",
+    F8: "F8",
+    F9: "F9",
+    F10: "F10",
+    F11: "F11",
+    F12: "F12",
+    NUMLOCK: "NumLock",
+    SCROLL_LOCK: "ScrollLock",
+    VOLUMEUP: "AudioVolumeUp",
+    VOLUMEDOWN: "AudioVolumeDown",
+    FASTFORWARD: "MediaTrackNext",
+    FASTREWIND: "MediaTrackPrevious",
+    PLAYPAUSE: "MediaPlayPause",
+    COMMA: "Comma",
+    PERIOD: "Period",
+    SLASH: "Slash",
+    LEFT_SQUARE_BRACKET: "BracketLeft",
+    RIGHT_SQUARE_BRACKET: "BracketRight",
+    BACKSLASH: "Backslash",
+    /* only on a 102-key board, between the left shift and the Z */
+    INTL_BACKSLASH: "IntlBackslash",
+    SHIFT_LEFT: "ShiftLeft",
+    SHIFT_RIGHT: "ShiftRight",
+    ALT_LEFT: "AltLeft",
+    ALT_RIGHT: "AltRight",
+    CTRL_LEFT: "ControlLeft",
+    CTRL_RIGHT: "ControlRight",
 };
+
+/**
+ * Host key names that stand for more than one `keyCodes` entry, for `KEY.` parameters.
+ * HASH is here because the UK `#~` key and the US `\|` key are one physical key, `Backslash`.
+ */
+export const keyCodeAliases = {
+    SHIFT: [keyCodes.SHIFT_LEFT, keyCodes.SHIFT_RIGHT],
+    CTRL: [keyCodes.CTRL_LEFT, keyCodes.CTRL_RIGHT],
+    ALT: [keyCodes.ALT_LEFT, keyCodes.ALT_RIGHT],
+    HASH: [keyCodes.BACKSLASH],
+};
+
+/**
+ * The host keys a jsbeeb key name stands for, or an empty array if it names none.
+ * @param {string} name a `keyCodes` name, or an alias covering more than one
+ * @returns {string[]} `KeyboardEvent.code` names
+ */
+export function hostKeyCodes(name) {
+    if (keyCodes[name]) return [keyCodes[name]];
+    return keyCodeAliases[name] ?? [];
+}
 
 export function detectKeyboardLayout() {
     if (runningInNode) {
@@ -389,45 +400,6 @@ export function detectKeyboardLayout() {
         if (navigator.language.toLowerCase() === "en-us") return "US";
     }
     return "UK"; // Default guess of UK
-}
-
-/**
- * Adjusts keyCodes for the browser this runs in. The table starts as Chrome on a
- * UK keyboard, which is also what node sees, so only the differences are applied.
- */
-export function adaptKeyCodesToBrowser() {
-    const isUKlayout = detectKeyboardLayout() === "UK";
-    if (isFirefox()) {
-        keyCodes.SEMICOLON = 59;
-        // #~ key (not on US keyboard)
-        keyCodes.HASH = 163;
-        keyCodes.APOSTROPHE = 222;
-        keyCodes.BACK_QUOTE = 192;
-        // Firefox doesn't return a keycode for this
-        keyCodes.MUTE = -1;
-        keyCodes.MINUS = 173;
-        keyCodes.EQUALS = 61;
-    } else {
-        // Chrome
-        // TODO(#1065) check other browsers
-        // https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent.keyCode
-        keyCodes.SEMICOLON = 186;
-        // #~ key (not on US keyboard)
-        keyCodes.HASH = isUKlayout ? 222 : 223;
-        keyCodes.APOSTROPHE = isUKlayout ? 192 : 222;
-        keyCodes.MUTE = 173;
-        keyCodes.MINUS = 189;
-        keyCodes.EQUALS = 187;
-        keyCodes.BACK_QUOTE = isUKlayout ? 223 : 192;
-    }
-
-    // Swap APOSTROPHE and BACK_QUOTE keys around for Mac users.  They are the opposite to what jsbeeb expects.
-    // Swap them to what jsbeeb expects, and tidy up the hash key to prevent duplicate key mappings.
-    if (!runningInNode && navigator.userAgent.indexOf("Mac") !== -1) {
-        keyCodes.BACK_QUOTE = 192;
-        keyCodes.APOSTROPHE = 222;
-        keyCodes.HASH = 223;
-    }
 }
 
 export function getKeyMap(keyLayout) {
@@ -469,11 +441,8 @@ export function getKeyMap(keyLayout) {
 
     // shiftDown undefined -> map both
     function map(s, colRow, shiftDown) {
-        if ((!s && s !== 0) || !colRow) {
+        if (!s || !colRow) {
             console.log("error binding key", s, colRow);
-        }
-        if (typeof s === "string") {
-            s = s.charCodeAt(0);
         }
 
         if (shiftDown === undefined) {
@@ -534,7 +503,6 @@ export function getKeyMap(keyLayout) {
     map(keyCodes.TAB, BBC.TAB);
     map(keyCodes.ENTER, BBC.RETURN);
 
-    map(keyCodes.SHIFT, BBC.SHIFT);
     // see later map(keyCodes.SHIFT_LEFT, BBC.SHIFT_LEFT);
     map(keyCodes.SHIFT_RIGHT, BBC.SHIFT);
 
@@ -587,7 +555,9 @@ export function getKeyMap(keyLayout) {
 
         map(keyCodes.APOSTROPHE, BBC.COLON_STAR, false);
 
-        map(keyCodes.HASH, BBC.HAT_TILDE); // OK for <Shift> at least
+        // UK prints `#~` on this key, which is the BBC's `^~` pair; a US board prints `\|`.
+        map(keyCodes.BACKSLASH, isUKlayout ? BBC.HAT_TILDE : BBC.PIPE_BACKSLASH);
+        map(keyCodes.INTL_BACKSLASH, BBC.PIPE_BACKSLASH);
 
         map(keyCodes.EQUALS, BBC.SEMICOLON_PLUS); // OK for <Shift> at least
 
@@ -599,7 +569,6 @@ export function getKeyMap(keyLayout) {
 
         map(keyCodes.ESCAPE, BBC.ESCAPE);
 
-        map(keyCodes.CTRL, BBC.CTRL);
         map(keyCodes.CTRL_LEFT, BBC.CTRL);
         map(keyCodes.CTRL_RIGHT, BBC.CTRL);
 
@@ -608,8 +577,6 @@ export function getKeyMap(keyLayout) {
         map(keyCodes.DELETE, BBC.DELETE);
 
         map(keyCodes.BACKSPACE, BBC.DELETE);
-
-        map(keyCodes.BACKSLASH, BBC.PIPE_BACKSLASH);
     } else if (keyLayout === "gaming") {
         // gaming keyboard
 
@@ -647,14 +614,12 @@ export function getKeyMap(keyLayout) {
         map(keyCodes.CAPSLOCK, BBC.CTRL);
         map(keyCodes.SEMICOLON, BBC.SEMICOLON_PLUS);
         map(keyCodes.APOSTROPHE, BBC.COLON_STAR);
-        // UK keyboard (key missing on US)
-        map(keyCodes.HASH, BBC.RIGHT_SQUARE_BRACKET);
+        // UK prints `#~` on this key, a US board `\|`.
+        map(keyCodes.BACKSLASH, isUKlayout ? BBC.RIGHT_SQUARE_BRACKET : BBC.UNDERSCORE_POUND);
 
-        // UK has extra key \| for SHIFT
+        // Only a 102-key board has a key here, so only there can the left shift be spared.
         map(keyCodes.SHIFT_LEFT, isUKlayout ? BBC.SHIFTLOCK : BBC.SHIFT);
-        // UK: key is between SHIFT and Z
-        // US: key is above ENTER
-        map(keyCodes.BACKSLASH, isUKlayout ? BBC.SHIFT : BBC.UNDERSCORE_POUND);
+        map(keyCodes.INTL_BACKSLASH, BBC.SHIFT);
 
         // 5th row
 
@@ -697,9 +662,7 @@ export function getKeyMap(keyLayout) {
         map(keyCodes.BACKSPACE, BBC.DELETE); // delete
         map(keyCodes.END, BBC.COPY); // copy key is end
         map(keyCodes.F11, BBC.COPY); // copy key is end for Apple
-        map(keyCodes.SHIFT, BBC.SHIFT); // shift
         map(keyCodes.ESCAPE, BBC.ESCAPE); // escape
-        map(keyCodes.CTRL, BBC.CTRL);
         map(keyCodes.CTRL_LEFT, BBC.CTRL);
         map(keyCodes.CTRL_RIGHT, BBC.CTRL);
         map(keyCodes.CAPSLOCK, BBC.CAPSLOCK); // caps (on Rich's/Mike's computer)
@@ -708,12 +671,12 @@ export function getKeyMap(keyLayout) {
         map(keyCodes.RIGHT, BBC.RIGHT); // arrow right
         map(keyCodes.DOWN, BBC.DOWN); // arrow down
         map(keyCodes.APOSTROPHE, BBC.COLON_STAR);
-        map(keyCodes.HASH, BBC.RIGHT_SQUARE_BRACKET);
 
         // None of this last group in great locations.
         // But better to have them mapped at least somewhere.
         map(keyCodes.BACK_QUOTE, BBC.AT);
         map(keyCodes.BACKSLASH, BBC.PIPE_BACKSLASH);
+        map(keyCodes.INTL_BACKSLASH, BBC.PIPE_BACKSLASH);
         map(keyCodes.PAGEUP, BBC.UNDERSCORE_POUND);
     }
 
@@ -728,7 +691,6 @@ export function getKeyMap(keyLayout) {
     map(keyCodes.NUMPAD7, BBC.NUMPAD7);
     map(keyCodes.NUMPAD8, BBC.NUMPAD8);
     map(keyCodes.NUMPAD9, BBC.NUMPAD9);
-    // small hack in main.js/keyCode() to make this work
     map(keyCodes.NUMPAD_DECIMAL_POINT, BBC.NUMPAD_DECIMAL_POINT);
 
     // "natural" mapping
@@ -738,7 +700,6 @@ export function getKeyMap(keyLayout) {
     map(keyCodes.NUMPADASTERISK, BBC.NUMPADASTERISK);
     //map(???, BBC.NUMPADCOMMA);
     //map(???, BBC.NUMPADHASH);
-    // no keycode for NUMPADENTER, small hack in main.js/keyCode()
     map(keyCodes.NUMPADENTER, BBC.NUMPADENTER);
 
     // TODO(#748) "game" mapping
@@ -748,7 +709,7 @@ export function getKeyMap(keyLayout) {
     // `KEY.` URL parameters, applied last so they win. Not consumed: this map is rebuilt on
     // layout and model changes, and the user's mapping has to survive that.
     for (const mapping of userKeymap) {
-        remap(keyCodes[mapping.native], BBC[mapping.key]);
+        for (const code of hostKeyCodes(mapping.native)) remap(code, BBC[mapping.key]);
     }
 
     return keys2;

--- a/src/keymap.js
+++ b/src/keymap.js
@@ -368,14 +368,16 @@ export const keyCodes = {
 };
 
 /**
- * Host key names that stand for more than one `keyCodes` entry, for `KEY.` parameters.
- * HASH is here because the UK `#~` key and the US `\|` key are one physical key, `Backslash`.
+ * Other names a `KEY.` parameter may use for a host key: one that covers both sides of a pair,
+ * or a second name for a key that is printed differently on different keyboards.
  */
 export const keyCodeAliases = {
     SHIFT: [keyCodes.SHIFT_LEFT, keyCodes.SHIFT_RIGHT],
     CTRL: [keyCodes.CTRL_LEFT, keyCodes.CTRL_RIGHT],
     ALT: [keyCodes.ALT_LEFT, keyCodes.ALT_RIGHT],
     HASH: [keyCodes.BACKSLASH],
+    /* an Apple keyboard prints "clear" on the key a PC calls num lock */
+    CLEAR: [keyCodes.NUMLOCK],
 };
 
 /**

--- a/src/machine-session.js
+++ b/src/machine-session.js
@@ -136,20 +136,19 @@ export class MachineSession {
     }
 
     /**
-     * Press a key (by browser keyCode).
-     * Use keyCodes from keymap.js for named keys, or ASCII charCode for letters/digits.
+     * Press a host key by its physical position, as `KeyboardEvent.code` names it:
+     * "KeyA", "Digit1", "ShiftLeft", "NumpadEnter". The `keyCodes` table in keymap.js
+     * gives jsbeeb's own name for each.
      */
-    keyDown(keyCode, shiftDown = false) {
+    keyDown(code, shiftDown = false) {
         this._requireKeyboard();
-        this._keyboard.keyDown(keyCode, shiftDown);
+        this._keyboard.keyDown(code, shiftDown);
     }
 
-    /**
-     * Release a key (by browser keyCode).
-     */
-    keyUp(keyCode) {
+    /** Release a host key, by the same `KeyboardEvent.code` name. */
+    keyUp(code) {
         this._requireKeyboard();
-        this._keyboard.keyUp(keyCode);
+        this._keyboard.keyUp(code);
     }
 
     /**

--- a/src/main.js
+++ b/src/main.js
@@ -38,10 +38,9 @@ import { DiscVisualiser } from "./web/disc-visualiser.js";
 import { MediaWindow } from "./web/media-window.js";
 import { PageActions } from "./web/page-actions.js";
 import { parseMediaParams, processAutobootParams, processDriveTrackParams, processInputParams } from "./url-params.js";
-import { adaptKeyCodesToBrowser, keyCodes, userKeymap } from "./keymap.js";
+import { hostKeyCodes, userKeymap } from "./keymap.js";
 
 installIcons();
-adaptKeyCodesToBrowser();
 
 // ------------------------------------------------------------------------
 // What the URL asked for.
@@ -104,7 +103,7 @@ speak(settings.speechOutput);
 settings.on("speechOutput", speak);
 
 // Must come after we know the model, to validate names against those of the hardware.
-const keyMappingWarnings = processInputParams(parsedQuery, model.keys, keyCodes, userKeymap, gamepad);
+const keyMappingWarnings = processInputParams(parsedQuery, model.keys, hostKeyCodes, userKeymap, gamepad);
 if (keyMappingWarnings.length) {
     toast(`${keyMappingWarnings.join(" ")} The key names are listed in the README.`, {
         title: "Mappings in the URL",

--- a/src/test-machine.js
+++ b/src/test-machine.js
@@ -239,7 +239,7 @@ export class TestMachine {
 
     /**
      * Press a key on the keyboard.
-     * @param {number} code - key code (BBC keyCode or Atom raw key)
+     * @param {string} code - the host key by physical position, as `keyCodes` in keymap.js names it
      */
     keyDown(code) {
         this._keyInterface.keyDown(code);
@@ -247,7 +247,7 @@ export class TestMachine {
 
     /**
      * Release a key on the keyboard.
-     * @param {number} code - key code
+     * @param {string} code - the host key by physical position
      */
     keyUp(code) {
         this._keyInterface.keyUp(code);

--- a/src/url-params.js
+++ b/src/url-params.js
@@ -182,12 +182,12 @@ export function buildUrlFromParams(baseUrl, parsedQuery, paramTypes = {}) {
  * Process keyboard and gamepad mapping parameters from query string
  * @param {Object} parsedQuery - The parsed query parameters
  * @param {Object} machineKeys - Emulated machine's key constants (`BBC`, or `ATOM` for the Atom)
- * @param {Object} keyCodes - Key code constants
+ * @param {(name: string) => string[]} hostKeyCodes - jsbeeb's host key name to `KeyboardEvent.code` names
  * @param {Array} userKeymap - Array to store user key mappings
  * @param {Object} gamepad - Gamepad object for handling mapping
  * @returns {string[]} descriptions of any mappings that were skipped, for showing to the user
  */
-export function processInputParams(parsedQuery, machineKeys, keyCodes, userKeymap, gamepad) {
+export function processInputParams(parsedQuery, machineKeys, hostKeyCodes, userKeymap, gamepad) {
     const warnings = [];
 
     Object.entries(parsedQuery).forEach(([key, val]) => {
@@ -201,7 +201,7 @@ export function processInputParams(parsedQuery, machineKeys, keyCodes, userKeyma
 
             if (!machineKeys[machineKey]) {
                 warnings.push(`${key}=${val}: "${machineKey}" is not a key on the emulated machine.`);
-            } else if (!keyCodes[nativeKey]) {
+            } else if (hostKeyCodes(nativeKey).length === 0) {
                 warnings.push(`${key}=${val}: "${nativeKey}" is not a key on your keyboard.`);
             } else {
                 console.log("mapping " + nativeKey + " to " + machineKey);

--- a/src/web/debug.js
+++ b/src/web/debug.js
@@ -478,7 +478,7 @@ export class Debugger {
         if (document.activeElement && document.activeElement !== document.body) {
             return false;
         }
-        switch (String.fromCharCode(key)) {
+        switch (key) {
             case "b":
                 if (this.disassStack.length) this.updateDisassembly(this.disassStack.pop());
                 break;

--- a/src/web/gamepads.js
+++ b/src/web/gamepads.js
@@ -1,4 +1,9 @@
-import { BBC, isFirefox } from "../keymap.js";
+import { BBC } from "../keymap.js";
+
+function isFirefox() {
+    // With thanks to http://stackoverflow.com/questions/9847580/how-to-detect-safari-chrome-ie-firefox-and-opera-browser
+    return typeof InstallTrigger !== "undefined"; // Firefox 1.0+
+}
 
 export class GamePad {
     constructor() {

--- a/src/web/keyboard-setup.js
+++ b/src/web/keyboard-setup.js
@@ -4,6 +4,17 @@ import { noteEvent } from "./analytics.js";
 import { keyCodes } from "../keymap.js";
 
 const PasteBoxId = "paste-text";
+/** The eight accessibility switches, each reachable from a number key and a function key. */
+const SwitchKeys = [
+    ["K1", "F1"],
+    ["K2", "F2"],
+    ["K3", "F3"],
+    ["K4", "F4"],
+    ["K5", "F5"],
+    ["K6", "F6"],
+    ["K7", "F7"],
+    ["K8", "F8"],
+];
 const TypingTargets = 'input, textarea, select, [contenteditable]:not([contenteditable="false"])';
 // Where keys are for the page, not the machine: the paste box, and the media window's controls.
 const KeyboardSinks = `#${PasteBoxId}, #media-panel`;
@@ -72,10 +83,9 @@ export class KeyboardSetup {
         // out early when a handler fires), so typing numbers or using function keys
         // works normally.
         const handleSwitch = (index) => (down) => accessibilitySwitches.setSwitch(index, down);
-        for (let i = 0; i < 8; i++) {
-            keyboard.registerKeyHandler(keyCodes.K1 + i, handleSwitch(i), alt);
-            keyboard.registerKeyHandler(keyCodes.F1 + i, handleSwitch(i), alt);
-        }
+        SwitchKeys.forEach((names, index) => {
+            for (const name of names) keyboard.registerKeyHandler(keyCodes[name], handleSwitch(index), alt);
+        });
 
         document.addEventListener("keydown", (evt) => {
             actions.onAnyKeyDown();

--- a/src/web/keyboard.js
+++ b/src/web/keyboard.js
@@ -38,75 +38,20 @@ export class Keyboard extends EventTarget {
         this.stepEmuWhenPaused = false;
         this.keyLayout = keyLayout;
         this.saidCapsLockIsTapped = false;
-
-        // Modifier key states
-        this.lastShiftLocation = 1;
-        this.lastCtrlLocation = 1;
-        this.lastAltLocation = 1;
     }
 
     /**
-     * Translates a keyboard event to a BBC key code
+     * The host key a keyboard event came from, by physical position.
      * @param {KeyboardEvent} evt - The keyboard event
-     * @returns {number} - The BBC key code
+     * @returns {string} - A `KeyboardEvent.code` name
      */
     keyCode(evt) {
-        const ret = evt.which || evt.charCode || evt.keyCode;
-
-        switch (evt.location) {
-            default:
-                // keyUp events seem to pass location = 0 (Chrome)
-                switch (ret) {
-                    case keyCodes.SHIFT:
-                        return this.lastShiftLocation === 1 ? keyCodes.SHIFT_LEFT : keyCodes.SHIFT_RIGHT;
-                    case keyCodes.ALT:
-                        return this.lastAltLocation === 1 ? keyCodes.ALT_LEFT : keyCodes.ALT_RIGHT;
-                    case keyCodes.CTRL:
-                        return this.lastCtrlLocation === 1 ? keyCodes.CTRL_LEFT : keyCodes.CTRL_RIGHT;
-                }
-                break;
-            case 1:
-                switch (ret) {
-                    case keyCodes.SHIFT:
-                        this.lastShiftLocation = 1;
-                        return keyCodes.SHIFT_LEFT;
-                    case keyCodes.ALT:
-                        this.lastAltLocation = 1;
-                        return keyCodes.ALT_LEFT;
-                    case keyCodes.CTRL:
-                        this.lastCtrlLocation = 1;
-                        return keyCodes.CTRL_LEFT;
-                }
-                break;
-            case 2:
-                switch (ret) {
-                    case keyCodes.SHIFT:
-                        this.lastShiftLocation = 2;
-                        return keyCodes.SHIFT_RIGHT;
-                    case keyCodes.ALT:
-                        this.lastAltLocation = 2;
-                        return keyCodes.ALT_RIGHT;
-                    case keyCodes.CTRL:
-                        this.lastCtrlLocation = 2;
-                        return keyCodes.CTRL_RIGHT;
-                }
-                break;
-            case 3: // numpad
-                switch (ret) {
-                    case keyCodes.ENTER:
-                        return keyCodes.NUMPADENTER;
-                    case keyCodes.DELETE:
-                        return keyCodes.NUMPAD_DECIMAL_POINT;
-                }
-                break;
-        }
-
-        return ret;
+        return evt.code;
     }
 
     /**
      * Registers a handler for a specific key with optional modifiers
-     * @param {number} keyCode - The key code to handle
+     * @param {string} keyCode - The host key, by physical position
      * @param {Function} handler - Called as (down, code, shiftKey) on the way down and up
      * @param {Object} [options] - Options for this handler
      * @param {boolean} [options.alt=true] - Whether this handler requires the Alt key
@@ -142,7 +87,7 @@ export class Keyboard extends EventTarget {
 
     /**
      * Find a matching key handler for the given key event
-     * @param {number} keyCode - The key code
+     * @param {string} keyCode - The host key, by physical position
      * @param {boolean} altKey - Whether Alt is pressed
      * @param {boolean} ctrlKey - Whether Ctrl is pressed
      * @returns {Object|null} The handler object or null if none found
@@ -163,19 +108,16 @@ export class Keyboard extends EventTarget {
      * @param {KeyboardEvent} evt - The keyboard event
      */
     keyPress(evt) {
-        // Common key constants
-        const LOWERCASE_G = 103;
-        const LOWERCASE_N = 110;
-
         // Early returns for common scenarios
         // Check if input is enabled. If inputEnabledFunction returns true, keyboard events should not be processed.
         if (this.inputEnabledFunction()) return;
         if (this.running || (!this.dbgr.enabled() && !this.pauseEmu)) return;
 
-        const code = this.keyCode(evt);
+        // The debugger's keys are the characters they print, not positions.
+        const key = evt.key;
 
         // Handle debugger 'g' key press
-        if (this.dbgr.enabled() && code === LOWERCASE_G) {
+        if (this.dbgr.enabled() && key === "g") {
             this.dbgr.hide();
             this.dispatchEvent(new Event("resume"));
             return;
@@ -183,10 +125,10 @@ export class Keyboard extends EventTarget {
 
         // Handle pause/step control keys
         if (this.pauseEmu) {
-            if (code === LOWERCASE_G) {
+            if (key === "g") {
                 this.resumeEmulation();
                 return;
-            } else if (code === LOWERCASE_N) {
+            } else if (key === "n") {
                 this.requestStep();
                 this.dispatchEvent(new Event("resume"));
                 return;
@@ -195,7 +137,7 @@ export class Keyboard extends EventTarget {
 
         // Pass any other keys to the debugger if it's enabled
         if (this.dbgr.enabled()) {
-            const handled = this.dbgr.keyPress(this.keyCode(evt));
+            const handled = this.dbgr.keyPress(key);
             if (handled) evt.preventDefault();
         }
     }
@@ -236,7 +178,7 @@ export class Keyboard extends EventTarget {
 
     /**
      * Handle special keys that must remain in keyboard.js
-     * @param {number} code - The key code
+     * @param {string} code - The host key, by physical position
      * @returns {boolean} True if the key was handled specially
      * @private
      */

--- a/tests/bench/cpu.bench.js
+++ b/tests/bench/cpu.bench.js
@@ -14,9 +14,9 @@ async function eliteUnderway() {
     const cpu = fake6502(findModel("B"));
     await cpu.initialise();
     cpu.fdc.loadDisc(0, discFor(EliteImage, await load(`discs/${EliteImage}`)));
-    cpu.sysvia.keyDown(keyCodes.SHIFT);
+    cpu.sysvia.keyDown(keyCodes.SHIFT_LEFT);
     cpu.execute(CyclesToBoot);
-    cpu.sysvia.keyUp(keyCodes.SHIFT);
+    cpu.sysvia.keyUp(keyCodes.SHIFT_LEFT);
     return cpu;
 }
 

--- a/tests/integration/machine-session.js
+++ b/tests/integration/machine-session.js
@@ -166,11 +166,11 @@ describe("MachineSession keyboard", () => {
 
     it("reports the keys held, however they were pressed", () => {
         session.keyDownRaw(BBC.A);
-        session.keyDown(keyCodes.SHIFT);
+        session.keyDown(keyCodes.SHIFT_LEFT);
         expect(session.heldKeys()).toEqual(expect.arrayContaining([BBC.A, BBC.SHIFT]));
 
         session.keyUpRaw(BBC.A);
-        session.keyUp(keyCodes.SHIFT);
+        session.keyUp(keyCodes.SHIFT_LEFT);
         expect(session.heldKeys()).toEqual([]);
     });
 
@@ -180,14 +180,14 @@ describe("MachineSession keyboard", () => {
         session.removeBreakpoint(id);
 
         expect(session.typingPending).toBe(true);
-        expect(() => session.keyDown(keyCodes.SHIFT)).toThrow(/cancelTyping/);
+        expect(() => session.keyDown(keyCodes.SHIFT_LEFT)).toThrow(/cancelTyping/);
         expect(() => session.keyDownRaw(BBC.SHIFT)).toThrow(/cancelTyping/);
 
         session.cancelTyping();
         expect(session.typingPending).toBe(false);
-        session.keyDown(keyCodes.SHIFT);
+        session.keyDown(keyCodes.SHIFT_LEFT);
         expect(session.heldKeys()).toEqual([BBC.SHIFT]);
-        session.keyUp(keyCodes.SHIFT);
+        session.keyUp(keyCodes.SHIFT_LEFT);
 
         await pressRaw(BBC.RETURN);
         await session.runUntilPrompt();

--- a/tests/unit/test-keyboard-setup.js
+++ b/tests/unit/test-keyboard-setup.js
@@ -7,11 +7,8 @@ import { domFromIndexHtml, teardownDom } from "./helpers.js";
 import { keyCodes } from "../../src/keymap.js";
 import { findModel } from "../../src/models.js";
 
-const keyEvent = (type, which, { alt = false, ctrl = false, shift = false } = {}) => {
-    const event = new KeyboardEvent(type, { altKey: alt, ctrlKey: ctrl, shiftKey: shift, cancelable: true });
-    Object.defineProperty(event, "which", { value: which });
-    return event;
-};
+const keyEvent = (type, code, { alt = false, ctrl = false, shift = false } = {}) =>
+    new KeyboardEvent(type, { code, altKey: alt, ctrlKey: ctrl, shiftKey: shift, cancelable: true });
 
 const pasteEvent = (text) => {
     const event = new Event("paste", { bubbles: true, cancelable: true });
@@ -157,11 +154,11 @@ describe("KeyboardSetup", () => {
 
         it("releases a key that was held while Alt-Shift-M moved focus into the window", () => {
             domFromIndexHtml("media-panel");
-            document.dispatchEvent(keyEvent("keydown", keyCodes.SHIFT, { shift: true }));
+            document.dispatchEvent(keyEvent("keydown", keyCodes.SHIFT_LEFT, { shift: true }));
             document.dispatchEvent(keyEvent("keydown", keyCodes.M, { alt: true, shift: true }));
             document.getElementById("media-search").focus();
             document.dispatchEvent(keyEvent("keyup", keyCodes.M, { alt: true, shift: true }));
-            document.dispatchEvent(keyEvent("keyup", keyCodes.SHIFT));
+            document.dispatchEvent(keyEvent("keyup", keyCodes.SHIFT_LEFT));
             expect(processor.sysvia.keyUp).toHaveBeenCalledWith(keyCodes.M);
             expect(processor.sysvia.keyUp).toHaveBeenCalledWith(keyCodes.SHIFT_LEFT);
         });

--- a/tests/unit/test-keyboard.js
+++ b/tests/unit/test-keyboard.js
@@ -69,66 +69,17 @@ describe("Keyboard", () => {
         expect(keyboard).toBeDefined();
     });
 
-    test("keyCode should handle location properly", () => {
-        // Test SHIFT key
-        const shiftEvent = { which: keyCodes.SHIFT, location: 1 };
-        expect(keyboard.keyCode(shiftEvent)).toBe(keyCodes.SHIFT_LEFT);
-
-        const shiftEvent2 = { which: keyCodes.SHIFT, location: 2 };
-        expect(keyboard.keyCode(shiftEvent2)).toBe(keyCodes.SHIFT_RIGHT);
-
-        // Test CTRL key
-        const ctrlEvent = { which: keyCodes.CTRL, location: 1 };
-        expect(keyboard.keyCode(ctrlEvent)).toBe(keyCodes.CTRL_LEFT);
-
-        const ctrlEvent2 = { which: keyCodes.CTRL, location: 2 };
-        expect(keyboard.keyCode(ctrlEvent2)).toBe(keyCodes.CTRL_RIGHT);
-
-        // Test ALT key
-        const altEvent = { which: keyCodes.ALT, location: 1 };
-        expect(keyboard.keyCode(altEvent)).toBe(keyCodes.ALT_LEFT);
-
-        const altEvent2 = { which: keyCodes.ALT, location: 2 };
-        expect(keyboard.keyCode(altEvent2)).toBe(keyCodes.ALT_RIGHT);
-
-        // Test numpad
-        const enterEvent = { which: keyCodes.ENTER, location: 3 };
-        expect(keyboard.keyCode(enterEvent)).toBe(keyCodes.NUMPADENTER);
-
-        const deleteEvent = { which: keyCodes.DELETE, location: 3 };
-        expect(keyboard.keyCode(deleteEvent)).toBe(keyCodes.NUMPAD_DECIMAL_POINT);
-
-        // Test normal key
-        const normalEvent = { which: keyCodes.A, location: 0 };
-        expect(keyboard.keyCode(normalEvent)).toBe(keyCodes.A);
-    });
-
-    test("keyCode should remember last modifier key locations", () => {
-        // First, set modifier locations to known values
-        keyboard.keyCode({ which: keyCodes.SHIFT, location: 1 });
-        keyboard.keyCode({ which: keyCodes.CTRL, location: 1 });
-        keyboard.keyCode({ which: keyCodes.ALT, location: 1 });
-
-        // When location = 0 (like in keyUp events), should return based on last location
-        expect(keyboard.keyCode({ which: keyCodes.SHIFT, location: 0 })).toBe(keyCodes.SHIFT_LEFT);
-        expect(keyboard.keyCode({ which: keyCodes.CTRL, location: 0 })).toBe(keyCodes.CTRL_LEFT);
-        expect(keyboard.keyCode({ which: keyCodes.ALT, location: 0 })).toBe(keyCodes.ALT_LEFT);
-
-        // Change the locations to right side
-        keyboard.keyCode({ which: keyCodes.SHIFT, location: 2 });
-        keyboard.keyCode({ which: keyCodes.CTRL, location: 2 });
-        keyboard.keyCode({ which: keyCodes.ALT, location: 2 });
-
-        // Should now use the updated locations
-        expect(keyboard.keyCode({ which: keyCodes.SHIFT, location: 0 })).toBe(keyCodes.SHIFT_RIGHT);
-        expect(keyboard.keyCode({ which: keyCodes.CTRL, location: 0 })).toBe(keyCodes.CTRL_RIGHT);
-        expect(keyboard.keyCode({ which: keyCodes.ALT, location: 0 })).toBe(keyCodes.ALT_RIGHT);
+    test("keyCode is the physical position the event came from", () => {
+        expect(keyboard.keyCode({ code: "ShiftLeft" })).toBe(keyCodes.SHIFT_LEFT);
+        expect(keyboard.keyCode({ code: "ShiftRight" })).toBe(keyCodes.SHIFT_RIGHT);
+        expect(keyboard.keyCode({ code: "NumpadEnter" })).toBe(keyCodes.NUMPADENTER);
+        expect(keyboard.keyCode({ code: "NumpadDecimal" })).toBe(keyCodes.NUMPAD_DECIMAL_POINT);
+        expect(keyboard.keyCode({ code: "KeyA" })).toBe(keyCodes.A);
     });
 
     test("keyDown should handle normal key press", () => {
         const event = {
-            which: keyCodes.A,
-            location: 0,
+            code: keyCodes.A,
             preventDefault: vi.fn(),
             ctrlKey: false,
             altKey: false,
@@ -144,8 +95,7 @@ describe("Keyboard", () => {
 
     test("keyDown should not handle keys when not running", () => {
         const event = {
-            which: keyCodes.A,
-            location: 0,
+            code: keyCodes.A,
             preventDefault: vi.fn(),
             ctrlKey: false,
             altKey: false,
@@ -160,8 +110,7 @@ describe("Keyboard", () => {
 
     test("keyDown should not handle keys when input is enabled", () => {
         const event = {
-            which: keyCodes.A,
-            location: 0,
+            code: keyCodes.A,
             preventDefault: vi.fn(),
             ctrlKey: false,
             altKey: false,
@@ -180,8 +129,7 @@ describe("Keyboard", () => {
 
     test("keyDown should handle F12/BREAK and emit break event", async () => {
         const event = {
-            which: keyCodes.F12,
-            location: 0,
+            code: keyCodes.F12,
             preventDefault: vi.fn(),
             ctrlKey: false,
             altKey: false,
@@ -201,8 +149,7 @@ describe("Keyboard", () => {
 
     test("keyUp should call sysvia.keyUp", () => {
         const event = {
-            which: keyCodes.A,
-            location: 0,
+            code: keyCodes.A,
             preventDefault: vi.fn(),
             altKey: false,
         };
@@ -216,8 +163,7 @@ describe("Keyboard", () => {
 
     test("keyUp still releases the key when input is enabled, but leaves the event to the page", () => {
         const event = {
-            which: keyCodes.A,
-            location: 0,
+            code: keyCodes.A,
             preventDefault: vi.fn(),
             altKey: false,
         };
@@ -233,8 +179,7 @@ describe("Keyboard", () => {
 
     test("keyUp should handle F12/BREAK and emit break event", async () => {
         const event = {
-            which: keyCodes.F12,
-            location: 0,
+            code: keyCodes.F12,
             preventDefault: vi.fn(),
             altKey: false,
         };
@@ -262,8 +207,7 @@ describe("Keyboard", () => {
 
     test("keyPress should not proceed when input is enabled", () => {
         const event = {
-            which: 103, // lowercase g key
-            location: 0,
+            key: "g",
             preventDefault: vi.fn(),
         };
 
@@ -283,8 +227,7 @@ describe("Keyboard", () => {
 
     test("keyPress should emit resume event when lowercase g pressed in pause mode", async () => {
         const event = {
-            which: 103, // lowercase g key
-            location: 0,
+            key: "g",
             preventDefault: vi.fn(),
         };
 
@@ -299,8 +242,7 @@ describe("Keyboard", () => {
 
     test("keyPress should handle debugger g key and emit resume event", async () => {
         const event = {
-            which: 103, // lowercase g key
-            location: 0,
+            key: "g",
             preventDefault: vi.fn(),
         };
 
@@ -324,8 +266,7 @@ describe("Keyboard", () => {
         keyboard.registerKeyHandler(keyCodes.Q, mockHandler, { alt: true, ctrl: false });
 
         const event = {
-            which: keyCodes.Q,
-            location: 0,
+            code: keyCodes.Q,
             preventDefault: vi.fn(),
             ctrlKey: false,
             altKey: true,
@@ -346,8 +287,7 @@ describe("Keyboard", () => {
 
         keyboard.setRunning(true);
         keyboard.keyDown({
-            which: keyCodes.K1,
-            location: 0,
+            code: keyCodes.K1,
             preventDefault: vi.fn(),
             altKey: true,
             ctrlKey: false,
@@ -361,8 +301,7 @@ describe("Keyboard", () => {
     test("unhandled keys still reach sysvia.keyDown", () => {
         keyboard.setRunning(true);
         keyboard.keyDown({
-            which: keyCodes.A,
-            location: 0,
+            code: keyCodes.A,
             preventDefault: vi.fn(),
             altKey: false,
             ctrlKey: false,
@@ -377,8 +316,7 @@ describe("Keyboard", () => {
         keyboard.registerKeyHandler(keyCodes.E, mockHandler, { alt: false, ctrl: true });
 
         const event = {
-            which: keyCodes.E,
-            location: 0,
+            code: keyCodes.E,
             preventDefault: vi.fn(),
             ctrlKey: true,
             altKey: false,
@@ -413,8 +351,7 @@ describe("Keyboard", () => {
         keyboard.setRunning(true);
 
         const escEvent = {
-            which: keyCodes.ESCAPE,
-            location: 0,
+            code: keyCodes.ESCAPE,
             preventDefault: vi.fn(),
             altKey: false,
             ctrlKey: false,
@@ -524,16 +461,16 @@ describe("Keyboard Atom adapter", () => {
     });
 
     test("keyDown should route to PPIA, not SysVia", () => {
-        const evt = { which: 65, location: 0, shiftKey: false, altKey: false, ctrlKey: false, preventDefault: vi.fn() };
+        const evt = { code: "KeyA", shiftKey: false, altKey: false, ctrlKey: false, preventDefault: vi.fn() };
         keyboard.keyDown(evt);
-        expect(mockAtomPPIA.keyDown).toHaveBeenCalledWith(65, false);
+        expect(mockAtomPPIA.keyDown).toHaveBeenCalledWith("KeyA", false);
         expect(mockProcessor.sysvia.keyDown).not.toHaveBeenCalled();
     });
 
     test("keyUp should route to PPIA", () => {
-        const evt = { which: 65, location: 0, altKey: false, ctrlKey: false, preventDefault: vi.fn() };
+        const evt = { code: "KeyA", altKey: false, ctrlKey: false, preventDefault: vi.fn() };
         keyboard.keyUp(evt);
-        expect(mockAtomPPIA.keyUp).toHaveBeenCalledWith(65);
+        expect(mockAtomPPIA.keyUp).toHaveBeenCalledWith("KeyA");
     });
 
     test("setKeyLayout hands the layout to the processor", () => {

--- a/tests/unit/test-keymap.js
+++ b/tests/unit/test-keymap.js
@@ -1,7 +1,7 @@
 import { afterEach, describe, expect, it } from "vitest";
 
 import { ATOM, getKeyMapAtom } from "../../src/keymap-atom.js";
-import { BBC, getKeyMap, keyCodes, stringToBBCKeys, userKeymap } from "../../src/keymap.js";
+import { BBC, getKeyMap, hostKeyCodes, keyCodes, stringToBBCKeys, userKeymap } from "../../src/keymap.js";
 import { processInputParams } from "../../src/url-params.js";
 
 describe("Keyboard mapping", function () {
@@ -29,7 +29,7 @@ describe("User key mapping from KEY. URL parameters", function () {
     });
 
     const applyParams = (params, machineKeys) =>
-        processInputParams(params, machineKeys, keyCodes, userKeymap, { remap: () => null });
+        processInputParams(params, machineKeys, hostKeyCodes, userKeymap, { remap: () => null });
 
     it("overrides the default binding for the host key", function () {
         expect(getKeyMap("physical")[false][keyCodes.ENTER]).toEqual(BBC.RETURN);
@@ -52,6 +52,20 @@ describe("User key mapping from KEY. URL parameters", function () {
         applyParams({ "KEY.ENTER": "LOCK" }, ATOM);
 
         expect(getKeyMapAtom("physical")[false][keyCodes.ENTER]).toEqual(ATOM.LOCK);
+    });
+
+    it("maps both sides at once for a host key name that names a pair", function () {
+        applyParams({ "KEY.SHIFT": "COPY" }, BBC);
+
+        const keyMap = getKeyMap("physical");
+        expect(keyMap[false][keyCodes.SHIFT_LEFT]).toEqual(BBC.COPY);
+        expect(keyMap[false][keyCodes.SHIFT_RIGHT]).toEqual(BBC.COPY);
+    });
+
+    it("still knows HASH as a name for the key a US keyboard prints as backslash", function () {
+        applyParams({ "KEY.HASH": "COPY" }, BBC);
+
+        expect(getKeyMap("physical")[false][keyCodes.BACKSLASH]).toEqual(BBC.COPY);
     });
 
     it("ignores unknown host and machine key names", function () {

--- a/tests/unit/test-keymap.js
+++ b/tests/unit/test-keymap.js
@@ -68,6 +68,18 @@ describe("User key mapping from KEY. URL parameters", function () {
         expect(getKeyMap("physical")[false][keyCodes.BACKSLASH]).toEqual(BBC.COPY);
     });
 
+    it("still knows CLEAR, which an Apple keyboard prints where a PC says num lock", function () {
+        applyParams({ "KEY.CLEAR": "COPY" }, BBC);
+
+        expect(getKeyMap("physical")[false][keyCodes.NUMLOCK]).toEqual(BBC.COPY);
+    });
+
+    it("binds a host key no layout uses by default", function () {
+        applyParams({ "KEY.WINDOWS_RIGHT": "SHIFTLOCK" }, BBC);
+
+        expect(getKeyMap("physical")[false][keyCodes.WINDOWS_RIGHT]).toEqual(BBC.SHIFTLOCK);
+    });
+
     it("ignores unknown host and machine key names", function () {
         // RETURN is the BBC's name for the key the host calls ENTER: not a host key name.
         const warnings = applyParams({ "KEY.RETURN": "COPY", "KEY.ENTER": "NOTAKEY" }, BBC);

--- a/tests/unit/test-url-params.js
+++ b/tests/unit/test-url-params.js
@@ -226,7 +226,7 @@ describe("URL Parameters", () => {
     describe("processInputParams", () => {
         it("should process keyboard mappings", () => {
             const machineKeys = { CTRL: "CTRL", SHIFT: "SHIFT" };
-            const keyCodes = { A: 65, B: 66 };
+            const hostKeyCodes = (name) => (["A", "B"].includes(name) ? ["Key" + name] : []);
             const userKeymap = [];
             const gamepad = { remap: vi.fn() };
 
@@ -238,7 +238,7 @@ describe("URL Parameters", () => {
                 other: "value",
             };
 
-            const warnings = processInputParams(parsedQuery, machineKeys, keyCodes, userKeymap, gamepad);
+            const warnings = processInputParams(parsedQuery, machineKeys, hostKeyCodes, userKeymap, gamepad);
 
             expect(userKeymap).toEqual([
                 { native: "A", key: "CTRL" },
@@ -253,14 +253,14 @@ describe("URL Parameters", () => {
 
         it("should report mappings it can't apply", () => {
             const machineKeys = { CTRL: "CTRL" };
-            const keyCodes = { A: 65 };
+            const hostKeyCodes = (name) => (name === "A" ? ["KeyA"] : []);
             const userKeymap = [];
             const gamepad = { remap: vi.fn().mockReturnValue('unknown gamepad control "WIBBLE".') };
 
             const warnings = processInputParams(
                 { "KEY.A": "NOTAKEY", "KEY.NOTAKEY": "CTRL", "GP.WIBBLE": "CTRL" },
                 machineKeys,
-                keyCodes,
+                hostKeyCodes,
                 userKeymap,
                 gamepad,
             );

--- a/tests/unit/test-web-debug.js
+++ b/tests/unit/test-web-debug.js
@@ -31,7 +31,7 @@ describe("Debugger", () => {
     const disRows = () => [...document.querySelectorAll("#disassembly .dis_elem:not(.template)")];
     const currentRow = () => document.querySelector("#disassembly .highlight");
     const memHighlight = () => document.querySelector("#memory .highlight");
-    const keyPress = (char) => dbgr.keyPress(char.charCodeAt(0));
+    const keyPress = (char) => dbgr.keyPress(char);
 
     describe("the panels", () => {
         it("start hidden and show when the debugger is entered", () => {

--- a/tools/audio-sweep.js
+++ b/tools/audio-sweep.js
@@ -608,6 +608,7 @@ async function runReference(outFile, { model = "Master", rate = "48000", output 
     const { TestMachine } = await import("../src/test-machine.js");
     const { SoundChip } = await import("../src/soundchip.js");
     const { PolyphaseResampler } = await import("../src/resampler.js");
+    const { keyCodes } = await import("../src/keymap.js");
     const { ResamplerCutoffOfOutputRate, ResamplerTaps, isAudioOutput, outputStages } =
         await import("../src/audio-output.js");
     if (!isAudioOutput(output)) throw new Error(`Unknown output "${output}"`);
@@ -649,11 +650,10 @@ async function runReference(outFile, { model = "Master", rate = "48000", output 
     await machine.initialise();
     machine.loadDiscData(disc);
     const cyclesPerSecond = machine.model.cyclesPerSecond;
-    const ShiftKey = 16;
-    machine.processor.sysvia.keyDown(ShiftKey);
+    machine.processor.sysvia.keyDown(keyCodes.SHIFT_LEFT);
     machine.reset(true);
     await machine.runFor(2 * cyclesPerSecond);
-    machine.processor.sysvia.keyUp(ShiftKey);
+    machine.processor.sysvia.keyUp(keyCodes.SHIFT_LEFT);
     const runSeconds = schedule.totalCs / 100 + StartDelayCs / 100 + 4;
     for (let s = 0; s < runSeconds; ++s) {
         await machine.runFor(cyclesPerSecond);


### PR DESCRIPTION
Host keys were identified by `KeyboardEvent.keyCode`, which names a key by the character it
produces. That number changes with the browser and with the keyboard layout, which is the root of
all three keyboard issues. This keys the host tables by `KeyboardEvent.code` instead, which names
the physical key and is the same in every browser.

Closes #1065. Lays the groundwork for #1075 and fixes the core of #123, neither of which this
finishes on its own; see below.

## What goes away

- The Firefox detector and the two-branch key code table.
- The Mac backquote and apostrophe swap.
- The `navigator.language` UK or US guess, from the physical layout entirely.
- The modifier reconstruction in the keyboard module: about seventy lines rebuilding left and right
  shift, alt and ctrl from `evt.location`, with carried-over state to work around Chrome reporting
  location zero on key up. `code` says `ShiftLeft` and `NumpadEnter` directly.

`keyCodes` keeps its property names and only its values change, so every call site and every `KEY.`
URL parameter still works.

## Three judgement calls

1. **The UK `#~` key and the US `\|` key are one physical key.** They had different numbers only
   because the layouts label them differently. They merge as `BACKSLASH`, with `HASH` kept as an
   accepted name, and the 102-key-only key between the left shift and the `Z` becomes
   `INTL_BACKSLASH`. A UK-only duplicate that put the BBC right square bracket on the hash key is
   dropped; that key still has its home on the bracket key.
2. **Plain `SHIFT`, `CTRL` and `ALT` stop being key codes.** An event always says which side, so
   they are now aliases mapping both. They were already unreachable from the browser, since the
   keyboard module rewrote them to a side before every lookup.
3. **The headless key API takes a name, not a number.** Hence the `!` on the commit type.

## Please look at these

- **This is `feat!`, so it bumps the major version.** `MachineSession.keyDown` and `TestMachine.keyDown`
  are both exported from the package and both take a host key name now rather than a number.
  jsbeeb-mcp's key table is numeric and it depends on `^1.25.0`: under a minor release it would
  install this and every key press by name would become a silent no-op. A major bump is what stops
  that happening by accident, and lets the consumer update deliberately.
- **A numeric compatibility path is not worth having.** The old numbers differed by browser and by
  keyboard layout, which is the bug this fixes, so there is no single correct table to translate
  from. Any shim would pick one browser's idea and be quietly wrong for the rest.
- **Apple ISO keyboards regress in the natural layout.** On an Apple UK board the key left of the
  `1` is `Backquote` but prints `§±`, and the key printing a backtick is `IntlBackslash`. The
  deleted Mac swap existed for that. Two punctuation keys are affected, in the natural layout only.
  The follow-up that maps natural by the character typed removes the problem by construction rather
  than by another platform test, which is why I have not reinstated one here.

## What is left for the other two issues

A Dvorak or Hungarian user now gets keys by position in the physical and gaming layouts, and the
accented keys that #123 reports as invisible report `Semicolon`, `Quote` and `Backslash` like any
other board. The natural layout is still keyed by position and still assumes UK or US printed
characters, so #123's literal title needs the follow-up that keys it by `evt.key`.

## Testing

Unit, integration and the benchmark all pass. Three review passes over the diff found four real
defects, all fixed here: a binding the rename silently moved to the wrong physical key on the Atom,
a mapping that was accidentally added rather than preserved, and two shift-boots that had become
silent no-ops, in the CPU benchmark and in the audio sweep tool. Neither of those two runs in CI.

Tested by hand on two machines, with a probe page that arms a key capture and records what each
physical key delivers:

- **Chrome on Linux, US ANSI keyboard.** Every key the physical layout uses arrives. The Meta key
  arrives but fires the desktop shortcut alongside it, so it is unusable for shift lock whatever the
  event says.
- **Firefox on macOS, US Dvorak, ANSI keyboard.** The apostrophe key reports `key` as `-` and `code`
  as `Quote`, which is #1075's complaint exactly: before this change that key pressed whatever the
  hyphen's number mapped to, and now it presses the BBC colon and star, where it physically sits.
  This is also the first evidence from a browser other than Chrome that the `code` values match,
  which is what #1065 was about. Firefox has no keyboard map API, as expected.

Still untested on Windows and Safari.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
