### PR TITLE
feat: put every jsbeeb shortcut on Alt, and give shift lock a home

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,28 +117,32 @@ The definitive lists are `keyCodes` with `keyCodeAliases` (host) and `BBC` (BBC 
 
 ### Emulator Shortcuts
 
-| Shortcut       | Action                          |
-| -------------- | ------------------------------- |
-| `Ctrl+Home`    | Stop and enter debugger         |
-| `Ctrl+Insert`  | Toggle turbo (fast-as-possible) |
-| `Ctrl+End`     | Pause emulation                 |
-| `Ctrl+B`       | Open printer output window      |
-| `Alt+PageDown` | Open rewind scrubber            |
-| `Alt+M`        | Media window, aimed at drive 0  |
-| `Alt+Shift+M`  | Media window, aimed at drive 1  |
-| `Alt+C`        | Media window, aimed at the deck |
+| Shortcut         | Action                                     |
+| ---------------- | ------------------------------------------ |
+| `Alt-S`          | Enter the debugger, or leave it and resume |
+| `Alt-P`          | Pause emulation, or resume                 |
+| `Alt-T`          | Toggle turbo (fast-as-possible)            |
+| `Alt-B`          | Open printer output window                 |
+| `Alt-W`          | Open rewind scrubber                       |
+| `Alt-M`          | Media window, aimed at drive 0             |
+| `Alt-Shift-M`    | Media window, aimed at drive 1             |
+| `Alt-C`          | Media window, aimed at the cassette        |
+| `Alt-1 to Alt-8` | Hold an accessibility switch down          |
+
+Every shortcut is on `Alt`, so that `Ctrl` belongs to the emulated machine: `Ctrl-B` is `VDU 2` on a BBC, `Ctrl-L`
+clears the screen, and jsbeeb should not be taking any of them.
 
 ### Printer Output
 
 Anything the machine prints is captured whether or not the printer window is open, so programs that print (with `VDU 2`, `*FX5,1` and the like) run rather than waiting for a printer that is not there.
 
-Press `Ctrl+B` to open a window showing what has been printed so far; it then keeps up with the output as it arrives. Only the most recent output is kept, roughly a dozen pages' worth, so a program printing forever cannot fill memory.
+Press `Alt-B` to open a window showing what has been printed so far; it then keeps up with the output as it arrives. Only the most recent output is kept, roughly a dozen pages' worth, so a program printing forever cannot fill memory.
 
 ### Save State and Rewind
 
 Save and load full emulator state snapshots from the **State** menu (or `Ctrl+S` / `Ctrl+O` in the Electron app).
 
-The emulator continuously captures snapshots into a 30-slot rewind buffer (~1 per second). Open the rewind scrubber from **State > Rewind** or press **Alt+PageDown** to browse recent states as a visual filmstrip:
+The emulator continuously captures snapshots into a 30-slot rewind buffer (~1 per second). Open the rewind scrubber from **State > Rewind** or press **Alt-W** to browse recent states as a visual filmstrip:
 
 - **Left/Right arrows**: navigate between snapshots (the main screen updates live)
 - **Click** a thumbnail to jump to that point

--- a/index.html
+++ b/index.html
@@ -889,24 +889,29 @@
                   <td>See notes</td>
                 </tr>
                 <tr>
-                  <td>Debug</td>
-                  <td><span class="key">Ctrl-Home</span></td>
-                  <td><span class="key">Ctrl-Home</span></td>
+                  <td>Debugger, in or out</td>
+                  <td><span class="key">Alt-S</span></td>
+                  <td><span class="key">Alt-S</span></td>
                 </tr>
                 <tr>
-                  <td>Pause</td>
-                  <td><span class="key">Ctrl-End</span></td>
-                  <td><span class="key">Ctrl-End</span></td>
+                  <td>Pause or resume</td>
+                  <td><span class="key">Alt-P</span></td>
+                  <td><span class="key">Alt-P</span></td>
                 </tr>
                 <tr>
                   <td>Full speed</td>
-                  <td><span class="key">Ctrl-Insert</span></td>
-                  <td><span class="key">Ctrl-Insert</span></td>
+                  <td><span class="key">Alt-T</span></td>
+                  <td><span class="key">Alt-T</span></td>
+                </tr>
+                <tr>
+                  <td>Printer output</td>
+                  <td><span class="key">Alt-B</span></td>
+                  <td><span class="key">Alt-B</span></td>
                 </tr>
                 <tr>
                   <td>Rewind</td>
-                  <td><span class="key">Alt-PageDown</span></td>
-                  <td><span class="key">Alt-PageDown</span></td>
+                  <td><span class="key">Alt-W</span></td>
+                  <td><span class="key">Alt-W</span></td>
                 </tr>
                 <tr>
                   <td>Discs and tapes, for drive 0</td>
@@ -922,6 +927,11 @@
                   <td>Discs and tapes, for the cassette</td>
                   <td><span class="key">Alt-C</span></td>
                   <td><span class="key">Alt-C</span></td>
+                </tr>
+                <tr>
+                  <td>Hold an accessibility switch</td>
+                  <td><span class="key">Alt-1 to Alt-8</span></td>
+                  <td><span class="key">Alt-1 to Alt-8</span></td>
                 </tr>
               </table>
               <div>

--- a/src/app/app.js
+++ b/src/app/app.js
@@ -238,8 +238,8 @@ const template = [
             },
             { type: "separator" },
             {
+                // No accelerator: Alt-S reaches the page, where it toggles rather than only stopping.
                 label: "Pause and Show Debugger",
-                accelerator: "CmdOrCtrl+Home",
                 click: sendAction("pause"),
             },
             {

--- a/src/keymap-atom.js
+++ b/src/keymap-atom.js
@@ -307,7 +307,6 @@ export function getKeyMapAtom(keyLayout) {
     map(keyCodes.F10, ATOM.REPT);
 
     map(keyCodes.F1, ATOM.LOCK); // which is better for ATOM.LOCK - use all of them?
-    map(keyCodes.WINDOWS, ATOM.LOCK);
     map(keyCodes.ALT_LEFT, ATOM.LOCK);
 
     if (keyLayout === "natural") {
@@ -357,6 +356,7 @@ export function getKeyMapAtom(keyLayout) {
         map(keyCodes.EQUALS, ATOM.SEMICOLON_PLUS); // OK for <Shift> at least
 
         map(keyCodes.END, ATOM.COPY);
+        map(keyCodes.HOME, ATOM.LOCK);
         map(keyCodes.F11, ATOM.COPY);
 
         map(keyCodes.CTRL_LEFT, ATOM.CTRL);

--- a/src/keymap-atom.js
+++ b/src/keymap-atom.js
@@ -425,6 +425,7 @@ export function getKeyMapAtom(keyLayout) {
         // UP/DOWN/LEFT/RIGHT are using arrow keys
         // REPT is using RIGHT_SHIFT
         // note: LOCK is on LEFT_ALT
+        map(keyCodes.HOME, ATOM.LOCK);
         map(keyCodes.K1, ATOM.K1);
         map(keyCodes.K2, ATOM.K2);
         map(keyCodes.K3, ATOM.K3);

--- a/src/keymap.js
+++ b/src/keymap.js
@@ -563,9 +563,9 @@ export function getKeyMap(keyLayout) {
 
         map(keyCodes.EQUALS, BBC.SEMICOLON_PLUS); // OK for <Shift> at least
 
-        map(keyCodes.WINDOWS, BBC.SHIFTLOCK);
-
         map(keyCodes.END, BBC.COPY);
+
+        map(keyCodes.HOME, BBC.SHIFTLOCK);
 
         map(keyCodes.F11, BBC.COPY);
 
@@ -635,7 +635,6 @@ export function getKeyMap(keyLayout) {
 
         // not in correct location
         map(keyCodes.ALT_RIGHT, BBC.SHIFTLOCK);
-        map(keyCodes.WINDOWS, BBC.SHIFTLOCK);
     } else {
         // Physical, and default
         map(keyCodes.K1, BBC.K1);
@@ -657,12 +656,12 @@ export function getKeyMap(keyLayout) {
         map(keyCodes.COMMA, BBC.COMMA); // ',' / '<'
         map(keyCodes.PERIOD, BBC.PERIOD); // '.' / '>'
         map(keyCodes.SLASH, BBC.SLASH); // '/' / '?'
-        map(keyCodes.WINDOWS, BBC.SHIFTLOCK); // shift lock mapped to "windows" key
         map(keyCodes.TAB, BBC.TAB); // tab
         map(keyCodes.ENTER, BBC.RETURN); // return
         map(keyCodes.DELETE, BBC.DELETE); // delete
         map(keyCodes.BACKSPACE, BBC.DELETE); // delete
         map(keyCodes.END, BBC.COPY); // copy key is end
+        map(keyCodes.HOME, BBC.SHIFTLOCK);
         map(keyCodes.F11, BBC.COPY); // copy key is end for Apple
         map(keyCodes.ESCAPE, BBC.ESCAPE); // escape
         map(keyCodes.CTRL_LEFT, BBC.CTRL);

--- a/src/main.js
+++ b/src/main.js
@@ -178,8 +178,11 @@ const processor = machine.processor;
 
 const { keyboard } = new KeyboardSetup({
     actions: {
-        enterDebugger: () => loop.stop(true),
-        reload: () => window.location.reload(),
+        toggleDebugger: () => {
+            if (!dbgr.enabled()) return loop.stop(true);
+            dbgr.hide();
+            loop.go();
+        },
         toggleFast: () => loop.toggleFastAsPossible(),
         openRewind: () => rewindUI.open(),
         openPrinter: () => frontPanel.checkPrinterWindow(),

--- a/src/web/front-panel.js
+++ b/src/web/front-panel.js
@@ -27,7 +27,7 @@ export class FrontPanel {
         loop.addEventListener("tick", () => this.syncLights());
         printer.addEventListener("output", (event) => this.printChar(event.detail));
         printer.addEventListener("first-output", () =>
-            toast("Printer output is being kept. Press Ctrl-B to open the printer window.", {
+            toast("Printer output is being kept. Press Alt-B to open the printer window.", {
                 title: "Printer",
                 quietKey: "quietPrinterOutput",
             }),
@@ -75,7 +75,7 @@ export class FrontPanel {
         this.printerWindow = window.open("", "_blank", "height=300,width=400");
         if (!this.printerWindow) {
             toast(
-                "The printer output window was blocked. Allow pop-up windows for this site, then press Ctrl-B again.",
+                "The printer output window was blocked. Allow pop-up windows for this site, then press Alt-B again.",
                 {
                     title: "Printer",
                 },

--- a/src/web/keyboard-setup.js
+++ b/src/web/keyboard-setup.js
@@ -2,19 +2,12 @@ import { Keyboard } from "./keyboard.js";
 import { showNotice } from "./reporting.js";
 import { noteEvent } from "./analytics.js";
 import { keyCodes } from "../keymap.js";
+import { Shortcuts } from "./shortcuts.js";
 
 const PasteBoxId = "paste-text";
-/** The eight accessibility switches, each reachable from a number key and a function key. */
-const SwitchKeys = [
-    ["K1", "F1"],
-    ["K2", "F2"],
-    ["K3", "F3"],
-    ["K4", "F4"],
-    ["K5", "F5"],
-    ["K6", "F6"],
-    ["K7", "F7"],
-    ["K8", "F8"],
-];
+/** The eight accessibility switches, on the number keys. */
+const SwitchKeys = ["K1", "K2", "K3", "K4", "K5", "K6", "K7", "K8"];
+
 const TypingTargets = 'input, textarea, select, [contenteditable]:not([contenteditable="false"])';
 // Where keys are for the page, not the machine: the paste box, and the media window's controls.
 const KeyboardSinks = `#${PasteBoxId}, #media-panel`;
@@ -27,7 +20,7 @@ export class KeyboardSetup {
     /**
      * @param {object} opts
      * @param {object} opts.actions what each shortcut does, supplied late-bound:
-     *   enterDebugger, reload, toggleFast, openRewind, openPrinter, openMedia,
+     *   toggleDebugger, toggleFast, openRewind, openPrinter, openMedia,
      *   pause, resume, paste, onAnyKeyDown
      * @param {import("./accessibility-switches.js").AccessibilitySwitches} opts.accessibilitySwitches
      */
@@ -53,39 +46,38 @@ export class KeyboardSetup {
             }
         };
         const alt = { alt: true, ctrl: false };
-        const ctrl = { alt: false, ctrl: true };
-        keyboard.registerKeyHandler(keyCodes.S, onDown("S", actions.enterDebugger), alt);
-        keyboard.registerKeyHandler(keyCodes.R, onDown(null, actions.reload), alt);
-        keyboard.registerKeyHandler(keyCodes.HOME, onDown("home", actions.enterDebugger), ctrl);
-        keyboard.registerKeyHandler(keyCodes.INSERT, onDown("insert", actions.toggleFast), ctrl);
-        keyboard.registerKeyHandler(
-            keyCodes.END,
-            onDown("end", () => keyboard.pauseEmulation()),
-            ctrl,
-        );
-        keyboard.registerKeyHandler(keyCodes.PAGEDOWN, onDown("pagedown", actions.openRewind), alt);
-        keyboard.registerKeyHandler(keyCodes.B, onDown(null, actions.openPrinter), ctrl);
-        keyboard.registerKeyHandler(
-            keyCodes.M,
-            (down, _code, shift) => {
-                if (down) actions.openMedia(shift ? 1 : 0);
-            },
-            alt,
-        );
-        keyboard.registerKeyHandler(
-            keyCodes.C,
-            onDown(null, () => actions.openMedia("tape")),
-            alt,
-        );
+        const runners = {
+            toggleDebugger: () => actions.toggleDebugger(),
+            togglePause: () => (keyboard.pauseEmu ? keyboard.resumeEmulation() : keyboard.pauseEmulation()),
+            toggleFast: () => actions.toggleFast(),
+            openPrinter: () => actions.openPrinter(),
+            openRewind: () => actions.openRewind(),
+            openMediaTape: () => actions.openMedia("tape"),
+        };
+        for (const shortcut of Shortcuts) {
+            if (!shortcut.key) continue;
+            if (shortcut.run === "openMediaDrive") {
+                // The only shortcut whose shift state changes what it does, rather than which key it is.
+                keyboard.registerKeyHandler(
+                    keyCodes[shortcut.key],
+                    (down, _code, shift) => {
+                        if (down) actions.openMedia(shift ? 1 : 0);
+                    },
+                    alt,
+                );
+                continue;
+            }
+            keyboard.registerKeyHandler(
+                keyCodes[shortcut.key],
+                onDown(shortcut.note ?? null, runners[shortcut.run]),
+                alt,
+            );
+        }
 
-        // Alt+1-8 and Alt+F1-F8 trigger the accessibility switches. Using Alt means
-        // the underlying key is never forwarded to the BBC Micro (keyboard.js bails
-        // out early when a handler fires), so typing numbers or using function keys
-        // works normally.
+        // Alt means the underlying key is never forwarded to the BBC Micro (keyboard.js bails
+        // out early when a handler fires), so typing numbers works normally.
         const handleSwitch = (index) => (down) => accessibilitySwitches.setSwitch(index, down);
-        SwitchKeys.forEach((names, index) => {
-            for (const name of names) keyboard.registerKeyHandler(keyCodes[name], handleSwitch(index), alt);
-        });
+        SwitchKeys.forEach((name, index) => keyboard.registerKeyHandler(keyCodes[name], handleSwitch(index), alt));
 
         document.addEventListener("keydown", (evt) => {
             actions.onAnyKeyDown();

--- a/src/web/keyboard.js
+++ b/src/web/keyboard.js
@@ -156,7 +156,8 @@ export class Keyboard extends EventTarget {
         const handler = this._findKeyHandler(code, evt.altKey, evt.ctrlKey);
         if (handler) {
             evt.preventDefault();
-            handler.handler(true, code, evt.shiftKey);
+            // Auto-repeat would toggle a shortcut over and over while the key is simply held.
+            if (!evt.repeat) handler.handler(true, code, evt.shiftKey);
             return;
         }
 

--- a/src/web/keyboard.js
+++ b/src/web/keyboard.js
@@ -147,11 +147,20 @@ export class Keyboard extends EventTarget {
      * @param {KeyboardEvent} evt - The keyboard event
      */
     keyDown(evt) {
-        // Early returns for common scenarios
         if (this.inputEnabledFunction()) return;
-        if (!this.running) return;
 
         const code = this.keyCode(evt);
+
+        // Shortcuts answer whether or not the machine is running, so the one that stopped it
+        // can start it again.
+        const handler = this._findKeyHandler(code, evt.altKey, evt.ctrlKey);
+        if (handler) {
+            evt.preventDefault();
+            handler.handler(true, code, evt.shiftKey);
+            return;
+        }
+
+        if (!this.running) return;
         evt.preventDefault();
 
         if (this.isPasting && code === keyCodes.ESCAPE) {
@@ -160,19 +169,8 @@ export class Keyboard extends EventTarget {
         }
 
         // Special handling cases that we always want to keep within keyboard.js
-        const isSpecialHandled = this._handleSpecialKeys(code);
-        if (isSpecialHandled) return;
+        if (this._handleSpecialKeys(code)) return;
 
-        // Check for registered handlers first; if one fires, don't pass to the emulator.
-        // This lets Alt+key and Ctrl+key handlers cleanly own their keys without the
-        // underlying key leaking through to the emulated machine.
-        const handler = this._findKeyHandler(code, evt.altKey, evt.ctrlKey);
-        if (handler) {
-            handler.handler(true, code, evt.shiftKey);
-            return;
-        }
-
-        // No handler claimed the key; pass it to the emulated machine.
         this.keyInterface.keyDown(code, evt.shiftKey);
     }
 
@@ -208,6 +206,15 @@ export class Keyboard extends EventTarget {
 
         if (this.inputEnabledFunction()) return;
 
+        // A switch held while the machine stopped still has to be released, so the handlers
+        // run whether or not it is running, as they do on the way down.
+        const handler = this._findKeyHandler(code, evt.altKey, evt.ctrlKey);
+        if (handler) {
+            evt.preventDefault();
+            handler.handler(false, code);
+            return;
+        }
+
         // No further special handling needed if not running
         if (!this.running) return;
 
@@ -217,17 +224,9 @@ export class Keyboard extends EventTarget {
         if (code === keyCodes.F12 || code === keyCodes.BREAK) {
             this.dispatchEvent(new CustomEvent("break", { detail: false }));
             this.processor.setReset(false);
-            return;
         } else if (isMac && code === keyCodes.CAPSLOCK) {
             // Special CapsLock handling for Mac
             this.handleMacCapsLock();
-            return;
-        }
-
-        // Check for registered handlers
-        const handler = this._findKeyHandler(code, evt.altKey, evt.ctrlKey);
-        if (handler) {
-            handler.handler(false, code);
         }
     }
 

--- a/src/web/shortcuts.js
+++ b/src/web/shortcuts.js
@@ -1,0 +1,26 @@
+/**
+ * Every shortcut jsbeeb answers. The handlers in keyboard-setup.js and both lists of documentation, in the
+ * README and in the page's own help, are checked against this, so a shortcut cannot be added
+ * without appearing in all three.
+ *
+ * All of them are on Alt, because Ctrl belongs to the emulated machine: Ctrl-B is VDU 2 on a
+ * BBC, Ctrl-L clears the screen, and so on. A row with no `key` is documentation for another
+ * row's handler.
+ */
+export const Shortcuts = [
+    {
+        combo: "Alt-S",
+        key: "S",
+        note: "S",
+        run: "toggleDebugger",
+        description: "Enter the debugger, or leave it and resume",
+    },
+    { combo: "Alt-P", key: "P", note: "pause", run: "togglePause", description: "Pause emulation, or resume" },
+    { combo: "Alt-T", key: "T", note: "turbo", run: "toggleFast", description: "Toggle turbo (fast-as-possible)" },
+    { combo: "Alt-B", key: "B", run: "openPrinter", description: "Open printer output window" },
+    { combo: "Alt-W", key: "W", note: "rewind", run: "openRewind", description: "Open rewind scrubber" },
+    { combo: "Alt-M", key: "M", run: "openMediaDrive", description: "Media window, aimed at drive 0" },
+    { combo: "Alt-Shift-M", description: "Media window, aimed at drive 1" },
+    { combo: "Alt-C", key: "C", run: "openMediaTape", description: "Media window, aimed at the cassette" },
+    { combo: "Alt-1 to Alt-8", description: "Hold an accessibility switch down" },
+];

--- a/tests/unit/test-front-panel.js
+++ b/tests/unit/test-front-panel.js
@@ -76,7 +76,7 @@ describe("FrontPanel", () => {
             const printer = new Printer();
             make(false, printer);
             printer.dispatchEvent(new Event("first-output"));
-            expect(toasts()).toEqual([expect.stringContaining("Ctrl-B")]);
+            expect(toasts()).toEqual([expect.stringContaining("Alt-B")]);
         });
 
         it("says when the pop-up was blocked", () => {

--- a/tests/unit/test-keyboard-setup.js
+++ b/tests/unit/test-keyboard-setup.js
@@ -25,8 +25,7 @@ describe("KeyboardSetup", () => {
     beforeEach(() => {
         document.body.innerHTML = "";
         actions = {
-            enterDebugger: vi.fn(),
-            reload: vi.fn(),
+            toggleDebugger: vi.fn(),
             toggleFast: vi.fn(),
             openRewind: vi.fn(),
             openPrinter: vi.fn(),
@@ -65,25 +64,28 @@ describe("KeyboardSetup", () => {
     afterEach(teardownDom);
 
     describe("the accessibility switches", () => {
-        it("clears a bit while its switch is held, keys and function keys alike", () => {
+        it("clears a bit while its switch is held", () => {
             document.dispatchEvent(keyEvent("keydown", keyCodes.K1, { alt: true }));
             expect(accessibilitySwitches.userPort.read()).toBe(0xfe);
             document.dispatchEvent(keyEvent("keyup", keyCodes.K1, { alt: true }));
             expect(accessibilitySwitches.userPort.read()).toBe(0xff);
 
-            document.dispatchEvent(keyEvent("keydown", keyCodes.F8, { alt: true }));
+            document.dispatchEvent(keyEvent("keydown", keyCodes.K8, { alt: true }));
             expect(accessibilitySwitches.userPort.read()).toBe(0x7f);
+        });
+
+        it("leaves the function keys to the machine, so Alt-F4 is not a switch", () => {
+            document.dispatchEvent(keyEvent("keydown", keyCodes.F4, { alt: true }));
+            expect(accessibilitySwitches.userPort.read()).toBe(0xff);
         });
     });
 
     describe("the shortcuts", () => {
         it.each([
-            ["Alt-S", keyCodes.S, { alt: true }, "enterDebugger"],
-            ["Ctrl-Home", keyCodes.HOME, { ctrl: true }, "enterDebugger"],
-            ["Alt-R", keyCodes.R, { alt: true }, "reload"],
-            ["Ctrl-Insert", keyCodes.INSERT, { ctrl: true }, "toggleFast"],
-            ["Alt-PageDown", keyCodes.PAGEDOWN, { alt: true }, "openRewind"],
-            ["Ctrl-B", keyCodes.B, { ctrl: true }, "openPrinter"],
+            ["Alt-S", keyCodes.S, { alt: true }, "toggleDebugger"],
+            ["Alt-T", keyCodes.T, { alt: true }, "toggleFast"],
+            ["Alt-W", keyCodes.W, { alt: true }, "openRewind"],
+            ["Alt-B", keyCodes.B, { alt: true }, "openPrinter"],
         ])("%s fires %s on the way down only", (name, which, modifiers, action) => {
             document.dispatchEvent(keyEvent("keydown", which, modifiers));
             expect(actions[action]).toHaveBeenCalledTimes(1);
@@ -104,7 +106,7 @@ describe("KeyboardSetup", () => {
 
         it("does nothing without the modifier", () => {
             document.dispatchEvent(keyEvent("keydown", keyCodes.S));
-            expect(actions.enterDebugger).not.toHaveBeenCalled();
+            expect(actions.toggleDebugger).not.toHaveBeenCalled();
             expect(processor.sysvia.keyDown).toHaveBeenCalled();
         });
 

--- a/tests/unit/test-keyboard-setup.js
+++ b/tests/unit/test-keyboard-setup.js
@@ -7,8 +7,8 @@ import { domFromIndexHtml, teardownDom } from "./helpers.js";
 import { keyCodes } from "../../src/keymap.js";
 import { findModel } from "../../src/models.js";
 
-const keyEvent = (type, code, { alt = false, ctrl = false, shift = false } = {}) =>
-    new KeyboardEvent(type, { code, altKey: alt, ctrlKey: ctrl, shiftKey: shift, cancelable: true });
+const keyEvent = (type, code, { alt = false, ctrl = false, shift = false, repeat = false } = {}) =>
+    new KeyboardEvent(type, { code, altKey: alt, ctrlKey: ctrl, shiftKey: shift, repeat, cancelable: true });
 
 const pasteEvent = (text) => {
     const event = new Event("paste", { bubbles: true, cancelable: true });
@@ -102,6 +102,14 @@ describe("KeyboardSetup", () => {
             expect(actions.openMedia).toHaveBeenLastCalledWith("tape");
             expect(actions.openMedia).toHaveBeenCalledTimes(3);
             expect(processor.sysvia.keyDown).not.toHaveBeenCalled();
+        });
+
+        it("fires once however long the key is held", () => {
+            document.dispatchEvent(keyEvent("keydown", keyCodes.S, { alt: true }));
+            document.dispatchEvent(keyEvent("keydown", keyCodes.S, { alt: true, repeat: true }));
+            document.dispatchEvent(keyEvent("keydown", keyCodes.S, { alt: true, repeat: true }));
+
+            expect(actions.toggleDebugger).toHaveBeenCalledTimes(1);
         });
 
         it("does nothing without the modifier", () => {

--- a/tests/unit/test-shortcuts.js
+++ b/tests/unit/test-shortcuts.js
@@ -1,0 +1,34 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+import { Shortcuts } from "../../src/web/shortcuts.js";
+
+const readme = readFileSync("README.md", "utf8");
+const indexHtml = readFileSync("index.html", "utf8");
+
+/** Every `Alt-...` the two lists of documentation claim jsbeeb answers. */
+function documentedCombos(text, pattern) {
+    return new Set([...text.matchAll(pattern)].map((match) => match[1]));
+}
+
+describe("Emulator shortcuts", () => {
+    const combos = Shortcuts.map((shortcut) => shortcut.combo);
+
+    it("puts every shortcut on Alt, leaving Ctrl to the emulated machine", () => {
+        for (const combo of combos) expect(combo.startsWith("Alt-")).toBe(true);
+    });
+
+    it("names a handler for every shortcut that is not documentation for another", () => {
+        for (const shortcut of Shortcuts) {
+            if (!shortcut.key) continue;
+            expect(shortcut.run, shortcut.combo).toBeTruthy();
+        }
+    });
+
+    it.each([
+        ["the README", () => documentedCombos(readme, /\| `(Alt-[^`]+)`/g)],
+        ["the page's own help", () => documentedCombos(indexHtml, /<span class="key">(Alt-[^<]+)<\/span>/g)],
+    ])("is listed in %s, exactly", (_where, documented) => {
+        expect([...documented()].sort()).toEqual([...combos].sort());
+    });
+});


### PR DESCRIPTION
Stacked on #1129.

`Ctrl-B` on a BBC is `VDU 2`, which turns the printer on. jsbeeb was intercepting it to open its
own printer window, so the key never reached the machine and the printer could not be started from
the keyboard at all. `Ctrl-C`, `VDU 3`, was unbound and passed straight through, so it could be
stopped but not started. That is the general problem: `Ctrl` plus anything is ordinary BBC usage,
and jsbeeb should not be taking any of it.

## The rule

**Ctrl belongs to the machine. Alt belongs to jsbeeb.**

| Action | Was | Now |
| --- | --- | --- |
| Debugger | Alt-S, Ctrl-Home | Alt-S, and it now leaves as well as enters |
| Pause | Ctrl-End | Alt-P, and it now resumes as well |
| Turbo | Ctrl-Insert | Alt-T |
| Printer window | Ctrl-B | Alt-B |
| Rewind | Alt-PageDown | Alt-W |
| Media, drive 0 and 1 | Alt-M, Alt-Shift-M | unchanged |
| Cassette | Alt-C | unchanged |
| Accessibility switches | Alt-1 to Alt-8, Alt-F1 to Alt-F8 | Alt-1 to Alt-8 |
| Reload | Alt-R | retired |

Retiring the `Ctrl` shortcuts has a second benefit: pause and turbo no longer need Insert, Home and
End, which no laptop keyboard has. `Alt-F1` to `Alt-F8` go because `Alt-F4` closes the window on
Windows and no page can prevent it, so that switch was both unreachable and destructive. `Alt-R`
goes because an undocumented single-modifier key that reloads the page and loses the machine is a
trap, and the browser already has `Ctrl-R`.

Making `Alt-S` and `Alt-P` toggle means the handlers have to answer while the machine is stopped,
which they now do on release as well as press, so a switch held when the machine stopped is still
released.

## Shift lock

It was on the Windows key, in every layout including the Atom's. Every window manager claims that
key for itself, so it effectively had no binding at all. It moves to Home, beside copy on End and
the pound key on Page Up.

## One table, three places

The shortcuts now live in `src/web/shortcuts.js`, and a test checks it against both the README
table and the page's own help. Neither can drift, and a shortcut cannot be added without appearing
in both.

That test exists because three shortcuts were registered and documented in neither place: `Alt-S`,
`Alt-R`, and the accessibility switches. The author of the project did not know `Alt-S` opened the
debugger.

## Not in here

The gaming layout keeps left Ctrl and left Alt as BBC caps lock and ctrl. Those two keys are side
by side under one hand, which is the property games like Zalaga and Hunchback depend on when they
use that pair for left and right, and the BBC has them adjacent for the same reason. The cost is
that Alt plus a digit, the accessibility switches, is unavailable while the gaming layout is
selected, which suits a layout whose point is giving the machine the keyboard.

## Testing

Unit and integration suites pass. Not yet exercised by hand: every shortcut on a real page, the
Electron menu, and shift lock on Home.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
