### PR TITLE
feat: key the natural layout by what you type, not by where the key is

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ different peripherals.
 
 - [Keyboard Mappings](#keyboard-mappings)
 - [Remapping Keys](#remapping-keys)
+- [Keyboard Layouts](#keyboard-layouts)
 - [Discs and Tapes](#discs-and-tapes)
 - [Emulator Shortcuts](#emulator-shortcuts)
 - [Printer Output](#printer-output)
@@ -110,6 +111,31 @@ Some things to know:
 The definitive lists are `keyCodes` with `keyCodeAliases` (host) and `BBC` (BBC micro) in
 [`src/keymap.js`](src/keymap.js), and `ATOM` in
 [`src/keymap-atom.js`](src/keymap-atom.js).
+
+### Keyboard Layouts
+
+A BBC keyboard is not a PC keyboard, so **Keyboard** on the top bar offers three ways to bridge the
+two. The choice is remembered, and `?keyLayout=physical`, `?keyLayout=natural` or `?keyLayout=gaming`
+sets it from a link.
+
+**Physical** is the default, and the one to use for games. Each key presses the BBC key in the same
+place on the keyboard, so `Z` is `Z` and the key to the right of the `L` is the BBC's `:` and `*`,
+whatever your keyboard is printed with. A Dvorak or Hungarian keyboard works the same as a UK one,
+because only position matters.
+
+**Natural** is for typing. Each key presses whatever the BBC needs to print the character your
+keyboard produces, so a `@` gives a `@` and a `*` gives a `*`, again whatever your layout. The BBC
+holds shift for a different set of characters than a PC does, which this deals with: `^` is
+unshifted on a BBC and `"` is shifted, and you do not have to know that.
+
+**Gaming** moves the BBC keys that a PC keyboard handles badly. Its main job is the BBC's `CAPS LOCK`
+and `CTRL`, which sit side by side and which many games use for left and right: Zalaga and Hunchback
+both do. On a PC those two are a row apart and diagonal, so this layout puts them on the left `Ctrl`
+and left `Alt` instead, which are side by side under one hand. The cost is that `Alt` and a number,
+which is an accessibility switch, does nothing while this layout is chosen.
+
+Whichever you choose, a `KEY.` parameter overrides individual keys on top of it, and survives
+changing layout.
 
 ### Discs and Tapes
 

--- a/README.md
+++ b/README.md
@@ -128,11 +128,17 @@ keyboard produces, so a `@` gives a `@` and a `*` gives a `*`, again whatever yo
 holds shift for a different set of characters than a PC does, which this deals with: `^` is
 unshifted on a BBC and `"` is shifted, and you do not have to know that.
 
+Two keys are exceptions, because characters alone cannot settle them. The BBC has no backtick and
+most keyboards cannot type a `£` at all, so the key that would print a backtick gives a `£`
+instead. And the Master's numeric keypad is a separate set of keys from the digits above the
+letters, which the characters cannot tell apart, so the keypad goes by position.
+
 **Gaming** moves the BBC keys that a PC keyboard handles badly. Its main job is the BBC's `CAPS LOCK`
 and `CTRL`, which sit side by side and which many games use for left and right: Zalaga and Hunchback
 both do. On a PC those two are a row apart and diagonal, so this layout puts them on the left `Ctrl`
-and left `Alt` instead, which are side by side under one hand. The cost is that `Alt` and a number,
-which is an accessibility switch, does nothing while this layout is chosen.
+and left `Alt` instead, which are side by side under one hand. The cost is that jsbeeb's own `Alt`
+shortcuts win over those keys, so while this layout is chosen you cannot hold the BBC's `CTRL` and
+press a letter or digit that jsbeeb has claimed.
 
 Whichever you choose, a `KEY.` parameter overrides individual keys on top of it, and survives
 changing layout.

--- a/index.html
+++ b/index.html
@@ -1087,7 +1087,7 @@
                     <a href="#" class="dropdown-item" data-target="physical">Physical: '*' is next to Enter/Return</a>
                   </li>
                   <li>
-                    <a href="#" class="dropdown-item" data-target="natural">Natural: '*' is shift-8</a>
+                    <a href="#" class="dropdown-item" data-target="natural">Natural: you get the character you type</a>
                   </li>
                   <li>
                     <a href="#" class="dropdown-item" data-target="gaming">Gaming: handy for games like Zalaga</a>

--- a/src/keymap.js
+++ b/src/keymap.js
@@ -122,6 +122,9 @@ export const BBC = {
  */
 const IsLetter = /^[A-Za-z]$/;
 
+/** BBC keys that print the same thing either way, so holding one must not disturb shift. */
+const ShiftMakesNoDifference = new Set([BBC.SPACE]);
+
 /** Every character a keyboard might produce that the BBC can print, for building the natural layout. */
 const PrintableCharacters = (() => {
     const chars = ["\u00a3"];
@@ -492,13 +495,24 @@ export function getKeyMap(keyLayout) {
         // Keyed by the character the host keyboard produces, not by where a key sits, so the
         // host's own layout never has to be guessed: press whatever gives a `@` and the BBC
         // gets a `@`. The BBC holds shift for a different set of characters than a PC does,
-        // so every non-letter says which shift state it needs. Letters take their case from
-        // the shift key as usual.
-        for (const char of PrintableCharacters) {
+        // so a key says which shift state it needs when that differs from the one being held.
+        const mapCharacter = (hostKey, char) => {
             const needs = bbcKeyForCharacter(char);
-            if (!needs) continue;
-            map(char, IsLetter.test(char) ? needs.key : withShiftOverride(needs.key, needs.shift));
-        }
+            if (!needs) return;
+            for (const shiftDown of [false, true]) {
+                // Overriding when the two already agree would take shift away from everything
+                // else held at the same time, and letters want the shift key as it is anyway.
+                const disagrees =
+                    needs.shift !== shiftDown && !IsLetter.test(char) && !ShiftMakesNoDifference.has(needs.key);
+                map(hostKey, disagrees ? withShiftOverride(needs.key, needs.shift) : needs.key, shiftDown);
+            }
+        };
+
+        for (const char of PrintableCharacters) mapCharacter(char, char);
+
+        // The BBC has no backtick, and a US or Dvorak keyboard cannot type a pound sign at all,
+        // so the key that would print one gives the pound sign instead.
+        mapCharacter(keyCodes.BACK_QUOTE, "\u00a3");
 
         // Keys that print nothing are still known by where they are.
         map(keyCodes.SHIFT_LEFT, BBC.SHIFT);

--- a/src/keymap.js
+++ b/src/keymap.js
@@ -110,133 +110,87 @@ export const BBC = {
     NUMPADENTER: [12, 3],
 };
 
+/**
+ * What a character costs on a BBC keyboard: which key, and whether shift is held while it is
+ * pressed. `!` is shift and `1`; `^` is its own unshifted key. Lower case is the same key as
+ * upper with the caps lock the other way, which `upperCase` says.
+ *
+ * The one table for this; the natural keyboard layout and pasting both read it.
+ *
+ * @param {string} char one character
+ * @returns {{key: [number, number], shift: boolean, upperCase: boolean}|null} null if the BBC has no such character
+ */
+export function bbcKeyForCharacter(char) {
+    const code = char.charCodeAt(0);
+    if (code >= 65 && code <= 90) return { key: BBC[char], shift: false, upperCase: true };
+    if (code >= 97 && code <= 122) return { key: BBC[String.fromCharCode(code - 32)], shift: false, upperCase: false };
+    if (code >= 48 && code <= 57) return { key: BBC["K" + char], shift: false, upperCase: true };
+    const shifted = ShiftedCharacters[char];
+    if (shifted) return { key: shifted, shift: true, upperCase: true };
+    const unshifted = UnshiftedCharacters[char];
+    if (unshifted) return { key: unshifted, shift: false, upperCase: true };
+    return null;
+}
+
+/** Characters the BBC prints with shift held. `!` to `)` are shift and the digit above them. */
+const ShiftedCharacters = {
+    "!": BBC.K1,
+    '"': BBC.K2,
+    "#": BBC.K3,
+    $: BBC.K4,
+    "%": BBC.K5,
+    "&": BBC.K6,
+    "'": BBC.K7,
+    "(": BBC.K8,
+    ")": BBC.K9,
+    "=": BBC.MINUS,
+    "~": BBC.HAT_TILDE,
+    "|": BBC.PIPE_BACKSLASH,
+    "{": BBC.LEFT_SQUARE_BRACKET,
+    "+": BBC.SEMICOLON_PLUS,
+    "*": BBC.COLON_STAR,
+    "}": BBC.RIGHT_SQUARE_BRACKET,
+    "<": BBC.COMMA,
+    ">": BBC.PERIOD,
+    "?": BBC.SLASH,
+};
+
+/** Characters the BBC prints without shift. */
+const UnshiftedCharacters = {
+    "\n": BBC.RETURN,
+    "\t": BBC.TAB,
+    " ": BBC.SPACE,
+    "-": BBC.MINUS,
+    "^": BBC.HAT_TILDE,
+    "\\": BBC.PIPE_BACKSLASH,
+    "@": BBC.AT,
+    "[": BBC.LEFT_SQUARE_BRACKET,
+    _: BBC.UNDERSCORE_POUND,
+    ";": BBC.SEMICOLON_PLUS,
+    ":": BBC.COLON_STAR,
+    "]": BBC.RIGHT_SQUARE_BRACKET,
+    ",": BBC.COMMA,
+    ".": BBC.PERIOD,
+    "/": BBC.SLASH,
+};
+
 export function stringToBBCKeys(str) {
     const array = [];
     let shiftState = false;
     let capsLockState = true;
-    for (let i = 0; i < str.length; ++i) {
-        const c = str.charCodeAt(i);
-        let charStr = str.charAt(i);
-        let bbcKey = null;
-        let needsShift = false;
-        let needsCapsLock = true;
-        if (c >= 65 && c <= 90) {
-            // A-Z
-            bbcKey = BBC[charStr];
-        } else if (c >= 97 && c <= 122) {
-            // a-z
-            charStr = String.fromCharCode(c - 32);
-            bbcKey = BBC[charStr];
-            needsCapsLock = false;
-        } else if (c >= 48 && c <= 57) {
-            // 0-9
-            bbcKey = BBC["K" + charStr];
-        } else if (c >= 33 && c <= 41) {
-            // ! to )
-            charStr = String.fromCharCode(c + 16);
-            bbcKey = BBC["K" + charStr];
-            needsShift = true;
-        } else {
-            switch (charStr) {
-                case "\n":
-                    bbcKey = BBC.RETURN;
-                    break;
-                case "\t":
-                    bbcKey = BBC.TAB;
-                    break;
-                case " ":
-                    bbcKey = BBC.SPACE;
-                    break;
-                case "-":
-                    bbcKey = BBC.MINUS;
-                    break;
-                case "=":
-                    bbcKey = BBC.MINUS;
-                    needsShift = true;
-                    break;
-                case "^":
-                    bbcKey = BBC.HAT_TILDE;
-                    break;
-                case "~":
-                    bbcKey = BBC.HAT_TILDE;
-                    needsShift = true;
-                    break;
-                case "\\":
-                    bbcKey = BBC.PIPE_BACKSLASH;
-                    break;
-                case "|":
-                    bbcKey = BBC.PIPE_BACKSLASH;
-                    needsShift = true;
-                    break;
-                case "@":
-                    bbcKey = BBC.AT;
-                    break;
-                case "[":
-                    bbcKey = BBC.LEFT_SQUARE_BRACKET;
-                    break;
-                case "{":
-                    bbcKey = BBC.LEFT_SQUARE_BRACKET;
-                    needsShift = true;
-                    break;
-                case "_":
-                    bbcKey = BBC.UNDERSCORE_POUND;
-                    break;
-                case ";":
-                    bbcKey = BBC.SEMICOLON_PLUS;
-                    break;
-                case "+":
-                    bbcKey = BBC.SEMICOLON_PLUS;
-                    needsShift = true;
-                    break;
-                case ":":
-                    bbcKey = BBC.COLON_STAR;
-                    break;
-                case "*":
-                    bbcKey = BBC.COLON_STAR;
-                    needsShift = true;
-                    break;
-                case "]":
-                    bbcKey = BBC.RIGHT_SQUARE_BRACKET;
-                    break;
-                case "}":
-                    bbcKey = BBC.RIGHT_SQUARE_BRACKET;
-                    needsShift = true;
-                    break;
-                case ",":
-                    bbcKey = BBC.COMMA;
-                    break;
-                case "<":
-                    bbcKey = BBC.COMMA;
-                    needsShift = true;
-                    break;
-                case ".":
-                    bbcKey = BBC.PERIOD;
-                    break;
-                case ">":
-                    bbcKey = BBC.PERIOD;
-                    needsShift = true;
-                    break;
-                case "/":
-                    bbcKey = BBC.SLASH;
-                    break;
-                case "?":
-                    bbcKey = BBC.SLASH;
-                    needsShift = true;
-                    break;
-            }
-        }
+    for (const char of str) {
+        const needs = bbcKeyForCharacter(char);
+        if (!needs) continue;
 
-        if (!bbcKey) continue;
-
-        if ((needsShift && !shiftState) || (!needsShift && shiftState)) {
+        if (needs.shift !== shiftState) {
             array.push(BBC.SHIFT);
-            shiftState = !shiftState;
+            shiftState = needs.shift;
         }
-        if ((needsCapsLock && !capsLockState) || (!needsCapsLock && capsLockState)) {
+        if (needs.upperCase !== capsLockState) {
             array.push(BBC.CAPSLOCK);
-            capsLockState = !capsLockState;
+            capsLockState = needs.upperCase;
         }
-        array.push(bbcKey);
+        array.push(needs.key);
     }
 
     if (shiftState) array.push(BBC.SHIFT);

--- a/src/keymap.js
+++ b/src/keymap.js
@@ -369,6 +369,15 @@ export function detectKeyboardLayout() {
     return "UK"; // Default guess of UK
 }
 
+/**
+ * Whether a `KEY.` parameter has claimed this host key. Those name a key by where it is, so they
+ * win over the character it prints in the layout that goes by character.
+ * @param {string} code a `KeyboardEvent.code` name
+ */
+export function isUserRemapped(code) {
+    return userKeymap.some((mapping) => hostKeyCodes(mapping.native).includes(code));
+}
+
 export function getKeyMap(keyLayout) {
     const isUKlayout = detectKeyboardLayout() === "UK";
     const keys2 = [];

--- a/src/keymap.js
+++ b/src/keymap.js
@@ -120,6 +120,15 @@ export const BBC = {
  * @param {string} char one character
  * @returns {{key: [number, number], shift: boolean, upperCase: boolean}|null} null if the BBC has no such character
  */
+const IsLetter = /^[A-Za-z]$/;
+
+/** Every character a keyboard might produce that the BBC can print, for building the natural layout. */
+const PrintableCharacters = (() => {
+    const chars = ["\u00a3"];
+    for (let code = 32; code < 127; ++code) chars.push(String.fromCharCode(code));
+    return chars;
+})();
+
 export function bbcKeyForCharacter(char) {
     const code = char.charCodeAt(0);
     if (code >= 65 && code <= 90) return { key: BBC[char], shift: false, upperCase: true };
@@ -471,69 +480,27 @@ export function getKeyMap(keyLayout) {
     map(keyCodes.DOWN, BBC.DOWN);
 
     if (keyLayout === "natural") {
-        // "natural" keyboard
+        // Keyed by the character the host keyboard produces, not by where a key sits, so the
+        // host's own layout never has to be guessed: press whatever gives a `@` and the BBC
+        // gets a `@`. The BBC holds shift for a different set of characters than a PC does,
+        // so every non-letter says which shift state it needs. Letters take their case from
+        // the shift key as usual.
+        for (const char of PrintableCharacters) {
+            const needs = bbcKeyForCharacter(char);
+            if (!needs) continue;
+            map(char, IsLetter.test(char) ? needs.key : withShiftOverride(needs.key, needs.shift));
+        }
 
+        // Keys that print nothing are still known by where they are.
         map(keyCodes.SHIFT_LEFT, BBC.SHIFT);
-
-        // US Keyboard: has Tilde on <Shift>BACK_QUOTE
-        map(keyCodes.BACK_QUOTE, isUKlayout ? BBC.UNDERSCORE_POUND : BBC.HAT_TILDE);
-        map(keyCodes.APOSTROPHE, isUKlayout ? BBC.AT : BBC.K2, true);
-        map(keyCodes.K2, isUKlayout ? BBC.K2 : BBC.AT, true);
-
-        // 1st row
-        map(keyCodes.K3, BBC.UNDERSCORE_POUND, true);
-        map(keyCodes.K7, BBC.K6, true);
-        map(keyCodes.K8, BBC.COLON_STAR, true);
-        map(keyCodes.K9, BBC.K8, true);
-        map(keyCodes.K0, BBC.K9, true);
-
-        map(keyCodes.K2, BBC.K2, false);
-        map(keyCodes.K3, BBC.K3, false);
-        map(keyCodes.K7, BBC.K7, false);
-        map(keyCodes.K8, BBC.K8, false);
-        map(keyCodes.K9, BBC.K9, false);
-        map(keyCodes.K0, BBC.K0, false);
-
-        map(keyCodes.K1, BBC.K1);
-        map(keyCodes.K4, BBC.K4);
-        map(keyCodes.K5, BBC.K5);
-        map(keyCodes.K6, BBC.K6, false);
-        map(keyCodes.K6, withShiftOverride(BBC.HAT_TILDE, false), true);
-
-        map(keyCodes.MINUS, BBC.MINUS);
-
-        // 2nd row
-        map(keyCodes.LEFT_SQUARE_BRACKET, BBC.LEFT_SQUARE_BRACKET);
-
-        map(keyCodes.RIGHT_SQUARE_BRACKET, BBC.RIGHT_SQUARE_BRACKET);
-
-        // 3rd row
-
-        map(keyCodes.SEMICOLON, BBC.SEMICOLON_PLUS);
-
-        map(keyCodes.APOSTROPHE, BBC.COLON_STAR, false);
-
-        // UK prints `#~` on this key, which is the BBC's `^~` pair; a US board prints `\|`.
-        map(keyCodes.BACKSLASH, isUKlayout ? BBC.HAT_TILDE : BBC.PIPE_BACKSLASH);
-        map(keyCodes.INTL_BACKSLASH, BBC.PIPE_BACKSLASH);
-
-        map(keyCodes.EQUALS, BBC.SEMICOLON_PLUS); // OK for <Shift> at least
-
         map(keyCodes.END, BBC.COPY);
-
         map(keyCodes.HOME, BBC.SHIFTLOCK);
-
         map(keyCodes.F11, BBC.COPY);
-
         map(keyCodes.ESCAPE, BBC.ESCAPE);
-
         map(keyCodes.CTRL_LEFT, BBC.CTRL);
         map(keyCodes.CTRL_RIGHT, BBC.CTRL);
-
         map(keyCodes.CAPSLOCK, BBC.CAPSLOCK);
-
         map(keyCodes.DELETE, BBC.DELETE);
-
         map(keyCodes.BACKSPACE, BBC.DELETE);
     } else if (keyLayout === "gaming") {
         // gaming keyboard

--- a/src/keymap.js
+++ b/src/keymap.js
@@ -153,6 +153,8 @@ const ShiftedCharacters = {
     "<": BBC.COMMA,
     ">": BBC.PERIOD,
     "?": BBC.SLASH,
+    // Character 96, where ASCII has a backtick: the MOS font at &C000 draws a pound sign.
+    "\u00a3": BBC.UNDERSCORE_POUND,
 };
 
 /** Characters the BBC prints without shift. */

--- a/src/main.js
+++ b/src/main.js
@@ -188,7 +188,11 @@ const { keyboard } = new KeyboardSetup({
         openPrinter: () => frontPanel.checkPrinterWindow(),
         openMedia: (target) => mediaWindow.openFor(target),
         pause: () => loop.stop(false),
-        resume: () => loop.go(),
+        resume: () => {
+            // However the machine was stopped, coming back leaves no debugger behind it.
+            dbgr.hide();
+            loop.go();
+        },
         paste: (text) => keyboard.sendRawKeyboard(autoBoot.stringToMachineKeys(text), true),
         onAnyKeyDown: () => {
             audioHandler.tryResume();

--- a/src/web/keyboard-setup.js
+++ b/src/web/keyboard-setup.js
@@ -48,7 +48,8 @@ export class KeyboardSetup {
         const alt = { alt: true, ctrl: false };
         const runners = {
             toggleDebugger: () => actions.toggleDebugger(),
-            togglePause: () => (keyboard.pauseEmu ? keyboard.resumeEmulation() : keyboard.pauseEmulation()),
+            // `running` is pushed in from the loop, so it stays true whatever stopped the machine.
+            togglePause: () => (keyboard.running ? keyboard.pauseEmulation() : keyboard.resumeEmulation()),
             toggleFast: () => actions.toggleFast(),
             openPrinter: () => actions.openPrinter(),
             openRewind: () => actions.openRewind(),

--- a/src/web/keyboard.js
+++ b/src/web/keyboard.js
@@ -38,14 +38,29 @@ export class Keyboard extends EventTarget {
         this.stepEmuWhenPaused = false;
         this.keyLayout = keyLayout;
         this.saidCapsLockIsTapped = false;
+        /** What each held physical key pressed, so releasing it releases the same thing. */
+        this.heldKeys = new Map();
     }
 
     /**
-     * The host key a keyboard event came from, by physical position.
+     * The host key a keyboard event came from, by physical position. jsbeeb's own shortcuts
+     * and special keys are always by position, whatever layout the machine is using.
      * @param {KeyboardEvent} evt - The keyboard event
      * @returns {string} - A `KeyboardEvent.code` name
      */
     keyCode(evt) {
+        return evt.code;
+    }
+
+    /**
+     * How the emulated machine's key map names the key this event came from. The natural
+     * layout is keyed by the character the host produced, so that what you type comes out
+     * right whatever layout the host keyboard is in; every other layout is by position.
+     * @param {KeyboardEvent} evt - The keyboard event
+     * @returns {string}
+     */
+    _machineKey(evt) {
+        if (this.keyLayout === "natural" && evt.key?.length === 1) return evt.key;
         return evt.code;
     }
 
@@ -73,6 +88,8 @@ export class Keyboard extends EventTarget {
      * @param {string} layout - The keyboard layout to use
      */
     setKeyLayout(layout) {
+        // Anything still held was named by the old layout, so release it before the names change.
+        this.clearKeys();
         this.keyLayout = layout;
         this.processor.setKeyLayout(layout);
     }
@@ -171,7 +188,11 @@ export class Keyboard extends EventTarget {
         // Special handling cases that we always want to keep within keyboard.js
         if (this._handleSpecialKeys(code)) return;
 
-        this.keyInterface.keyDown(code, evt.shiftKey);
+        // In the natural layout the character can change between press and release, as it does
+        // when shift is let go first, so what went down is remembered against the physical key.
+        const machineKey = this._machineKey(evt);
+        this.heldKeys.set(code, machineKey);
+        this.keyInterface.keyDown(machineKey, evt.shiftKey);
     }
 
     /**
@@ -202,7 +223,8 @@ export class Keyboard extends EventTarget {
         // Always let the key ups come through to avoid sticky keys: a key held while focus
         // moved into a text field or the media window still has to be released in the machine.
         const code = this.keyCode(evt);
-        this.keyInterface.keyUp(code);
+        this.keyInterface.keyUp(this.heldKeys.get(code) ?? this._machineKey(evt));
+        this.heldKeys.delete(code);
 
         if (this.inputEnabledFunction()) return;
 
@@ -275,6 +297,7 @@ export class Keyboard extends EventTarget {
      * Clears all pressed keys
      */
     clearKeys() {
+        this.heldKeys.clear();
         this.keyInterface.clearKeys();
     }
 

--- a/src/web/keyboard.js
+++ b/src/web/keyboard.js
@@ -63,6 +63,9 @@ export class Keyboard extends EventTarget {
         if (this.keyLayout !== "natural") return evt.code;
         // A `KEY.` parameter names a key by where it is, so it outranks what the key prints.
         if (isUserRemapped(evt.code)) return evt.code;
+        // The Master's keypad is a separate set of keys from the digits above the letters, and
+        // the characters cannot tell them apart.
+        if (evt.code?.startsWith("Numpad")) return evt.code;
         return evt.key?.length === 1 ? evt.key : evt.code;
     }
 

--- a/src/web/keyboard.js
+++ b/src/web/keyboard.js
@@ -1,4 +1,4 @@
-import { keyCodes } from "../keymap.js";
+import { isUserRemapped, keyCodes } from "../keymap.js";
 import { Typist } from "../typist.js";
 
 const isMac = typeof window !== "undefined" && /^Mac/i.test(window.navigator?.platform || "");
@@ -60,8 +60,10 @@ export class Keyboard extends EventTarget {
      * @returns {string}
      */
     _machineKey(evt) {
-        if (this.keyLayout === "natural" && evt.key?.length === 1) return evt.key;
-        return evt.code;
+        if (this.keyLayout !== "natural") return evt.code;
+        // A `KEY.` parameter names a key by where it is, so it outranks what the key prints.
+        if (isUserRemapped(evt.code)) return evt.code;
+        return evt.key?.length === 1 ? evt.key : evt.code;
     }
 
     /**
@@ -190,7 +192,8 @@ export class Keyboard extends EventTarget {
 
         // In the natural layout the character can change between press and release, as it does
         // when shift is let go first, so what went down is remembered against the physical key.
-        const machineKey = this._machineKey(evt);
+        // Auto-repeat reports the new character too, so a repeat sticks with what it started as.
+        const machineKey = (evt.repeat && this.heldKeys.get(code)) || this._machineKey(evt);
         this.heldKeys.set(code, machineKey);
         this.keyInterface.keyDown(machineKey, evt.shiftKey);
     }

--- a/tests/unit/test-keyboard.js
+++ b/tests/unit/test-keyboard.js
@@ -69,6 +69,63 @@ describe("Keyboard", () => {
         expect(keyboard).toBeDefined();
     });
 
+    describe("in the natural layout", () => {
+        const evt = (code, key, extra = {}) => ({
+            code,
+            key,
+            preventDefault: vi.fn(),
+            ctrlKey: false,
+            altKey: false,
+            shiftKey: false,
+            ...extra,
+        });
+
+        beforeEach(() => {
+            keyboard.setKeyLayout("natural");
+            keyboard.setRunning(true);
+            mockSysvia.keyDown.mockClear();
+            mockSysvia.keyUp.mockClear();
+        });
+
+        test("sends the character the host produced, not the key's position", () => {
+            // A Dvorak keyboard types a hyphen where a QWERTY one has the apostrophe.
+            keyboard.keyDown(evt("Quote", "-"));
+
+            expect(mockSysvia.keyDown).toHaveBeenCalledWith("-", false);
+        });
+
+        test("releases what the press sent, even once the character has changed", () => {
+            keyboard.keyDown(evt("Digit2", '"', { shiftKey: true }));
+            // Shift let go first, so the release reports the unshifted character.
+            keyboard.keyUp(evt("Digit2", "2"));
+
+            expect(mockSysvia.keyUp).toHaveBeenCalledWith('"');
+        });
+
+        test("still names keys that print nothing by where they are", () => {
+            keyboard.keyDown(evt("ArrowLeft", "ArrowLeft"));
+
+            expect(mockSysvia.keyDown).toHaveBeenCalledWith("ArrowLeft", false);
+        });
+
+        test("leaves jsbeeb's own shortcuts on the physical key", () => {
+            const handler = vi.fn();
+            keyboard.registerKeyHandler(keyCodes.S, handler, { alt: true, ctrl: false });
+
+            keyboard.keyDown(evt("KeyS", "s", { altKey: true }));
+
+            expect(handler).toHaveBeenCalledWith(true, "KeyS", false);
+            expect(mockSysvia.keyDown).not.toHaveBeenCalled();
+        });
+
+        test("lets go of everything held when the layout changes under it", () => {
+            keyboard.keyDown(evt("KeyA", "a"));
+            keyboard.setKeyLayout("physical");
+
+            expect(mockSysvia.clearKeys).toHaveBeenCalled();
+        });
+    });
+
     test("keyCode is the physical position the event came from", () => {
         expect(keyboard.keyCode({ code: "ShiftLeft" })).toBe(keyCodes.SHIFT_LEFT);
         expect(keyboard.keyCode({ code: "ShiftRight" })).toBe(keyCodes.SHIFT_RIGHT);

--- a/tests/unit/test-keyboard.js
+++ b/tests/unit/test-keyboard.js
@@ -2,7 +2,7 @@ import { expect, describe, test, beforeEach, vi } from "vitest";
 import { Keyboard } from "../../src/web/keyboard.js";
 import { Scheduler } from "../../src/scheduler.js";
 import { ATOM, stringToATOMKeys } from "../../src/keymap-atom.js";
-import { BBC, keyCodes } from "../../src/keymap.js";
+import { BBC, keyCodes, userKeymap } from "../../src/keymap.js";
 import { findModel } from "../../src/models.js";
 
 describe("Keyboard", () => {
@@ -116,6 +116,28 @@ describe("Keyboard", () => {
 
             expect(handler).toHaveBeenCalledWith(true, "KeyS", false);
             expect(mockSysvia.keyDown).not.toHaveBeenCalled();
+        });
+
+        test("keeps the character it started with while a key auto-repeats", () => {
+            keyboard.keyDown(evt("Digit6", "^", { shiftKey: true }));
+            // Shift let go while the key stays down: the repeats report the plain character.
+            keyboard.keyDown(evt("Digit6", "6", { repeat: true }));
+            keyboard.keyUp(evt("Digit6", "6"));
+
+            expect(mockSysvia.keyDown).toHaveBeenCalledTimes(2);
+            expect(mockSysvia.keyDown).toHaveBeenLastCalledWith("^", false);
+            expect(mockSysvia.keyUp).toHaveBeenCalledWith("^");
+        });
+
+        test("gives a KEY. parameter its key by position, over the character", () => {
+            userKeymap.push({ native: "K1", key: "COPY" });
+            try {
+                keyboard.keyDown(evt("Digit1", "1"));
+
+                expect(mockSysvia.keyDown).toHaveBeenCalledWith("Digit1", false);
+            } finally {
+                userKeymap.length = 0;
+            }
         });
 
         test("lets go of everything held when the layout changes under it", () => {

--- a/tests/unit/test-keymap.js
+++ b/tests/unit/test-keymap.js
@@ -49,6 +49,10 @@ describe("What a character costs on a BBC keyboard", function () {
         expect(bbcKeyForCharacter("a")).toEqual({ key: BBC.A, shift: false, upperCase: false });
     });
 
+    it("puts the pound sign on shift and the underscore key, where the BBC draws it", function () {
+        expect(bbcKeyForCharacter("\u00a3")).toEqual({ key: BBC.UNDERSCORE_POUND, shift: true, upperCase: true });
+    });
+
     it("has nothing for a character the BBC cannot print", function () {
         expect(bbcKeyForCharacter("`")).toBeNull();
         expect(bbcKeyForCharacter("\u00e9")).toBeNull();

--- a/tests/unit/test-keymap.js
+++ b/tests/unit/test-keymap.js
@@ -1,7 +1,15 @@
 import { afterEach, describe, expect, it } from "vitest";
 
 import { ATOM, getKeyMapAtom } from "../../src/keymap-atom.js";
-import { BBC, getKeyMap, hostKeyCodes, keyCodes, stringToBBCKeys, userKeymap } from "../../src/keymap.js";
+import {
+    BBC,
+    bbcKeyForCharacter,
+    getKeyMap,
+    hostKeyCodes,
+    keyCodes,
+    stringToBBCKeys,
+    userKeymap,
+} from "../../src/keymap.js";
 import { processInputParams } from "../../src/url-params.js";
 
 describe("Keyboard mapping", function () {
@@ -20,6 +28,30 @@ describe("Keyboard mapping", function () {
         expect(stringToBBCKeys("Q").length).toBe(1);
         expect(stringToBBCKeys("a").length).toBe(3); // With CAPSLOCK toggles
         expect(stringToBBCKeys("!").length).toBe(3); // With SHIFT
+    });
+});
+
+describe("What a character costs on a BBC keyboard", function () {
+    it("puts the shifted characters on their unshifted key", function () {
+        expect(bbcKeyForCharacter("!")).toEqual({ key: BBC.K1, shift: true, upperCase: true });
+        expect(bbcKeyForCharacter("*")).toEqual({ key: BBC.COLON_STAR, shift: true, upperCase: true });
+        expect(bbcKeyForCharacter("?")).toEqual({ key: BBC.SLASH, shift: true, upperCase: true });
+    });
+
+    it("knows the characters the BBC prints without shift, where a PC needs it", function () {
+        expect(bbcKeyForCharacter("@")).toEqual({ key: BBC.AT, shift: false, upperCase: true });
+        expect(bbcKeyForCharacter("^")).toEqual({ key: BBC.HAT_TILDE, shift: false, upperCase: true });
+        expect(bbcKeyForCharacter(":")).toEqual({ key: BBC.COLON_STAR, shift: false, upperCase: true });
+    });
+
+    it("asks for the caps lock the other way round for lower case", function () {
+        expect(bbcKeyForCharacter("A")).toEqual({ key: BBC.A, shift: false, upperCase: true });
+        expect(bbcKeyForCharacter("a")).toEqual({ key: BBC.A, shift: false, upperCase: false });
+    });
+
+    it("has nothing for a character the BBC cannot print", function () {
+        expect(bbcKeyForCharacter("`")).toBeNull();
+        expect(bbcKeyForCharacter("\u00e9")).toBeNull();
     });
 });
 

--- a/tests/unit/test-via.js
+++ b/tests/unit/test-via.js
@@ -426,48 +426,44 @@ describe("SysVia natural keyboard shift override", () => {
         return via.keys[bbcKey[0]][bbcKey[1]] === 1;
     }
 
-    it("should produce ^ (HAT_TILDE without shift) when shift+6 is pressed", () => {
-        // Simulate: user presses SHIFT, then 6
+    it("holds no BBC shift for a `^`, which the BBC prints unshifted", () => {
         via.keyDown(keyCodes.SHIFT_LEFT, false);
         expect(bbcKeyPressed(BBC.SHIFT)).toBe(true);
 
-        via.keyDown(keyCodes.K6, true);
-        // HAT_TILDE should be pressed
+        via.keyDown("^", true);
         expect(bbcKeyPressed(BBC.HAT_TILDE)).toBe(true);
-        // BBC SHIFT should be suppressed (override active)
         expect(bbcKeyPressed(BBC.SHIFT)).toBe(false);
     });
 
-    it("should restore BBC SHIFT when the override key is released", () => {
+    it("gives the shift key back when the character is released", () => {
         via.keyDown(keyCodes.SHIFT_LEFT, false);
-        via.keyDown(keyCodes.K6, true);
+        via.keyDown("^", true);
         expect(bbcKeyPressed(BBC.SHIFT)).toBe(false);
 
-        // Release 6, keep shift held
-        via.keyUp(keyCodes.K6);
+        via.keyUp("^");
         expect(bbcKeyPressed(BBC.HAT_TILDE)).toBe(false);
-        // BBC SHIFT should be restored since physical shift is still held
         expect(bbcKeyPressed(BBC.SHIFT)).toBe(true);
     });
 
-    it("should handle shift released before the override key", () => {
+    it("keeps the shift suppressed when shift is let go first", () => {
         via.keyDown(keyCodes.SHIFT_LEFT, false);
-        via.keyDown(keyCodes.K6, true);
-        expect(bbcKeyPressed(BBC.SHIFT)).toBe(false);
+        via.keyDown("^", true);
 
-        // Release shift while 6 is still held
         via.keyUp(keyCodes.SHIFT_LEFT);
-        // Override is still active, so SHIFT stays suppressed
         expect(bbcKeyPressed(BBC.SHIFT)).toBe(false);
 
-        // Release 6
-        via.keyUp(keyCodes.K6);
-        // No override, no physical shift → SHIFT should be off
+        via.keyUp("^");
         expect(bbcKeyPressed(BBC.SHIFT)).toBe(false);
     });
 
-    it("should produce 6 without shift override when 6 is pressed unshifted", () => {
-        via.keyDown(keyCodes.K6, false);
+    it('holds BBC shift for a `"`, which the BBC prints shifted', () => {
+        via.keyDown('"', false);
+        expect(bbcKeyPressed(BBC.K2)).toBe(true);
+        expect(bbcKeyPressed(BBC.SHIFT)).toBe(true);
+    });
+
+    it("asks for no shift either way for a plain digit", () => {
+        via.keyDown("6", false);
         expect(bbcKeyPressed(BBC.K6)).toBe(true);
         expect(bbcKeyPressed(BBC.SHIFT)).toBe(false);
     });

--- a/tests/unit/test-via.js
+++ b/tests/unit/test-via.js
@@ -462,6 +462,24 @@ describe("SysVia natural keyboard shift override", () => {
         expect(bbcKeyPressed(BBC.SHIFT)).toBe(true);
     });
 
+    it("leaves shift alone for the space bar, which prints the same either way", () => {
+        via.keyDown(" ", true);
+        via.keyDown(keyCodes.SHIFT_LEFT, true);
+
+        expect(bbcKeyPressed(BBC.SPACE)).toBe(true);
+        expect(bbcKeyPressed(BBC.SHIFT)).toBe(true);
+    });
+
+    it("leaves shift alone when the host is already holding what the BBC wants", () => {
+        // A `"` is shifted on both, so nothing needs correcting and nothing else should suffer.
+        via.keyDown(keyCodes.SHIFT_LEFT, true);
+        via.keyDown('"', true);
+        via.keyDown("A", true);
+
+        expect(bbcKeyPressed(BBC.SHIFT)).toBe(true);
+        expect(bbcKeyPressed(BBC.A)).toBe(true);
+    });
+
     it("asks for no shift either way for a plain digit", () => {
         via.keyDown("6", false);
         expect(bbcKeyPressed(BBC.K6)).toBe(true);


### PR DESCRIPTION
Stacked on #1130. Finishes #123 and #1075.

The natural layout exists so that what you type comes out right. It was keyed by physical
position, and guessed whether your keyboard was UK or US from the browser's language setting. On
Dave Jeffery's Hungarian keyboard the keys to the right of the `L` print accented letters the
layout had never heard of. On Tom Seddon's Dvorak the key that types a hyphen pressed the BBC's
colon, because that is where it sits.

It now reads the character the host produced. Press whatever gives an `@` and the machine gets an
`@`, on any keyboard in any layout. Nothing has to know what your keyboard is printed with, so the
UK and US guess is gone from this layout entirely.

## What that needed

**One statement of what a character costs.** `stringToBBCKeys` held the only copy, as a switch
inside its loop, reachable only by pasting. `bbcKeyForCharacter` now gives the key, the shift
state, and which way the caps lock has to be. Verified identical for every character from 9 to
255, so the paste path cannot have changed.

**The BBC's shift state comes from the character.** A BBC holds shift for a different set of
characters than a PC: `^` is unshifted there, `"` is shifted. Every non-letter now says which shift
state it needs and the machine is held to it, which is what the existing shift override already did
for the single case anyone had noticed. Letters take their case from the shift key as before.

**A key remembers what it pressed.** The character changes between press and release when shift is
let go first, so what went down is kept against the physical key and released on the way up.
Changing layout releases everything held first, since the names are about to mean something else.

Keys that print nothing, the arrows and escape and the function keys, are still known by where they
are. So are jsbeeb's own shortcuts: `Alt-S` is the key in that position whatever it happens to
type.

The layout's menu entry said "`*` is shift-8", which was only ever true on some keyboards. It now
says you get the character you type.

## A pound sign, while we were here

The BBC draws a pound sign for character 96, where ASCII has a backtick; its font in the MOS at
`&C000` shows it plainly. On the keyboard it is shift and the underscore key, which a real machine
confirms: that key gives 95 alone and 96 with shift. Pasting one dropped it silently before.

## Not in here

The Atom has its own natural layout with the same guess in it. Its caps lock handling differs and
its key tables have no test coverage at all, so converting it at the end of this is not a careful
thing to do. Worth its own change.

## Testing

Unit and integration suites pass. The character table is proved identical to what it replaced. The
new browser behaviour has tests: a Dvorak press sends the character rather than the position, a
release after shift is let go still releases the right key, non-printing keys stay positional,
shortcuts stay positional, and a layout change lets go of what is held.

What cannot be tested here is a real non-QWERTY keyboard typing into a real machine. We have
willing users on Dvorak and Hungarian layouts, and the intent is to ask them and iterate.

## Known caveat, from testing

On Firefox under Windows, pressing Alt appears to leave focus on the menu bar when released. That
affects the gaming layout, which holds left Alt as BBC ctrl, rather than anything here. Being
checked; noted so it is not lost.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
